### PR TITLE
fix(openai): preserve multipart tool result content

### DIFF
--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -602,27 +602,29 @@ impl TryFrom<message::ToolResult> for Message {
     type Error = message::MessageError;
 
     fn try_from(value: message::ToolResult) -> Result<Self, Self::Error> {
-        let text = value
+        let parts = value
             .content
             .into_iter()
-            .map(|content| {
-                match content {
-                message::ToolResultContent::Text(message::Text { text, .. }) => Ok(text),
-                message::ToolResultContent::Json { value } => Ok(value.to_string()),
+            .map(|content| match content {
+                message::ToolResultContent::Text(message::Text { text, .. }) => Ok(ToolResultContent::from(text)),
+                message::ToolResultContent::Json { value } => Ok(ToolResultContent::from(value.to_string())),
                 message::ToolResultContent::Image(_) => Err(message::MessageError::ConversionError(
-                    "OpenAI does not support images in tool results. Tool results must be text."
+                    "OpenAI Chat Completions does not support images in tool results. Tool results must be text."
                         .into(),
                 )),
-            }
             })
-            .collect::<Result<Vec<_>, _>>()?
-            .join("\n");
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let content = match parts.as_slice() {
+            [part] => ToolResultContentValue::String(part.text.clone()),
+            _ => ToolResultContentValue::Array(parts),
+        };
 
         Ok(Message::ToolResult {
             // `call_id` carries the provider-issued call id when it differs
             // from the rig-level tool-result id (e.g. Mistral, llama.cpp).
             tool_call_id: value.call_id.unwrap_or(value.id),
-            content: ToolResultContentValue::String(text),
+            content,
         })
     }
 }
@@ -1793,11 +1795,15 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
             ));
         }
 
