### PR TITLE
fix(anthropic): support URL-backed PDF documents in requests

### DIFF
--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -1274,21 +1274,19 @@ impl TryFrom<message::Message> for Message {
                         ))?;
 
                         let source = match media_type {
-                            DocumentMediaType::PDF => {
-                                let data = match data {
-                                    DocumentSourceKind::Base64(data)
-                                    | DocumentSourceKind::String(data) => data,
-                                    _ => {
-                                        return Err(MessageError::ConversionError(
-                                            "Only base64 encoded data is supported for PDF documents".into(),
-                                        ));
-                                    }
-                                };
-                                DocumentSource::Base64 {
+                            DocumentMediaType::PDF => match data {
+                                DocumentSourceKind::Base64(data)
+                                | DocumentSourceKind::String(data) => DocumentSource::Base64 {
                                     data,
                                     media_type: DocumentFormat::PDF,
+                                },
+                                DocumentSourceKind::Url(url) => DocumentSource::Url { url },
+                                _ => {
+                                    return Err(MessageError::ConversionError(
+                                        "Only base64 encoded data or URLs are supported for PDF documents".into(),
+                                    ));
                                 }
-                            }
+                            },
                             DocumentMediaType::TXT => {
                                 let data = match data {
                                     DocumentSourceKind::String(data)
@@ -6000,5 +5998,33 @@ mod tests {
         assert_eq!(coerce_tool_input(json!([1, 2, 3])), json!({}));
         assert_eq!(coerce_tool_input(json!(42)), json!({}));
         assert_eq!(coerce_tool_input(json!(true)), json!({}));
+    }
+
+    // Regression test for issue #1429: PR #1431 added the `DocumentSource::Url`
+    // wire variant and response-side parsing, but the request-side
+    // `UserContent::Document` conversion still rejected URL-backed PDFs even
+    // though the Anthropic Messages API supports
+    // `"source": {"type": "url", ...}` for PDFs.
+    //
+    // See <https://docs.anthropic.com/en/docs/build-with-claude/pdf-support>
+    // for URL-sourced PDF documents.
+    #[test]
+    fn url_pdf_converts_to_url_document_source() {
+        let pdf_url = "https://example.com/resume.pdf";
+        let msg = message::Message::User {
+            content: OneOrMany::one(message::UserContent::document_url(
+                pdf_url,
+                Some(message::DocumentMediaType::PDF),
+            )),
+        };
+
+        let converted = Message::try_from(msg).expect("URL PDF should convert");
+        let json = serde_json::to_value(&converted).expect("message should serialize");
+
+        assert_eq!(
+            json.pointer("/content/0/source"),
+            Some(&json!({ "type": "url", "url": pdf_url })),
+            "URL PDF should map to a url document source: {json:#}"
+        );
     }
 }

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -1269,9 +1269,19 @@ impl TryFrom<message::Message> for Message {
                             });
                         }
 
-                        let media_type = media_type.ok_or(MessageError::ConversionError(
-                            "Document media type is required".to_string(),
-                        ))?;
+                        let media_type = match media_type {
+                            Some(media_type) => media_type,
+                            // Anthropic's URL document source has no media-type field and is
+                            // defined specifically for PDFs, so the source itself is sufficient.
+                            None if matches!(&data, DocumentSourceKind::Url(_)) => {
+                                DocumentMediaType::PDF
+                            }
+                            None => {
+                                return Err(MessageError::ConversionError(
+                                    "Document media type is required".to_string(),
+                                ));
+                            }
+                        };
 
                         let source = match media_type {
                             DocumentMediaType::PDF => match data {
@@ -6005,26 +6015,28 @@ mod tests {
     // `UserContent::Document` conversion still rejected URL-backed PDFs even
     // though the Anthropic Messages API supports
     // `"source": {"type": "url", ...}` for PDFs.
+    // The media type is optional because Anthropic's URL source is implicitly a
+    // PDF and does not include a media-type field on the wire.
     //
     // See <https://docs.anthropic.com/en/docs/build-with-claude/pdf-support>
     // for URL-sourced PDF documents.
     #[test]
-    fn url_pdf_converts_to_url_document_source() {
+    fn url_pdf_with_or_without_media_type_converts_to_url_document_source() {
         let pdf_url = "https://example.com/resume.pdf";
-        let msg = message::Message::User {
-            content: OneOrMany::one(message::UserContent::document_url(
-                pdf_url,
-                Some(message::DocumentMediaType::PDF),
-            )),
-        };
 
-        let converted = Message::try_from(msg).expect("URL PDF should convert");
-        let json = serde_json::to_value(&converted).expect("message should serialize");
+        for media_type in [Some(message::DocumentMediaType::PDF), None] {
+            let msg = message::Message::User {
+                content: OneOrMany::one(message::UserContent::document_url(pdf_url, media_type)),
+            };
 
-        assert_eq!(
-            json.pointer("/content/0/source"),
-            Some(&json!({ "type": "url", "url": pdf_url })),
-            "URL PDF should map to a url document source: {json:#}"
-        );
+            let converted = Message::try_from(msg).expect("URL PDF should convert");
+            let json = serde_json::to_value(&converted).expect("message should serialize");
+
+            assert_eq!(
+                json.pointer("/content/0/source"),
+                Some(&json!({ "type": "url", "url": pdf_url })),
+                "URL PDF should map to a url document source: {json:#}"
+            );
+        }
     }
 }

--- a/tests/cassettes/anthropic/url_pdf_document/url_pdf_document_prompt.yaml
+++ b/tests/cassettes/anthropic/url_pdf_document/url_pdf_document_prompt.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":64000,"messages":[{"content":[{"source":{"type":"url","url":"https://bitcoin.org/bitcoin.pdf"},"type":"document"},{"text":"What is the title of this paper? Answer in one short sentence.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"You are a helpful assistant that analyzes documents.","type":"text"}],"temperature":0.0}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"content":[{"text":"The title of this paper is **\"Bitcoin: A Peer-to-Peer Electronic Cash System\"** by Satoshi Nakamoto.","type":"text"}],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"end_turn","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":19396,"output_tokens":34,"service_tier":"standard"}}'

--- a/tests/providers/anthropic/cassette/url_pdf_document.rs
+++ b/tests/providers/anthropic/cassette/url_pdf_document.rs
@@ -1,0 +1,48 @@
+//! Cassette-backed Anthropic coverage for URL-backed PDF documents.
+//!
+//! Regression coverage for sending a `DocumentSourceKind::Url` PDF through
+//! the request-side message conversion: the document must map to a
+//! `"source": {"type": "url", ...}` content block.
+//! See <https://docs.anthropic.com/en/docs/build-with-claude/pdf-support>.
+
+use rig::OneOrMany;
+use rig::client::CompletionClient;
+use rig::completion::Prompt;
+use rig::message::{DocumentMediaType, Message, UserContent};
+use rig::providers::anthropic::completion::CLAUDE_SONNET_4_6;
+
+use super::super::support::with_anthropic_cassette;
+use crate::support::{assert_contains_any_case_insensitive, assert_nonempty_response};
+
+const PDF_URL: &str = "https://bitcoin.org/bitcoin.pdf";
+
+#[tokio::test]
+async fn url_pdf_document_prompt() {
+    with_anthropic_cassette(
+        "url_pdf_document/url_pdf_document_prompt",
+        |client| async move {
+            let agent = client
+                .agent(CLAUDE_SONNET_4_6)
+                .preamble("You are a helpful assistant that analyzes documents.")
+                .temperature(0.0)
+                .build();
+
+            let response = agent
+                .prompt(Message::User {
+                    content: OneOrMany::many(vec![
+                        UserContent::document_url(PDF_URL, Some(DocumentMediaType::PDF)),
+                        UserContent::text(
+                            "What is the title of this paper? Answer in one short sentence.",
+                        ),
+                    ])
+                    .expect("content should be non-empty"),
+                })
+                .await
+                .expect("URL PDF document prompt should succeed");
+
+            assert_nonempty_response(&response);
+            assert_contains_any_case_insensitive(&response, &["bitcoin"]);
+        },
+    )
+    .await;
+}

--- a/tests/providers/anthropic/cassette/url_pdf_document.rs
+++ b/tests/providers/anthropic/cassette/url_pdf_document.rs
@@ -1,13 +1,13 @@
 //! Cassette-backed Anthropic coverage for URL-backed PDF documents.
 //!
-//! Regression coverage for sending a `DocumentSourceKind::Url` PDF through
-//! the request-side message conversion: the document must map to a
-//! `"source": {"type": "url", ...}` content block.
+//! Regression coverage for sending a `DocumentSourceKind::Url` PDF without an
+//! explicit media type through the request-side message conversion: the
+//! document must map to a `"source": {"type": "url", ...}` content block.
 //! See <https://docs.anthropic.com/en/docs/build-with-claude/pdf-support>.
 
 use rig::OneOrMany;
 use rig::completion::Prompt;
-use rig::message::{DocumentMediaType, Message, UserContent};
+use rig::message::{Message, UserContent};
 use rig::prelude::*;
 use rig::providers::anthropic::completion::CLAUDE_SONNET_4_6;
 
@@ -30,7 +30,7 @@ async fn url_pdf_document_prompt() {
             let response = agent
                 .prompt(Message::User {
                     content: OneOrMany::many(vec![
-                        UserContent::document_url(PDF_URL, Some(DocumentMediaType::PDF)),
+                        UserContent::document_url(PDF_URL, None),
                         UserContent::text(
                             "What is the title of this paper? Answer in one short sentence.",
                         ),

--- a/tests/providers/anthropic/cassette/url_pdf_document.rs
+++ b/tests/providers/anthropic/cassette/url_pdf_document.rs
@@ -6,9 +6,9 @@
 //! See <https://docs.anthropic.com/en/docs/build-with-claude/pdf-support>.
 
 use rig::OneOrMany;
-use rig::client::CompletionClient;
 use rig::completion::Prompt;
 use rig::message::{DocumentMediaType, Message, UserContent};
+use rig::prelude::*;
 use rig::providers::anthropic::completion::CLAUDE_SONNET_4_6;
 
 use super::super::support::with_anthropic_cassette;

--- a/tests/providers/anthropic/mod.rs
+++ b/tests/providers/anthropic/mod.rs
@@ -27,6 +27,7 @@ mod cassette {
     mod think_tool_with_other_tools;
     mod tool_call_rewrite_args;
     mod tool_result_rewrite;
+    mod url_pdf_document;
 }
 
 mod live {}


### PR DESCRIPTION
## Summary

- supersedes #2167 with the same implementation rebased onto the latest `main`
- preserves the original authored implementation commit and its message
- adds a separate compatibility commit for the current `AgentClientExt` import
- sends URL-backed PDF documents using Anthropic's URL document source shape
- infers PDF for URL documents when the optional media type is omitted
- adds unit and cassette-backed regression coverage for both explicit and inferred PDF paths

## Why

The Anthropic request conversion previously handled base64 PDF documents but rejected PDF documents backed by a URL. Anthropic supports URL document sources, so the conversion should preserve that source instead of returning an unsupported-document error.

Anthropic's URL document source has no media-type field and is defined specifically for PDFs. Requiring Rig callers to provide `DocumentMediaType::PDF` therefore prevented `document_url(url, None)` and provider-to-generic-to-provider URL document round trips from working even though the outgoing wire request is unambiguous.

## Impact

This changes only Anthropic URL PDF request conversion. A missing media type is inferred as PDF only for `DocumentSourceKind::Url`. Existing base64, plain-text, file-ID, and explicitly non-PDF URL validation remains intact. No public API is added or removed.

## Commit stack

1. `5f10f1f0` — original #2167 implementation by Dave Grijalva
2. `f8e4abce` — current-main test trait-import compatibility fix
3. `3f35e788` — infer PDF for URL documents without an explicit media type

## Verification

- `cargo fmt --all --check`
- `cargo test -p rig-core --lib url_pdf_with_or_without_media_type_converts_to_url_document_source`
- `cargo test -p rig --all-features --test anthropic anthropic::cassette -- --nocapture --test-threads=1` (69 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- cassette secret/content inspection
- independent full-diff review: no actionable findings

#2167 remains unchanged for comparison and history.