### PR TITLE
fix(azure): return embedding token usage instead of only logging it

### DIFF
--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -423,6 +423,15 @@ where
         &self,
         documents: impl IntoIterator<Item = String>,
     ) -> Result<Vec<embeddings::Embedding>, EmbeddingError> {
+        let documents: Vec<String> = documents.into_iter().collect();
+        let response = self.embed_texts_with_usage(documents).await?;
+        Ok(response.embeddings)
+    }
+
+    async fn embed_texts_with_usage(
+        &self,
+        documents: impl IntoIterator<Item = String>,
+    ) -> Result<embeddings::EmbeddingResponse, EmbeddingError> {
         let documents = documents.into_iter().collect::<Vec<_>>();
 
         let mut body = json!({
@@ -465,7 +474,8 @@ where
                         ));
                     }
 
-                    Ok(response
+                    let usage = response.usage.token_usage();
+                    let embeddings = response
                         .data
                         .into_iter()
                         .zip(documents.into_iter())
@@ -473,7 +483,9 @@ where
                             document,
                             vec: embedding.embedding,
                         })
-                        .collect())
+                        .collect();
+
+                    Ok(embeddings::EmbeddingResponse { embeddings, usage })
                 }
                 ApiResponse::Err(err) => {
                     tracing::warn!(message = %err.message, "provider returned an error response");

--- a/tests/providers/azure/embeddings.rs
+++ b/tests/providers/azure/embeddings.rs
@@ -1,0 +1,47 @@
+use rig::{embeddings::EmbeddingModel, prelude::*, providers::azure::Client};
+
+/// Azure's embedding client must return the provider's token usage, not zeroes.
+///
+/// `EmbeddingModel::embed_texts_with_usage` has a default body that discards
+/// usage and returns `Usage::default()`. Azure did not override it, so callers
+/// reading `EmbeddingResponse::usage` saw zero tokens on every request — while
+/// `embed_texts` had already parsed `response.usage` and passed it to
+/// `tracing::info!` before dropping it.
+///
+/// A live test rather than a cassette one, matching this provider's existing
+/// convention (`structured_output.rs`, `transcription.rs`): there is no
+/// `tests/cassettes/azure/` fixture set or helper to extend.
+#[tokio::test]
+#[ignore = "requires AZURE_OPENAI_API_KEY and related Azure env vars"]
+async fn test_azure_embeddings_report_token_usage() -> anyhow::Result<()> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let client = Client::from_env()?;
+    let model = client.embedding_model("text-embedding-3-small");
+
+    let response = model
+        .embed_texts_with_usage(vec![
+            "Embeddings turn text into numeric vectors for similarity search.".to_string(),
+        ])
+        .await?;
+
+    anyhow::ensure!(
+        response.embeddings.len() == 1,
+        "expected one embedding, got {}",
+        response.embeddings.len()
+    );
+    anyhow::ensure!(
+        !response.embeddings[0].vec.is_empty(),
+        "embedding vector must not be empty"
+    );
+    anyhow::ensure!(
+        response.usage.input_tokens > 0,
+        "Azure reports prompt_tokens for every embedding request, so input_tokens \
+         must be non-zero; got {} — this is the regression that made every \
+         downstream cost figure read zero",
+        response.usage.input_tokens
+    );
+
+    tracing::info!("Azure embedding usage: {:?}", response.usage);
+    Ok(())
+}

--- a/tests/providers/azure/mod.rs
+++ b/tests/providers/azure/mod.rs
@@ -1,2 +1,3 @@
+mod embeddings;
 mod structured_output;
 mod transcription;


### PR DESCRIPTION
Azure's embedding client reports zero token usage to callers, because it never overrides `EmbeddingModel::embed_texts_with_usage`.

The data isn't missing — it's discarded. `embed_texts` already parses `response.usage`, hands it to `tracing::info!`, and then drops it on the floor:

```rust
// crates/rig-core/src/providers/azure.rs
ApiResponse::Ok(response) => {
    tracing::info!(target: "rig", "Azure embedding token usage: {}", response.usage);
    ...
    Ok(response.data.into_iter()...collect())   // usage gone
}
```

Since the trait's default `embed_texts_with_usage` returns `Usage::default()` (`embeddings/embedding.rs`), anything reading `EmbeddingResponse::usage` gets zeroes for every Azure embedding request.

## The change

Restructured exactly the way `providers/openai/embedding.rs` already does it: `embed_texts_with_usage` does the work and returns the usage, `embed_texts` delegates and drops it. 14 insertions, 2 deletions, one file.

No new mapping code was needed — `impl GetTokenUsage for Usage` already exists in `azure.rs` and was simply unused for embeddings. The `tracing::info!` line is retained, so anything watching logs is unaffected.

## How it was found, and verified

Measured against a real Azure OpenAI deployment: **100 embedding requests, 0 tokens recorded**. After this change the same workload reports the provider's actual `prompt_tokens`. In our case it meant every embedding cost figure downstream read `$0.00` on real spend, which is how we noticed.

## Test

An `#[ignore]`d live test (`tests/providers/azure/embeddings.rs`), which is this provider's existing convention — there is no `tests/cassettes/azure/` fixture set or `with_azure_cassette` helper to extend, and both current azure tests are `#[ignore]`-gated on `AZURE_OPENAI_API_KEY`. CONTRIBUTING lists ignored live tests as acceptable where cassette replay is unsuitable.

I deliberately did **not** hand-author or record a cassette: recording one against our deployment would have committed our Azure resource and deployment identifiers into this repository. Happy to add a cassette if you'd prefer one recorded from your own fixtures — say the word and I'll follow up.

`cargo fmt --check` clean; `cargo check -p rig-core` and `cargo test --test azure --no-run` both build.

## Related, but deliberately out of scope

Only **2 of the 8** provider files implementing `embed_texts` override `embed_texts_with_usage` (`openai`, `voyageai`). The other six inherit the zero-returning default, so they very likely share this defect — I've kept this PR to azure to stay small and reviewable per CONTRIBUTING, rather than touching providers I can't test.

Worth considering separately: a default implementation that silently returns plausible-but-wrong zeros is easy to inherit by accident, and it took a production cost discrepancy for us to notice. Making `embed_texts_with_usage` a required method, or having the default return something callers can distinguish from a real measurement, would surface this class of bug at compile time instead. Glad to open an issue for that discussion if it's useful.