-        if tool_result_array_content {
-            for msg in &mut full_history {
-                if let Message::ToolResult { content, .. } = msg {
-                    *content = content.to_array();
-                }
+        for msg in &mut full_history {
+            if let Message::ToolResult { content, .. } = msg {
+                let normalized = if tool_result_array_content {
+                    content.to_array()
+                } else {
+                    ToolResultContentValue::String(content.as_text())
+                };
+
+                *content = normalized;
             }
         }
 
@@ -2057,6 +2063,34 @@ mod tests {
         }
     }
 
+    fn request_with_multi_block_tool_result() -> CoreCompletionRequest {
+        let tool_result = message::ToolResult {
+            id: "result-id".to_string(),
+            call_id: Some("call-id".to_string()),
+            content: OneOrMany::many(vec![
+                message::ToolResultContent::text("first"),
+                message::ToolResultContent::text("second"),
+            ])
+            .expect("multiple tool-result blocks should be non-empty"),
+        };
+
+        CoreCompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: OneOrMany::one(message::Message::User {
+                content: OneOrMany::one(message::UserContent::ToolResult(tool_result)),
+            }),
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: None,
+            output_schema: None,
+            record_telemetry_content: false,
+        }
+    }
+
     #[test]
     fn mixed_user_content_preserves_order_around_tool_results() {
         let content = OneOrMany::many(vec![
@@ -2200,6 +2234,97 @@ mod tests {
 
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0]["content"], "First.\nSecond.");
+    }
+
+    #[test]
+    fn tool_result_array_content_preserves_multiple_text_blocks() {
+        let request = CompletionRequest::try_from(OpenAIRequestParams {
+            model: "gpt-4o-mini".to_string(),
+            request: request_with_multi_block_tool_result(),
+            strict_tools: false,
+            tool_result_array_content: true,
+            supports_response_format: true,
+            supports_tools: true,
+        })
+        .expect("request conversion should succeed");
+
+        let wire = serde_json::to_value(&request.messages).expect("messages should serialize");
+
+        assert_eq!(
+            wire,
+            serde_json::json!([
+                {
+                    "role": "tool",
+                    "tool_call_id": "call-id",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "first"
+                        },
+                        {
+                            "type": "text",
+                            "text": "second"
+                        }
+                    ]
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn tool_result_string_content_flattens_multiple_text_blocks() {
+        let request = CompletionRequest::try_from(OpenAIRequestParams {
+            model: "gpt-4o-mini".to_string(),
+            request: request_with_multi_block_tool_result(),
+            strict_tools: false,
+            tool_result_array_content: false,
+            supports_response_format: true,
+            supports_tools: true,
+        })
+        .expect("request conversion should succeed");
+
+        let wire = serde_json::to_value(&request.messages).expect("messages should serialize");
+
+        assert_eq!(
+            wire,
+            serde_json::json!([
+                {
+                    "role": "tool",
+                    "tool_call_id": "call-id",
+                    "content": "first\nsecond"
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn multiple_tool_result_blocks_convert_to_distinct_content_parts() {
+        let result = message::ToolResult {
+            id: "result-id".to_string(),
+            call_id: Some("call-id".to_string()),
+            content: OneOrMany::many(vec![
+                message::ToolResultContent::text("first"),
+                message::ToolResultContent::json(serde_json::json!({
+                "status": "ok"
+            })),
+                message::ToolResultContent::text("second"),
+            ])
+                .expect("tool-result content should be non-empty"),
+        };
+
+        let converted = Message::try_from(result).expect("tool result should convert");
+
+        assert_eq!(
+            converted,
+            Message::ToolResult {
+                tool_call_id: "call-id".to_string(),
+                content: ToolResultContentValue::Array(vec![
+                    ToolResultContent::from("first".to_string()),
+                    ToolResultContent::from(r#"{"status":"ok"}"#.to_string()),
+                    ToolResultContent::from("second".to_string()),
+                ]),
+            }
+        );
     }
 
     #[test]

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -2305,11 +2305,11 @@ mod tests {
             content: OneOrMany::many(vec![
                 message::ToolResultContent::text("first"),
                 message::ToolResultContent::json(serde_json::json!({
-                "status": "ok"
-            })),
+                    "status": "ok"
+                })),
                 message::ToolResultContent::text("second"),
             ])
-                .expect("tool-result content should be non-empty"),
+            .expect("tool-result content should be non-empty"),
         };
 
         let converted = Message::try_from(result).expect("tool result should convert");

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -320,20 +320,17 @@ pub enum ToolResultOutputContent {
 fn responses_tool_result_output(
     content: OneOrMany<message::ToolResultContent>,
 ) -> Result<ToolResultOutput, MessageError> {
-    let mut text_output = Vec::new();
     let mut rich_output = Vec::new();
-    let mut has_image = false;
 
     for content in content {
         match content {
             message::ToolResultContent::Text(Text { text, .. }) => {
-                text_output.push(text.clone());
                 rich_output.push(ToolResultOutputContent::InputText { text });
             }
             message::ToolResultContent::Json { value } => {
-                let text = value.to_string();
-                text_output.push(text.clone());
-                rich_output.push(ToolResultOutputContent::InputText { text });
+                rich_output.push(ToolResultOutputContent::InputText {
+                    text: value.to_string(),
+                });
             }
             message::ToolResultContent::Image(message::Image {
                 data,
@@ -341,7 +338,6 @@ fn responses_tool_result_output(
                 detail,
                 ..
             }) => {
-                has_image = true;
                 let (image_url, file_id) = match data {
                     DocumentSourceKind::Base64(data) => {
                         let media_type = media_type.ok_or_else(|| {
@@ -374,10 +370,10 @@ fn responses_tool_result_output(
         }
     }
 
-    if has_image {
-        Ok(ToolResultOutput::Content(rich_output))
-    } else {
-        Ok(ToolResultOutput::Text(text_output.join("\n")))
+    match rich_output.as_slice() {
+        [ToolResultOutputContent::InputText { text }] => Ok(ToolResultOutput::Text(text.clone())),
+
+        _ => Ok(ToolResultOutput::Content(rich_output)),
     }
 }
 
@@ -2862,6 +2858,106 @@ mod tests {
                 }] if output == &expected
             ));
         }
+    }
+
+    #[test]
+    fn multiple_text_tool_result_blocks_preserve_order_as_rich_function_output() {
+        let content = OneOrMany::many(vec![
+            message::ToolResultContent::text("first"),
+            message::ToolResultContent::text("second"),
+        ])
+        .expect("multiple tool-result blocks should be non-empty");
+
+        let input = message::Message::User {
+            content: OneOrMany::one(message::UserContent::ToolResult(message::ToolResult {
+                id: "result-id".to_string(),
+                call_id: Some("call-id".to_string()),
+                content,
+            })),
+        };
+
+        let expected = ToolResultOutput::Content(vec![
+            ToolResultOutputContent::InputText {
+                text: "first".to_string(),
+            },
+            ToolResultOutputContent::InputText {
+                text: "second".to_string(),
+            },
+        ]);
+
+        let messages: Vec<Message> = input.clone().try_into().expect("message conversion");
+
+        match messages.as_slice() {
+            [Message::ToolResult { output, .. }] => {
+                assert_eq!(output, &expected);
+            }
+            other => panic!("expected one tool result, got {other:?}"),
+        }
+
+        let items: Vec<InputItem> = input.try_into().expect("input item conversion");
+
+        match items.as_slice() {
+            [
+                InputItem {
+                    input: InputContent::FunctionCallOutput(ToolResult { output, .. }),
+                    ..
+                },
+            ] => {
+                assert_eq!(output, &expected);
+            }
+            other => panic!("expected one function-call output, got {other:?}"),
+        }
+
+        let wire = serde_json::to_value(&items[0]).expect("input item should serialize");
+
+        assert_eq!(
+            wire,
+            json!({
+                "type": "function_call_output",
+                "call_id": "call-id",
+                "output": [
+                    {
+                        "type": "input_text",
+                        "text": "first"
+                    },
+                    {
+                        "type": "input_text",
+                        "text": "second"
+                    }
+                ],
+                "status": "completed"
+            })
+        );
+    }
+
+    #[test]
+    fn multiple_text_and_json_tool_result_blocks_preserve_boundaries() {
+        let content = OneOrMany::many(vec![
+            message::ToolResultContent::text("before"),
+            message::ToolResultContent::json(json!({
+                "status": "ok"
+            })),
+            message::ToolResultContent::text("after"),
+        ])
+        .expect("multiple tool-result blocks should be non-empty");
+
+        let output =
+            responses_tool_result_output(content).expect("tool-result conversion should succeed");
+
+        assert_eq!(
+            output,
+            ToolResultOutput::Content(vec![
+                ToolResultOutputContent::InputText {
+                    text: "before".to_string(),
+                },
+                ToolResultOutputContent::InputText {
+                    text: r#"{"status":"ok"}"#.to_string(),
+                },
+                ToolResultOutputContent::InputText {
+                    text: "after".to_string(),
+                },
+            ])
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2201

## Summary

- supersedes #2202 with the same implementation rebased onto the latest `main`
- preserves the original authored implementation commit and its message
- adds a separate rustfmt-only commit to fix the required formatting check
- preserves multipart tool-result boundaries in OpenAI Chat Completions array mode
- preserves ordered text, JSON, and image tool-result blocks in the Responses API
- retains the existing newline-flattened compatibility behavior for string-only providers

## Why

OpenAI provider conversion previously concatenated multipart tool results before provider-specific wire normalization. That destroyed the original block boundaries and made `tool_result_array_content` emit a single already-flattened item. PR #2202 implements the correct boundary-preserving conversion, but its required formatting check fails on one newly added test.

This successor replays the original implementation unchanged on current `main` and applies only rustfmt's requested indentation as a second commit.

## Impact

Single text or JSON tool results retain their compact string representation. Multiple Responses API blocks serialize as ordered rich content, while Chat Completions preserves separate text parts only when array-form tool results are enabled. Default string-form behavior remains unchanged for OpenAI-compatible providers that require it.

## Commit stack

1. `93632f2d` — original #2202 implementation by k.marinus
2. `3d53381f` — rustfmt-only correction to the multipart regression test

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p rig-core --all-features --lib tool_result -- --nocapture` (30 passed)
- `cargo test -p rig-core --all-features --lib` (1001 passed, 3 ignored)
- `cargo check --package rig-core --target wasm32-unknown-unknown`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `git range-diff` confirms the original #2202 patch is unchanged
- independent full-diff review: no actionable P0-P3 findings

#2202 remains unchanged for comparison and history.
