### PR TITLE
fix(release): align macro-hygiene publish config

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -16,6 +16,7 @@ git_tag_name = "v{{ version }}"
 [[package]]
 name = "rig-core-macro-hygiene"
 release = false
+publish = false
 
 [changelog]
 body = """


### PR DESCRIPTION
## Summary

- align release-plz's package-level publish setting with `rig-core-macro-hygiene`'s `Cargo.toml`
- retain `release = false` so the compile-only tripwire is neither versioned nor released
- use the `release-plz-` recovery branch prefix required when `release_always = false`

## Root cause

PR #2208 added the non-publishable `rig-core-macro-hygiene` workspace crate and a release-plz package override with only `release = false`. release-plz 0.3.160 still inherited `publish = true` for that package and rejected the mismatch with the manifest's `publish = false` before publishing v0.41.0.

## Impact

Merging this PR allows the release workflow to retry the unpublished v0.41.0 package sequence. The compile-only hygiene crate remains excluded from release processing and cargo publishing.

## Verification

- `cargo metadata --format-version 1 --no-deps`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo test`
- release-plz 0.3.160 `release --dry-run`: clears the original configuration error and begins the release sequence; it then reaches the expected dry-run limitation where `rig-core` cannot resolve unpublished `rig-derive 0.41.0` because dry-run mode skipped the preceding upload
- independent full-diff review: no actionable findings