### PR TITLE
test(openai): cover nullable strict extractor responses

### DIFF
--- a/tests/providers/openai/mod.rs
+++ b/tests/providers/openai/mod.rs
@@ -1,5 +1,7 @@
 mod support;
 
+mod regressions;
+
 mod cassette {
     mod agent;
     mod chat_history;

--- a/tests/providers/openai/regressions.rs
+++ b/tests/providers/openai/regressions.rs
@@ -1,0 +1,91 @@
+//! OpenAI-compatible response regressions that use an in-memory HTTP backend.
+
+use rig::prelude::*;
+use rig::providers::openai;
+use rig_core::test_utils::RecordingHttpClient;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
+struct KeywordPayload {
+    keywords: Vec<String>,
+}
+
+#[tokio::test]
+async fn extractor_accepts_nullable_strict_in_echoed_tool_definition() {
+    let response = json!({
+        "id": "resp_local",
+        "object": "response",
+        "created_at": 0,
+        "status": "completed",
+        "error": null,
+        "incomplete_details": null,
+        "instructions": null,
+        "max_output_tokens": null,
+        "model": "gpt-oss-120b",
+        "usage": {
+            "input_tokens": 42,
+            "input_tokens_details": { "cached_tokens": 0 },
+            "output_tokens": 12,
+            "output_tokens_details": { "reasoning_tokens": 0 },
+            "total_tokens": 54
+        },
+        "output": [{
+            "type": "function_call",
+            "id": "fc_submit",
+            "call_id": "call_submit",
+            "name": "submit",
+            "arguments": r#"{"keywords":["fruit","produce"]}"#,
+            "status": "completed"
+        }],
+        "tools": [{
+            "type": "function",
+            "name": "submit",
+            "description": "Submit the extracted keywords.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "keywords": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                    }
+                },
+                "required": ["keywords"]
+            },
+            "strict": null
+        }]
+    });
+    let http_client = RecordingHttpClient::new(response.to_string());
+    let client = openai::Client::builder()
+        .api_key("test-key")
+        .base_url("http://localhost:8000/v1")
+        .http_client(http_client.clone())
+        .build()
+        .expect("OpenAI-compatible client should build");
+
+    let extracted = client
+        .extractor::<KeywordPayload>("gpt-oss-120b")
+        .build()
+        .extract("What fruit is mentioned in the database?")
+        .await
+        .expect("nullable strict should not prevent extraction");
+
+    assert_eq!(
+        extracted,
+        KeywordPayload {
+            keywords: vec!["fruit".to_string(), "produce".to_string()]
+        }
+    );
+
+    let requests = http_client.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].uri, "http://localhost:8000/v1/responses");
+    let request: serde_json::Value =
+        serde_json::from_slice(&requests[0].body).expect("request body should be valid JSON");
+    assert_eq!(request["tools"][0]["name"], "submit");
+    assert!(
+        request["tools"][0].get("strict").is_none(),
+        "non-strict extractor tools should omit strict on the request"
+    );
+}


### PR DESCRIPTION
## Description

Adds an end-to-end regression test for #2194 through Rig's public extractor API and an in-memory OpenAI-compatible Responses transport.

The regression began when #1991 made Responses API tools non-strict by default: Rig omits `strict` from the extractor's tool definition, while some compatible servers echo that definition as `"strict": null`. In v0.40.0, `CompletionResponseWire.tools` deserialized into `ResponsesToolDefinition { strict: bool }`, so the nullable field failed before the extractor could process the returned `submit` call.

The production normalization merged after v0.40.0 in #2178 and is already present on latest `main`: omitted or null `strict` values deserialize to `false`, explicit booleans are preserved, and invalid non-boolean values remain errors. This PR adds the missing issue-level regression without duplicating that production change.

Closes #2194

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] `cargo test -p rig --all-features --test openai extractor_accepts_nullable_strict_in_echoed_tool_definition -- --nocapture --test-threads=1`
- [x] `cargo test -p rig-core responses_tool_definitions_accept_nullable_strict -- --nocapture`
- [x] `cargo test -p rig --all-features --test openai openai::cassette -- --nocapture --test-threads=1`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test`
- [x] `cargo fmt --all -- --check`

As a negative control, temporarily removing the existing `null_or_default` deserializer makes the new test fail with the issue's exact `invalid type: null, expected a boolean` error. Restoring it makes the test pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] No explanatory code comments are needed beyond the regression module/test naming
- [x] Documentation changes are not required for this test-only change
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] New and existing tests pass locally with my changes

## Notes

A fresh independent full-diff review found no correctness, regression, security, or test-coverage issues.