### PR TITLE
docs(migrating): extend the guide back to 0.30

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -31,22 +31,13 @@ something different — the ones a compiler upgrade will not point at.
 
 ## Silent behavior changes
 
-Nothing in this section produces a compile error. Check each one against your
-code before upgrading. Entries are ordered oldest-first, so you can skip
-everything below the version you are on.
+Nothing in this section produces a compile error. Grouped by the release that
+introduced it, oldest-first — read from the version you are on upwards, and
+check each entry against your code before upgrading.
 
-| Release | Silent changes |
-| --- | --- |
-| 0.31 | [TLS backend](#the-default-tls-backend-is-now-rustls-031), [reasoning JSON shape](#persisted-reasoning-json-no-longer-round-trips-031) |
-| 0.32 | [gemini embedding model id](#geminiembedding_001-points-at-a-different-model-032), [proxy env vars](#proxy-environment-variables-are-now-honored-032) |
-| 0.33 | [preamble is a system message](#preamble-is-now-a-system-message-and-completionrequestpreamble-is-empty-033), [`max_tokens` forwarded](#max_tokens-is-forwarded-on-chat-completions-033) |
-| 0.35 | [string tool outputs](#string-tool-outputs-are-no-longer-json-encoded-035) |
-| 0.36 | [rustls everywhere](#rustls-became-the-default-for-websockets-middleware-and-companion-crates-036) |
-| 0.38 | [hallucinated tool calls](#hallucinated-tool-calls-now-fail-the-run-038), [`#[rig_tool]` schemas](#rig_tool-advertises-a-different-schema-038) |
-| 0.40 | [`max_turns`](#max_turns-counts-differently-040), [empty text](#providers-that-used-to-return-empty-text-now-error-040), [moonshot](#moonshot-drops-reasoning-only-history-turns-040), [request contents](#request-contents-changed-for-several-providers-040), [video](#rig-video-content-now-serializes-instead-of-erroring-040), [telemetry](#telemetry-span-names-and-fields-040) |
-| 0.41 | [Ollama `max_tokens`](#ollama-now-honors-max_tokens-041), [multipart tool results](#multipart-tool-results-reach-openai-intact-041), [`if_wasm!`](#if_wasm--if_not_wasm-key-on-the-target-041) |
+### 0.31
 
-### The default TLS backend is now rustls (0.31)
+#### The default TLS backend is now rustls
 
 `rig-core`'s default feature switched from `reqwest-tls` (native TLS) to
 `reqwest-rustls`, alongside the upgrade to reqwest 0.13. Unless you opt back in
@@ -57,7 +48,7 @@ CAs installed in the macOS Keychain or the Windows certificate store, corporate
 TLS-inspecting proxies, and servers still on legacy cipher suites can start
 failing handshakes on a build that changed nothing but the Rig version.
 
-### Persisted `Reasoning` JSON no longer round-trips (0.31)
+#### Persisted `Reasoning` JSON no longer round-trips
 
 `Reasoning` changed from `{ id, reasoning: [String], signature: Option<String> }`
 to `{ id, content: [ReasoningContent] }`, where each block is typed (`Text` with
@@ -69,7 +60,9 @@ If you store conversation history as JSON, records written by 0.30 or earlier
 that contain reasoning blocks fail to deserialize on 0.31. Migrate the stored
 rows, or drop reasoning content from history you replay.
 
-### `gemini::EMBEDDING_001` points at a different model (0.32)
+### 0.32
+
+#### `gemini::EMBEDDING_001` points at a different model
 
 The constant kept its name and changed its value from `"embedding-001"` to
 `"gemini-embedding-001"`. Embeddings written before and after the upgrade come
@@ -79,14 +72,16 @@ literal `"embedding-001"` if the old model is what you want.
 See also [gemini embedding dimensions](#4-gemini-embedding-dimensions-come-from-the-model)
 in 0.32 → 0.33, which moves the reported dimension count for this model.
 
-### Proxy environment variables are now honored (0.32)
+#### Proxy environment variables are now honored
 
 reqwest's `system-proxy` feature was enabled (#1442). `HTTP_PROXY`,
 `HTTPS_PROXY`, and `NO_PROXY` in the environment now route provider traffic;
 previously they were ignored. On machines that set those variables for unrelated
 reasons, provider calls start going through the proxy.
 
-### Preamble is now a system message, and `CompletionRequest.preamble` is empty (0.33)
+### 0.33
+
+#### Preamble is now a system message, and `CompletionRequest.preamble` is empty
 
 `CompletionRequestBuilder::build` no longer populates `CompletionRequest.preamble`.
 It inserts the preamble as a leading `Message::System` in `chat_history` and
@@ -97,13 +92,15 @@ callers that construct `CompletionRequest` by hand.
 system prompt silently vanishes.** Read the leading `Message::System` from
 `chat_history` instead. Bundled providers were all updated.
 
-### `max_tokens` is forwarded on Chat Completions (0.33)
+#### `max_tokens` is forwarded on Chat Completions
 
 `max_tokens` was dropped when building Chat Completions requests (#1495) and is
 now sent. A limit your code has been setting with no effect starts applying, so
 responses that ran to their natural stop can begin truncating.
 
-### String tool outputs are no longer JSON-encoded (0.35)
+### 0.35
+
+#### String tool outputs are no longer JSON-encoded
 
 A tool whose `Output` serializes to a JSON string used to be handed to the model
 as `serde_json::to_string(&output)` — wrapped in quotes, with newlines escaped
@@ -114,7 +111,9 @@ This is the intended behavior, but a tool returning `String` now presents to the
 model as raw text rather than a quoted JSON literal. Prompts and few-shot
 examples tuned against the quoted form are worth re-checking.
 
-### rustls became the default for websockets, middleware, and companion crates (0.36)
+### 0.36
+
+#### rustls became the default for websockets, middleware, and companion crates
 
 0.31 switched `rig-core`'s own HTTP client to rustls; 0.36 finished the job
 (#1682). `websocket` is now an alias for `websocket-rustls`,
@@ -122,11 +121,13 @@ examples tuned against the quoted form are worth re-checking.
 `native-tls` features on the workspace fan out to the companion crates.
 
 If you were relying on those paths still using native TLS, the trust-store
-caveat from [0.31](#the-default-tls-backend-is-now-rustls-031) now applies to
+caveat from [0.31](#the-default-tls-backend-is-now-rustls) now applies to
 them as well. Opt back in with `websocket-native-tls` /
 `reqwest-middleware-native-tls`.
 
-### Hallucinated tool calls now fail the run (0.38)
+### 0.38
+
+#### Hallucinated tool calls now fail the run
 
 Tool calls are validated against the registered tools and against `tool_choice`
 before dispatch (#1823). A call naming a tool that does not exist — or any tool
@@ -139,7 +140,7 @@ now stop. 0.38 also adds the recovery path: implement
 `InvalidToolCallHookAction::{Retry, Repair, Skip, Fail}`, and bound the retries
 with `.max_invalid_tool_call_retries(n)`.
 
-### `#[rig_tool]` advertises a different schema (0.38)
+#### `#[rig_tool]` advertises a different schema
 
 Parameter schemas are generated by schemars instead of the previous hand-rolled
 type mapping (#1576). The macro's surface is unchanged, but what reaches the
@@ -158,9 +159,11 @@ Better schemas usually mean better tool calls, but they are different input to
 the model. There is also a compile-time consequence — see
 [section 1 of 0.37 → 0.38](#1-rig_tool-parameters-must-implement-jsonschema).
 
-### `max_turns` counts differently (0.40)
+### 0.40
 
-The highest-impact change in either release. `max_turns` and
+#### `max_turns` counts differently
+
+The highest-impact change in this release. `max_turns` and
 `default_max_turns` now bound the **exact total number of model calls**,
 including the initial call, tool continuations, and retries.
 
@@ -177,20 +180,20 @@ old effective `n + 2`; otherwise set the literal total you actually intend.
 If you set `max_turns` at all, re-derive the number. A budget that used to
 permit a tool round-trip may now stop after the first model call.
 
-### Providers that used to return empty text now error (0.40)
+#### Providers that used to return empty text now error
 
 Responses with empty assistant content and no tool calls surface the shared
 path's "empty response" error on **hyperbolic, perplexity, and huggingface**.
 Previously each returned an empty text completion. Code that treated an empty
 string as a normal outcome now takes an error branch.
 
-### Moonshot drops reasoning-only history turns (0.40)
+#### Moonshot drops reasoning-only history turns
 
 The shared conversion drops assistant messages carrying neither text nor tool
 calls. Reasoning attached to a text or tool-call turn still round-trips via
 `reasoning_content`; reasoning-only turns no longer survive in history.
 
-### Request contents changed for several providers (0.40)
+#### Request contents changed for several providers
 
 Consequences of the `GenericCompletionModel` consolidation. None of these
 change your source, all of them change what goes over the wire:
@@ -209,14 +212,14 @@ change your source, all of them change what goes over the wire:
 - groq's streaming usage no longer falls back to the legacy `x_groq.usage`
   envelope.
 
-### Rig `Video` content now serializes instead of erroring (0.40)
+#### Rig `Video` content now serializes instead of erroring
 
 On the shared conversion, `Video` user content serializes a `video_url` content
 part (an OpenRouter/gateway extension) rather than returning a client-side
 conversion error. Providers without video support now reject it **server-side**
 — the failure moved from your process to theirs, and moved later.
 
-### Telemetry span names and fields (0.40)
+#### Telemetry span names and fields
 
 - Migrated providers' streaming spans are named `chat` with
   `gen_ai.operation.name = "chat"`, previously `chat_streaming`. Dashboards and
@@ -228,7 +231,9 @@ conversion error. Providers without video support now reject it **server-side**
 - minimax, zai, and xiaomimimo spans stop reporting as `"openai"` and report
   their own provider name.
 
-### Ollama now honors `max_tokens` (0.41)
+### 0.41
+
+#### Ollama now honors `max_tokens`
 
 Ollama's native `/api/chat` has no top-level `max_tokens` field, so the value
 was serialized into a field the server does not define and silently discarded.
@@ -242,7 +247,7 @@ budget you configured, possibly long ago. Check the value is one you still want.
 `temperature` is unaffected: it was already being sent inside `options` and only
 a redundant top-level copy was removed.
 
-### Multipart tool results reach OpenAI intact (0.41)
+#### Multipart tool results reach OpenAI intact
 
 Tool results carrying several `ToolResultContent` blocks were flattened before
 being sent to the Responses and Chat Completions APIs. Individual blocks are now
@@ -254,7 +259,7 @@ distinct blocks rather than one merged blob. That is the intended behavior, but
 it does change what the model sees, so prompts tuned against the flattened shape
 are worth re-checking.
 
-### `if_wasm!` / `if_not_wasm!` key on the target (0.41)
+#### `if_wasm!` / `if_not_wasm!` key on the target
 
 These macros are `#[macro_export]`ed, and a `cfg` inside a macro expansion is
 evaluated in the **calling** crate. The old expansion therefore tested whether
@@ -542,7 +547,7 @@ never built. See `crates/rig-agent/README.md` for the full target matrix.
 
 ## 0.39 → 0.40
 
-### 1. `max_turns` — see [Silent behavior changes](#max_turns-counts-differently-040)
+### 1. `max_turns` — see [Silent behavior changes](#max_turns-counts-differently)
 
 The single most likely change to alter your program's behavior without a
 compile error.
@@ -703,7 +708,7 @@ You do not need a direct `schemars` dependency — the macro refers to
 `rig_core::schemars`.
 
 For what the model now sees, see
-[`#[rig_tool]` advertises a different schema](#rig_tool-advertises-a-different-schema-038).
+[`#[rig_tool]` advertises a different schema](#rig_tool-advertises-a-different-schema).
 
 ### 2. Invalid tool calls are validated and recoverable
 
@@ -1088,7 +1093,7 @@ does.
 
 `Message` gained a `System` variant (#1527) — it is not `#[non_exhaustive]`, so
 exhaustive matches need the arm. See
-[Preamble is now a system message](#preamble-is-now-a-system-message-and-completionrequestpreamble-is-empty-033)
+[Preamble is now a system message](#preamble-is-now-a-system-message-and-completionrequestpreamble-is-empty)
 for the behavioral half of this change.
 
 Separately, `ProviderToolDefinition` and
@@ -1254,7 +1259,7 @@ Constructors and accessors cover the common cases: `Reasoning::new`,
 `display_text` / `first_text` / `first_signature` / `encrypted_content`.
 
 Stored histories need attention — see
-[Persisted `Reasoning` JSON no longer round-trips](#persisted-reasoning-json-no-longer-round-trips-031).
+[Persisted `Reasoning` JSON no longer round-trips](#persisted-reasoning-json-no-longer-round-trips).
 
 ### 4. Structured outputs and per-request model override
 
@@ -1289,7 +1294,7 @@ The HTTP stack moved to reqwest 0.13 (#1218). Feature names moved with it:
 `reqwest/macos-system-configuration` is no longer pulled in. If you pass a
 `reqwest::Client` into a Rig client, it has to be a 0.13 one. For the runtime
 consequences, see
-[The default TLS backend is now rustls](#the-default-tls-backend-is-now-rustls-031).
+[The default TLS backend is now rustls](#the-default-tls-backend-is-now-rustls).
 
 ### 7. Anthropic source types became enums
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,17 +1,27 @@
 # Migrating Rig
 
-This guide covers every breaking change from 0.38 through 0.41. Releases 0.39
-and 0.40 were large, and 0.40 in particular carried 31 breaking changes.
+This guide covers every breaking change from 0.30 through 0.41. Releases 0.36,
+0.37, 0.40 and 0.41 were the disruptive ones; 0.40 alone carried 31 breaking
+changes, and 0.37 renamed `rig-core`'s library target.
 
 ## Which sections apply to you
 
-Work upwards from the version you are on. Each section is self-contained.
+Sections run newest-first. Find the version you are on and read every section
+above it, in order. Each one is self-contained.
 
-| You are on | Read |
+| You are on | Start at |
 | --- | --- |
 | 0.40 | [0.40 → 0.41](#040--041) |
-| 0.39 | [0.39 → 0.40](#039--040), then [0.40 → 0.41](#040--041) |
-| 0.38 or earlier | [0.38 → 0.39](#038--039), then both sections above |
+| 0.39 | [0.39 → 0.40](#039--040) |
+| 0.38 | [0.38 → 0.39](#038--039) |
+| 0.37 | [0.37 → 0.38](#037--038) |
+| 0.36 | [0.36 → 0.37](#036--037) |
+| 0.35 | [0.35 → 0.36](#035--036) |
+| 0.34 | [0.34 → 0.35](#034--035) |
+| 0.33 | [0.33 → 0.34](#033--034) |
+| 0.32 | [0.32 → 0.33](#032--033) |
+| 0.31 | [0.31 → 0.32](#031--032) |
+| 0.30 | [0.30 → 0.31](#030--031) |
 
 **Everyone should read [Silent behavior changes](#silent-behavior-changes)
 first.** Those are the changes that leave your code compiling and make it do
@@ -22,7 +32,131 @@ something different — the ones a compiler upgrade will not point at.
 ## Silent behavior changes
 
 Nothing in this section produces a compile error. Check each one against your
-code before upgrading.
+code before upgrading. Entries are ordered oldest-first, so you can skip
+everything below the version you are on.
+
+| Release | Silent changes |
+| --- | --- |
+| 0.31 | [TLS backend](#the-default-tls-backend-is-now-rustls-031), [reasoning JSON shape](#persisted-reasoning-json-no-longer-round-trips-031) |
+| 0.32 | [gemini embedding model id](#geminiembedding_001-points-at-a-different-model-032), [proxy env vars](#proxy-environment-variables-are-now-honored-032) |
+| 0.33 | [preamble is a system message](#preamble-is-now-a-system-message-and-completionrequestpreamble-is-empty-033), [`max_tokens` forwarded](#max_tokens-is-forwarded-on-chat-completions-033) |
+| 0.35 | [string tool outputs](#string-tool-outputs-are-no-longer-json-encoded-035) |
+| 0.36 | [rustls everywhere](#rustls-became-the-default-for-websockets-middleware-and-companion-crates-036) |
+| 0.38 | [hallucinated tool calls](#hallucinated-tool-calls-now-fail-the-run-038), [`#[rig_tool]` schemas](#rig_tool-advertises-a-different-schema-038) |
+| 0.40 | [`max_turns`](#max_turns-counts-differently-040), [empty text](#providers-that-used-to-return-empty-text-now-error-040), [moonshot](#moonshot-drops-reasoning-only-history-turns-040), [request contents](#request-contents-changed-for-several-providers-040), [video](#rig-video-content-now-serializes-instead-of-erroring-040), [telemetry](#telemetry-span-names-and-fields-040) |
+| 0.41 | [Ollama `max_tokens`](#ollama-now-honors-max_tokens-041), [multipart tool results](#multipart-tool-results-reach-openai-intact-041), [`if_wasm!`](#if_wasm--if_not_wasm-key-on-the-target-041) |
+
+### The default TLS backend is now rustls (0.31)
+
+`rig-core`'s default feature switched from `reqwest-tls` (native TLS) to
+`reqwest-rustls`, alongside the upgrade to reqwest 0.13. Unless you opt back in
+with `reqwest-native-tls`, HTTPS now goes through rustls.
+
+rustls does not read the platform trust store the way native TLS does. Private
+CAs installed in the macOS Keychain or the Windows certificate store, corporate
+TLS-inspecting proxies, and servers still on legacy cipher suites can start
+failing handshakes on a build that changed nothing but the Rig version.
+
+### Persisted `Reasoning` JSON no longer round-trips (0.31)
+
+`Reasoning` changed from `{ id, reasoning: [String], signature: Option<String> }`
+to `{ id, content: [ReasoningContent] }`, where each block is typed (`Text` with
+an optional signature, `Summary`, `Encrypted`, `Redacted`). The struct change
+is a compile error, but the **serde shape change is not**: `Message` derives
+`Serialize`/`Deserialize`, and there are no field aliases for the old names.
+
+If you store conversation history as JSON, records written by 0.30 or earlier
+that contain reasoning blocks fail to deserialize on 0.31. Migrate the stored
+rows, or drop reasoning content from history you replay.
+
+### `gemini::EMBEDDING_001` points at a different model (0.32)
+
+The constant kept its name and changed its value from `"embedding-001"` to
+`"gemini-embedding-001"`. Embeddings written before and after the upgrade come
+from different models and are not comparable — re-embed the corpus, or pin the
+literal `"embedding-001"` if the old model is what you want.
+
+See also [gemini embedding dimensions](#4-gemini-embedding-dimensions-come-from-the-model)
+in 0.32 → 0.33, which moves the reported dimension count for this model.
+
+### Proxy environment variables are now honored (0.32)
+
+reqwest's `system-proxy` feature was enabled (#1442). `HTTP_PROXY`,
+`HTTPS_PROXY`, and `NO_PROXY` in the environment now route provider traffic;
+previously they were ignored. On machines that set those variables for unrelated
+reasons, provider calls start going through the proxy.
+
+### Preamble is now a system message, and `CompletionRequest.preamble` is empty (0.33)
+
+`CompletionRequestBuilder::build` no longer populates `CompletionRequest.preamble`.
+It inserts the preamble as a leading `Message::System` in `chat_history` and
+leaves `preamble` as `None`. The field survives only as a legacy carrier for
+callers that construct `CompletionRequest` by hand.
+
+**If you implement `CompletionModel` yourself and read `request.preamble`, the
+system prompt silently vanishes.** Read the leading `Message::System` from
+`chat_history` instead. Bundled providers were all updated.
+
+### `max_tokens` is forwarded on Chat Completions (0.33)
+
+`max_tokens` was dropped when building Chat Completions requests (#1495) and is
+now sent. A limit your code has been setting with no effect starts applying, so
+responses that ran to their natural stop can begin truncating.
+
+### String tool outputs are no longer JSON-encoded (0.35)
+
+A tool whose `Output` serializes to a JSON string used to be handed to the model
+as `serde_json::to_string(&output)` — wrapped in quotes, with newlines escaped
+as `\n`. It is now passed through verbatim (#1608). Non-string outputs are
+unchanged.
+
+This is the intended behavior, but a tool returning `String` now presents to the
+model as raw text rather than a quoted JSON literal. Prompts and few-shot
+examples tuned against the quoted form are worth re-checking.
+
+### rustls became the default for websockets, middleware, and companion crates (0.36)
+
+0.31 switched `rig-core`'s own HTTP client to rustls; 0.36 finished the job
+(#1682). `websocket` is now an alias for `websocket-rustls`,
+`reqwest-middleware` for `reqwest-middleware-rustls`, and the `rustls` /
+`native-tls` features on the workspace fan out to the companion crates.
+
+If you were relying on those paths still using native TLS, the trust-store
+caveat from [0.31](#the-default-tls-backend-is-now-rustls-031) now applies to
+them as well. Opt back in with `websocket-native-tls` /
+`reqwest-middleware-native-tls`.
+
+### Hallucinated tool calls now fail the run (0.38)
+
+Tool calls are validated against the registered tools and against `tool_choice`
+before dispatch (#1823). A call naming a tool that does not exist — or any tool
+call at all under `ToolChoice::None` — returns `PromptError::UnknownToolCall`
+instead of being attempted.
+
+Runs that previously limped along on a provider's occasional invented tool name
+now stop. 0.38 also adds the recovery path: implement
+`PromptHook::on_invalid_tool_call` and return
+`InvalidToolCallHookAction::{Retry, Repair, Skip, Fail}`, and bound the retries
+with `.max_invalid_tool_call_retries(n)`.
+
+### `#[rig_tool]` advertises a different schema (0.38)
+
+Parameter schemas are generated by schemars instead of the previous hand-rolled
+type mapping (#1576). The macro's surface is unchanged, but what reaches the
+model is not:
+
+- Integer parameters advertise `"type": "integer"`; they were `"number"`.
+- Structs, enums, and other non-primitive parameters get real schemas with
+  `$defs`, instead of a bare `{"type": "object"}`.
+- Doc comments on the function and on individual parameters become the tool and
+  parameter descriptions, replacing the `Function to <name>` /
+  `Parameter <name>` defaults.
+- `Option<T>` parameters get `#[serde(default)]`, so a model that omits them
+  deserializes to `None` rather than failing.
+
+Better schemas usually mean better tool calls, but they are different input to
+the model. There is also a compile-time consequence — see
+[section 1 of 0.37 → 0.38](#1-rig_tool-parameters-must-implement-jsonschema).
 
 ### `max_turns` counts differently (0.40)
 
@@ -554,6 +688,637 @@ duplicate-name behavior may see different tools advertised.
 
 ---
 
+## 0.37 → 0.38
+
+### 1. `#[rig_tool]` parameters must implement `JsonSchema`
+
+The macro now derives `schemars::JsonSchema` on the generated parameters struct
+(#1576), so **every parameter type must implement `JsonSchema`**. Primitives,
+`String`, `Vec<T>`, and `Option<T>` are covered; your own types need
+`#[derive(schemars::JsonSchema)]`. Previously an unknown type was quietly
+advertised as `{"type": "object"}` with no fields, so this converts a class of
+runtime tool-call failures into a compile error.
+
+You do not need a direct `schemars` dependency — the macro refers to
+`rig_core::schemars`.
+
+For what the model now sees, see
+[`#[rig_tool]` advertises a different schema](#rig_tool-advertises-a-different-schema-038).
+
+### 2. Invalid tool calls are validated and recoverable
+
+Tool calls are checked against the registered tools and the request's
+`tool_choice` before dispatch (#1823). The new `PromptError::UnknownToolCall`
+variant carries the offending `tool_name`, the `available_tools`, the
+`allowed_tools`, and the `chat_history` at the point of failure. `PromptError`
+is not `#[non_exhaustive]`, so an exhaustive `match` over it needs the new arm.
+
+Recovery is a hook (#1840). `PromptHook` gains `on_invalid_tool_call`, taking an
+`InvalidToolCallContext` and returning `InvalidToolCallHookAction`:
+
+| Action | Effect |
+| --- | --- |
+| `Retry(feedback)` | re-prompt the model with your feedback text |
+| `Repair(tool_name)` | rewrite the call to name a real tool |
+| `Skip` | drop the call and continue |
+| `Fail` | surface `PromptError::UnknownToolCall` |
+
+Bound the loop with `.max_invalid_tool_call_retries(n)` on either prompt builder.
+
+### 3. The streaming final response carries content, not a string
+
+`MultiTurnStreamItem::final_response` and `final_response_with_history` take
+`OneOrMany<AssistantContent>` where they took `&str`:
+
+```rust
+// before
+MultiTurnStreamItem::final_response("some text", usage)
+
+// after
+MultiTurnStreamItem::final_response(OneOrMany::one(AssistantContent::text("some text")), usage)
+```
+
+`FinalResponse` keeps `response()` for the concatenated text and adds
+`content()` / `assistant_content()` for the structured form. `MultiTurnStreamItem`
+is `#[non_exhaustive]`, so its new `CompletionCall` variant does not break
+existing matches.
+
+### 4. Per-completion-call usage on responses
+
+`PromptResponse` and `TypedPromptResponse` gain
+`completion_calls: Vec<CompletionCall>` (#1787), one entry per model call in the
+turn, each with a `call_index` and optional `Usage`. Streaming emits the same
+data as `MultiTurnStreamItem::CompletionCall`. Aggregate `usage` is unchanged.
+
+This is additive unless you construct those responses yourself — use
+`.with_completion_calls(...)` if you do.
+
+### 5. New enum variants and struct fields
+
+None of these are `#[non_exhaustive]`, so exhaustive matches and struct literals
+break:
+
+| Type | Change |
+| --- | --- |
+| `RawStreamingChoice` | new `TextStart` and `TextAdditionalParams` variants |
+| `message::Text` | new `additional_params` field — use `Text::new(text)` |
+| `completion::Usage` | new `tool_use_prompt_tokens` field |
+| `anthropic::Content` | new `ServerToolUse` and `WebSearchToolResult` variants |
+| `anthropic::ContentDelta` | new `CitationsDelta` and `Unknown` variants |
+| `gemini::FinishReason` | new `MalformedResponse`, `MissingThoughtSignature`, `TooManyToolCalls`, `UnexpectedToolCall` variants |
+
+`openai::responses_api`'s `ArgsTextChunk.content_index` and
+`DeltaTextChunkWithItemId.content_index` became `Option<u64>`, and
+`DeltaTextChunkWithItemId` lost its `item_id` field (#1828).
+
+### 6. Embedding token usage is additive
+
+`EmbeddingModel` gains `embed_text_with_usage` / `embed_texts_with_usage`
+returning `EmbeddingResponse { embeddings, usage }`, plus
+`EmbeddingsBuilder::build_with_usage` (#1791). Both trait methods have default
+implementations that delegate to the existing ones and report zero usage, so
+custom embedding models keep compiling.
+
+### 7. `AgentBuilder::hook` no longer resets tool state
+
+`.hook(...)` returned `AgentBuilder<M, P2, NoToolConfig>`, discarding the
+typestate that records how tools were registered. It now returns
+`AgentBuilder<M, P2, ToolState>`. Builders that called `.hook(...)` after
+`.tool(...)` and then hit a type error can drop the workaround.
+
+### 8. 0.38.1 unified the workspace versions
+
+Every crate in the workspace moved to the workspace version (#1853). Companion
+crates that were on their own numbering — `rig-mongodb` was at `0.4.7`, for
+example — jump to `0.38.1`. Nothing about their APIs changed; the version line
+in your `Cargo.toml` does.
+
+From 0.38.1 onward, a companion crate's version tracks the `rig-core` release it
+was built against.
+
+---
+
+## 0.36 → 0.37
+
+### 1. `rig-core`'s library is now `rig_core`
+
+`rig-core` built a library target named `rig`, so the idiomatic code was
+`cargo add rig-core` followed by `use rig::...`. In 0.37 the library target is
+named `rig_core`, and the name `rig` belongs to a new facade crate (#1699).
+
+**This breaks every `use rig::...` in a crate that depends on `rig-core`.** Two
+ways out:
+
+```toml
+# preferred: depend on the facade, keep `use rig::...` unchanged
+rig = "0.37"
+```
+
+```toml
+# or: stay on rig-core and rewrite the imports to `use rig_core::...`
+rig-core = "0.37"
+```
+
+The facade re-exports `rig-core` and puts every companion crate behind one
+feature each (`mongodb`, `qdrant`, `lancedb`, `memory`, …), so a workspace that
+was juggling `rig-core` plus several `rig-*` dependencies can collapse to one.
+
+Related: `#[rig_tool]` and `#[derive(Embed)]` used to emit hardcoded `rig::`
+paths, which is why depending on `rig-core` under any other name failed. They
+now resolve `rig-core` or `rig` through `proc-macro-crate`, so both layouts work
+and renamed dependencies do too.
+
+### 2. `Chat::chat` takes `&mut Vec<Message>` and appends to it
+
+```rust
+// before — history passed by value, response only
+fn chat<I, T>(&self, prompt: impl Into<Message>, chat_history: I) -> Result<String, PromptError>
+where I: IntoIterator<Item = T>, T: Into<Message>;
+
+// after — history borrowed and updated in place
+fn chat(&self, prompt: impl Into<Message>, chat_history: &mut Vec<Message>)
+    -> Result<String, PromptError>;
+```
+
+The prompt and every assistant and tool message produced during the turn are
+appended to the vector you pass (#1733). **Do not push the user prompt yourself
+before calling** — you will send it twice. Callers that were manually
+reconstructing history after each turn should delete that code.
+
+### 3. Conversation memory
+
+A new `rig::memory` module (#1702) with the `ConversationMemory` trait,
+`MemoryError`, a `MessageFilter` trait, and an `InMemoryConversationMemory`
+backend. `AgentBuilder` gains `.memory(...)` and `.conversation_id(...)`; both
+prompt builders gain `.conversation(id)` and `.without_memory()`.
+
+`MemoryError` is `#[non_exhaustive]` from the start, and `load` failures are
+fatal while `append` failures are logged and swallowed. Later releases added
+`DemotionHook` (#1737) and `Compactor` (#1748) for eviction and rolling
+summaries, with the named policies living in the `rig-memory` companion crate.
+
+Entirely additive — agents without `.memory(...)` behave as before.
+
+### 4. `ClientBuilder`'s HTTP client slot is a typestate
+
+`ClientBuilder<Ext, ApiKey = Missing, H = Missing>` — the `H` parameter defaulted
+to `reqwest::Client` and now defaults to `Missing`, with every provider's
+`ClientBuilder` alias following. Building without supplying a client still
+produces a `reqwest`-backed one, so ordinary `Client::builder().api_key(k).build()`
+chains are unaffected. Code that named `H` explicitly needs updating.
+
+### 5. Test doubles moved behind a feature
+
+`MockStreamingClient`, `MockResponse`, and friends moved to
+`rig_core::test_utils` behind the new `test-utils` feature (#1745). Add
+`rig-core = { version = "0.37", features = ["test-utils"] }` to your
+`[dev-dependencies]` if you used them.
+
+`rig-core`'s `default` feature also picked up `derive`, so `#[rig_tool]` and
+`#[derive(Embed)]` are available without opting in. The `all` feature was
+removed; name `derive`, `pdf`, and `rayon` individually.
+
+### 6. Smaller surface changes
+
+- `DocumentSourceKind::FileId` and `anthropic::DocumentSource::File` support
+  provider-side file IDs (#1740). `DocumentSourceKind` is `#[non_exhaustive]`,
+  so matches are safe.
+- `completion::Usage` gains `reasoning_tokens`, and gemini's `UsageMetadata`
+  gains per-modality token detail — breaking for struct literals.
+- Ollama's `think` additional-parameter accepts `"low"`/`"medium"`/`"high"` as
+  well as a bool (#1747). Bools keep working.
+
+---
+
+## 0.35 → 0.36
+
+The largest release in this range. Sections 1 and 3 touch every provider
+integration.
+
+### 1. `DynClientBuilder` and the `*Dyn` traits are gone
+
+Deprecated since 0.25, removed in #1633. All of this no longer exists:
+
+| Removed | Replacement |
+| --- | --- |
+| `DynClientBuilder`, `AnyClient`, `ProviderFactory`, `DefaultProviders` | construct the provider client directly |
+| `CompletionClientDyn`, `EmbeddingsClientDyn`, `TranscriptionClientDyn`, `ImageGenerationClientDyn`, `AudioGenerationClientDyn`, `VerifyClientDyn` | the non-`Dyn` client traits |
+| `CompletionModelDyn`, `EmbeddingModelDyn`, `TranscriptionModelDyn`, `ImageGenerationModelDyn`, `AudioGenerationModelDyn` | the corresponding `*Model` traits |
+| `CompletionModelHandle`, `TranscriptionModelHandle`, `ImageGenerationModelHandle`, `AudioGenerationModelHandle` | the concrete model types |
+
+If you were selecting a provider at runtime through `DynClientBuilder`, you now
+own that dispatch — a `match` over your own provider enum returning a boxed
+`Agent`, or an enum of concrete clients.
+
+### 2. Required builder fields are enforced by types
+
+Builders that used to accept a field and fail at `build()` now encode
+required-ness in the type (#1611), using the `Missing` / `Provided<T>` markers:
+
+| Builder | Required field(s) |
+| --- | --- |
+| `VectorSearchRequestBuilder` | `query`, `samples` |
+| `TranscriptionRequestBuilder` | `data` |
+| `ImageGenerationRequestBuilder` | `prompt` |
+| `AudioGenerationRequestBuilder` | `text`, `voice` |
+| `ChatBotBuilder` | the chatbot impl |
+| `ClientBuilder` | `api_key` (`NeedsApiKey` is now `Missing`) |
+
+Two consequences. `VectorSearchRequestBuilder::build()` returns
+`VectorSearchRequest<F>` instead of `Result<_, VectorStoreError>` — drop the `?`.
+And `TranscriptionRequestBuilder::load_file` returns
+`io::Result<TranscriptionRequestBuilder<M, Provided<Vec<u8>>>>`, so it needs a
+`?` where it previously did not.
+
+Naming these builder types explicitly requires the marker parameters; chained
+builder expressions need no change.
+
+### 3. `ProviderClient` construction is fallible
+
+```rust
+// before
+fn from_env() -> Self;              // panicked on a missing/invalid variable
+fn from_val(input: Self::Input) -> Self;
+
+// after
+type Error;
+fn from_env() -> Result<Self, Self::Error>;
+fn from_val(input: Self::Input) -> Result<Self, Self::Error>;
+```
+
+Bundled providers use `ProviderClientError` (`EnvironmentVariable`, `Http`,
+`InvalidConfiguration`) via the `ProviderClientResult<T>` alias, and
+`required_env_var` / `optional_env_var` are available for your own
+implementations. `llamafile::from_url` became fallible for the same reason.
+
+Add `?` at every `Client::from_env()` call site — this is the most common
+mechanical edit in this release.
+
+### 4. Provider models moved onto `GenericCompletionModel`
+
+`openai::CompletionModel`, `openai::ResponsesCompletionModel`,
+`openai::EmbeddingModel`, and `anthropic::CompletionModel` became type aliases
+over generic structs parameterized by a provider extension. The aliases keep
+their old parameter lists and their fields stay public, so ordinary use is
+unaffected. This is the groundwork that 0.40 extended to eleven more providers.
+
+### 5. Smaller surface changes
+
+- `DynamicContextStore` dropped its `RwLock` — it is now `Arc<Vec<...>>`
+  (#1641). Immutable after construction, so tool lookups no longer contend.
+- `cohere::CompletionResponse::message` returns
+  `Result<AssistantMessageParts, CompletionError>` instead of a three-element
+  tuple.
+- Ollama's client builder takes an `OllamaApiKey` instead of `Nothing`, so a
+  base URL and key can be set programmatically (#1511).
+- `openai::responses_api::Output` gained an `Unknown` catch-all (#1552) —
+  exhaustive matches need an arm. (0.40 later gave it a payload.)
+- `deepseek::DEEPSEEK_CHAT` and `DEEPSEEK_REASONER` are `#[deprecated]` in favor
+  of the `deepseek-v4-flash` names (#1664).
+- `json_utils::empty_or_none` was removed.
+- `#[rig_tool]` accepts `name = "..."`, validated against the
+  1–64 character, ASCII-alphanumeric-plus `_`/`-` rule providers enforce (#1619).
+
+---
+
+## 0.34 → 0.35
+
+### 1. Legacy Anthropic model constants removed
+
+`CLAUDE_3_5_HAIKU`, `CLAUDE_3_5_SONNET`, `CLAUDE_3_7_SONNET`, `CLAUDE_4_OPUS`,
+and `CLAUDE_4_SONNET` are gone (#1616), replaced by `CLAUDE_OPUS_4_6`,
+`CLAUDE_SONNET_4_6`, and `CLAUDE_HAIKU_4_5`. Model ids are plain strings — pass
+the literal (`"claude-3-5-sonnet-latest"`) if you need a retired model.
+
+### 2. `ToolServer` internals are private
+
+`ToolServerRequest`, `ToolServerResponse`, `ToolServerRequestMessageKind`,
+`ToolServer::run`, `ToolServer::handle_message`, and
+`ToolServerHandle::get_tool_definitions` left the public API, along with the
+`ToolServerError::{Canceled, InvalidMessage, SendError}` variants (#1607). The
+lock-free rework behind them removed contention during tool lookup.
+
+`ToolServerHandle` remains the supported interface. If you were driving the
+message enum directly, move to the handle.
+
+### 3. Provider examples became integration tests
+
+Roughly 60% of `rig-core`'s examples moved under `tests/`, organized by provider
+(#1603), so `cargo run --example <name>` stopped resolving for those. They run
+as ignored tests instead:
+
+```
+cargo test -p rig-core --test <provider> -- --ignored --test-threads=1
+```
+
+`--test-threads=1` matters: the provider suites share rate limits.
+
+### 4. rmcp 1.3
+
+The rmcp integration was upgraded from 0.x to 1.3 (#1596). If you pass
+`rmcp::model::Tool` or `rmcp::service::ServerSink` values into
+`AgentBuilder::rmcp_tool(s)`, your own rmcp dependency has to move in lockstep.
+
+### 5. `response_format` is deferred on tool turns
+
+When a request carries tools that have not produced a result yet, the
+`response_format` derived from `output_schema` is withheld until the tool round
+trip completes (#1622). Structured output still applies to the final answer;
+providers stop rejecting the intermediate tool turns.
+
+---
+
+## 0.33 → 0.34
+
+### 1. History is generic and immutable
+
+`with_history` no longer borrows a `&'a mut Vec<Message>` (#1563):
+
+```rust
+// before
+agent.prompt("hi").with_history(&mut history).await?;
+
+// after — anything that iterates into messages
+agent.prompt("hi").with_history(history.clone()).await?;
+```
+
+`PromptRequest` and `TypedPromptRequest` lost their `'a` lifetime parameter as a
+result — `PromptRequest<'a, S, M, P>` is now `PromptRequest<S, M, P>`. The
+streaming builder's `with_history` changed the same way, and
+`CompletionRequestBuilder::{documents, messages}` now take
+`impl IntoIterator<...>`.
+
+Because the history is no longer borrowed mutably, the updated conversation
+comes back on the response rather than being written into your vector. Read
+`PromptResponse::messages` (see [0.31 → 0.32](#031--032)).
+
+### 2. TLS features were restructured
+
+| Before | After |
+| --- | --- |
+| `reqwest-rustls` | `reqwest` + `rustls` |
+| `reqwest-native-tls` | `reqwest` + `native-tls` |
+| — | `websocket`, `reqwest-middleware-native-tls` |
+
+`default` is `["reqwest", "rustls"]`. The old composite names are gone, so a
+dependency line naming them fails to resolve — which is the loud failure you
+want here.
+
+### 3. Anthropic automatic prompt caching
+
+`CompletionModel::with_automatic_caching()` and `with_automatic_caching_1h()`
+add a top-level `cache_control` to the request and let the API place the
+breakpoint (#1572). The existing `with_prompt_caching()` — explicit breakpoints
+on the system prompt and messages — is unchanged. `CacheTtl::{FiveMinutes, OneHour}`
+and `Usage::cache_creation_input_tokens` came along with it.
+
+### 4. Custom `Authorization` headers win
+
+A header set through `http_headers()` is no longer overwritten by the provider's
+generated auth header (#1553). This is what lets OpenAI-compatible endpoints
+that want a non-`Bearer` scheme work. If you were setting an `Authorization`
+header expecting the provider's key to take precedence anyway, it no longer
+does.
+
+---
+
+## 0.32 → 0.33
+
+### 1. `Message::System` and provider-native tools
+
+`Message` gained a `System` variant (#1527) — it is not `#[non_exhaustive]`, so
+exhaustive matches need the arm. See
+[Preamble is now a system message](#preamble-is-now-a-system-message-and-completionrequestpreamble-is-empty-033)
+for the behavioral half of this change.
+
+Separately, `ProviderToolDefinition` and
+`CompletionRequestBuilder::{provider_tool, provider_tools}` expose hosted tools
+that run on the provider's side — OpenAI's `web_search`, `file_search`,
+`computer_use`, and `code_interpreter` (#1430).
+
+### 2. `McpTool` was replaced by the rmcp handler
+
+`tool::McpTool`, `tool::McpToolError`, and `McpTool::from_mcp_server` were
+removed in favor of `McpClientHandler` and the `rmcp_tool(s)` builder methods
+(#1525).
+
+### 3. Raw embedding payloads use `serde_json::Number`
+
+Provider embedding response types — cohere, gemini, mistral, openai, openrouter,
+together — changed their vector fields from `Vec<f64>` to
+`Vec<serde_json::Number>` so they deserialize under
+`serde_json/arbitrary_precision` (#1518, #1526). The `embeddings::Embedding`
+type you actually consume still holds `Vec<f64>`; only the raw provider structs
+changed. Call `.as_f64()` if you were reading them directly.
+
+### 4. Gemini embedding dimensions come from the model
+
+`gemini::EmbeddingModel::{new, with_model}` take `ndims: usize` instead of
+`Option<usize>` (#1513). `ndims()` used to return a hardcoded `768` for every
+model while `output_dimensionality` went to the API as `null`; it now reports
+the value you passed, or the model's documented default — 3072 for
+`gemini-embedding-001`, 768 for `text-embedding-004`.
+
+**If you sized a vector-store column from `ndims()`, the number changes.** For
+`gemini-embedding-001` the vectors were already 3072-wide; the reported count
+was simply wrong.
+
+### 5. Other provider changes
+
+- `GenerateContentRequest.tools` is `Option<Vec<Value>>`, and
+  `ThinkingConfig.thinking_budget` is `Option<u32>` alongside the new
+  `thinking_level: Option<ThinkingLevel>` for Gemini 3 (#1520).
+- `gemini::Client::{generate_content_api, interactions_api}` select between the
+  two Gemini surfaces (#1230).
+- `openai::Client::responses_websocket` opens a stateful Responses session
+  behind the `websocket` feature (#1500).
+- New `llamafile` provider (#1519).
+
+---
+
+## 0.31 → 0.32
+
+### 1. `PromptResponse::total_usage` is `usage`
+
+Renamed in #1453, and the response gained `messages: Option<Vec<Message>>` —
+the full conversation for the turn, populated with `.extended_details()`
+(#1450). `PromptResponse::new(output, usage)` keeps its shape.
+
+### 2. Prompt requests carry a response-detail typestate
+
+`TypedPromptRequest<'a, T, M, P>` became `TypedPromptRequest<'a, T, S, M, P>`,
+where `S: PromptType` records whether `.extended_details()` was called (#1446).
+`TypedPromptResponse<T>` is the extended form, with `output`, `usage`, and later
+`completion_calls`. Chained builder expressions are unaffected; explicit type
+annotations need the extra parameter.
+
+### 3. Custom providers: `ProviderBuilder` reshaped
+
+```rust
+// before
+trait ProviderBuilder: Sized {
+    type Output: Provider;
+    // Provider::build did the work
+}
+
+// after
+trait ProviderBuilder: Sized + Default + Clone {
+    type Extension<H>;
+    type ApiKey;
+    fn build(self, ...) -> ...;
+}
+```
+
+`Provider::build` was removed, `Client::builder()` returns
+`ClientBuilder<Ext::Builder, NeedsApiKey, reqwest::Client>`, and `Client::new`
+takes `<Ext::Builder as ProviderBuilder>::ApiKey` instead of a bare key type
+(#1436). Only affects crates implementing their own provider.
+
+### 4. The SSE event source was reified
+
+`GenericEventSource` gained a retry-policy parameter
+(`GenericEventSource<HttpClient, RequestBody, Retry = ExponentialBackoff>`) and
+a `with_retry_policy` constructor (#1428). `ReadyState` and `ready_state()` were
+removed, and `last_event_id()` returns `Option<&str>` rather than `&str`.
+
+### 5. New media variants
+
+`AudioMediaType` gained `M4A`, `PCM16`, and `PCM24`; `VideoMediaType` gained
+`MOV` and `WEBM`; openrouter's `UserContent` gained `InputAudio` and `VideoUrl`
+(#1413). None are `#[non_exhaustive]` — exhaustive matches need the new arms.
+
+### 6. `rig-eternalai` and `rig-wasm` were archived
+
+Both moved to `archived/` and out of the workspace (#1472). They are no longer
+published or built. `rig-eternalai` had already stopped publishing in an earlier
+release; 0.32 is where the source left the tree.
+
+### 7. Extractors gained retrieval and usage
+
+`Extractor::dynamic_context(sample, index)` mirrors the agent builder, and
+`extract_with_usage` / `extract_with_chat_history_with_usage` return
+`ExtractionResponse<T> { data, usage }` (#1447). Both additive.
+
+---
+
+## 0.30 → 0.31
+
+### 1. `AgentBuilderSimple` is gone; `AgentBuilder` is a typestate
+
+`AgentBuilder<M>` became `AgentBuilder<M, P = (), ToolState = NoToolConfig>`,
+and the separate `AgentBuilderSimple` that `.tool()` used to return no longer
+exists. The `ToolState` parameter is `NoToolConfig`, `WithBuilderTools`, or
+`WithToolServerHandle`.
+
+The practical effect is that **mixing builder-registered tools with a
+`ToolServerHandle` is now a compile error.** In 0.30, `.tool()` converted the
+builder into an `AgentBuilderSimple` that had no field for the handle — so
+`.tool_server_handle(h).tool(t)` dropped `h` on the floor, along with any
+`dynamic_context` and `dynamic_tools` configured up to that point. Pick one
+registration style; the compiler now enforces it.
+
+Chained expressions otherwise need no change; explicit `AgentBuilder<M>`
+annotations do.
+
+`Agent<M>` became `Agent<M, P = ()>`, which still resolves for existing code.
+
+### 2. One `PromptHook` for blocking and streaming
+
+`StreamingPromptHook` was removed and its methods folded into `PromptHook`
+(#1352): `on_text_delta`, `on_tool_call_delta`, and
+`on_stream_completion_response_finish` joined `on_completion_call`,
+`on_completion_response`, `on_tool_call`, and `on_tool_result`. Every method has
+a default, so a hook that only cares about one event stays small.
+
+The types also moved from `agent::prompt_request` to
+`agent::prompt_request::hooks`; `rig::agent::{PromptHook, HookAction,
+ToolCallHookAction}` re-exports them either way.
+
+Hooks can now be attached to the agent instead of the call (#1356):
+`AgentBuilder::hook(h)` sets a default that every `prompt` and `stream_prompt`
+picks up, and `StreamingPrompt`/`StreamingChat` gained a `type Hook: PromptHook<M>`
+associated type — use `type Hook = ();` if you implement them and want none.
+
+`PromptRequest::new` was replaced by `PromptRequest::from_agent(&agent, prompt)`.
+
+### 3. Reasoning content is typed
+
+`Reasoning { reasoning: Vec<String>, signature: Option<String> }` became
+`Reasoning { content: Vec<ReasoningContent> }`, with variants `Text { text,
+signature }`, `Summary(String)`, `Encrypted(String)`, and `Redacted { data }`
+(#1395, #1396). This is what makes reasoning traces survive a round trip across
+providers.
+
+Constructors and accessors cover the common cases: `Reasoning::new`,
+`new_with_signature`, `summaries`, `encrypted`, `redacted`, and
+`display_text` / `first_text` / `first_signature` / `encrypted_content`.
+
+Stored histories need attention — see
+[Persisted `Reasoning` JSON no longer round-trips](#persisted-reasoning-json-no-longer-round-trips-031).
+
+### 4. Structured outputs and per-request model override
+
+`CompletionRequest` gained `output_schema: Option<schemars::Schema>` and
+`model: Option<String>` (#1382, #1374), with
+`AgentBuilder::{output_schema, output_schema_raw}`,
+`CompletionRequestBuilder::{output_schema, output_schema_opt, model, model_opt}`,
+the `TypedPrompt` trait, `TypedPromptRequest`, and `StructuredOutputError`.
+
+Additive unless you build `CompletionRequest` with a struct literal, which the
+new fields break — use the builder.
+
+### 5. Model listing
+
+A new `ModelLister` / `ModelListingClient` pair with `model::listing::{Model,
+ModelList, ModelListingError}` (#1243). Providers that support it can enumerate
+models at runtime.
+
+**Breaking for custom providers:** `client::Capabilities` gained a
+`type ModelListing: Capability;` associated type. Set it to the unsupported
+marker if your provider cannot list models.
+
+### 6. reqwest 0.13, rustls by default
+
+The HTTP stack moved to reqwest 0.13 (#1218). Feature names moved with it:
+
+| Before | After |
+| --- | --- |
+| `reqwest-tls` | `reqwest-native-tls` |
+| `reqwest-rustls` (opt-in) | `reqwest-rustls` (**default**) |
+
+`reqwest/macos-system-configuration` is no longer pulled in. If you pass a
+`reqwest::Client` into a Rig client, it has to be a 0.13 one. For the runtime
+consequences, see
+[The default TLS backend is now rustls](#the-default-tls-backend-is-now-rustls-031).
+
+### 7. Anthropic source types became enums
+
+`ImageSource` and `DocumentSource` changed from structs to enums, and
+`ImageSourceData` was removed:
+
+```rust
+// before — media_type and type carried even for URLs, where they mean nothing
+ImageSource { data: ImageSourceData::Url(url), media_type, r#type: SourceType::URL }
+
+// after
+ImageSource::Url { url }
+ImageSource::Base64 { data, media_type }
+```
+
+`DocumentSource` gained `Base64` and `Text` variants (`Url` followed in 0.32),
+`PlainTextMediaType` was added, and `Content` gained `RedactedThinking` — the
+enums model what Anthropic actually accepts for URL-backed images and plain-text
+documents (#1403, #1377).
+
+### 8. Streaming message ids
+
+`RawStreamingChoice` gained a `MessageId` variant and
+`StreamingCompletionResponse` a `message_id: Option<String>` field.
+`RawStreamingChoice` is not `#[non_exhaustive]`, so an exhaustive match over it
+needs the new arm.
+
+---
+
 ## Appendix: symbol reference
 
 Renamed or relocated items, for searching.
@@ -583,3 +1348,34 @@ Renamed or relocated items, for searching.
 | `Output::Unknown` | `Output::Unknown(Value)` | 0.40 |
 | provider-specific `StreamingCompletionResponse` | shared `openai::StreamingCompletionResponse` | 0.40 |
 | `GenericCompletionModel::with_model` | `GenericCompletionModel::new` | 0.40 |
+| `MultiTurnStreamItem::final_response(&str, ..)` | `final_response(OneOrMany<AssistantContent>, ..)` | 0.38 |
+| `DeltaTextChunkWithItemId.item_id` | none | 0.38 |
+| library target `rig` in `rig-core` | `rig_core`, or the new `rig` facade crate | 0.37 |
+| `Chat::chat(prompt, impl IntoIterator)` | `Chat::chat(prompt, &mut Vec<Message>)` | 0.37 |
+| `rig_core::http_client::MockStreamingClient`, `streaming::MockResponse` | `rig_core::test_utils::*` (feature `test-utils`) | 0.37 |
+| `all` feature | `derive` + `pdf` + `rayon` | 0.37 |
+| `DynClientBuilder` / `AnyClient` / `ProviderFactory` | none — dispatch yourself | 0.36 |
+| `CompletionModelDyn` / `EmbeddingModelDyn` / `TranscriptionModelDyn` / `ImageGenerationModelDyn` / `AudioGenerationModelDyn` | the corresponding `*Model` traits | 0.36 |
+| `CompletionClientDyn` / `EmbeddingsClientDyn` / `TranscriptionClientDyn` / `ImageGenerationClientDyn` / `AudioGenerationClientDyn` / `VerifyClientDyn` | the non-`Dyn` client traits | 0.36 |
+| `client::NeedsApiKey` | `markers::Missing` | 0.36 |
+| `ProviderClient::from_env() -> Self` | `-> Result<Self, Self::Error>` | 0.36 |
+| `VectorSearchRequestBuilder::build() -> Result<_, _>` | infallible `build()` | 0.36 |
+| `json_utils::empty_or_none` | none | 0.36 |
+| `anthropic::{CLAUDE_3_5_HAIKU, CLAUDE_3_5_SONNET, CLAUDE_3_7_SONNET, CLAUDE_4_OPUS, CLAUDE_4_SONNET}` | `CLAUDE_OPUS_4_6` / `CLAUDE_SONNET_4_6` / `CLAUDE_HAIKU_4_5` | 0.35 |
+| `ToolServerRequest` / `ToolServerResponse` / `ToolServerRequestMessageKind` | `ToolServerHandle` | 0.35 |
+| `reqwest-rustls` / `reqwest-native-tls` features | `reqwest` + `rustls` / `native-tls` | 0.34 |
+| `PromptRequest<'a, S, M, P>` | `PromptRequest<S, M, P>` | 0.34 |
+| `tool::McpTool` / `McpToolError` / `McpTool::from_mcp_server` | `McpClientHandler` + `rmcp_tool(s)` | 0.33 |
+| `CompletionRequest.preamble` | leading `Message::System` in `chat_history` | 0.33 |
+| `gemini::EmbeddingModel::new(.., Option<usize>)` | `new(.., usize)` | 0.33 |
+| `PromptResponse.total_usage` | `PromptResponse.usage` | 0.32 |
+| `Provider::build` | `ProviderBuilder::build` | 0.32 |
+| `ProviderBuilder::Output` | `ProviderBuilder::Extension<H>` | 0.32 |
+| `http_client::sse::ReadyState` / `ready_state()` | none | 0.32 |
+| `rig-eternalai`, `rig-wasm` | none — archived | 0.32 |
+| `AgentBuilderSimple` | `AgentBuilder<M, P, ToolState>` | 0.31 |
+| `StreamingPromptHook` | `PromptHook` | 0.31 |
+| `PromptRequest::new` | `PromptRequest::from_agent` | 0.31 |
+| `Reasoning.reasoning` / `Reasoning.signature` | `Reasoning.content: Vec<ReasoningContent>` | 0.31 |
+| `anthropic::ImageSourceData` | `anthropic::ImageSource` enum variants | 0.31 |
+| `reqwest-tls` feature | `reqwest-native-tls` | 0.31 |


### PR DESCRIPTION
Follow-up to #2216, which rewrote `MIGRATING.md` as a full guide but scoped it to 0.38 through 0.41. Anyone on an older release still had a per-crate CHANGELOG and nothing else.

That is a real gap. 0.36 removed the entire deprecated dyn-client layer and made `ProviderClient::from_env` fallible. 0.37 renamed `rig-core`'s library target from `rig` to `rig_core` — which breaks every `use rig::...` in a crate that depends on `rig-core`, and appears in the CHANGELOG only as "improve project organization and create rig crate".

This adds per-release sections for 0.30 → 0.31 through 0.37 → 0.38 in the existing newest-first layout, and extends the silent-behavior lead section and the symbol appendix to match.

## Method

The CHANGELOG marks four breaking changes across these eight releases (#1356, #1218, #1513, #1603, #1733). The real count is much higher, so the sections were built by extracting the public API at each `rig-core-v0.3x.0` tag — items, fn signatures, struct fields, enum variants, trait members — and diffing consecutive tags, then reading the underlying PRs for anything the diff flagged. Feature tables came from diffing `[features]` per tag, and the `#[rig_tool]` entries from diffing `rig-derive`.

## Silent behavior changes

Findings that leave code compiling and change what it does. These are the ones worth reading even if you are not upgrading across them:

- **0.33** stopped populating `CompletionRequest.preamble`. `CompletionRequestBuilder::build` now inserts the preamble as a leading `Message::System` and leaves the field `None`, so a custom `CompletionModel` that reads `preamble` silently loses the system prompt.
- **0.35** stopped JSON-encoding tool outputs that serialize to a string (#1608). A tool returning `String` used to reach the model quoted, with escaped newlines; it now arrives verbatim.
- **0.32** repointed `gemini::EMBEDDING_001` from `"embedding-001"` to `"gemini-embedding-001"` without renaming the constant. **0.33** then moved that model's reported `ndims()` from a hardcoded 768 to its actual 3072.
- **0.31** switched the default TLS backend to rustls, which does not read the platform trust store — private CAs and TLS-inspecting proxies can start failing on a build that changed nothing but the Rig version.
- **0.31** reshaped `Reasoning`'s serde representation with no field aliases, so persisted histories containing reasoning blocks fail to deserialize.
- **0.32** enabled reqwest's `system-proxy`, so `HTTPS_PROXY` in the environment now routes provider traffic.
- **0.33** started forwarding `max_tokens` on Chat Completions requests (#1495).
- **0.38** began rejecting tool calls naming unregistered tools with `PromptError::UnknownToolCall` (#1823), and moved `#[rig_tool]` schemas onto schemars (#1576) — integers advertise as `"integer"`, nested types get real schemas, omitted `Option<T>` deserializes to `None`.

## Structure

The silent-behavior section now spans nine releases, so it is grouped by the release that introduced each change rather than run as one flat list. Entry headings dropped their trailing `(0.4x)` suffix, now redundant under a release heading, so those anchors changed; in-document links follow. The per-release section anchors #2216 established are untouched.

Docs-only; no code touched.