### PR TITLE
docs(changelog): credit every 0.41 contributor, not just merged-PR authors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,10 +50,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Contributors
 
+* [alshdavid](https://github.com/alshdavid)
+* [arnold-jr](https://github.com/arnold-jr)
+* [BANG404](https://github.com/BANG404)
+* [boondocklabs](https://github.com/boondocklabs)
 * [bugprone](https://github.com/bugprone)
+* [christoph-wulf](https://github.com/christoph-wulf)
 * [dgrijalva](https://github.com/dgrijalva)
 * [gold-silver-copper](https://github.com/gold-silver-copper)
+* [hacctarr](https://github.com/hacctarr)
+* [joshua-mo-143](https://github.com/joshua-mo-143)
+* [KaasPeer1](https://github.com/KaasPeer1)
+* [macaujack](https://github.com/macaujack)
+* [Niedzwiedzw](https://github.com/Niedzwiedzw)
+* [suxiaoshao](https://github.com/suxiaoshao)
+* [Sytten](https://github.com/Sytten)
 * [ThomasMarches](https://github.com/ThomasMarches)
+* [xiao-e-yun](https://github.com/xiao-e-yun)
 
 ### Added
 


### PR DESCRIPTION
The generated 0.41 contributor list named four people. It missed one merged-PR author outright, and by construction everyone who contributed without landing a commit.

## The miss

**[@boondocklabs](https://github.com/boondocklabs) authored [#2196](https://github.com/0xPlaygrounds/rig/pull/2196)**, which merged into 0.41 — it filters empty `encrypted_content` so Responses consumers stop receiving a duplicate, empty reasoning event alongside the visible one.

release-plz builds the list from conventional-commit subjects. That PR's subject is prose (`openai Responses API: Filter empty encrypted reasoning content ...`), so the parser dropped the commit and the contributor with it. **Twelve PRs in the release range have no changelog entry** for related reasons — this PR fixes the credit, not the body.

## Who else was added

Everyone whose issue closed as `completed` after the `v0.40.0` tag, plus authors of PRs replaced by stacked follow-ups:

| Person | Contribution |
| --- | --- |
| [@KaasPeer1](https://github.com/KaasPeer1) | reported #2201; opened #2202, superseded by #2217 |
| [@dgrijalva](https://github.com/dgrijalva) | reported #2164/#2165; opened #2167, superseded by #2215 *(already listed)* |
| [@alshdavid](https://github.com/alshdavid) | reported #2149, the 0.40 `rustls-webpki` advisory |
| [@Niedzwiedzw](https://github.com/Niedzwiedzw) | reported #2154, Anthropic `code_execution_tool_result` |
| [@suxiaoshao](https://github.com/suxiaoshao) | requested #2102, GPT-5.6 support |
| [@arnold-jr](https://github.com/arnold-jr) | reported #2194, extraction failure on local models |
| [@Sytten](https://github.com/Sytten) | #1056, closed by #2151, plus #1072 |
| [@BANG404](https://github.com/BANG404), [@christoph-wulf](https://github.com/christoph-wulf), [@hacctarr](https://github.com/hacctarr), [@joshua-mo-143](https://github.com/joshua-mo-143), [@macaujack](https://github.com/macaujack), [@xiao-e-yun](https://github.com/xiao-e-yun) | older reports closed as completed in this window |

## Deliberately excluded

[@domenic-donato](https://github.com/domenic-donato)'s #2067 and #2091 both closed **before** the `v0.40.0` tag (`#2091` at `2026-07-10T23:52:33Z`, tag at `2026-07-11T00:11:05Z`), so they belong to 0.40's credits rather than 0.41's.

## Verification

- All 41 issues closed in the window carry `state_reason: completed` — none were closed as stale or not-planned.
- All 17 handles resolve against the GitHub users API.
- List is sorted case-insensitively, matching the generated format.

## Worth knowing

Six of the additions ([#975](https://github.com/0xPlaygrounds/rig/issues/975), [#1038](https://github.com/0xPlaygrounds/rig/issues/1038), [#1072](https://github.com/0xPlaygrounds/rig/issues/1072), [#1179](https://github.com/0xPlaygrounds/rig/issues/1179), [#1250](https://github.com/0xPlaygrounds/rig/issues/1250), [#1551](https://github.com/0xPlaygrounds/rig/issues/1551), [#1597](https://github.com/0xPlaygrounds/rig/issues/1597)) all closed on 2026-07-12, which reads more like a backlog sweep than seven individual 0.41 fixes. They meet the stated bar — closed as completed, inside the window — but if you would rather credit only issues a 0.41 PR explicitly closed, that trims the list to boondocklabs, KaasPeer1, alshdavid, Niedzwiedzw, suxiaoshao, arnold-jr, and Sytten.