### PR TITLE
docs(migrating): cover 0.38 through unreleased, not just the runtime split

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,118 +1,538 @@
-# Migrating to the runtime split
+# Migrating Rig
 
-This release splits Rig's monolithic core into two crates behind the `rig`
-facade:
+This guide covers every breaking change from 0.38 through the current
+unreleased version. Releases 0.39 and 0.40 were large, and 0.40 in particular
+carried 31 breaking changes.
 
-- **`rig-core`** — portable, runtime-independent contracts: provider/model
-  clients, canonical messages and completion values, streaming values, the
-  portable tool contracts, memory and vector-store traits, and WASM support.
-- **`rig-agent`** — the classic agent runtime: the builder, run state machine,
-  typed hooks, contextual tools, memory orchestration, extraction, and the
-  blocking/streaming driver.
-- **`rig`** — the facade you depend on. It re-exports both at their familiar
-  `rig::…` paths.
+## Which sections apply to you
 
-## If you depend on the `rig` facade (most users)
+Work upwards from the version you are on. Each section is self-contained.
 
-**Almost nothing changes.** These all keep working:
+| You are on | Read |
+| --- | --- |
+| 0.40 | [0.40 → unreleased](#040--unreleased) |
+| 0.39 | [0.39 → 0.40](#039--040), then [0.40 → unreleased](#040--unreleased) |
+| 0.38 or earlier | [0.38 → 0.39](#038--039), then both sections above |
+
+**Everyone should read [Silent behavior changes](#silent-behavior-changes)
+first.** Those are the changes that leave your code compiling and make it do
+something different — the ones a compiler upgrade will not point at.
+
+---
+
+## Silent behavior changes
+
+Nothing in this section produces a compile error. Check each one against your
+code before upgrading.
+
+### `max_turns` counts differently (0.40)
+
+The highest-impact change in either release. `max_turns` and
+`default_max_turns` now bound the **exact total number of model calls**,
+including the initial call, tool continuations, and retries.
+
+| Budget | Before | After |
+| --- | --- | --- |
+| `0` | initial call + 2 | no model call at all |
+| `1` | initial call + 2 | only the initial call |
+| `n` | effectively `n + 2` | exactly `n` |
+
+An unconfigured tool-then-answer flow now needs an explicit budget of `2`. To
+preserve the maximum allowance of an old explicit budget `n`, account for the
+old effective `n + 2`; otherwise set the literal total you actually intend.
+
+If you set `max_turns` at all, re-derive the number. A budget that used to
+permit a tool round-trip may now stop after the first model call.
+
+### Providers that used to return empty text now error (0.40)
+
+Responses with empty assistant content and no tool calls surface the shared
+path's "empty response" error on **hyperbolic, perplexity, and huggingface**.
+Previously each returned an empty text completion. Code that treated an empty
+string as a normal outcome now takes an error branch.
+
+### Moonshot drops reasoning-only history turns (0.40)
+
+The shared conversion drops assistant messages carrying neither text nor tool
+calls. Reasoning attached to a text or tool-call turn still round-trips via
+`reasoning_content`; reasoning-only turns no longer survive in history.
+
+### Request contents changed for several providers (0.40)
+
+Consequences of the `GenericCompletionModel` consolidation. None of these
+change your source, all of them change what goes over the wire:
+
+- `max_tokens` is now **forwarded** by deepseek, together, hyperbolic, and
+  azure. It was silently dropped before — these providers will now respect a
+  limit your code has been setting all along with no effect.
+- together's streaming uses standard `stream`/`stream_options` rather than
+  `stream_tokens`, and a rig-level `ToolChoice::Required` serializes as
+  `required` instead of erroring.
+- perplexity's non-streaming endpoint drops a stray `/v1` prefix.
+- mira sends its preamble as a `system` message instead of `user`.
+- `response_format` derived from `output_schema` is deferred while tools are
+  pending a result. groq, mistral, and azure previously applied it
+  unconditionally.
+- groq's streaming usage no longer falls back to the legacy `x_groq.usage`
+  envelope.
+
+### Rig `Video` content now serializes instead of erroring (0.40)
+
+On the shared conversion, `Video` user content serializes a `video_url` content
+part (an OpenRouter/gateway extension) rather than returning a client-side
+conversion error. Providers without video support now reject it **server-side**
+— the failure moved from your process to theirs, and moved later.
+
+### Telemetry span names and fields (0.40)
+
+- Migrated providers' streaming spans are named `chat` with
+  `gen_ai.operation.name = "chat"`, previously `chat_streaming`. Dashboards and
+  alerts keying on `chat_streaming` go blank.
+- `gen_ai.input.messages` / `gen_ai.output.messages` are intentionally left
+  empty rather than recording serialized messages.
+- `gen_ai.request.model` reports the per-request model override when one
+  applies.
+- minimax, zai, and xiaomimimo spans stop reporting as `"openai"` and report
+  their own provider name.
+
+### `if_wasm!` / `if_not_wasm!` key on the target (unreleased)
+
+These macros are `#[macro_export]`ed, and a `cfg` inside a macro expansion is
+evaluated in the **calling** crate. The old expansion therefore tested whether
+*your* crate had a feature named `wasm`, not whether `rig-core` did. Any caller
+without such a feature took the `if_not_wasm!` branch on every target, browser
+wasm included.
+
+They now key on `all(target_arch = "wasm32", target_os = "unknown")`. If you
+defined a `wasm` feature and expected it to drive these macros, you now get the
+target's answer instead. Gate on the target directly if you need the old
+association.
+
+---
+
+## 0.40 → unreleased
+
+### 1. The crate split
+
+The monolithic core is now a portable contracts crate (`rig-core`) plus the
+classic agent runtime (`rig-agent`), presented behind the `rig` facade.
+
+**If you depend on the `rig` facade — almost nothing changes.** These keep
+working unchanged:
 
 ```rust
 use rig::prelude::*;
-use rig::tool::{Tool, ToolContext};   // classic contextual tool trait
+use rig::tool::{Tool, ToolContext};   // still the classic contextual trait
 use rig::completion::Prompt;
 ```
 
-`use rig::prelude::*;` brings the canonical `CompletionClient`
-(`completion_model`) together with the classic `AgentClientExt` (`agent` /
-`extractor`) — the full pre-split client surface from one import.
+**If you depend on `rig-core` directly**, it is now portable-only. Agent
+construction — `AgentBuilder`, `ExtractorBuilder`, contextual tools, hooks, the
+run loop — moved to `rig-agent`. Depend on `rig-agent` or the facade.
 
-`rig::tool::Tool` is still the classic *contextual* trait (the one whose
-`call` takes `&mut ToolContext`). The only two things to know:
+**If you depend on `rig-agent` directly**, its root no longer re-exports all of
+`rig-core`. The previous `pub use rig_core::*;` made it an implicit second
+facade. Reach portable items through the explicit namespace:
 
-1. **Constructing agents/extractors needs the client traits in scope.** Provider
-   clients no longer have inherent `.agent()` / `.extractor()` methods. Bring the
-   client surface in through the prelude:
+```rust
+use rig_agent::core::OneOrMany;   // was: rig_agent::OneOrMany
+```
 
-   ```rust
-   use rig::prelude::*;
-   let agent = client.agent(model).build();          // from AgentClientExt
-   let extractor = client.extractor::<T>(model).build();
-   let m = client.completion_model(model);            // from CompletionClient
-   ```
+The `impl From<rmcp::model::Tool> for ToolDefinition` and its `&`-borrow variant
+were removed — with `ToolDefinition` in `rig-core` and `rmcp::model::Tool`
+foreign, the orphan rule forbids the impl in `rig-agent`. Normal MCP use is
+unchanged; if you relied on the direct conversion, build the `ToolDefinition`
+from the tool's `name`, `description`, and `schema_as_json_value()`.
 
-   If you prefer explicit imports:
-   `use rig::client::{CompletionClient, AgentClientExt};` — `CompletionClient`
-   provides `completion_model`, `AgentClientExt` provides `agent` / `extractor`.
+### 2. Client construction needs traits in scope
 
-2. **The portable, context-free tool contract is `PortableTool`.** If you were
-   using a runtime-independent tool, it is now `rig::tool::PortableTool`
-   (`rig_core::tool::Tool` no longer exists). Classic contextual tools are
-   unchanged. A `PortableTool` still registers with the classic runtime — it
-   blanket-implements the contextual `Tool`.
+Provider clients no longer carry inherent `.agent()` / `.extractor()` methods.
+There is one canonical `CompletionClient` (in `rig-core`, providing
+`completion_model`); the classic constructors live on a new `AgentClientExt`.
 
-   ```rust
-   use rig::tool::PortableTool;              // or rig_core::tool::PortableTool
-   // The whole portable surface also lives under rig::tool::portable::*
-   ```
+```rust
+use rig::prelude::*;                  // brings both into scope
 
-## If you depend on `rig-core` directly
+let agent     = client.agent(model).build();          // AgentClientExt
+let extractor = client.extractor::<T>(model).build(); // AgentClientExt
+let m         = client.completion_model(model);       // CompletionClient
+```
 
-`rig-core` is now portable-only. It no longer provides agent construction:
-`CompletionClient::agent` / `extractor`, `AgentBuilder`, `ExtractorBuilder`,
-contextual tools, hooks, and the run loop moved to `rig-agent`. Depend on
-`rig-agent` (or the `rig` facade) for those. The canonical
-`CompletionClient` (`completion_model`) lives in `rig-core`; `rig-agent` adds
-`rig_agent::client::AgentClientExt` for `.agent()` / `.extractor()`. Bring both
-in at once with `use rig_agent::prelude::*;`.
+Or import explicitly: `use rig::client::{CompletionClient, AgentClientExt};`
 
-Portable tools implement `rig_core::tool::PortableTool`. The `#[rig_tool]` macro
-for context-free functions produces a `PortableTool`; for functions that take
-`#[rig(context)] &mut ToolContext` it produces the classic contextual `Tool`
-(available via `rig-agent` or the facade).
+### 3. The portable tool contract is `PortableTool`
 
-## If you depend on `rig-agent` directly
+The context-free tool contract is now `PortableTool` (with
+`PortableToolEmbedding`, `PortableDynamicTool`, `portable_tool_definition`).
+The `rig_core::tool::Tool` alias is removed.
 
-Import portable `rig-core` contracts through the explicit `rig_agent::core`
-namespace (e.g. `rig_agent::core::OneOrMany`) — the `rig-agent` crate root
-exposes only runtime-owned items, not a blanket re-export of `rig-core`.
+On the facade, `rig::tool::Tool` remains the classic *contextual* trait, so
+existing facade code is unchanged. Portable contracts are available as
+`rig::tool::PortableTool`, and in full under `rig::tool::portable`. A
+`PortableTool` still registers with the classic runtime — it blanket-implements
+the contextual `Tool`.
 
-- The `impl From<rmcp::model::Tool> for ToolDefinition` and its `&`-borrow
-  variant were removed: with `ToolDefinition` now in `rig-core` and
-  `rmcp::model::Tool` foreign, the orphan rule forbids the impl in `rig-agent`.
-  Normal use is unchanged — MCP tools are still turned into definitions through
-  the `ToolSet` / `ErasedTool` path. If you relied on the direct
-  `rmcp_tool.into()` / `ToolDefinition::from(&rmcp_tool)` conversion, build the
-  `ToolDefinition` explicitly from the tool's `name`, `description`, and
-  `schema_as_json_value()`.
+### 4. Tool authoring and dispatch, reworked
 
-## `#[rig_tool]` schema/deserializer coherence
+The largest change in this release. Typed tools now implement only:
 
-`#[rig_tool]`'s `required` handling previously described the schema only: a
-parameter left out of an explicit `required(...)` list was advertised as
-optional, but the generated deserializer still demanded it, failing at runtime
-whenever the model legitimately omitted it. Required-ness now has one source
-of truth and the schema always matches the deserializer:
+```rust
+Tool::call(&mut ToolContext, Args) -> Result<Output, Error>
+```
 
-- **No `required(...)` (the default):** non-`Option` parameters are required;
-  `Option<T>` parameters are optional and deserialize to `None` when absent.
-  (Previously `Option` parameters were *advertised* as required.) If a
-  provider integration needs every parameter marked required, list them
-  explicitly: `required(a, b, ...)`.
-- **Explicit `required(...)`:** listed parameters are required. Listing an
-  `Option<T>` parameter is a compile error — schemars excludes `Option`
-  fields from `required` and serde deserializes a missing `Option` to `None`,
-  so the directive would be silently ignored on both sides; drop the `Option`
-  or omit it from the list. Omitted parameters get `#[serde(default)]`, so
-  their types must be `Option<T>` or implement `Default`; a type that is
-  neither is now a compile error instead of a runtime deserialization
-  failure.
-- Names in `params(...)` and `required(...)` must match actual parameters, and
-  malformed or duplicate attribute entries are compile errors. A typo that
-  used to silently mis-advertise the schema no longer compiles.
+Author-facing errors stay typed until private runtime erasure normalizes them
+into `ToolExecutionError`.
 
-Two dependency-related improvements need no action but may let you tidy up:
-crates using `#[rig_tool]` / `#[derive(Embed)]` no longer need direct `serde`
-or `serde_json` dependencies for the generated code, the `Embed` trait no
-longer needs to be imported where it is derived, and fully qualified
-`&mut rig::tool::ToolContext` parameters are recognized without
-`#[rig(context)]` even under renamed dependencies.
+**Tool implementations.** Keep one typed `type Error` for ordinary `?`
+propagation. Remove `classify_error`, `call_with_extensions`, and
+`call_structured`. The optional `map_error` classifies domain failures at the
+erased boundary; its default preserves the source as `Other`. Return refusals
+through `map_error` with `ToolExecutionError::refused`. Attach host-only result
+metadata with `ToolContext::insert_result`.
+
+**Context.** `ToolCallExtensions` and `ToolResultExtensions` are replaced by
+`ToolContext`; `.tool_extensions(...)` becomes `.tool_context(...)`.
+
+**Dynamic tools.** `ToolDyn` is removed from the public API — use
+`DynamicTool`. Rig's erased dispatch trait is now private. Typed tools use
+`Tool::NAME` as their sole identity; runtime-named agents convert explicitly
+with `Agent::into_tool()`.
+
+**Registration:**
+
+| Before | After |
+| --- | --- |
+| `AgentBuilder::tools(Vec<Box<dyn ToolDyn>>)` | repeated `.tool(...)`, or `dynamic_tools(Vec<DynamicTool>)` |
+| `dynamic_tools(sample, index, toolset)` | `retrieved_tools` |
+| `ToolSetBuilder::dynamic_tool(ToolEmbedding)` | `retrieved_tool` |
+| `ToolSetBuilder::dynamic_tool(...)` (callbacks) | `dynamic_tool(DynamicTool)` |
+
+**Dispatch:**
+
+| Before | After |
+| --- | --- |
+| `ToolSet::{call, call_with_extensions, call_structured}` | `ToolSet::execute` |
+| `ToolServerHandle::{call_tool, call_tool_with_extensions, call_tool_structured}` | `ToolServerHandle::execute` |
+
+**Errors.** Replace `ToolError`, `ToolFailure`, `ToolFailureKind`, `ToolReturn`,
+`ToolReturnOutcome`, `ToolExecutionResult`, and `ToolOutcome` with
+`ToolExecutionError`, `ToolErrorKind`, and the read-only `ToolResult` that hooks
+observe. `ToolSetError` is removed.
+
+Explicit `ToolExecutionError` constructors keep actionable diagnostics
+model-visible. The generic `from_error` path preserves operator diagnostics and
+the concrete source but defaults to safe kind-level model feedback — use
+`with_model_feedback` for deliberate replacement text, or `with_model_output`
+for JSON/multimodal feedback.
+
+**Model presentation.** Serializable outputs convert once into canonical
+`ToolOutput` content blocks. Strings stay literal text, explicit
+`serde_json::Value` stays JSON, and multimodal tools use `ToolOutput::content` /
+`ToolOutput::one` or return typed `ToolResultContent`. Rig never reparses
+strings to infer rich content. Inspect with `as_text` / `as_json`, and decode
+explicitly with `deserialize_json`.
+
+**Registry.** `ToolSet` is the single ordered registry and records whether each
+tool is always advertised or retrieval-only. `ToolSet::{get_tool_definitions,
+documents}` are now synchronous and infallible, and `ToolServerHandle`
+registration/removal no longer returns an artificial `Result`.
+
+### 5. Hooks are event-specific and provider-independent
+
+`AgentHook::on_event`, `StepEvent`, and `Flow` are replaced by event-specific
+`AgentHook` methods with their own action types: `CompletionCallAction`,
+`ToolCallAction`, `ToolResultAction`, `InvalidToolCallAction`,
+`ObservationAction`. This makes invalid event/action combinations
+unrepresentable.
+
+`AgentHook`, `HookStack`, and the internal erased-hook interface no longer carry
+a completion-model type parameter. `CompletionResponseEvent` and
+`StreamResponseFinish` expose canonical Rig content, usage, prompt, and message
+ID fields instead of typed provider responses. Direct `CompletionModel`
+completion and streaming APIs still return typed raw provider responses.
+
+Invalid-tool hooks return `None` to defer; every explicit action, including
+`Fail`, is terminal for that hook stack. The atomically surfaced post-batch
+streaming event is named `ToolExecutionCommitted` — for live host lifecycle
+events, observe `on_tool_call` / `on_tool_result`.
+
+### 6. `AgentRunner` is the only execution path
+
+The raw `Completion` and `StreamingCompletion` traits and their `Agent`
+implementations are removed; agent execution state is private.
+
+```rust
+// before
+agent.completion(prompt, history).await?.send().await?;
+agent.stream_completion(prompt, history).await?.stream().await?;
+
+// after — pick a turn budget large enough for tool follow-ups
+agent.runner(prompt).history(history).max_turns(3).run().await?;
+agent.runner(prompt).history(history).max_turns(3).stream().await;
+```
+
+The runner consumes tool calls rather than returning the first raw model
+response. For intentionally hook-free transport, start from
+`model.completion_request(prompt).messages(history)` then `.send()` or
+`.stream()`.
+
+`AgentRun::new(prompt).with_history(history)` remains a sans-I/O state machine
+for custom drivers. It holds no configured model, tools, memory, or hooks and is
+not an alternate execution path for configured agents.
+
+An `Agent`'s model is fixed and private. Former per-call `.model(...)` /
+`.model_opt(...)` users should retain the provider `CompletionModel` and use its
+raw request API, or construct a separate `Agent`.
+
+`Extractor` now routes through the full hook lifecycle.
+
+### 7. `dynamic_context` is removed
+
+`AgentBuilder::dynamic_context`, `ExtractorBuilder::dynamic_context`, and the
+internal `DynamicContextStore` passive-retrieval pipeline are gone. Static
+builder context remains.
+
+For passive RAG, applications now own query selection, retrieval, filtering,
+reranking, formatting, caching, failure handling, and per-turn policy in a local
+`AgentHook`.
+
+### 8. `#[rig_tool]` required-ness follows the parameter types
+
+Required-ness now has one source of truth, and the advertised schema always
+agrees with the deserializer. Previously a parameter left out of an explicit
+`required(...)` was advertised optional while the generated deserializer still
+demanded it — failing at runtime whenever the model legitimately omitted it.
+
+- **No `required(...)`:** non-`Option` parameters are required; `Option<T>` is
+  optional and deserializes to `None` when absent. Previously `Option`
+  parameters were *advertised* as required. If a provider needs everything
+  marked required, list them explicitly.
+- **Explicit `required(...)`:** listed parameters are required. Omitted ones get
+  `#[serde(default)]`, so their types must be `Option<T>` or implement
+  `Default` — a type that is neither is now a **compile error** instead of a
+  runtime deserialization failure.
+- Listing an `Option<T>` in `required(...)` is a compile error: schemars
+  excludes `Option` fields from `required` and serde deserializes a missing
+  `Option` to `None`, so the directive would be silently ignored on both sides.
+- Names in `params(...)` and `required(...)` must match actual parameters.
+  Malformed or duplicate entries are compile errors rather than silently
+  ignored.
+- A wildcard context binding (`#[rig(context)] _: &mut ToolContext`) is
+  rejected — name it `_context`.
+
+Two dependency improvements need no action but may let you tidy up: crates using
+`#[rig_tool]` / `#[derive(Embed)]` no longer need direct `serde` or `serde_json`
+dependencies, the `Embed` trait no longer needs importing where it is derived,
+and fully qualified `&mut rig::tool::ToolContext` parameters are recognized
+without `#[rig(context)]` even under renamed dependencies.
+
+### 9. Core errors are `#[non_exhaustive]`
+
+`PromptError`, `StructuredOutputError`, and `VectorStoreError` are now
+`#[non_exhaustive]`. Downstream `match` expressions need a wildcard arm.
+
+Conversation memory load failures surface as the typed
+`PromptError::MemoryError` instead of `CompletionError::RequestError`.
+
+### 10. Every wasm feature flag is gone
+
+`rig-core`'s `wasm`, `rig-agent`'s `wasm`, and the facade's `wasm` are all
+removed. **Building for `wasm32-unknown-unknown` is the entire opt-in** — there
+are no wasm feature flags anywhere in the workspace.
+
+Drop `features = ["wasm"]` from any dependency line. Nothing replaces it; Cargo
+rejects the unknown feature at resolution, so this fails loudly.
+
+Relaxing the bounds cannot break *implementors* — the relaxed markers are
+blanket-implemented (`impl<T> WasmCompatSend for T {}`), so every type that
+satisfied the strict form satisfies the relaxed one. The one exception is a
+generic *consumer* on browser wasm that wrote `T: WasmCompatSend` and then
+relied on `T: Send` internally, and only if it was previously building with the
+feature off.
+
+**`rmcp` is native-only.** It never compiled for wasm — rmcp's `ClientHandler`
+requires `Send + Sync` unconditionally, which rig's wasm tool registry cannot
+satisfy — but it used to fail with a wall of `dyn ErasedTool` trait errors. It
+now fails with a single explanatory `compile_error!`.
+
+WASI (`wasm32-wasip1` / `wasip2`) is **not supported**; its dependency graph has
+never built. See `crates/rig-agent/README.md` for the full target matrix.
+
+---
+
+## 0.39 → 0.40
+
+### 1. `max_turns` — see [Silent behavior changes](#max_turns-counts-differently-040)
+
+The single most likely change to alter your program's behavior without a
+compile error.
+
+### 2. `Tool` / `ToolDyn` metadata is flat
+
+Tool authors implement `description()` and `parameters()` directly.
+`Tool::definition(prompt)` and `ToolDyn::definition(prompt)` are removed.
+
+`ToolDefinition` remains a provider/request artifact generated from registered
+tools. `Tool::NAME` / `Tool::name()` / `ToolDyn::name()` are the single source of
+truth for advertised and dispatched tool names.
+
+### 3. Structured tool-execution results, and hook system v2
+
+Two large additions that also broke existing surfaces (#2015, #2012). Hooks
+became composable middleware; tool execution gained structured results. If you
+implemented hooks or tools against 0.39, expect to rewrite against the new
+shapes — and note that both were reworked *again* before the unreleased version
+([section 4](#4-tool-authoring-and-dispatch-reworked) and
+[section 5](#5-hooks-are-event-specific-and-provider-independent) above). If you
+are jumping 0.39 → unreleased, migrate straight to the newer shape and skip this
+intermediate form.
+
+### 4. `PromptResponse` and `FinalResponse` are one type
+
+Unified in #2056. `FinalResponse` and its accessors (`content`,
+`assistant_content`, `completion_calls`) no longer exist as a separate type.
+
+### 5. Providers consolidated onto `GenericCompletionModel<Ext>`
+
+groq, deepseek, mistral, together, moonshot (OpenAI side), perplexity,
+hyperbolic, mira, azure, huggingface, and llamafile all lose their hand-rolled
+`CompletionModel` structs, request types, and `TryFrom<message::Message>`
+conversions. `CompletionModel` in each module is now a **type alias** for the
+generic model, and provider-specific `StreamingCompletionResponse` types are
+replaced by the shared OpenAI one.
+
+A new `OpenAICompatibleProvider` trait (mirroring `AnthropicCompatibleProvider`)
+is now **required** by `GenericCompletionModel`'s `Ext` parameter. It carries the
+telemetry provider name and an `EMITS_COMPLETE_SINGLE_CHUNK_TOOL_CALLS` flag for
+llama.cpp-style streaming tool calls, plus `SUPPORTS_RESPONSE_FORMAT`,
+`STREAM_INCLUDE_USAGE`, and `SUPPORTS_TOOLS` consts. Provider wire dialects live
+in its `completion_path`, `prepare_request`, and `finalize_request_body` hooks.
+
+Also in this area:
+
+- `openai::ToolChoice` gains a `Function { name }` variant and is now
+  `#[non_exhaustive]`.
+- `openai::CompletionRequest` fields are now public; `OpenAIRequestParams` gains
+  `supports_response_format`.
+- `GenericCompletionModel`'s `strict_tools` / `tool_result_array_content` fields
+  are private — use the `with_*` builder methods. The redundant `with_model`
+  constructor is removed; use `new`.
+- `StreamingCompletionResponse` is generic over the provider's streaming usage
+  payload (`StreamingCompletionResponse<U = Usage>`).
+- perplexity, hyperbolic, and mira set `SUPPORTS_TOOLS = false`;
+  `tools`/`tool_choice` are dropped with a warning during request conversion.
+
+### 6. OpenRouter de-forked
+
+`openrouter::{Message, UserContent, ImageUrl}` are re-exports of the shared
+OpenAI types. The fork's `FileContent` / `VideoUrlContent` are replaced by shared
+`FileData` / `VideoUrl`. `ReasoningDetails` / `ResponseImage` move into the
+openai module (re-exported from openrouter).
+
+The shared OpenAI types gained OpenRouter's extensions to support this:
+`UserContent::Video`, `ImageUrl.detail` becomes `Option<ImageDetail>`, and
+`Message::Assistant` gains `reasoning_details`, an inbound-only `images` field,
+and a deserialize-only `role: "model"` alias.
+
+Message conversion goes through `openrouter::messages_from_rig_message`.
+OpenRouter's `UserContent` builder helpers (`image_url`, `file_base64`,
+`video_url`, …) are removed — construct the shared `openai` content variants
+directly. `ToolChoice::Specific` with multiple function names now errors
+client-side.
+
+### 7. Error types gained a `ProviderResponse` variant (#1944)
+
+> Not recorded in the CHANGELOG. Found by diffing the public API.
+
+Every provider HTTP-error path is routed through a shared
+`from_http_response` / `from_provider_body` funnel, so `provider_response_*`
+helpers recover the raw status and body instead of flattening into
+`ProviderError(String)`.
+
+Practical impact: **`RerankError` becomes `#[non_exhaustive]` and gains a
+`ProviderResponse` variant**, and public `from_http_response` /
+`from_provider_body` constructors are added on every capability error. An
+exhaustive `match` on `RerankError` will no longer compile — add a wildcard arm.
+
+### 8. `Output::Unknown` carries a payload (#1950)
+
+> Only its sibling PR (#1951) is in the CHANGELOG.
+
+In the OpenAI Responses API, `Output::Unknown` was a fieldless variant, so every
+unrecognized output item decoded to a unit and its payload was discarded.
+Provider-native hosted tools (`web_search_call`, `file_search_call`,
+`computer_use_call`, `code_interpreter_call`) arrive as exactly these items, so
+their data was destroyed at the typed-decode boundary.
+
+`Output::Unknown` is now `Output::Unknown(serde_json::Value)`. Any `match` arm
+binding that variant needs updating — and the data you were previously losing is
+now available.
+
+### 9. Removed outright
+
+| Removed | Replacement |
+| --- | --- |
+| `providers::galadriel` (whole integration) | none |
+| `evals` module + `experimental` feature | none |
+| experimental `pipeline` module | none |
+| `rig_derive::ProviderClient` derive | none |
+| `Extractor::{get_inner, into_inner}` | none |
+| `TryFrom<String> for Nothing` (always failed) | none |
+| `streaming::stream_completion_to_stdout` | `agent::stream_to_stdout` |
+| `AudioGeneration<M>` / `ImageGeneration<M>` / `Transcription<M>` wrapper traits | the corresponding `*Model` APIs and request builders |
+| `providers::anthropic::decoders` | shared SSE machinery |
+| `SpanCombinator::record_model_output` | none |
+| `together::ToolChoice`, `together::ToolChoiceFunctionKind`, `moonshot::ToolChoice` | shared `openai::ToolChoice` |
+| `groq::send_compatible_streaming_request`, `deepseek::send_compatible_streaming_request` | `openai::send_compatible_streaming_request` |
+| raw response types of perplexity / hyperbolic / huggingface (`Message`, `Choice`, `Usage`, `Delta`, `Role`) | each module keeps a `CompletionResponse` alias to the shared OpenAI payload |
+
+---
+
+## 0.38 → 0.39
+
+Only two breaking changes.
+
+### 1. Sans-I/O `AgentRun` state machine (#1899)
+
+Both agent loops became thin drivers over a sans-I/O `AgentRun` state machine.
+If you drove the agent loop yourself rather than calling `prompt` / `chat`,
+you are affected. Note that the surrounding execution API changed again in the
+unreleased version — see
+[`AgentRunner` is the only execution path](#6-agentrunner-is-the-only-execution-path).
+
+### 2. Deterministic, duplicate-safe tool registration (#1913)
+
+Tool registration became order-deterministic and duplicate-safe, with `ToolSet`
+backed by an `IndexMap`. Code relying on the previous registration order or on
+duplicate-name behavior may see different tools advertised.
+
+---
+
+## Appendix: symbol reference
+
+Renamed or relocated items, for searching.
+
+| Old | New | Version |
+| --- | --- | --- |
+| `rig_core::tool::Tool` (portable) | `rig_core::tool::PortableTool` | unreleased |
+| `rig_agent::<item>` (portable re-export) | `rig_agent::core::<item>` | unreleased |
+| `client.agent(...)` inherent method | `AgentClientExt::agent` (via `rig::prelude::*`) | unreleased |
+| `ToolCallExtensions` / `ToolResultExtensions` | `ToolContext` | unreleased |
+| `.tool_extensions(...)` | `.tool_context(...)` | unreleased |
+| `ToolDyn` (public) | `DynamicTool` | unreleased |
+| `ToolSet::{call, call_with_extensions, call_structured}` | `ToolSet::execute` | unreleased |
+| `ToolServerHandle::call_tool*` | `ToolServerHandle::execute` | unreleased |
+| `ToolError` / `ToolFailure` / `ToolReturn` / `ToolOutcome` / `ToolExecutionResult` | `ToolExecutionError` / `ToolErrorKind` / `ToolResult` | unreleased |
+| `AgentHook::on_event` + `StepEvent` + `Flow` | event-specific `AgentHook` methods + action types | unreleased |
+| `agent.completion(...)` / `agent.stream_completion(...)` | `agent.runner(...).run()` / `.stream()` | unreleased |
+| `AgentBuilder::dynamic_context` | own it in an `AgentHook` | unreleased |
+| `dynamic_tools(sample, index, toolset)` | `retrieved_tools` | unreleased |
+| `ToolSetBuilder::dynamic_tool(ToolEmbedding)` | `retrieved_tool` | unreleased |
+| `features = ["wasm"]` | nothing — target is the opt-in | unreleased |
+| `Tool::definition(prompt)` | `description()` + `parameters()` | 0.40 |
+| `FinalResponse` | `PromptResponse` | 0.40 |
+| `streaming::stream_completion_to_stdout` | `agent::stream_to_stdout` | 0.40 |
+| `groq`/`deepseek`::`send_compatible_streaming_request` | `openai::send_compatible_streaming_request` | 0.40 |
+| `Output::Unknown` | `Output::Unknown(Value)` | 0.40 |
+| provider-specific `StreamingCompletionResponse` | shared `openai::StreamingCompletionResponse` | 0.40 |
+| `GenericCompletionModel::with_model` | `GenericCompletionModel::new` | 0.40 |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -95,6 +95,32 @@ conversion error. Providers without video support now reject it **server-side**
 - minimax, zai, and xiaomimimo spans stop reporting as `"openai"` and report
   their own provider name.
 
+### Ollama now honors `max_tokens` (unreleased)
+
+Ollama's native `/api/chat` has no top-level `max_tokens` field, so the value
+was serialized into a field the server does not define and silently discarded.
+It is now sent as the `num_predict` model parameter inside `options`, where
+Ollama actually reads it.
+
+Nothing to change — but if you set `max_tokens` on an Ollama agent at any point
+and moved on when it appeared to do nothing, **it starts applying now**.
+Responses that had been running to their natural stop will truncate at the
+budget you configured, possibly long ago. Check the value is one you still want.
+`temperature` is unaffected: it was already being sent inside `options` and only
+a redundant top-level copy was removed.
+
+### Multipart tool results reach OpenAI intact (unreleased)
+
+Tool results carrying several `ToolResultContent` blocks were flattened before
+being sent to the Responses and Chat Completions APIs. Individual blocks are now
+preserved — retained as multipart when array-form tool results are enabled, and
+flattened only where string-form content is required.
+
+Tools that return mixed text/JSON/rich output now present to the model as
+distinct blocks rather than one merged blob. That is the intended behavior, but
+it does change what the model sees, so prompts tuned against the flattened shape
+are worth re-checking.
+
 ### `if_wasm!` / `if_not_wasm!` key on the target (unreleased)
 
 These macros are `#[macro_export]`ed, and a `cfg` inside a macro expansion is
@@ -286,15 +312,36 @@ raw request API, or construct a separate `Agent`.
 
 `Extractor` now routes through the full hook lifecycle.
 
-### 7. `dynamic_context` is removed
+### 7. `dynamic_context` is back, but it is a hook now
 
-`AgentBuilder::dynamic_context`, `ExtractorBuilder::dynamic_context`, and the
-internal `DynamicContextStore` passive-retrieval pipeline are gone. Static
-builder context remains.
+`AgentBuilder::dynamic_context` and `ExtractorBuilder::dynamic_context` were
+removed in #2174 and **restored in #2219**. If you are tracking `main`, you may
+have seen the gap; if you are upgrading from a release, the call still exists
+and **your `.dynamic_context(samples, index)` calls need no change**.
 
-For passive RAG, applications now own query selection, retrieval, filtering,
-reranking, formatting, caching, failure handling, and per-turn policy in a local
-`AgentHook`.
+What changed underneath: the separate retrieval pipeline in agent request
+construction is gone for good, and the internal `DynamicContextStore` with it.
+The helper is now a thin wrapper over a private `AgentHook` on the ordinary
+completion-call lifecycle. Behavior that is deliberately preserved: retrieval on
+every model call, current-prompt query selection with latest-textual-history
+fallback, sample-count forwarding, pretty-JSON document formatting,
+static-context-before-retrieved-context ordering, failure raised before provider
+I/O, and support across blocking, streaming, and extractor execution.
+
+Two consequences of it being an ordinary hook are worth checking:
+
+- **Registration order matters.** Retrieval and the injected documents now
+  follow hook registration order relative to your own hooks. Register a stop
+  policy *before* `dynamic_context` if it should be able to suppress retrieval —
+  previously the side pipeline ran regardless.
+- **Multiple registrations run sequentially.** Several `dynamic_context` calls
+  now execute in order through `HookStack` rather than concurrently through the
+  former side pipeline. If you registered several against independent indexes
+  and depended on the concurrency, expect added latency.
+
+If you want control beyond that — filtering, reranking, caching, per-turn policy
+— write your own `AgentHook`; that is the only passive-RAG execution path now,
+and `dynamic_context` is simply a prepackaged one.
 
 ### 8. `#[rig_tool]` required-ness follows the parameter types
 
@@ -525,7 +572,8 @@ Renamed or relocated items, for searching.
 | `ToolError` / `ToolFailure` / `ToolReturn` / `ToolOutcome` / `ToolExecutionResult` | `ToolExecutionError` / `ToolErrorKind` / `ToolResult` | unreleased |
 | `AgentHook::on_event` + `StepEvent` + `Flow` | event-specific `AgentHook` methods + action types | unreleased |
 | `agent.completion(...)` / `agent.stream_completion(...)` | `agent.runner(...).run()` / `.stream()` | unreleased |
-| `AgentBuilder::dynamic_context` | own it in an `AgentHook` | unreleased |
+| `AgentBuilder::dynamic_context` | unchanged call, now hook-backed (removed in #2174, restored in #2219) | unreleased |
+| `DynamicContextStore` | none — the side retrieval pipeline is gone for good | unreleased |
 | `dynamic_tools(sample, index, toolset)` | `retrieved_tools` | unreleased |
 | `ToolSetBuilder::dynamic_tool(ToolEmbedding)` | `retrieved_tool` | unreleased |
 | `features = ["wasm"]` | nothing — target is the opt-in | unreleased |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,8 +1,7 @@
 # Migrating Rig
 
-This guide covers every breaking change from 0.38 through the current
-unreleased version. Releases 0.39 and 0.40 were large, and 0.40 in particular
-carried 31 breaking changes.
+This guide covers every breaking change from 0.38 through 0.41. Releases 0.39
+and 0.40 were large, and 0.40 in particular carried 31 breaking changes.
 
 ## Which sections apply to you
 
@@ -10,8 +9,8 @@ Work upwards from the version you are on. Each section is self-contained.
 
 | You are on | Read |
 | --- | --- |
-| 0.40 | [0.40 → unreleased](#040--unreleased) |
-| 0.39 | [0.39 → 0.40](#039--040), then [0.40 → unreleased](#040--unreleased) |
+| 0.40 | [0.40 → 0.41](#040--041) |
+| 0.39 | [0.39 → 0.40](#039--040), then [0.40 → 0.41](#040--041) |
 | 0.38 or earlier | [0.38 → 0.39](#038--039), then both sections above |
 
 **Everyone should read [Silent behavior changes](#silent-behavior-changes)
@@ -95,7 +94,7 @@ conversion error. Providers without video support now reject it **server-side**
 - minimax, zai, and xiaomimimo spans stop reporting as `"openai"` and report
   their own provider name.
 
-### Ollama now honors `max_tokens` (unreleased)
+### Ollama now honors `max_tokens` (0.41)
 
 Ollama's native `/api/chat` has no top-level `max_tokens` field, so the value
 was serialized into a field the server does not define and silently discarded.
@@ -109,7 +108,7 @@ budget you configured, possibly long ago. Check the value is one you still want.
 `temperature` is unaffected: it was already being sent inside `options` and only
 a redundant top-level copy was removed.
 
-### Multipart tool results reach OpenAI intact (unreleased)
+### Multipart tool results reach OpenAI intact (0.41)
 
 Tool results carrying several `ToolResultContent` blocks were flattened before
 being sent to the Responses and Chat Completions APIs. Individual blocks are now
@@ -121,7 +120,7 @@ distinct blocks rather than one merged blob. That is the intended behavior, but
 it does change what the model sees, so prompts tuned against the flattened shape
 are worth re-checking.
 
-### `if_wasm!` / `if_not_wasm!` key on the target (unreleased)
+### `if_wasm!` / `if_not_wasm!` key on the target (0.41)
 
 These macros are `#[macro_export]`ed, and a `cfg` inside a macro expansion is
 evaluated in the **calling** crate. The old expansion therefore tested whether
@@ -136,7 +135,7 @@ association.
 
 ---
 
-## 0.40 → unreleased
+## 0.40 → 0.41
 
 ### 1. The crate split
 
@@ -428,10 +427,10 @@ truth for advertised and dispatched tool names.
 Two large additions that also broke existing surfaces (#2015, #2012). Hooks
 became composable middleware; tool execution gained structured results. If you
 implemented hooks or tools against 0.39, expect to rewrite against the new
-shapes — and note that both were reworked *again* before the unreleased version
-([section 4](#4-tool-authoring-and-dispatch-reworked) and
-[section 5](#5-hooks-are-event-specific-and-provider-independent) above). If you
-are jumping 0.39 → unreleased, migrate straight to the newer shape and skip this
+shapes — and note that both were reworked *again* in 0.41 ([section
+4](#4-tool-authoring-and-dispatch-reworked) and [section
+5](#5-hooks-are-event-specific-and-provider-independent) above). If you are
+jumping 0.39 → 0.41, migrate straight to the newer shape and skip this
 intermediate form.
 
 ### 4. `PromptResponse` and `FinalResponse` are one type
@@ -542,10 +541,10 @@ Only two breaking changes.
 ### 1. Sans-I/O `AgentRun` state machine (#1899)
 
 Both agent loops became thin drivers over a sans-I/O `AgentRun` state machine.
-If you drove the agent loop yourself rather than calling `prompt` / `chat`,
-you are affected. Note that the surrounding execution API changed again in the
-unreleased version — see
-[`AgentRunner` is the only execution path](#6-agentrunner-is-the-only-execution-path).
+If you drove the agent loop yourself rather than calling `prompt` / `chat`, you
+are affected. Note that the surrounding execution API changed again in 0.41 —
+see [`AgentRunner` is the only execution
+path](#6-agentrunner-is-the-only-execution-path).
 
 ### 2. Deterministic, duplicate-safe tool registration (#1913)
 
@@ -561,22 +560,22 @@ Renamed or relocated items, for searching.
 
 | Old | New | Version |
 | --- | --- | --- |
-| `rig_core::tool::Tool` (portable) | `rig_core::tool::PortableTool` | unreleased |
-| `rig_agent::<item>` (portable re-export) | `rig_agent::core::<item>` | unreleased |
-| `client.agent(...)` inherent method | `AgentClientExt::agent` (via `rig::prelude::*`) | unreleased |
-| `ToolCallExtensions` / `ToolResultExtensions` | `ToolContext` | unreleased |
-| `.tool_extensions(...)` | `.tool_context(...)` | unreleased |
-| `ToolDyn` (public) | `DynamicTool` | unreleased |
-| `ToolSet::{call, call_with_extensions, call_structured}` | `ToolSet::execute` | unreleased |
-| `ToolServerHandle::call_tool*` | `ToolServerHandle::execute` | unreleased |
-| `ToolError` / `ToolFailure` / `ToolReturn` / `ToolOutcome` / `ToolExecutionResult` | `ToolExecutionError` / `ToolErrorKind` / `ToolResult` | unreleased |
-| `AgentHook::on_event` + `StepEvent` + `Flow` | event-specific `AgentHook` methods + action types | unreleased |
-| `agent.completion(...)` / `agent.stream_completion(...)` | `agent.runner(...).run()` / `.stream()` | unreleased |
-| `AgentBuilder::dynamic_context` | unchanged call, now hook-backed (removed in #2174, restored in #2219) | unreleased |
-| `DynamicContextStore` | none — the side retrieval pipeline is gone for good | unreleased |
-| `dynamic_tools(sample, index, toolset)` | `retrieved_tools` | unreleased |
-| `ToolSetBuilder::dynamic_tool(ToolEmbedding)` | `retrieved_tool` | unreleased |
-| `features = ["wasm"]` | nothing — target is the opt-in | unreleased |
+| `rig_core::tool::Tool` (portable) | `rig_core::tool::PortableTool` | 0.41 |
+| `rig_agent::<item>` (portable re-export) | `rig_agent::core::<item>` | 0.41 |
+| `client.agent(...)` inherent method | `AgentClientExt::agent` (via `rig::prelude::*`) | 0.41 |
+| `ToolCallExtensions` / `ToolResultExtensions` | `ToolContext` | 0.41 |
+| `.tool_extensions(...)` | `.tool_context(...)` | 0.41 |
+| `ToolDyn` (public) | `DynamicTool` | 0.41 |
+| `ToolSet::{call, call_with_extensions, call_structured}` | `ToolSet::execute` | 0.41 |
+| `ToolServerHandle::call_tool*` | `ToolServerHandle::execute` | 0.41 |
+| `ToolError` / `ToolFailure` / `ToolReturn` / `ToolOutcome` / `ToolExecutionResult` | `ToolExecutionError` / `ToolErrorKind` / `ToolResult` | 0.41 |
+| `AgentHook::on_event` + `StepEvent` + `Flow` | event-specific `AgentHook` methods + action types | 0.41 |
+| `agent.completion(...)` / `agent.stream_completion(...)` | `agent.runner(...).run()` / `.stream()` | 0.41 |
+| `AgentBuilder::dynamic_context` | unchanged call, now hook-backed (removed in #2174, restored in #2219) | 0.41 |
+| `DynamicContextStore` | none — the side retrieval pipeline is gone for good | 0.41 |
+| `dynamic_tools(sample, index, toolset)` | `retrieved_tools` | 0.41 |
+| `ToolSetBuilder::dynamic_tool(ToolEmbedding)` | `retrieved_tool` | 0.41 |
+| `features = ["wasm"]` | nothing — target is the opt-in | 0.41 |
 | `Tool::definition(prompt)` | `description()` + `parameters()` | 0.40 |
 | `FinalResponse` | `PromptResponse` | 0.40 |
 | `streaming::stream_completion_to_stdout` | `agent::stream_to_stdout` | 0.40 |


### PR DESCRIPTION
**TL;DR:** `MIGRATING.md` covered only the unreleased runtime split and said
nothing about 0.40, the release with 31 breaking changes. It is now a full guide
across 0.38 → unreleased, led by the changes that *don't* fail to compile. Two
breaking changes missing from the CHANGELOG were found and documented. Docs
only; no code changes.

## The gap

| Release | Breaking entries | Covered before this PR |
| --- | --- | --- |
| 0.39.0 | 2 | no |
| **0.40.0** | **31** | **no** |
| Unreleased | 13 | yes — the only thing it covered |

The file was titled "Migrating to the runtime split." It was the companion doc
for #2197/#2205/#2207 that happened to live at that filename — good at its job,
but not a migration guide. A user on 0.39 upgrading to 0.40 had a flat
123-line CHANGELOG section ordered by merge date and nothing else.

## Method

The obvious approach is to read every merged PR and write up what changed. I
did not do that, for three reasons:

1. **Ratio.** 127 PRs merged since v0.39.0; ~20 are conventional-breaking.
2. **Diffs mis-weight.** #2214 was 5,500 lines with zero user-facing migration
   content. A one-line change to a `pub type` alias breaks every downstream user
   and looks like nothing. Diff size and migration impact are near-uncorrelated.
3. **Diffs answer the wrong question.** They say what changed internally, not
   what breaks a *user*. The ground truth for "what will fail to compile
   downstream" is the public API surface.

Three sources instead, each covering the others' blind spots:

- **Spine — mechanical public-API diff.** `cargo public-api -p rig-core
  --simplified diff v0.39.0..v0.40.0`. Exhaustive and independent of whether
  anyone remembered to flag a PR breaking.
- **Narrative — the CHANGELOG's breaking entries.** Hand-curated and unusually
  specific; they carry the *why*, which a diff never does. Most of the prose
  here derives from them.
- **Detail — targeted PR and commit bodies**, only for items the first two
  flagged. ~20 read deliberately rather than 127 skimmed.

### What the spine caught that the CHANGELOG missed

This is the part that justifies the tooling, and it isn't hypothetical. Both
are verified in the tree, not just inferred from commit messages:

- **#1944 — absent from the CHANGELOG entirely.** Its own commit body is marked
  `[breaking]`. `crates/rig-core/src/rerank.rs:19-20` confirms `RerankError` is
  `#[non_exhaustive]` and gained
  `ProviderResponse(provider_response::ProviderResponseError)`. Anyone matching
  it exhaustively breaks with no changelog warning. Public
  `from_http_response` / `from_provider_body` constructors were added on every
  capability error (`crates/rig-core/src/provider_response.rs:82,104`).
- **#1950 — only its sibling #1951 is listed.** `Output::Unknown` is now
  `Output::Unknown(Value)`
  (`crates/rig-core/src/providers/openai/responses_api/mod.rs:2056`). It was a
  fieldless variant, so provider-native hosted-tool payloads (`web_search_call`,
  `file_search_call`, `computer_use_call`, `code_interpreter_call`) were
  destroyed at the typed-decode boundary. Both the break and the recovered data
  are documented.

Also noted: #2093 (`max_turns`) and #2114 (non-exhaustive errors) are described
in the CHANGELOG but without PR links, so they don't turn up when searching by
number.

## Structure

Newest-first, per-release, self-contained sections, with the old runtime-split
content absorbed into the unreleased section rather than left to compete with it.

**The lead section is "Silent behavior changes"** — seven changes that leave
your code compiling and make it do something different. These are the ones a
compiler upgrade will not point at, and they were previously scattered through a
merge-ordered list:

- **`max_turns` counts differently.** The headline. It now bounds the exact
  total number of model calls including the initial call, tool continuations,
  and retries — `0` makes no call at all, `1` permits only the initial one, and
  an unconfigured tool-then-answer flow needs an explicit `2`. An existing
  working `max_turns(n)` may now stop before its tool round-trip. Old-vs-new
  table included.
- **`max_tokens` is now actually forwarded** by deepseek, together, hyperbolic,
  and azure — silently dropped before, so a limit your code has been setting
  with no effect suddenly applies.
- **Three providers switched from empty text to an error** (hyperbolic,
  perplexity, huggingface).
- **`chat_streaming` → `chat` span rename**, which blanks any dashboard keyed on
  the old name.
- Plus moonshot dropping reasoning-only history turns, `Video` content
  serializing instead of erroring client-side, and the `if_wasm!` macro
  behavior change.

Then `0.40 → unreleased`, `0.39 → 0.40`, `0.38 → 0.39`, and a symbol-reference
appendix (old → new → version) for people who arrive by searching for a name
that no longer exists.

One cross-cutting note is called out in the text: the tool and hook surfaces
changed in 0.40 and were **reworked again** before the unreleased version.
Anyone jumping 0.39 → unreleased should skip the intermediate form entirely, so
the 0.40 sections say so and link forward.

## Verification

**Verified against the tree** — every symbol name the guide claims:
`PromptResponse` is the survivor of the #2056 unification and `FinalResponse` is
gone; `PortableTool`, `AgentClientExt`, `ToolExecutionError`, `ToolErrorKind`,
`DynamicTool`, `ToolContext`, `stream_to_stdout`, `OpenAICompatibleProvider`,
`ToolExecutionCommitted`, `retrieved_tools`, `into_tool` all exist at the paths
named; `ToolSet::execute` and `ToolServerHandle::execute` exist;
`PromptError::MemoryError` exists. All 9 internal anchor links resolve against
the 35 generated headings.

(Worth stating because the first pass of this check was broken — a bad `git
grep` pathspec reported every symbol missing. The numbers above are from the
corrected run.)

**Not verified — transcribed.** The before/after code snippets and the finer
provider-behavior details are taken from CHANGELOG prose and PR descriptions.
They are not compiled. The CHANGELOG is specific enough that I stayed close to
its wording rather than inventing API shapes, but a reader should treat the
snippets as illustrative.

## Follow-ups, not in this PR

- **Make the snippets doctests.** The only way to keep them true as the API
  moves. Real work, worth doing separately.
- **Add `cargo public-api diff` to the release process.** Two breaking changes
  reached a release without a CHANGELOG entry; this is the check that would have
  caught both.
- **Backfill #1944 and #1950 into the 0.40.0 CHANGELOG section**, so the
  changelog and the guide agree.
