### PR TITLE
refactor: adopt MaybeSend portability vocabulary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,10 +70,10 @@ Providers declare capabilities explicitly with `Capable<T>` and `Nothing`.
 
 Rig supports WebAssembly targets.
 
-Use `WasmCompatSend` and `WasmCompatSync` in trait bounds instead of raw `Send`
+Use `MaybeSend` and `MaybeSync` in trait bounds instead of raw `Send`
 and `Sync`.
 
-Use `WasmBoxedFuture` for boxed futures.
+Use `BoxFuture` for boxed futures.
 
 When an error type stores boxed errors, use platform-specific bounds:
 
@@ -148,7 +148,7 @@ Use an appropriate backend-specific filter type.
 
 Return `VectorStoreError` variants instead of ad hoc string errors.
 
-Use `WasmCompatSend` and `WasmCompatSync` bounds.
+Use `MaybeSend` and `MaybeSync` bounds.
 
 ## Agent Hook Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- *(core, agent)* [**breaking**] Rename Rig's target-conditional portability
+  vocabulary to `MaybeSend`, `MaybeSync`, and `BoxFuture`. “Maybe” is
+  target-conditional, not runtime-optional: only browser WASM
+  (`all(target_arch = "wasm32", target_os = "unknown")`) relaxes `Send`/`Sync`
+  and uses `futures::future::LocalBoxFuture`; every other target uses real
+  `Send`/`Sync` and `futures::future::BoxFuture`. The old names are removed.
+  The HTTP-only stream marker is also removed in favor of the existing
+  target-specific `http_client::sse::BoxedStream` alias. Browser-portable
+  image/audio generation, embedding, in-memory vector-store, agent retrieval,
+  and device-code callback bounds now follow the same predicate.
+
 ## [0.41.0](https://github.com/0xPlaygrounds/rig/compare/v0.40.0...v0.41.0) - 2026-07-28
 
 ### Added
@@ -90,11 +104,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wasm32-unknown-unknown` is the entire opt-in. The feature was a pure `cfg`
   switch that every consumer already flipped from a target table, and its one
   optional dependency was never referenced. Relaxing the bounds cannot break
-  implementors — the relaxed markers are blanket-implemented
-  (`impl<T> WasmCompatSend for T {}`), so every type that satisfied the strict
-  form satisfies the relaxed one. (Generic *consumers* on browser wasm that
-  wrote `T: WasmCompatSend` and then relied on `T: Send` internally are the one
-  exception, and only if they were previously building with the feature off.)
+  implementors — the relaxed compatibility markers are blanket-implemented,
+  so every type that satisfied the strict form satisfies the relaxed one.
+  Generic consumers that relied on the compatibility marker to imply `Send`
+  are the one exception, and only on browser wasm if they were previously
+  building with the feature off.
   Dependents passing `features = ["wasm"]` should drop it; nothing replaces it.
 
 - *(core)* `if_wasm!`/`if_not_wasm!` now key on the target rather than a feature.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ As with every open source repo, not every contribution is within the scope of th
 - Changes that would force model provider integrations to diverge from the original API (eg attempting to add a field to the OpenAI API that does not actually exist within the OpenAI API for the sake of satisfying another model provider)
 - Lazy workarounds such as `String` error types, scattered `.unwrap()` calls, stubbed error handling, or incomplete edge-case handling
 - TODO comments, placeholder implementations, or `unimplemented!()` in submitted code
-- Missing WASM compatibility where `WasmCompatSend` or `WasmCompatSync` should be used instead of raw `Send` or `Sync`
+- Missing WASM compatibility where `MaybeSend` or `MaybeSync` should be used instead of raw `Send` or `Sync`
 - Unclear code that needs comments to explain what it is doing instead of being refactored for readability
 - Major architectural changes, new abstractions, or public API reshaping without prior discussion
 - PRs with arbitrary markdown files. The only markdown files we currently allow are ones that are already traditional convention (DEVELOPING.md, CONTRIBUTIONS.md, ARCHITECTURE.md, ... etc)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10060,7 +10060,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,8 +1,9 @@
 # Migrating Rig
 
-This guide covers every breaking change from 0.30 through 0.41. Releases 0.36,
-0.37, 0.40 and 0.41 were the disruptive ones; 0.40 alone carried 31 breaking
-changes, and 0.37 renamed `rig-core`'s library target.
+This guide covers every breaking change from 0.30 through the current
+unreleased version. Releases 0.36, 0.37, 0.40 and 0.41 were the disruptive
+ones; 0.40 alone carried 31 breaking changes, and 0.37 renamed `rig-core`'s
+library target.
 
 ## Which sections apply to you
 
@@ -11,6 +12,7 @@ above it, in order. Each one is self-contained.
 
 | You are on | Start at |
 | --- | --- |
+| 0.41 | [0.41 → Unreleased](#041--unreleased) |
 | 0.40 | [0.40 → 0.41](#040--041) |
 | 0.39 | [0.39 → 0.40](#039--040) |
 | 0.38 | [0.38 → 0.39](#038--039) |
@@ -271,6 +273,45 @@ They now key on `all(target_arch = "wasm32", target_os = "unknown")`. If you
 defined a `wasm` feature and expected it to drive these macros, you now get the
 target's answer instead. Gate on the target directly if you need the old
 association.
+
+---
+
+## 0.41 → Unreleased
+
+### Target-conditional compatibility types were renamed
+
+Rig now uses conventional “maybe thread-safe” vocabulary:
+
+```rust
+use rig_core::wasm_compat::{BoxFuture, MaybeSend, MaybeSync};
+```
+
+Update imports and bounds as follows:
+
+| 0.41 name | Unreleased name |
+| --- | --- |
+| `WasmCompatSend` | `MaybeSend` |
+| `WasmCompatSync` | `MaybeSync` |
+| `WasmBoxedFuture` | `BoxFuture` |
+
+The old aliases are removed. “Maybe” is target-conditional, not
+runtime-optional. On exactly browser WASM
+(`all(target_arch = "wasm32", target_os = "unknown")`), `MaybeSend` and
+`MaybeSync` are no-op marker traits and `BoxFuture` is
+`futures::future::LocalBoxFuture`. On every other target, including WASI, the
+markers require `Send`/`Sync` and `BoxFuture` is
+`futures::future::BoxFuture`.
+
+The HTTP-specific `WasmCompatSendStream` marker was removed rather than renamed.
+Code naming Rig's HTTP byte stream should use
+`rig_core::http_client::sse::BoxedStream`; code boxing an unrelated stream
+should select `futures::stream::BoxStream` or `LocalBoxStream` with the same
+browser-WASM predicate.
+
+Browser-portable image/audio generation, image embeddings, embedding builders,
+in-memory vector indexes, classic-agent retrieval indexes, and device-code
+callbacks now consistently use the target-conditional bounds. Native-only and
+inherently multithreaded integrations continue to require raw `Send`/`Sync`.
 
 ---
 

--- a/crates/rig-agent/Cargo.toml
+++ b/crates/rig-agent/Cargo.toml
@@ -38,8 +38,8 @@ tracing-futures = { workspace = true, features = ["futures-03"] }
 
 # MCP is native-only. rmcp's `ClientHandler` requires `Send + Sync`
 # unconditionally (its `local` feature relaxes only the future bounds), which
-# rig's tool registry cannot satisfy on wasm, where `WasmCompatSend`/
-# `WasmCompatSync` are no-op markers. Scoping the dependency out of the wasm
+# rig's tool registry cannot satisfy on wasm, where `MaybeSend`/
+# `MaybeSync` are no-op markers. Scoping the dependency out of the wasm
 # graph keeps the wasm dependency tree honest; `tool/mod.rs` raises a targeted
 # `compile_error!` if the feature is requested there anyway.
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/crates/rig-agent/README.md
+++ b/crates/rig-agent/README.md
@@ -34,7 +34,8 @@ Classic tools that need mutable per-call state implement
 
 **Building for `wasm32-unknown-unknown` is the entire opt-in** — there are no
 wasm feature flags anywhere in the workspace. `rig-core` relaxes its
-`WasmCompat*` bounds from the target alone.
+`MaybeSend`/`MaybeSync` bounds from the target alone; “Maybe” is
+target-conditional, not runtime-optional.
 
 Wasm gates name a `target_os` (`all(target_arch = "wasm32", target_os =
 "unknown")`) rather than a bare `target_arch = "wasm32"`, because the latter

--- a/crates/rig-agent/src/agent/builder.rs
+++ b/crates/rig-agent/src/agent/builder.rs
@@ -116,7 +116,7 @@ pub struct WithToolServerHandle {
 /// will be created with all the configured tools.
 pub struct WithBuilderTools {
     tools: ToolSet,
-    retrieval_indexes: Vec<(usize, Arc<dyn VectorStoreIndexDyn + Send + Sync>)>,
+    retrieval_indexes: Vec<(usize, Arc<dyn VectorStoreIndexDyn>)>,
 }
 
 /// A builder for creating an agent
@@ -605,7 +605,7 @@ where
     pub fn retrieved_tools(
         self,
         sample: usize,
-        index: impl VectorStoreIndexDyn + Send + Sync + 'static,
+        index: impl VectorStoreIndexDyn + 'static,
         toolset: ToolSet,
     ) -> AgentBuilder<M, WithBuilderTools> {
         let mut tools = ToolSet::default();
@@ -766,7 +766,7 @@ where
     pub fn retrieved_tools(
         mut self,
         sample: usize,
-        index: impl VectorStoreIndexDyn + Send + Sync + 'static,
+        index: impl VectorStoreIndexDyn + 'static,
         toolset: ToolSet,
     ) -> Self {
         self.tool_state

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -12,7 +12,7 @@ use crate::{
     streaming::{StreamingChat, StreamingPrompt},
     tool::server::{ToolRegistrySnapshot, ToolServerError, ToolServerHandle},
 };
-use rig_core::{message::ToolChoice, wasm_compat::WasmCompatSend};
+use rig_core::{message::ToolChoice, wasm_compat::MaybeSend};
 use std::{collections::BTreeSet, sync::Arc};
 
 use super::UNKNOWN_AGENT_NAME;
@@ -647,7 +647,7 @@ where
 {
     fn prompt(
         &self,
-        prompt: impl Into<Message> + WasmCompatSend,
+        prompt: impl Into<Message> + MaybeSend,
     ) -> PromptRequest<prompt_request::Standard, M> {
         PromptRequest::from_agent(self, prompt)
     }
@@ -661,7 +661,7 @@ where
     #[tracing::instrument(skip(self, prompt), fields(agent_name = self.name_or_default()))]
     fn prompt(
         &self,
-        prompt: impl Into<Message> + WasmCompatSend,
+        prompt: impl Into<Message> + MaybeSend,
     ) -> PromptRequest<prompt_request::Standard, M> {
         PromptRequest::from_agent(*self, prompt)
     }
@@ -675,7 +675,7 @@ where
     #[tracing::instrument(skip(self, prompt, chat_history), fields(agent_name = self.name_or_default()))]
     async fn chat(
         &self,
-        prompt: impl Into<Message> + WasmCompatSend,
+        prompt: impl Into<Message> + MaybeSend,
         chat_history: &mut Vec<Message>,
     ) -> Result<String, PromptError> {
         let response = PromptRequest::from_agent(self, prompt)
@@ -696,10 +696,7 @@ where
     M: CompletionModel + 'static,
     M::StreamingResponse: GetTokenUsage,
 {
-    fn stream_prompt(
-        &self,
-        prompt: impl Into<Message> + WasmCompatSend,
-    ) -> StreamingPromptRequest<M> {
+    fn stream_prompt(&self, prompt: impl Into<Message> + MaybeSend) -> StreamingPromptRequest<M> {
         StreamingPromptRequest::<M>::from_agent(self, prompt)
     }
 }
@@ -711,7 +708,7 @@ where
 {
     fn stream_chat<I, T>(
         &self,
-        prompt: impl Into<Message> + WasmCompatSend,
+        prompt: impl Into<Message> + MaybeSend,
         chat_history: I,
     ) -> StreamingPromptRequest<M>
     where
@@ -734,7 +731,7 @@ where
     type TypedRequest<T>
         = TypedPromptRequest<T, prompt_request::Standard, M>
     where
-        T: JsonSchema + DeserializeOwned + WasmCompatSend + 'static;
+        T: JsonSchema + DeserializeOwned + MaybeSend + 'static;
 
     /// Send a prompt and receive a typed structured response.
     ///
@@ -770,10 +767,10 @@ where
     /// ```
     fn prompt_typed<T>(
         &self,
-        prompt: impl Into<Message> + WasmCompatSend,
+        prompt: impl Into<Message> + MaybeSend,
     ) -> TypedPromptRequest<T, prompt_request::Standard, M>
     where
-        T: JsonSchema + DeserializeOwned + WasmCompatSend,
+        T: JsonSchema + DeserializeOwned + MaybeSend,
     {
         TypedPromptRequest::from_agent(self, prompt)
     }
@@ -787,14 +784,14 @@ where
     type TypedRequest<T>
         = TypedPromptRequest<T, prompt_request::Standard, M>
     where
-        T: JsonSchema + DeserializeOwned + WasmCompatSend + 'static;
+        T: JsonSchema + DeserializeOwned + MaybeSend + 'static;
 
     fn prompt_typed<T>(
         &self,
-        prompt: impl Into<Message> + WasmCompatSend,
+        prompt: impl Into<Message> + MaybeSend,
     ) -> TypedPromptRequest<T, prompt_request::Standard, M>
     where
-        T: JsonSchema + DeserializeOwned + WasmCompatSend,
+        T: JsonSchema + DeserializeOwned + MaybeSend,
     {
         TypedPromptRequest::from_agent(*self, prompt)
     }

--- a/crates/rig-agent/src/agent/hook.rs
+++ b/crates/rig-agent/src/agent/hook.rs
@@ -122,7 +122,7 @@ use crate::tool::extensions::TypeMap;
 use rig_core::{
     OneOrMany,
     message::{AssistantContent, Message, ToolChoice},
-    wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync},
+    wasm_compat::{BoxFuture, MaybeSend, MaybeSync},
 };
 
 use crate::{
@@ -166,7 +166,7 @@ impl Scratchpad {
     /// Insert a value.
     pub fn insert<T>(&self, value: T) -> Option<T>
     where
-        T: Clone + WasmCompatSend + WasmCompatSync + 'static,
+        T: Clone + MaybeSend + MaybeSync + 'static,
     {
         self.lock().insert(value)
     }
@@ -174,7 +174,7 @@ impl Scratchpad {
     /// Get a cloned value.
     pub fn get<T>(&self) -> Option<T>
     where
-        T: Clone + WasmCompatSend + WasmCompatSync + 'static,
+        T: Clone + MaybeSend + MaybeSync + 'static,
     {
         self.lock().get::<T>().cloned()
     }
@@ -182,7 +182,7 @@ impl Scratchpad {
     /// Whether a type is present.
     pub fn contains<T>(&self) -> bool
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: MaybeSend + MaybeSync + 'static,
     {
         self.lock().contains::<T>()
     }
@@ -190,7 +190,7 @@ impl Scratchpad {
     /// Remove a value.
     pub fn remove<T>(&self) -> Option<T>
     where
-        T: Clone + WasmCompatSend + WasmCompatSync + 'static,
+        T: Clone + MaybeSend + MaybeSync + 'static,
     {
         self.lock().remove::<T>()
     }
@@ -198,7 +198,7 @@ impl Scratchpad {
     /// Atomically update a value, starting at `Default`.
     pub fn update<T, R>(&self, update: impl FnOnce(&mut T) -> R) -> R
     where
-        T: Clone + Default + WasmCompatSend + WasmCompatSync + 'static,
+        T: Clone + Default + MaybeSend + MaybeSync + 'static,
     {
         let mut guard = self.lock();
         let mut value = guard.remove::<T>().unwrap_or_default();
@@ -914,7 +914,7 @@ impl ObservationAction {
 }
 
 /// Per-run lifecycle observer and steerer.
-pub trait AgentHook: WasmCompatSend + WasmCompatSync {
+pub trait AgentHook: MaybeSend + MaybeSync {
     /// Runs before a completion request is sent.
     ///
     /// Return a per-turn patch, continue without one, or stop the run. Patches
@@ -923,7 +923,7 @@ pub trait AgentHook: WasmCompatSend + WasmCompatSync {
         &self,
         _ctx: &HookContext,
         _event: CompletionCall<'_>,
-    ) -> impl Future<Output = CompletionCallAction> + WasmCompatSend {
+    ) -> impl Future<Output = CompletionCallAction> + MaybeSend {
         async { CompletionCallAction::Continue }
     }
 
@@ -934,7 +934,7 @@ pub trait AgentHook: WasmCompatSend + WasmCompatSync {
         &self,
         _ctx: &HookContext,
         _event: CompletionResponse<'_>,
-    ) -> impl Future<Output = ObservationAction> + WasmCompatSend {
+    ) -> impl Future<Output = ObservationAction> + MaybeSend {
         async { ObservationAction::Continue }
     }
 
@@ -946,7 +946,7 @@ pub trait AgentHook: WasmCompatSend + WasmCompatSync {
         &self,
         _ctx: &HookContext,
         _event: ModelTurnFinished<'_>,
-    ) -> impl Future<Output = ModelTurnAction> + WasmCompatSend {
+    ) -> impl Future<Output = ModelTurnAction> + MaybeSend {
         async { ModelTurnAction::Continue }
     }
 
@@ -960,7 +960,7 @@ pub trait AgentHook: WasmCompatSend + WasmCompatSync {
         &self,
         _ctx: &HookContext,
         _event: &InvalidToolCallContext,
-    ) -> impl Future<Output = Option<InvalidToolCallAction>> + WasmCompatSend {
+    ) -> impl Future<Output = Option<InvalidToolCallAction>> + MaybeSend {
         async { None }
     }
 
@@ -973,7 +973,7 @@ pub trait AgentHook: WasmCompatSend + WasmCompatSync {
         &self,
         _ctx: &HookContext,
         _event: ToolCall<'_>,
-    ) -> impl Future<Output = ToolCallAction> + WasmCompatSend {
+    ) -> impl Future<Output = ToolCallAction> + MaybeSend {
         async { ToolCallAction::Run }
     }
 
@@ -988,7 +988,7 @@ pub trait AgentHook: WasmCompatSend + WasmCompatSync {
         &self,
         _ctx: &HookContext,
         _event: ToolResultEvent<'_>,
-    ) -> impl Future<Output = ToolResultAction> + WasmCompatSend {
+    ) -> impl Future<Output = ToolResultAction> + MaybeSend {
         async { ToolResultAction::Keep }
     }
 
@@ -999,7 +999,7 @@ pub trait AgentHook: WasmCompatSend + WasmCompatSync {
         &self,
         _ctx: &HookContext,
         _event: TextDelta<'_>,
-    ) -> impl Future<Output = ObservationAction> + WasmCompatSend {
+    ) -> impl Future<Output = ObservationAction> + MaybeSend {
         async { ObservationAction::Continue }
     }
 
@@ -1010,7 +1010,7 @@ pub trait AgentHook: WasmCompatSend + WasmCompatSync {
         &self,
         _ctx: &HookContext,
         _event: ToolCallDelta<'_>,
-    ) -> impl Future<Output = ObservationAction> + WasmCompatSend {
+    ) -> impl Future<Output = ObservationAction> + MaybeSend {
         async { ObservationAction::Continue }
     }
 
@@ -1021,7 +1021,7 @@ pub trait AgentHook: WasmCompatSend + WasmCompatSync {
         &self,
         _ctx: &HookContext,
         _event: StreamResponseFinish<'_>,
-    ) -> impl Future<Output = ObservationAction> + WasmCompatSend {
+    ) -> impl Future<Output = ObservationAction> + MaybeSend {
         async { ObservationAction::Continue }
     }
 
@@ -1037,52 +1037,52 @@ impl AgentHook for () {
     }
 }
 
-trait DynAgentHook: WasmCompatSend + WasmCompatSync {
+trait DynAgentHook: MaybeSend + MaybeSync {
     fn completion_call<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: CompletionCall<'a>,
-    ) -> WasmBoxedFuture<'a, CompletionCallAction>;
+    ) -> BoxFuture<'a, CompletionCallAction>;
     fn completion_response<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: CompletionResponse<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction>;
+    ) -> BoxFuture<'a, ObservationAction>;
     fn model_turn_finished<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: ModelTurnFinished<'a>,
-    ) -> WasmBoxedFuture<'a, ModelTurnAction>;
+    ) -> BoxFuture<'a, ModelTurnAction>;
     fn invalid_tool_call<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: &'a InvalidToolCallContext,
-    ) -> WasmBoxedFuture<'a, Option<InvalidToolCallAction>>;
+    ) -> BoxFuture<'a, Option<InvalidToolCallAction>>;
     fn tool_call<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: ToolCall<'a>,
-    ) -> WasmBoxedFuture<'a, (ToolCallAction, Option<serde_json::Value>)>;
+    ) -> BoxFuture<'a, (ToolCallAction, Option<serde_json::Value>)>;
     fn tool_result<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: ToolResultEvent<'a>,
-    ) -> WasmBoxedFuture<'a, ToolResultAction>;
+    ) -> BoxFuture<'a, ToolResultAction>;
     fn text_delta<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: TextDelta<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction>;
+    ) -> BoxFuture<'a, ObservationAction>;
     fn tool_call_delta<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: ToolCallDelta<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction>;
+    ) -> BoxFuture<'a, ObservationAction>;
     fn stream_response_finish<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: StreamResponseFinish<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction>;
+    ) -> BoxFuture<'a, ObservationAction>;
     fn observes(&self, kind: StepEventKind) -> bool;
 }
 
@@ -1094,35 +1094,35 @@ where
         &'a self,
         ctx: &'a HookContext,
         event: CompletionCall<'a>,
-    ) -> WasmBoxedFuture<'a, CompletionCallAction> {
+    ) -> BoxFuture<'a, CompletionCallAction> {
         Box::pin(self.on_completion_call(ctx, event))
     }
     fn completion_response<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: CompletionResponse<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction> {
+    ) -> BoxFuture<'a, ObservationAction> {
         Box::pin(self.on_completion_response(ctx, event))
     }
     fn model_turn_finished<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: ModelTurnFinished<'a>,
-    ) -> WasmBoxedFuture<'a, ModelTurnAction> {
+    ) -> BoxFuture<'a, ModelTurnAction> {
         Box::pin(self.on_model_turn_finished(ctx, event))
     }
     fn invalid_tool_call<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: &'a InvalidToolCallContext,
-    ) -> WasmBoxedFuture<'a, Option<InvalidToolCallAction>> {
+    ) -> BoxFuture<'a, Option<InvalidToolCallAction>> {
         Box::pin(self.on_invalid_tool_call(ctx, event))
     }
     fn tool_call<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: ToolCall<'a>,
-    ) -> WasmBoxedFuture<'a, (ToolCallAction, Option<serde_json::Value>)> {
+    ) -> BoxFuture<'a, (ToolCallAction, Option<serde_json::Value>)> {
         Box::pin(async move {
             // Only `on_tool_call` is public dispatch. A nested `HookStack`
             // records terminal-path rewrite state into this private frame.
@@ -1135,28 +1135,28 @@ where
         &'a self,
         ctx: &'a HookContext,
         event: ToolResultEvent<'a>,
-    ) -> WasmBoxedFuture<'a, ToolResultAction> {
+    ) -> BoxFuture<'a, ToolResultAction> {
         Box::pin(self.on_tool_result(ctx, event))
     }
     fn text_delta<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: TextDelta<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction> {
+    ) -> BoxFuture<'a, ObservationAction> {
         Box::pin(self.on_text_delta(ctx, event))
     }
     fn tool_call_delta<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: ToolCallDelta<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction> {
+    ) -> BoxFuture<'a, ObservationAction> {
         Box::pin(self.on_tool_call_delta(ctx, event))
     }
     fn stream_response_finish<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: StreamResponseFinish<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction> {
+    ) -> BoxFuture<'a, ObservationAction> {
         Box::pin(self.on_stream_response_finish(ctx, event))
     }
     fn observes(&self, kind: StepEventKind) -> bool {

--- a/crates/rig-agent/src/agent/prompt_request/mod.rs
+++ b/crates/rig-agent/src/agent/prompt_request/mod.rs
@@ -4,7 +4,7 @@ use super::{Agent, hook::AgentHook, run::OutputMode, runner::AgentRunner};
 use rig_core::{
     OneOrMany,
     message::{AssistantContent, ToolResultContent, UserContent},
-    wasm_compat::{WasmBoxedFuture, WasmCompatSend},
+    wasm_compat::{BoxFuture, MaybeSend},
 };
 
 use crate::{
@@ -284,7 +284,7 @@ where
     M: CompletionModel + 'static,
 {
     type Output = Result<String, PromptError>;
-    type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
+    type IntoFuture = BoxFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.send())
@@ -296,7 +296,7 @@ where
     M: CompletionModel + 'static,
 {
     type Output = Result<PromptResponse, PromptError>;
-    type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
+    type IntoFuture = BoxFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.send())
@@ -710,7 +710,7 @@ use serde::de::DeserializeOwned;
 /// ```
 pub struct TypedPromptRequest<T, S, M>
 where
-    T: JsonSchema + DeserializeOwned + WasmCompatSend,
+    T: JsonSchema + DeserializeOwned + MaybeSend,
     S: PromptType,
     M: CompletionModel,
 {
@@ -720,7 +720,7 @@ where
 
 impl<T, M> TypedPromptRequest<T, Standard, M>
 where
-    T: JsonSchema + DeserializeOwned + WasmCompatSend,
+    T: JsonSchema + DeserializeOwned + MaybeSend,
     M: CompletionModel,
 {
     /// Create a new TypedPromptRequest from an agent.
@@ -746,7 +746,7 @@ where
 
 impl<T, S, M> TypedPromptRequest<T, S, M>
 where
-    T: JsonSchema + DeserializeOwned + WasmCompatSend,
+    T: JsonSchema + DeserializeOwned + MaybeSend,
     S: PromptType,
     M: CompletionModel,
 {
@@ -809,7 +809,7 @@ fn deserialize_structured_output<T: DeserializeOwned>(text: &str) -> Result<T, s
 
 impl<T, M> TypedPromptRequest<T, Standard, M>
 where
-    T: JsonSchema + DeserializeOwned + WasmCompatSend,
+    T: JsonSchema + DeserializeOwned + MaybeSend,
     M: CompletionModel,
 {
     /// Send the typed prompt request and deserialize the response.
@@ -827,7 +827,7 @@ where
 
 impl<T, M> TypedPromptRequest<T, Extended, M>
 where
-    T: JsonSchema + DeserializeOwned + WasmCompatSend,
+    T: JsonSchema + DeserializeOwned + MaybeSend,
     M: CompletionModel,
 {
     /// Send the typed prompt request with extended details and deserialize the response.
@@ -846,11 +846,11 @@ where
 
 impl<T, M> IntoFuture for TypedPromptRequest<T, Standard, M>
 where
-    T: JsonSchema + DeserializeOwned + WasmCompatSend + 'static,
+    T: JsonSchema + DeserializeOwned + MaybeSend + 'static,
     M: CompletionModel + 'static,
 {
     type Output = Result<T, StructuredOutputError>;
-    type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
+    type IntoFuture = BoxFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.send())
@@ -859,11 +859,11 @@ where
 
 impl<T, M> IntoFuture for TypedPromptRequest<T, Extended, M>
 where
-    T: JsonSchema + DeserializeOwned + WasmCompatSend + 'static,
+    T: JsonSchema + DeserializeOwned + MaybeSend + 'static,
     M: CompletionModel + 'static,
 {
     type Output = Result<TypedPromptResponse<T>, StructuredOutputError>;
-    type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
+    type IntoFuture = BoxFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.send())

--- a/crates/rig-agent/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-agent/src/agent/prompt_request/streaming.rs
@@ -1,7 +1,7 @@
 use rig_core::{
     OneOrMany,
     message::{AssistantContent, UserContent},
-    wasm_compat::{WasmBoxedFuture, WasmCompatSend},
+    wasm_compat::{BoxFuture, MaybeSend},
 };
 
 use crate::{
@@ -26,7 +26,7 @@ use crate::{
 };
 use futures::{Stream, StreamExt, stream};
 use serde::{Deserialize, Serialize};
-use std::{collections::VecDeque, pin::Pin, sync::Arc};
+use std::{collections::VecDeque, sync::Arc};
 use tracing_futures::Instrument;
 
 use super::{CompletionCall, PromptResponse, forward_prompt_setters};
@@ -36,17 +36,17 @@ use crate::{
 };
 use rig_core::message::{Message, Text};
 
-// The `Send` bound is dropped exactly where `rig-core`'s `WasmCompat*` markers
-// go no-op — browser wasm. `rig-core` keys those markers on this same
+// The `Send` bound is dropped exactly where `rig-core`'s `MaybeSend` and
+// `MaybeSync` markers go no-op — browser wasm. `rig-core` keys them on this same
 // predicate, so keep the two in step: a bare `target_arch = "wasm32"` would
 // also drop `Send` on WASI, where `rig-core` still requires it.
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 pub type StreamingResult<R> =
-    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>> + Send>>;
+    futures::stream::BoxStream<'static, Result<MultiTurnStreamItem<R>, StreamingError>>;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub type StreamingResult<R> =
-    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>>>>;
+    futures::stream::LocalBoxStream<'static, Result<MultiTurnStreamItem<R>, StreamingError>>;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(tag = "type", rename_all = "camelCase")]
@@ -299,7 +299,7 @@ where
 impl<M> StreamingPromptRequest<M>
 where
     M: CompletionModel + 'static,
-    <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetTokenUsage,
+    <M as CompletionModel>::StreamingResponse: MaybeSend + GetTokenUsage,
 {
     /// Create a new `StreamingPromptRequest` from an agent, including its
     /// default hooks.
@@ -367,11 +367,11 @@ where
 // Same browser-wasm predicate as `StreamingResult` above, for the same reason.
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 pub(crate) type DriveStream<'a, R> =
-    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>> + Send + 'a>>;
+    futures::stream::BoxStream<'a, Result<MultiTurnStreamItem<R>, StreamingError>>;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) type DriveStream<'a, R> =
-    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>> + 'a>>;
+    futures::stream::LocalBoxStream<'a, Result<MultiTurnStreamItem<R>, StreamingError>>;
 
 /// One item emitted by the shared engine [`drive_agent`].
 ///
@@ -402,12 +402,12 @@ pub(crate) enum DriveItem<R> {
 /// genuinely divergent pieces are behind this trait. Invalid-tool-call recovery
 /// is one of them — it lives inside each source's `run_model_turn` (end-of-turn
 /// for blocking, mid-stream for streaming), not in `drive_agent`.
-pub(crate) trait TurnSource<M>: WasmCompatSend
+pub(crate) trait TurnSource<M>: MaybeSend
 where
     M: CompletionModel,
 {
     /// The raw provider response carried on per-delta stream items.
-    type Raw: WasmCompatSend;
+    type Raw: MaybeSend;
 
     /// Build this medium's per-turn `chat` span (name + parenting + any
     /// `follows_from` chaining differ between blocking and streaming).
@@ -706,8 +706,8 @@ pub(crate) fn drive_tool_calls<'a, M, R, F>(
 ) -> DriveStream<'a, R>
 where
     M: CompletionModel,
-    R: WasmCompatSend + 'a,
-    F: Fn(tracing::Span) -> tracing::Span + WasmCompatSend + 'a,
+    R: MaybeSend + 'a,
+    F: Fn(tracing::Span) -> tracing::Span + MaybeSend + 'a,
 {
     // Per-call working state: a stable internal_call_id and the execute span,
     // paired with the model's tool call. `span` is `Span::none()` for a
@@ -1026,7 +1026,7 @@ impl StreamingTurnSource {
 impl<M> TurnSource<M> for StreamingTurnSource
 where
     M: CompletionModel,
-    <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetTokenUsage,
+    <M as CompletionModel>::StreamingResponse: MaybeSend + GetTokenUsage,
 {
     type Raw = M::StreamingResponse;
 
@@ -1493,7 +1493,7 @@ where
 impl<M> AgentRunner<M>
 where
     M: CompletionModel + 'static,
-    <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetTokenUsage,
+    <M as CompletionModel>::StreamingResponse: MaybeSend + GetTokenUsage,
 {
     /// Drive the agent loop, streaming assistant content, tool activity, and a
     /// final response. Hooks fire at every observable point, including streamed
@@ -1573,10 +1573,10 @@ where
 impl<M> IntoFuture for StreamingPromptRequest<M>
 where
     M: CompletionModel + 'static,
-    <M as CompletionModel>::StreamingResponse: WasmCompatSend,
+    <M as CompletionModel>::StreamingResponse: MaybeSend,
 {
     type Output = StreamingResult<M::StreamingResponse>; // what `.await` returns
-    type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
+    type IntoFuture = BoxFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         // Wrap send() in a future, because send() returns a stream immediately

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -1658,7 +1658,7 @@ mod migrated_tests {
     use rig_core::vector_store::{
         VectorSearchRequest, VectorStoreError, VectorStoreIndex, request::Filter,
     };
-    use rig_core::wasm_compat::WasmCompatSend;
+    use rig_core::wasm_compat::MaybeSend;
 
     /// Records the kind of every hook event (and every tool-result payload) so a
     /// run() and a stream() of the same scenario can be compared.
@@ -7479,7 +7479,7 @@ mod migrated_tests {
     impl VectorStoreIndex for RecordingContextIndex {
         type Filter = Filter<serde_json::Value>;
 
-        async fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
+        async fn top_n<T: for<'a> Deserialize<'a> + MaybeSend>(
             &self,
             req: VectorSearchRequest,
         ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
@@ -7504,7 +7504,7 @@ mod migrated_tests {
     impl VectorStoreIndex for FailingContextIndex {
         type Filter = Filter<serde_json::Value>;
 
-        async fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
+        async fn top_n<T: for<'a> Deserialize<'a> + MaybeSend>(
             &self,
             _req: VectorSearchRequest,
         ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
@@ -7530,7 +7530,7 @@ mod migrated_tests {
     impl VectorStoreIndex for QueryRecordingToolIndex {
         type Filter = Filter<serde_json::Value>;
 
-        async fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
+        async fn top_n<T: for<'a> Deserialize<'a> + MaybeSend>(
             &self,
             _req: VectorSearchRequest,
         ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
@@ -8367,7 +8367,7 @@ mod migrated_tests {
     impl VectorStoreIndex for LateFinalResultIndex {
         type Filter = Filter<serde_json::Value>;
 
-        async fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
+        async fn top_n<T: for<'a> Deserialize<'a> + MaybeSend>(
             &self,
             _req: VectorSearchRequest,
         ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {

--- a/crates/rig-agent/src/client.rs
+++ b/crates/rig-agent/src/client.rs
@@ -4,7 +4,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{agent::AgentBuilder, extractor::ExtractorBuilder};
-use rig_core::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use rig_core::wasm_compat::{MaybeSend, MaybeSync};
 
 /// Classic-runtime construction sugar layered on any portable completion client.
 ///
@@ -30,12 +30,7 @@ pub trait AgentClientExt: rig_core::client::completion::CompletionClient {
     /// Construct a classic typed extractor builder for `model`.
     fn extractor<T>(&self, model: impl Into<String>) -> ExtractorBuilder<Self::CompletionModel, T>
     where
-        T: JsonSchema
-            + for<'de> Deserialize<'de>
-            + Serialize
-            + WasmCompatSend
-            + WasmCompatSync
-            + 'static,
+        T: JsonSchema + for<'de> Deserialize<'de> + Serialize + MaybeSend + MaybeSync + 'static,
     {
         ExtractorBuilder::new(self.completion_model(model))
     }

--- a/crates/rig-agent/src/completion.rs
+++ b/crates/rig-agent/src/completion.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 use rig_core::{
     memory::MemoryError,
-    wasm_compat::{WasmCompatSend, WasmCompatSync},
+    wasm_compat::{MaybeSend, MaybeSync},
 };
 
 pub use rig_core::completion::*;
@@ -136,35 +136,35 @@ impl StructuredOutputError {
 }
 
 /// High-level one-shot prompting for the classic runtime.
-pub trait Prompt: WasmCompatSend + WasmCompatSync {
+pub trait Prompt: MaybeSend + MaybeSync {
     /// Send a prompt and return accepted assistant text after runtime orchestration.
     fn prompt(
         &self,
-        prompt: impl Into<Message> + WasmCompatSend,
-    ) -> impl std::future::IntoFuture<Output = Result<String, PromptError>, IntoFuture: WasmCompatSend>;
+        prompt: impl Into<Message> + MaybeSend,
+    ) -> impl std::future::IntoFuture<Output = Result<String, PromptError>, IntoFuture: MaybeSend>;
 }
 
 /// High-level prompting with caller-owned canonical chat history.
-pub trait Chat: WasmCompatSend + WasmCompatSync {
+pub trait Chat: MaybeSend + MaybeSync {
     /// Execute one turn and append only committed messages to `chat_history`.
     fn chat(
         &self,
-        prompt: impl Into<Message> + WasmCompatSend,
+        prompt: impl Into<Message> + MaybeSend,
         chat_history: &mut Vec<Message>,
-    ) -> impl std::future::Future<Output = Result<String, PromptError>> + WasmCompatSend;
+    ) -> impl std::future::Future<Output = Result<String, PromptError>> + MaybeSend;
 }
 
 /// High-level typed structured prompting for the classic runtime.
-pub trait TypedPrompt: WasmCompatSend + WasmCompatSync {
+pub trait TypedPrompt: MaybeSend + MaybeSync {
     /// Request type returned for one target output type.
     type TypedRequest<T>: std::future::IntoFuture<Output = Result<T, StructuredOutputError>>
     where
-        T: schemars::JsonSchema + DeserializeOwned + WasmCompatSend + 'static;
+        T: schemars::JsonSchema + DeserializeOwned + MaybeSend + 'static;
 
     /// Send a prompt and deserialize the accepted structured response as `T`.
-    fn prompt_typed<T>(&self, prompt: impl Into<Message> + WasmCompatSend) -> Self::TypedRequest<T>
+    fn prompt_typed<T>(&self, prompt: impl Into<Message> + MaybeSend) -> Self::TypedRequest<T>
     where
-        T: schemars::JsonSchema + DeserializeOwned + WasmCompatSend;
+        T: schemars::JsonSchema + DeserializeOwned + MaybeSend;
 }
 
 #[cfg(test)]

--- a/crates/rig-agent/src/extractor.rs
+++ b/crates/rig-agent/src/extractor.rs
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 use rig_core::{
     message::{Message, ToolChoice},
     vector_store::VectorStoreIndexDyn,
-    wasm_compat::{WasmCompatSend, WasmCompatSync},
+    wasm_compat::{MaybeSend, MaybeSync},
 };
 
 use crate::{
@@ -76,7 +76,7 @@ pub enum ExtractionError {
 pub struct Extractor<M, T>
 where
     M: CompletionModel,
-    T: JsonSchema + for<'a> Deserialize<'a> + WasmCompatSend + WasmCompatSync,
+    T: JsonSchema + for<'a> Deserialize<'a> + MaybeSend + MaybeSync,
 {
     agent: Agent<M>,
     _t: PhantomData<T>,
@@ -86,7 +86,7 @@ where
 impl<M, T> Extractor<M, T>
 where
     M: CompletionModel,
-    T: JsonSchema + for<'a> Deserialize<'a> + WasmCompatSend + WasmCompatSync,
+    T: JsonSchema + for<'a> Deserialize<'a> + MaybeSend + MaybeSync,
 {
     /// Attempts to extract data from the given text with a number of retries.
     ///
@@ -96,7 +96,7 @@ where
     /// The number of retries is determined by the `retries` field on the Extractor struct.
     pub async fn extract(
         &self,
-        text: impl Into<Message> + WasmCompatSend,
+        text: impl Into<Message> + MaybeSend,
     ) -> Result<T, ExtractionError> {
         let (data, _usage) = self.retry_extract(text.into(), vec![]).await?;
         Ok(data)
@@ -110,7 +110,7 @@ where
     /// The number of retries is determined by the `retries` field on the Extractor struct.
     pub async fn extract_with_chat_history(
         &self,
-        text: impl Into<Message> + WasmCompatSend,
+        text: impl Into<Message> + MaybeSend,
         chat_history: Vec<Message>,
     ) -> Result<T, ExtractionError> {
         let (data, _usage) = self.retry_extract(text.into(), chat_history).await?;
@@ -132,7 +132,7 @@ where
     /// fails the returned error carries no usage information at all.
     pub async fn extract_with_usage(
         &self,
-        text: impl Into<Message> + WasmCompatSend,
+        text: impl Into<Message> + MaybeSend,
     ) -> Result<ExtractionResponse<T>, ExtractionError> {
         let (data, usage) = self.retry_extract(text.into(), vec![]).await?;
         Ok(ExtractionResponse { data, usage })
@@ -154,7 +154,7 @@ where
     /// fails the returned error carries no usage information at all.
     pub async fn extract_with_chat_history_with_usage(
         &self,
-        text: impl Into<Message> + WasmCompatSend,
+        text: impl Into<Message> + MaybeSend,
         chat_history: Vec<Message>,
     ) -> Result<ExtractionResponse<T>, ExtractionError> {
         let (data, usage) = self.retry_extract(text.into(), chat_history).await?;
@@ -252,7 +252,7 @@ where
 pub struct ExtractorBuilder<M, T>
 where
     M: CompletionModel,
-    T: JsonSchema + for<'a> Deserialize<'a> + Serialize + WasmCompatSend + WasmCompatSync + 'static,
+    T: JsonSchema + for<'a> Deserialize<'a> + Serialize + MaybeSend + MaybeSync + 'static,
 {
     agent_builder: AgentBuilder<M>,
     _t: PhantomData<T>,
@@ -262,7 +262,7 @@ where
 impl<M, T> ExtractorBuilder<M, T>
 where
     M: CompletionModel,
-    T: JsonSchema + for<'a> Deserialize<'a> + Serialize + WasmCompatSend + WasmCompatSync + 'static,
+    T: JsonSchema + for<'a> Deserialize<'a> + Serialize + MaybeSend + MaybeSync + 'static,
 {
     pub fn new(model: M) -> Self {
         Self {
@@ -487,7 +487,7 @@ mod tests {
     impl VectorStoreIndex for ExtractorContextIndex {
         type Filter = Filter<serde_json::Value>;
 
-        async fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
+        async fn top_n<T: for<'a> Deserialize<'a> + MaybeSend>(
             &self,
             req: VectorSearchRequest,
         ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {

--- a/crates/rig-agent/src/integrations/cli_chatbot.rs
+++ b/crates/rig-agent/src/integrations/cli_chatbot.rs
@@ -1,7 +1,7 @@
 use rig_core::{
     markers::{Missing, Provided},
     message::Message,
-    wasm_compat::WasmCompatSend,
+    wasm_compat::MaybeSend,
 };
 
 use crate::{
@@ -66,7 +66,7 @@ where
 
 impl<M> CliChat for AgentImpl<M>
 where
-    M: CompletionModel + WasmCompatSend + 'static,
+    M: CompletionModel + MaybeSend + 'static,
 {
     async fn request(
         &mut self,

--- a/crates/rig-agent/src/streaming.rs
+++ b/crates/rig-agent/src/streaming.rs
@@ -4,7 +4,7 @@ use crate::{
     agent::StreamingPromptRequest,
     completion::{CompletionModel, GetTokenUsage, Message},
 };
-use rig_core::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use rig_core::wasm_compat::{MaybeSend, MaybeSync};
 
 pub use rig_core::streaming::*;
 
@@ -12,30 +12,27 @@ pub use rig_core::streaming::*;
 pub trait StreamingPrompt<M, R>
 where
     M: CompletionModel + 'static,
-    M::StreamingResponse: WasmCompatSend,
+    M::StreamingResponse: MaybeSend,
     R: Clone + Unpin + GetTokenUsage,
 {
     /// Create a classic streaming request for `prompt`.
-    fn stream_prompt(
-        &self,
-        prompt: impl Into<Message> + WasmCompatSend,
-    ) -> StreamingPromptRequest<M>;
+    fn stream_prompt(&self, prompt: impl Into<Message> + MaybeSend) -> StreamingPromptRequest<M>;
 }
 
 /// High-level streaming chat interface with caller-provided history.
-pub trait StreamingChat<M, R>: WasmCompatSend + WasmCompatSync
+pub trait StreamingChat<M, R>: MaybeSend + MaybeSync
 where
     M: CompletionModel + 'static,
-    M::StreamingResponse: WasmCompatSend,
+    M::StreamingResponse: MaybeSend,
     R: Clone + Unpin + GetTokenUsage,
 {
     /// Create a classic streaming request with canonical chat history.
     fn stream_chat<I, T>(
         &self,
-        prompt: impl Into<Message> + WasmCompatSend,
+        prompt: impl Into<Message> + MaybeSend,
         chat_history: I,
     ) -> StreamingPromptRequest<M>
     where
-        I: IntoIterator<Item = T> + WasmCompatSend,
+        I: IntoIterator<Item = T> + MaybeSend,
         T: Into<Message>;
 }

--- a/crates/rig-agent/src/test_utils/tools.rs
+++ b/crates/rig-agent/src/test_utils/tools.rs
@@ -9,7 +9,7 @@ use rig_core::{
     OneOrMany,
     message::{ImageMediaType, ToolResultContent},
     vector_store::{VectorSearchRequest, VectorStoreError, VectorStoreIndex, request::Filter},
-    wasm_compat::WasmCompatSend,
+    wasm_compat::MaybeSend,
 };
 
 use crate::tool::{Tool, ToolContext, ToolErrorKind, ToolExecutionError, ToolOutput, ToolSet};
@@ -441,7 +441,7 @@ impl MockToolIndex {
 impl VectorStoreIndex for MockToolIndex {
     type Filter = Filter<serde_json::Value>;
 
-    async fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
+    async fn top_n<T: for<'a> Deserialize<'a> + MaybeSend>(
         &self,
         _req: VectorSearchRequest,
     ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
@@ -480,7 +480,7 @@ impl BarrierMockToolIndex {
 impl VectorStoreIndex for BarrierMockToolIndex {
     type Filter = Filter<serde_json::Value>;
 
-    async fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
+    async fn top_n<T: for<'a> Deserialize<'a> + MaybeSend>(
         &self,
         _req: VectorSearchRequest,
     ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {

--- a/crates/rig-agent/src/tool/extensions.rs
+++ b/crates/rig-agent/src/tool/extensions.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::hash::{BuildHasherDefault, Hasher};
 
 use crate::tool::ToolExecutionError;
-use rig_core::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use rig_core::wasm_compat::{MaybeSend, MaybeSync};
 
 type AnyMap = HashMap<TypeId, Box<dyn AnyClone>, BuildHasherDefault<IdHasher>>;
 
@@ -28,7 +28,7 @@ impl Hasher for IdHasher {
     }
 }
 
-trait AnyClone: Any + WasmCompatSend + WasmCompatSync {
+trait AnyClone: Any + MaybeSend + MaybeSync {
     fn clone_box(&self) -> Box<dyn AnyClone>;
     fn as_any(&self) -> &dyn Any;
     fn as_any_mut(&mut self) -> &mut dyn Any;
@@ -38,7 +38,7 @@ trait AnyClone: Any + WasmCompatSend + WasmCompatSync {
 
 impl<T> AnyClone for T
 where
-    T: Clone + WasmCompatSend + WasmCompatSync + 'static,
+    T: Clone + MaybeSend + MaybeSync + 'static,
 {
     fn clone_box(&self) -> Box<dyn AnyClone> {
         Box::new(self.clone())
@@ -78,7 +78,7 @@ impl TypeMap {
 
     pub(crate) fn insert<T>(&mut self, value: T) -> Option<T>
     where
-        T: Clone + WasmCompatSend + WasmCompatSync + 'static,
+        T: Clone + MaybeSend + MaybeSync + 'static,
     {
         self.map
             .get_or_insert_with(Default::default)
@@ -89,7 +89,7 @@ impl TypeMap {
 
     pub(crate) fn get<T>(&self) -> Option<&T>
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: MaybeSend + MaybeSync + 'static,
     {
         self.map
             .as_ref()
@@ -99,7 +99,7 @@ impl TypeMap {
 
     pub(crate) fn get_mut<T>(&mut self) -> Option<&mut T>
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: MaybeSend + MaybeSync + 'static,
     {
         self.map
             .as_mut()
@@ -109,7 +109,7 @@ impl TypeMap {
 
     pub(crate) fn remove<T>(&mut self) -> Option<T>
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: MaybeSend + MaybeSync + 'static,
     {
         self.map
             .as_mut()
@@ -120,7 +120,7 @@ impl TypeMap {
 
     pub(crate) fn contains<T>(&self) -> bool
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: MaybeSend + MaybeSync + 'static,
     {
         self.map
             .as_ref()
@@ -171,7 +171,7 @@ impl ToolContext {
     /// Insert an inbound typed value, returning the displaced value if present.
     pub fn insert<T>(&mut self, value: T) -> Option<T>
     where
-        T: Clone + WasmCompatSend + WasmCompatSync + 'static,
+        T: Clone + MaybeSend + MaybeSync + 'static,
     {
         self.inbound.insert(value)
     }
@@ -179,7 +179,7 @@ impl ToolContext {
     /// Read an inbound typed value.
     pub fn get<T>(&self) -> Option<&T>
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: MaybeSend + MaybeSync + 'static,
     {
         self.inbound.get::<T>()
     }
@@ -187,7 +187,7 @@ impl ToolContext {
     /// Require an inbound typed value.
     pub fn require<T>(&self) -> Result<&T, MissingToolContext>
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: MaybeSend + MaybeSync + 'static,
     {
         self.get::<T>().ok_or(MissingToolContext(type_name::<T>()))
     }
@@ -195,7 +195,7 @@ impl ToolContext {
     /// Mutably access an inbound typed value.
     pub fn get_mut<T>(&mut self) -> Option<&mut T>
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: MaybeSend + MaybeSync + 'static,
     {
         self.inbound.get_mut::<T>()
     }
@@ -203,7 +203,7 @@ impl ToolContext {
     /// Remove an inbound typed value.
     pub fn remove<T>(&mut self) -> Option<T>
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: MaybeSend + MaybeSync + 'static,
     {
         self.inbound.remove::<T>()
     }
@@ -211,7 +211,7 @@ impl ToolContext {
     /// Attach host-only metadata to this execution's result.
     pub fn insert_result<T>(&mut self, value: T) -> Option<T>
     where
-        T: Clone + WasmCompatSend + WasmCompatSync + 'static,
+        T: Clone + MaybeSend + MaybeSync + 'static,
     {
         self.result.insert(value)
     }
@@ -219,7 +219,7 @@ impl ToolContext {
     /// Read host-only result metadata.
     pub fn result<T>(&self) -> Option<&T>
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: MaybeSend + MaybeSync + 'static,
     {
         self.result.get::<T>()
     }
@@ -227,7 +227,7 @@ impl ToolContext {
     /// Require host-only result metadata.
     pub fn require_result<T>(&self) -> Result<&T, MissingToolContext>
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: MaybeSend + MaybeSync + 'static,
     {
         self.result::<T>()
             .ok_or(MissingToolContext(type_name::<T>()))
@@ -236,7 +236,7 @@ impl ToolContext {
     /// Whether this context contains the inbound type `T`.
     pub fn contains<T>(&self) -> bool
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: MaybeSend + MaybeSync + 'static,
     {
         self.inbound.contains::<T>()
     }

--- a/crates/rig-agent/src/tool/mod.rs
+++ b/crates/rig-agent/src/tool/mod.rs
@@ -118,7 +118,7 @@ use serde::{Deserialize, Serialize};
 
 use rig_core::{
     embeddings::{embed::EmbedError, tool::ToolSchema},
-    wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync},
+    wasm_compat::{BoxFuture, MaybeSend, MaybeSync},
 };
 
 use crate::completion::{self, ToolDefinition};
@@ -130,7 +130,7 @@ pub(crate) mod extensions;
 // the future bounds (`MaybeSendFuture`) but not the handler itself — and this
 // crate's handler owns the tool registry, whose `Arc<dyn ErasedTool>` is
 // deliberately neither `Send` nor `Sync` on wasm because `rig-core`'s
-// `WasmCompatSend`/`WasmCompatSync` are no-op markers there. The two
+// `MaybeSend`/`MaybeSync` are no-op markers there. The two
 // maybe-`Send` abstractions cannot be reconciled from this side.
 //
 // Raise that as one sentence instead of a page of `dyn ErasedTool` trait errors.
@@ -159,11 +159,11 @@ pub use rig_core::tool::{
 /// context and host-only result metadata share the [`ToolContext`] path. Rig's
 /// object-safe dispatch boundary is private; use [`DynamicTool`] when the tool
 /// name or callback is only known at runtime.
-pub trait Tool: Sized + WasmCompatSend + WasmCompatSync {
+pub trait Tool: Sized + MaybeSend + MaybeSync {
     /// Unique registration and provider-facing name.
     const NAME: &'static str;
     /// Typed JSON arguments.
-    type Args: for<'de> Deserialize<'de> + WasmCompatSend + WasmCompatSync;
+    type Args: for<'de> Deserialize<'de> + MaybeSend + MaybeSync;
     /// Output convertible into Rig's canonical model presentation.
     ///
     /// Every owned serializable value implements [`IntoToolOutput`]
@@ -178,7 +178,7 @@ pub trait Tool: Sized + WasmCompatSend + WasmCompatSync {
     /// dispatch boundary. This keeps ordinary `?` propagation and typed unit
     /// tests available to tool authors without creating a second runtime error
     /// representation.
-    type Error: std::error::Error + WasmCompatSend + WasmCompatSync + 'static;
+    type Error: std::error::Error + MaybeSend + MaybeSync + 'static;
 
     /// Model-facing description.
     fn description(&self) -> String;
@@ -200,7 +200,7 @@ pub trait Tool: Sized + WasmCompatSend + WasmCompatSync {
         &self,
         context: &mut ToolContext,
         args: Self::Args,
-    ) -> impl Future<Output = Result<Self::Output, Self::Error>> + WasmCompatSend;
+    ) -> impl Future<Output = Result<Self::Output, Self::Error>> + MaybeSend;
 }
 
 impl<T> Tool for T
@@ -236,11 +236,11 @@ where
 /// A tool that can be stored in a vector store and reconstructed for RAG.
 pub trait ToolEmbedding: Tool {
     /// Error returned while reconstructing the tool.
-    type InitError: std::error::Error + WasmCompatSend + WasmCompatSync + 'static;
+    type InitError: std::error::Error + MaybeSend + MaybeSync + 'static;
     /// Serializable static context.
     type Context: for<'de> Deserialize<'de> + Serialize;
     /// Runtime initialization state.
-    type State: WasmCompatSend;
+    type State: MaybeSend;
 
     /// Documents used to retrieve the tool.
     fn embedding_docs(&self) -> Vec<String>;
@@ -289,7 +289,7 @@ where
 }
 
 /// Crate-private, object-safe dispatch boundary.
-pub(crate) trait ErasedTool: WasmCompatSend + WasmCompatSync {
+pub(crate) trait ErasedTool: MaybeSend + MaybeSync {
     fn name(&self) -> String;
     fn description(&self) -> String;
     fn parameters(&self) -> serde_json::Value;
@@ -305,7 +305,7 @@ pub(crate) trait ErasedTool: WasmCompatSend + WasmCompatSync {
         &'a self,
         args: String,
         context: &'a mut ToolContext,
-    ) -> WasmBoxedFuture<'a, ToolResult>;
+    ) -> BoxFuture<'a, ToolResult>;
 }
 
 impl<T> ErasedTool for T
@@ -328,7 +328,7 @@ where
         &'a self,
         args: String,
         context: &'a mut ToolContext,
-    ) -> WasmBoxedFuture<'a, ToolResult> {
+    ) -> BoxFuture<'a, ToolResult> {
         Box::pin(async move {
             let args = match parse_tool_args::<T::Args>(&args) {
                 Ok(args) => args,
@@ -349,9 +349,9 @@ trait DynamicCallback:
     for<'a> Fn(
         &'a mut ToolContext,
         serde_json::Value,
-    ) -> WasmBoxedFuture<'a, Result<ToolOutput, ToolExecutionError>>
-    + WasmCompatSend
-    + WasmCompatSync
+    ) -> BoxFuture<'a, Result<ToolOutput, ToolExecutionError>>
+    + MaybeSend
+    + MaybeSync
 {
 }
 
@@ -359,9 +359,9 @@ impl<F> DynamicCallback for F where
     F: for<'a> Fn(
             &'a mut ToolContext,
             serde_json::Value,
-        ) -> WasmBoxedFuture<'a, Result<ToolOutput, ToolExecutionError>>
-        + WasmCompatSend
-        + WasmCompatSync
+        ) -> BoxFuture<'a, Result<ToolOutput, ToolExecutionError>>
+        + MaybeSend
+        + MaybeSync
 {
 }
 
@@ -389,9 +389,9 @@ impl DynamicTool {
         F: for<'a> Fn(
                 &'a mut ToolContext,
                 serde_json::Value,
-            ) -> WasmBoxedFuture<'a, Result<ToolOutput, ToolExecutionError>>
-            + WasmCompatSend
-            + WasmCompatSync
+            ) -> BoxFuture<'a, Result<ToolOutput, ToolExecutionError>>
+            + MaybeSend
+            + MaybeSync
             + 'static,
     {
         Self {
@@ -457,7 +457,7 @@ impl ErasedTool for DynamicTool {
         &'a self,
         args: String,
         context: &'a mut ToolContext,
-    ) -> WasmBoxedFuture<'a, ToolResult> {
+    ) -> BoxFuture<'a, ToolResult> {
         Box::pin(async move {
             let args = match serde_json::from_str(&args) {
                 Ok(args) => args,

--- a/crates/rig-agent/src/tool/rmcp.rs
+++ b/crates/rig-agent/src/tool/rmcp.rs
@@ -77,7 +77,7 @@ use crate::tool::server::{ManagedToolToken, ToolServerHandle};
 use crate::tool::{ToolContext, ToolExecutionError, ToolOutput, ToolResult};
 use rig_core::OneOrMany;
 use rig_core::message::{ImageMediaType, MimeType, ToolResultContent};
-use rig_core::wasm_compat::WasmBoxedFuture;
+use rig_core::wasm_compat::BoxFuture;
 
 /// Re-export of [`rmcp::model::Meta`]: place one in a [`ToolContext`] to have
 /// Rig's MCP registration methods forward it as a call's `_meta`.
@@ -291,7 +291,7 @@ impl McpTool {
         &self,
         args: String,
         meta: Option<rmcp::model::Meta>,
-    ) -> WasmBoxedFuture<'_, Result<CallToolResult, ToolExecutionError>> {
+    ) -> BoxFuture<'_, Result<CallToolResult, ToolExecutionError>> {
         let name = self.definition.name.clone();
 
         Box::pin(async move {
@@ -482,7 +482,7 @@ impl ErasedTool for McpTool {
         &'a self,
         args: String,
         context: &'a mut ToolContext,
-    ) -> WasmBoxedFuture<'a, ToolResult> {
+    ) -> BoxFuture<'a, ToolResult> {
         let meta = context.get::<rmcp::model::Meta>().cloned();
         Box::pin(async move {
             match self.execute_mcp(args, meta).await {

--- a/crates/rig-agent/src/tool/server.rs
+++ b/crates/rig-agent/src/tool/server.rs
@@ -67,7 +67,7 @@ impl ToolRegistrySnapshot {
 /// Shared state behind a `ToolServerHandle`.
 struct ToolServerState {
     /// Vector indexes used to select retrieval-only tools for each prompt.
-    retrieval_indexes: Vec<(usize, Arc<dyn VectorStoreIndexDyn + Send + Sync>)>,
+    retrieval_indexes: Vec<(usize, Arc<dyn VectorStoreIndexDyn>)>,
     /// The authoritative ordered registry for execution and exposure.
     toolset: ToolSet,
     /// Generation tokens for registrations managed by MCP client handlers.
@@ -126,7 +126,7 @@ impl Eq for ManagedToolToken {}
 /// Accumulates tools and configuration, then produces a shared handle via
 /// [`run()`](ToolServer::run).
 pub struct ToolServer {
-    retrieval_indexes: Vec<(usize, Arc<dyn VectorStoreIndexDyn + Send + Sync>)>,
+    retrieval_indexes: Vec<(usize, Arc<dyn VectorStoreIndexDyn>)>,
     toolset: ToolSet,
 }
 
@@ -151,7 +151,7 @@ impl ToolServer {
 
     pub(crate) fn add_retrieval_indexes(
         mut self,
-        indexes: Vec<(usize, Arc<dyn VectorStoreIndexDyn + Send + Sync>)>,
+        indexes: Vec<(usize, Arc<dyn VectorStoreIndexDyn>)>,
     ) -> Self {
         self.retrieval_indexes = indexes;
         self
@@ -210,7 +210,7 @@ impl ToolServer {
     pub fn retrieved_tools(
         mut self,
         sample: usize,
-        index: impl VectorStoreIndexDyn + Send + Sync + 'static,
+        index: impl VectorStoreIndexDyn + 'static,
         toolset: ToolSet,
     ) -> Self {
         self.retrieval_indexes.push((sample, Arc::new(index)));

--- a/crates/rig-core/src/audio_generation.rs
+++ b/crates/rig-core/src/audio_generation.rs
@@ -3,7 +3,7 @@
 use crate::markers::{Missing, Provided};
 use crate::{
     http_client, provider_response,
-    wasm_compat::{WasmCompatSend, WasmCompatSync},
+    wasm_compat::{MaybeSend, MaybeSync},
 };
 use serde_json::Value;
 use thiserror::Error;
@@ -28,9 +28,15 @@ pub enum AudioGenerationError {
     #[error("JsonError: {0}")]
     JsonError(#[from] serde_json::Error),
 
-    /// Error building the audio generation request
+    #[cfg(not(target_family = "wasm"))]
+    /// Error building the audio generation request.
     #[error("RequestError: {0}")]
     RequestError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    #[cfg(target_family = "wasm")]
+    /// Error building the audio generation request.
+    #[error("RequestError: {0}")]
+    RequestError(#[from] Box<dyn std::error::Error + 'static>),
 
     /// Error parsing the audio generation response
     #[error("ResponseError: {0}")]
@@ -52,8 +58,8 @@ pub struct AudioGenerationResponse<T> {
     pub response: T,
 }
 
-pub trait AudioGenerationModel: Sized + Clone + WasmCompatSend + WasmCompatSync {
-    type Response: Send + Sync;
+pub trait AudioGenerationModel: Sized + Clone + MaybeSend + MaybeSync {
+    type Response: MaybeSend + MaybeSync;
 
     type Client;
 
@@ -64,7 +70,7 @@ pub trait AudioGenerationModel: Sized + Clone + WasmCompatSend + WasmCompatSync 
         request: AudioGenerationRequest,
     ) -> impl std::future::Future<
         Output = Result<AudioGenerationResponse<Self::Response>, AudioGenerationError>,
-    > + Send;
+    > + MaybeSend;
 
     fn audio_generation_request(&self) -> AudioGenerationRequestBuilder<Self, Missing, Missing> {
         AudioGenerationRequestBuilder::new(self.clone())

--- a/crates/rig-core/src/client/mod.rs
+++ b/crates/rig-core/src/client/mod.rs
@@ -40,7 +40,7 @@ use crate::{
     prelude::TranscriptionClient,
     rerank::RerankModel,
     transcription::TranscriptionModel,
-    wasm_compat::{WasmCompatSend, WasmCompatSync},
+    wasm_compat::{MaybeSend, MaybeSync},
 };
 
 #[derive(Debug, Error)]
@@ -370,16 +370,16 @@ impl<Ext, H> Client<Ext, H> {
 impl<Ext, H> HttpClientExt for Client<Ext, H>
 where
     H: HttpClientExt + 'static,
-    Ext: WasmCompatSend + WasmCompatSync + 'static,
+    Ext: MaybeSend + MaybeSync + 'static,
 {
     fn send<T, U>(
         &self,
         mut req: Request<T>,
-    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + MaybeSend + 'static
     where
-        T: Into<Bytes> + WasmCompatSend,
+        T: Into<Bytes> + MaybeSend,
         U: From<Bytes>,
-        U: WasmCompatSend + 'static,
+        U: MaybeSend + 'static,
     {
         req.headers_mut().insert(
             http::header::CONTENT_TYPE,
@@ -392,10 +392,10 @@ where
     fn send_multipart<U>(
         &self,
         req: Request<MultipartForm>,
-    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + MaybeSend + 'static
     where
         U: From<Bytes>,
-        U: WasmCompatSend + 'static,
+        U: MaybeSend + 'static,
     {
         self.http_client.send_multipart(req)
     }
@@ -403,9 +403,9 @@ where
     fn send_streaming<T>(
         &self,
         mut req: Request<T>,
-    ) -> impl Future<Output = http_client::Result<http_client::StreamingResponse>> + WasmCompatSend
+    ) -> impl Future<Output = http_client::Result<http_client::StreamingResponse>> + MaybeSend
     where
-        T: Into<Bytes> + WasmCompatSend,
+        T: Into<Bytes> + MaybeSend,
     {
         req.headers_mut().insert(
             http::header::CONTENT_TYPE,
@@ -512,7 +512,7 @@ where
 impl<Ext, H> VerifyClient for Client<Ext, H>
 where
     H: HttpClientExt,
-    Ext: DebugExt + Provider + WasmCompatSync,
+    Ext: DebugExt + Provider + MaybeSync,
 {
     async fn verify(&self) -> Result<(), VerifyError> {
         use http::StatusCode;
@@ -801,7 +801,7 @@ where
 impl<M, Ext, H> TranscriptionClient for Client<Ext, H>
 where
     Ext: Capabilities<H, Transcription = Capable<M>>,
-    M: TranscriptionModel<Client = Self> + WasmCompatSend,
+    M: TranscriptionModel<Client = Self> + MaybeSend,
 {
     type TranscriptionModel = M;
 
@@ -839,14 +839,14 @@ where
 impl<M, Ext, H> ModelListingClient for Client<Ext, H>
 where
     Ext: Capabilities<H, ModelListing = Capable<M>> + Clone,
-    M: ModelLister<H, Client = Self> + WasmCompatSend + WasmCompatSync + Clone + 'static,
-    H: WasmCompatSend + WasmCompatSync + Clone,
+    M: ModelLister<H, Client = Self> + MaybeSend + MaybeSync + Clone + 'static,
+    H: MaybeSend + MaybeSync + Clone,
 {
     fn list_models(
         &self,
     ) -> impl std::future::Future<
         Output = Result<crate::model::ModelList, crate::model::ModelListingError>,
-    > + WasmCompatSend {
+    > + MaybeSend {
         let lister = M::new(self.clone());
         async move { lister.list_all().await }
     }
@@ -858,7 +858,7 @@ mod wasm_model_listing_compile_checks {
     use crate::{
         http_client::{self, HttpClientExt, LazyBody, MultipartForm, Request, Response},
         providers::{anthropic, deepseek, mistral, ollama, openai, openrouter},
-        wasm_compat::WasmCompatSend,
+        wasm_compat::MaybeSend,
     };
     use bytes::Bytes;
     use std::{
@@ -876,10 +876,10 @@ mod wasm_model_listing_compile_checks {
         fn send<T, U>(
             &self,
             _req: Request<T>,
-        ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+        ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + MaybeSend + 'static
         where
-            T: Into<Bytes> + WasmCompatSend,
-            U: From<Bytes> + WasmCompatSend + 'static,
+            T: Into<Bytes> + MaybeSend,
+            U: From<Bytes> + MaybeSend + 'static,
         {
             future::ready(Err(http_client::Error::StreamEnded))
         }
@@ -887,9 +887,9 @@ mod wasm_model_listing_compile_checks {
         fn send_multipart<U>(
             &self,
             _req: Request<MultipartForm>,
-        ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+        ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + MaybeSend + 'static
         where
-            U: From<Bytes> + WasmCompatSend + 'static,
+            U: From<Bytes> + MaybeSend + 'static,
         {
             future::ready(Err(http_client::Error::StreamEnded))
         }
@@ -897,9 +897,9 @@ mod wasm_model_listing_compile_checks {
         fn send_streaming<T>(
             &self,
             _req: Request<T>,
-        ) -> impl Future<Output = http_client::Result<http_client::StreamingResponse>> + WasmCompatSend
+        ) -> impl Future<Output = http_client::Result<http_client::StreamingResponse>> + MaybeSend
         where
-            T: Into<Bytes> + WasmCompatSend,
+            T: Into<Bytes> + MaybeSend,
         {
             future::ready(Err(http_client::Error::StreamEnded))
         }

--- a/crates/rig-core/src/client/model_listing.rs
+++ b/crates/rig-core/src/client/model_listing.rs
@@ -1,6 +1,6 @@
 use crate::model::{ModelList, ModelListingError};
-use crate::wasm_compat::WasmCompatSend;
-use crate::wasm_compat::WasmCompatSync;
+use crate::wasm_compat::MaybeSend;
+use crate::wasm_compat::MaybeSync;
 use std::future::Future;
 
 /// A provider client with model listing capabilities.
@@ -66,9 +66,8 @@ pub trait ModelListingClient {
     ///     println!("- {} ({})", model.display_name(), model.id);
     /// }
     /// ```
-    fn list_models(
-        &self,
-    ) -> impl Future<Output = Result<ModelList, ModelListingError>> + WasmCompatSend;
+    fn list_models(&self)
+    -> impl Future<Output = Result<ModelList, ModelListingError>> + MaybeSend;
 }
 
 /// A trait for implementing model listing logic for a specific provider.
@@ -94,7 +93,7 @@ pub trait ModelListingClient {
 ///
 /// impl<H> ModelLister<H> for MyProviderModelLister<H>
 /// where
-///     H: HttpClientExt + WasmCompatSend + WasmCompatSync,
+///     H: HttpClientExt + MaybeSend + MaybeSync,
 /// {
 ///     type Client = Client<MyProviderExt, H>;
 ///
@@ -108,7 +107,7 @@ pub trait ModelListingClient {
 ///     }
 /// }
 /// ```
-pub trait ModelLister<H = reqwest::Client>: WasmCompatSend + WasmCompatSync {
+pub trait ModelLister<H = reqwest::Client>: MaybeSend + MaybeSync {
     /// The client type associated with this lister
     type Client;
 
@@ -124,7 +123,7 @@ pub trait ModelLister<H = reqwest::Client>: WasmCompatSend + WasmCompatSync {
     /// A `ModelList` containing all available models.
     fn list_all(
         &self,
-    ) -> impl std::future::Future<Output = Result<ModelList, ModelListingError>> + WasmCompatSend;
+    ) -> impl std::future::Future<Output = Result<ModelList, ModelListingError>> + MaybeSend;
 }
 
 #[cfg(test)]

--- a/crates/rig-core/src/client/verify.rs
+++ b/crates/rig-core/src/client/verify.rs
@@ -1,4 +1,4 @@
-use crate::{http_client, provider_response, wasm_compat::WasmCompatSend};
+use crate::{http_client, provider_response, wasm_compat::MaybeSend};
 use thiserror::Error;
 
 /// Errors from provider client verification.
@@ -34,7 +34,7 @@ crate::provider_response::impl_provider_response_helpers!(VerifyError);
 /// Clone is required for conversions between client types.
 pub trait VerifyClient {
     /// Verify the configuration.
-    fn verify(&self) -> impl Future<Output = Result<(), VerifyError>> + WasmCompatSend;
+    fn verify(&self) -> impl Future<Output = Result<(), VerifyError>> + MaybeSend;
 }
 
 #[cfg(test)]

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -36,7 +36,7 @@ use super::message::{AssistantContent, DocumentMediaType};
 use crate::message::ToolChoice;
 use crate::provider_response;
 use crate::streaming::StreamingCompletionResponse;
-use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use crate::wasm_compat::{MaybeSend, MaybeSync};
 use crate::{OneOrMany, http_client};
 use crate::{
     json_utils,
@@ -335,14 +335,14 @@ impl AddAssign for Usage {
 /// Trait defining a completion model that can be used to generate completion responses.
 /// This trait is meant to be implemented by the user to define a custom completion model,
 /// either from a third party provider (e.g.: OpenAI) or a local model.
-pub trait CompletionModel: Clone + WasmCompatSend + WasmCompatSync {
+pub trait CompletionModel: Clone + MaybeSend + MaybeSync {
     /// The raw response type returned by the underlying completion model.
-    type Response: WasmCompatSend + WasmCompatSync + Serialize + DeserializeOwned;
+    type Response: MaybeSend + MaybeSync + Serialize + DeserializeOwned;
     /// The raw response type returned by the underlying completion model when streaming.
     type StreamingResponse: Clone
         + Unpin
-        + WasmCompatSend
-        + WasmCompatSync
+        + MaybeSend
+        + MaybeSync
         + Serialize
         + DeserializeOwned
         + GetTokenUsage;
@@ -359,14 +359,14 @@ pub trait CompletionModel: Clone + WasmCompatSend + WasmCompatSync {
         request: CompletionRequest,
     ) -> impl std::future::Future<
         Output = Result<CompletionResponse<Self::Response>, CompletionError>,
-    > + WasmCompatSend;
+    > + MaybeSend;
 
     fn stream(
         &self,
         request: CompletionRequest,
     ) -> impl std::future::Future<
         Output = Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError>,
-    > + WasmCompatSend;
+    > + MaybeSend;
 
     /// Generates a completion request builder for the given `prompt`.
     fn completion_request(&self, prompt: impl Into<Message>) -> CompletionRequestBuilder<Self> {

--- a/crates/rig-core/src/embeddings/builder.rs
+++ b/crates/rig-core/src/embeddings/builder.rs
@@ -13,6 +13,7 @@ use crate::{
         Embed, EmbedError, Embedding, EmbeddingError, EmbeddingModel, EmbeddingResponse,
         embed::TextEmbedder,
     },
+    wasm_compat::MaybeSend,
 };
 
 /// Builder for creating embeddings from one or more documents of type `T`.
@@ -96,7 +97,7 @@ where
 impl<M, T> EmbeddingsBuilder<M, T>
 where
     M: EmbeddingModel,
-    T: Embed + Send,
+    T: Embed + MaybeSend,
 {
     /// Generate embeddings for all documents in the builder.
     ///

--- a/crates/rig-core/src/embeddings/embed.rs
+++ b/crates/rig-core/src/embeddings/embed.rs
@@ -9,14 +9,25 @@
 //!
 //! Finally, the module implements [Embed] for many common primitive types.
 
+use crate::wasm_compat::{MaybeSend, MaybeSync};
+
+#[cfg(not(target_family = "wasm"))]
+type BoxedEmbedError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+#[cfg(target_family = "wasm")]
+type BoxedEmbedError = Box<dyn std::error::Error + 'static>;
+
 /// Error type used for when the [Embed::embed] method of the [Embed] trait fails.
 /// Used by default implementations of [Embed] for common types.
 #[derive(Debug, thiserror::Error)]
 #[error("{0}")]
-pub struct EmbedError(#[from] Box<dyn std::error::Error + Send + Sync>);
+pub struct EmbedError(#[from] BoxedEmbedError);
 
 impl EmbedError {
-    pub fn new<E: std::error::Error + Send + Sync + 'static>(error: E) -> Self {
+    pub fn new<E>(error: E) -> Self
+    where
+        E: std::error::Error + MaybeSend + MaybeSync + 'static,
+    {
         EmbedError(Box::new(error))
     }
 }

--- a/crates/rig-core/src/embeddings/embedding.rs
+++ b/crates/rig-core/src/embeddings/embedding.rs
@@ -9,7 +9,7 @@
 use crate::{
     completion::Usage,
     http_client, provider_response,
-    wasm_compat::{WasmCompatSend, WasmCompatSync},
+    wasm_compat::{MaybeSend, MaybeSync},
 };
 use serde::{Deserialize, Serialize};
 
@@ -95,7 +95,7 @@ pub enum EmbeddingError {
 crate::provider_response::impl_provider_response_helpers!(EmbeddingError);
 
 /// Trait for embedding models that can generate embeddings for documents.
-pub trait EmbeddingModel: WasmCompatSend + WasmCompatSync {
+pub trait EmbeddingModel: MaybeSend + MaybeSync {
     /// The maximum number of documents that can be embedded in a single request.
     const MAX_DOCUMENTS: usize;
 
@@ -111,14 +111,14 @@ pub trait EmbeddingModel: WasmCompatSend + WasmCompatSync {
     /// Embed multiple text documents in a single request
     fn embed_texts(
         &self,
-        texts: impl IntoIterator<Item = String> + WasmCompatSend,
-    ) -> impl std::future::Future<Output = Result<Vec<Embedding>, EmbeddingError>> + WasmCompatSend;
+        texts: impl IntoIterator<Item = String> + MaybeSend,
+    ) -> impl std::future::Future<Output = Result<Vec<Embedding>, EmbeddingError>> + MaybeSend;
 
     /// Embed a single text document.
     fn embed_text(
         &self,
         text: &str,
-    ) -> impl std::future::Future<Output = Result<Embedding, EmbeddingError>> + WasmCompatSend {
+    ) -> impl std::future::Future<Output = Result<Embedding, EmbeddingError>> + MaybeSend {
         async {
             let mut embeddings = self.embed_texts(vec![text.to_string()]).await?;
             embeddings.pop().ok_or_else(|| {
@@ -136,8 +136,8 @@ pub trait EmbeddingModel: WasmCompatSend + WasmCompatSync {
     /// should override this method.
     fn embed_texts_with_usage(
         &self,
-        texts: impl IntoIterator<Item = String> + WasmCompatSend,
-    ) -> impl std::future::Future<Output = Result<EmbeddingResponse, EmbeddingError>> + WasmCompatSend
+        texts: impl IntoIterator<Item = String> + MaybeSend,
+    ) -> impl std::future::Future<Output = Result<EmbeddingResponse, EmbeddingError>> + MaybeSend
     {
         async {
             let embeddings = self.embed_texts(texts).await?;
@@ -155,7 +155,7 @@ pub trait EmbeddingModel: WasmCompatSend + WasmCompatSync {
     fn embed_text_with_usage(
         &self,
         text: &str,
-    ) -> impl std::future::Future<Output = Result<EmbeddingResponse, EmbeddingError>> + WasmCompatSend
+    ) -> impl std::future::Future<Output = Result<EmbeddingResponse, EmbeddingError>> + MaybeSend
     {
         async {
             let response = self.embed_texts_with_usage(vec![text.to_string()]).await?;
@@ -180,7 +180,7 @@ pub struct EmbeddingResponse {
 }
 
 /// Trait for embedding models that can generate embeddings for images.
-pub trait ImageEmbeddingModel: Clone + WasmCompatSend + WasmCompatSync {
+pub trait ImageEmbeddingModel: Clone + MaybeSend + MaybeSync {
     /// The maximum number of images that can be embedded in a single request.
     const MAX_DOCUMENTS: usize;
 
@@ -192,14 +192,14 @@ pub trait ImageEmbeddingModel: Clone + WasmCompatSend + WasmCompatSync {
     /// Implementations should preserve input order in the returned embeddings.
     fn embed_images(
         &self,
-        images: impl IntoIterator<Item = Vec<u8>> + WasmCompatSend,
-    ) -> impl std::future::Future<Output = Result<Vec<Embedding>, EmbeddingError>> + Send;
+        images: impl IntoIterator<Item = Vec<u8>> + MaybeSend,
+    ) -> impl std::future::Future<Output = Result<Vec<Embedding>, EmbeddingError>> + MaybeSend;
 
     /// Embed a single image from bytes.
     fn embed_image<'a>(
         &'a self,
         bytes: &'a [u8],
-    ) -> impl std::future::Future<Output = Result<Embedding, EmbeddingError>> + WasmCompatSend {
+    ) -> impl std::future::Future<Output = Result<Embedding, EmbeddingError>> + MaybeSend {
         async move {
             let mut embeddings = self.embed_images(vec![bytes.to_owned()]).await?;
             embeddings.pop().ok_or_else(|| {

--- a/crates/rig-core/src/http_client/mod.rs
+++ b/crates/rig-core/src/http_client/mod.rs
@@ -9,7 +9,6 @@ pub mod sse;
 use crate::wasm_compat::*;
 pub use multipart::MultipartForm;
 pub use reqwest::Client as ReqwestClient;
-use std::pin::Pin;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -75,8 +74,8 @@ async fn non_success_status_error(response: reqwest::Response) -> Error {
     Error::InvalidStatusCodeWithMessage(status, message)
 }
 
-pub type LazyBytes = WasmBoxedFuture<'static, Result<Bytes>>;
-pub type LazyBody<T> = WasmBoxedFuture<'static, Result<T>>;
+pub type LazyBytes = BoxFuture<'static, Result<Bytes>>;
+pub type LazyBody<T> = BoxFuture<'static, Result<T>>;
 
 pub type StreamingResponse = Response<BoxedStream>;
 
@@ -122,40 +121,40 @@ pub fn with_bearer_auth(mut req: Builder, auth: &str) -> Result<Builder> {
 }
 
 /// A helper trait to make generic requests (both regular and SSE) possible.
-pub trait HttpClientExt: WasmCompatSend + WasmCompatSync {
+pub trait HttpClientExt: MaybeSend + MaybeSync {
     /// Send a HTTP request, get a response back (as bytes). Response must be able to be turned back into Bytes.
     fn send<T, U>(
         &self,
         req: Request<T>,
-    ) -> impl Future<Output = Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    ) -> impl Future<Output = Result<Response<LazyBody<U>>>> + MaybeSend + 'static
     where
         T: Into<Bytes>,
-        T: WasmCompatSend,
+        T: MaybeSend,
         U: From<Bytes>,
-        U: WasmCompatSend + 'static;
+        U: MaybeSend + 'static;
 
     /// Send a HTTP request with a multipart body, get a response back (as bytes). Response must be able to be turned back into Bytes (although usually for the response, you will probably want to specify Bytes anyway).
     fn send_multipart<U>(
         &self,
         req: Request<MultipartForm>,
-    ) -> impl Future<Output = Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    ) -> impl Future<Output = Result<Response<LazyBody<U>>>> + MaybeSend + 'static
     where
         U: From<Bytes>,
-        U: WasmCompatSend + 'static;
+        U: MaybeSend + 'static;
 
     /// Send a HTTP request, get a streamed response back (as a stream of [`bytes::Bytes`].)
     fn send_streaming<T>(
         &self,
         req: Request<T>,
-    ) -> impl Future<Output = Result<StreamingResponse>> + WasmCompatSend
+    ) -> impl Future<Output = Result<StreamingResponse>> + MaybeSend
     where
-        T: Into<Bytes> + WasmCompatSend;
+        T: Into<Bytes> + MaybeSend;
 }
 
 async fn into_lazy_response<U>(response: reqwest::Response) -> Result<Response<LazyBody<U>>>
 where
     U: From<Bytes>,
-    U: WasmCompatSend + 'static,
+    U: MaybeSend + 'static,
 {
     if !response.status().is_success() {
         return Err(non_success_status_error(response).await);
@@ -182,10 +181,10 @@ macro_rules! impl_http_client_ext {
             fn send<T, U>(
                 &self,
                 req: Request<T>,
-            ) -> impl Future<Output = Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+            ) -> impl Future<Output = Result<Response<LazyBody<U>>>> + MaybeSend + 'static
             where
                 T: Into<Bytes>,
-                U: From<Bytes> + WasmCompatSend + 'static,
+                U: From<Bytes> + MaybeSend + 'static,
             {
                 let (parts, body) = req.into_parts();
                 let req = self
@@ -202,10 +201,10 @@ macro_rules! impl_http_client_ext {
             fn send_multipart<U>(
                 &self,
                 req: Request<MultipartForm>,
-            ) -> impl Future<Output = Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+            ) -> impl Future<Output = Result<Response<LazyBody<U>>>> + MaybeSend + 'static
             where
                 U: From<Bytes>,
-                U: WasmCompatSend + 'static,
+                U: MaybeSend + 'static,
             {
                 let (parts, body) = req.into_parts();
                 let body = reqwest::multipart::Form::from(body);
@@ -224,9 +223,9 @@ macro_rules! impl_http_client_ext {
             fn send_streaming<T>(
                 &self,
                 req: Request<T>,
-            ) -> impl Future<Output = Result<StreamingResponse>> + WasmCompatSend
+            ) -> impl Future<Output = Result<StreamingResponse>> + MaybeSend
             where
-                T: Into<Bytes> + WasmCompatSend,
+                T: Into<Bytes> + MaybeSend,
             {
                 let (parts, body) = req.into_parts();
 
@@ -259,9 +258,7 @@ macro_rules! impl_http_client_ext {
 
                     use futures::StreamExt;
 
-                    let mapped_stream: Pin<
-                        Box<dyn WasmCompatSendStream<InnerItem = Result<Bytes>>>,
-                    > = Box::pin(
+                    let mapped_stream: BoxedStream = Box::pin(
                         response
                             .bytes_stream()
                             .map(|chunk| chunk.map_err(|e| Error::Instance(Box::new(e)))),

--- a/crates/rig-core/src/http_client/sse.rs
+++ b/crates/rig-core/src/http_client/sse.rs
@@ -7,7 +7,7 @@ use crate::{
         HttpClientExt, Result as StreamResult,
         retry::{DEFAULT_RETRY, ExponentialBackoff, RetryPolicy},
     },
-    wasm_compat::{WasmCompatSend, WasmCompatSendStream},
+    wasm_compat::MaybeSend,
 };
 use bytes::Bytes;
 use eventsource_stream::{Event as MessageEvent, EventStreamError, Eventsource};
@@ -27,7 +27,12 @@ use std::{
     time::Duration,
 };
 
-pub type BoxedStream = Pin<Box<dyn WasmCompatSendStream<InnerItem = StreamResult<Bytes>>>>;
+/// Boxed HTTP byte stream, sendable except on browser WASM.
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+pub type BoxedStream = BoxStream<'static, StreamResult<Bytes>>;
+/// Boxed HTTP byte stream that may be non-`Send` on browser WASM.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub type BoxedStream = LocalBoxStream<'static, StreamResult<Bytes>>;
 
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 type ResponseFuture = BoxFuture<'static, Result<Response<BoxedStream>, super::Error>>;
@@ -87,7 +92,7 @@ pin_project! {
 impl<HttpClient, RequestBody> GenericEventSource<HttpClient, RequestBody>
 where
     HttpClient: HttpClientExt + Clone + 'static,
-    RequestBody: Into<Bytes> + Clone + WasmCompatSend + 'static,
+    RequestBody: Into<Bytes> + Clone + MaybeSend + 'static,
 {
     /// Create a new event source that will connect to the given request.
     pub fn new(client: HttpClient, req: Request<RequestBody>) -> Self {
@@ -163,7 +168,7 @@ impl From<MessageEvent> for Event {
 impl<HttpClient, RequestBody> Stream for GenericEventSource<HttpClient, RequestBody>
 where
     HttpClient: HttpClientExt + Clone + 'static,
-    RequestBody: Into<Bytes> + Clone + WasmCompatSend + 'static,
+    RequestBody: Into<Bytes> + Clone + MaybeSend + 'static,
 {
     type Item = Result<Event, super::Error>;
 

--- a/crates/rig-core/src/image_generation.rs
+++ b/crates/rig-core/src/image_generation.rs
@@ -1,7 +1,10 @@
 //! Everything related to core image generation abstractions in Rig.
 //! Rig allows calling a number of different providers (that support image generation) using the [ImageGenerationModel] trait.
 use crate::markers::{Missing, Provided};
-use crate::{http_client, provider_response};
+use crate::{
+    http_client, provider_response,
+    wasm_compat::{MaybeSend, MaybeSync},
+};
 use serde_json::Value;
 use thiserror::Error;
 
@@ -20,9 +23,15 @@ pub enum ImageGenerationError {
     #[error("JsonError: {0}")]
     JsonError(#[from] serde_json::Error),
 
-    /// Error building the image generation request
+    #[cfg(not(target_family = "wasm"))]
+    /// Error building the image generation request.
     #[error("RequestError: {0}")]
     RequestError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    #[cfg(target_family = "wasm")]
+    /// Error building the image generation request.
+    #[error("RequestError: {0}")]
+    RequestError(#[from] Box<dyn std::error::Error + 'static>),
 
     /// Error parsing the image generation response
     #[error("ResponseError: {0}")]
@@ -46,8 +55,8 @@ pub struct ImageGenerationResponse<T> {
     pub response: T,
 }
 
-pub trait ImageGenerationModel: Clone + Send + Sync {
-    type Response: Send + Sync;
+pub trait ImageGenerationModel: Clone + MaybeSend + MaybeSync {
+    type Response: MaybeSend + MaybeSync;
 
     type Client;
 
@@ -58,7 +67,7 @@ pub trait ImageGenerationModel: Clone + Send + Sync {
         request: ImageGenerationRequest,
     ) -> impl std::future::Future<
         Output = Result<ImageGenerationResponse<Self::Response>, ImageGenerationError>,
-    > + Send;
+    > + MaybeSend;
 
     fn image_generation_request(&self) -> ImageGenerationRequestBuilder<Self, Missing> {
         ImageGenerationRequestBuilder::new(self.clone())

--- a/crates/rig-core/src/memory.rs
+++ b/crates/rig-core/src/memory.rs
@@ -42,7 +42,7 @@ use std::{
 
 use crate::{
     completion::Message,
-    wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync},
+    wasm_compat::{BoxFuture, MaybeSend, MaybeSync},
 };
 
 /// Boxed error source for memory backend failures.
@@ -90,14 +90,14 @@ impl MemoryError {
 ///
 /// Implementations should keep `append` cheap; it runs inline before the agent
 /// returns its response.
-pub trait ConversationMemory: WasmCompatSend + WasmCompatSync {
+pub trait ConversationMemory: MaybeSend + MaybeSync {
     /// Load the full conversation history for `conversation_id`.
     ///
     /// Returns an empty `Vec` if the conversation has no stored messages.
     fn load<'a>(
         &'a self,
         conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>>;
+    ) -> BoxFuture<'a, Result<Vec<Message>, MemoryError>>;
 
     /// Append `messages` to the conversation identified by `conversation_id`.
     ///
@@ -107,13 +107,10 @@ pub trait ConversationMemory: WasmCompatSend + WasmCompatSync {
         &'a self,
         conversation_id: &'a str,
         messages: Vec<Message>,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>>;
+    ) -> BoxFuture<'a, Result<(), MemoryError>>;
 
     /// Remove all stored messages for `conversation_id`.
-    fn clear<'a>(
-        &'a self,
-        conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>>;
+    fn clear<'a>(&'a self, conversation_id: &'a str) -> BoxFuture<'a, Result<(), MemoryError>>;
 }
 
 impl<M> ConversationMemory for Arc<M>
@@ -123,7 +120,7 @@ where
     fn load<'a>(
         &'a self,
         conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
+    ) -> BoxFuture<'a, Result<Vec<Message>, MemoryError>> {
         (**self).load(conversation_id)
     }
 
@@ -131,14 +128,11 @@ where
         &'a self,
         conversation_id: &'a str,
         messages: Vec<Message>,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    ) -> BoxFuture<'a, Result<(), MemoryError>> {
         (**self).append(conversation_id, messages)
     }
 
-    fn clear<'a>(
-        &'a self,
-        conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    fn clear<'a>(&'a self, conversation_id: &'a str) -> BoxFuture<'a, Result<(), MemoryError>> {
         (**self).clear(conversation_id)
     }
 }
@@ -150,7 +144,7 @@ where
     fn load<'a>(
         &'a self,
         conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
+    ) -> BoxFuture<'a, Result<Vec<Message>, MemoryError>> {
         (**self).load(conversation_id)
     }
 
@@ -158,14 +152,11 @@ where
         &'a self,
         conversation_id: &'a str,
         messages: Vec<Message>,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    ) -> BoxFuture<'a, Result<(), MemoryError>> {
         (**self).append(conversation_id, messages)
     }
 
-    fn clear<'a>(
-        &'a self,
-        conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    fn clear<'a>(&'a self, conversation_id: &'a str) -> BoxFuture<'a, Result<(), MemoryError>> {
         (**self).clear(conversation_id)
     }
 }
@@ -175,15 +166,9 @@ where
 /// Implemented automatically for any closure with the right signature; the
 /// trait exists to combine `Fn` with the WASM-compatible `Send`/`Sync` markers
 /// in a single trait object.
-pub trait MessageFilter:
-    Fn(Vec<Message>) -> Vec<Message> + WasmCompatSend + WasmCompatSync
-{
-}
+pub trait MessageFilter: Fn(Vec<Message>) -> Vec<Message> + MaybeSend + MaybeSync {}
 
-impl<F> MessageFilter for F where
-    F: Fn(Vec<Message>) -> Vec<Message> + WasmCompatSend + WasmCompatSync
-{
-}
+impl<F> MessageFilter for F where F: Fn(Vec<Message>) -> Vec<Message> + MaybeSend + MaybeSync {}
 
 /// A side-channel for messages that a memory policy or adapter removes from
 /// active history during [`ConversationMemory::load`].
@@ -217,7 +202,7 @@ impl<F> MessageFilter for F where
 /// messages again. Hooks that append to durable storage should
 /// deduplicate by content hash, by `(conversation_id, message_id)`,
 /// or by an equivalent stable key.
-pub trait DemotionHook: WasmCompatSend + WasmCompatSync {
+pub trait DemotionHook: MaybeSend + MaybeSync {
     /// Receive `messages` that were demoted out of the active window for
     /// `conversation_id`.
     ///
@@ -227,7 +212,7 @@ pub trait DemotionHook: WasmCompatSend + WasmCompatSync {
         &'a self,
         conversation_id: &'a str,
         messages: Vec<Message>,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>>;
+    ) -> BoxFuture<'a, Result<(), MemoryError>>;
 }
 
 /// A [`DemotionHook`] that does nothing. Useful as a default when an adapter
@@ -240,7 +225,7 @@ impl DemotionHook for NoopDemotionHook {
         &'a self,
         _conversation_id: &'a str,
         _messages: Vec<Message>,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    ) -> BoxFuture<'a, Result<(), MemoryError>> {
         Box::pin(async move { Ok(()) })
     }
 }
@@ -256,7 +241,7 @@ where
         &'a self,
         conversation_id: &'a str,
         messages: Vec<Message>,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    ) -> BoxFuture<'a, Result<(), MemoryError>> {
         (**self).on_demote(conversation_id, messages)
     }
 }
@@ -293,14 +278,14 @@ where
 /// that have side effects (writing summaries to a vector store, billing an
 /// LLM call) should deduplicate by conversation id and content hash, the
 /// same way [`DemotionHook`] implementations do.
-pub trait Compactor: WasmCompatSend + WasmCompatSync {
+pub trait Compactor: MaybeSend + MaybeSync {
     /// The summary value produced by [`Compactor::compact`].
     ///
     /// `Into<Message>` is required so the composing adapter can splice the
     /// artifact at the front of the loaded history. `Clone` is required so
     /// the adapter can keep a private copy as `carry_over` for the next
     /// compaction.
-    type Artifact: Into<Message> + Clone + WasmCompatSend + WasmCompatSync + 'static;
+    type Artifact: Into<Message> + Clone + MaybeSend + MaybeSync + 'static;
 
     /// Produce a summary artifact for `evicted`, optionally combining it
     /// with the previous summary in `carry_over`.
@@ -316,7 +301,7 @@ pub trait Compactor: WasmCompatSend + WasmCompatSync {
         conversation_id: &'a str,
         evicted: &'a [Message],
         carry_over: Option<&'a Self::Artifact>,
-    ) -> WasmBoxedFuture<'a, Result<Self::Artifact, MemoryError>>;
+    ) -> BoxFuture<'a, Result<Self::Artifact, MemoryError>>;
 }
 
 /// Forwarding impl so callers can pass `Arc<C>` wherever a `Compactor` is
@@ -332,7 +317,7 @@ where
         conversation_id: &'a str,
         evicted: &'a [Message],
         carry_over: Option<&'a Self::Artifact>,
-    ) -> WasmBoxedFuture<'a, Result<Self::Artifact, MemoryError>> {
+    ) -> BoxFuture<'a, Result<Self::Artifact, MemoryError>> {
         (**self).compact(conversation_id, evicted, carry_over)
     }
 }
@@ -390,7 +375,7 @@ impl ConversationMemory for InMemoryConversationMemory {
     fn load<'a>(
         &'a self,
         conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
+    ) -> BoxFuture<'a, Result<Vec<Message>, MemoryError>> {
         Box::pin(async move {
             let messages = {
                 let guard = self.lock()?;
@@ -407,7 +392,7 @@ impl ConversationMemory for InMemoryConversationMemory {
         &'a self,
         conversation_id: &'a str,
         messages: Vec<Message>,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    ) -> BoxFuture<'a, Result<(), MemoryError>> {
         Box::pin(async move {
             let mut guard = self.lock()?;
             guard
@@ -418,10 +403,7 @@ impl ConversationMemory for InMemoryConversationMemory {
         })
     }
 
-    fn clear<'a>(
-        &'a self,
-        conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    fn clear<'a>(&'a self, conversation_id: &'a str) -> BoxFuture<'a, Result<(), MemoryError>> {
         Box::pin(async move {
             let mut guard = self.lock()?;
             guard.remove(conversation_id);

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -2456,8 +2456,8 @@ pub(super) fn build_tool_definitions(
 
 impl<Ext, T> completion::CompletionModel for GenericCompletionModel<Ext, T>
 where
-    T: HttpClientExt + Clone + Default + WasmCompatSend + WasmCompatSync + 'static,
-    Ext: AnthropicCompatibleProvider + Clone + WasmCompatSend + WasmCompatSync + 'static,
+    T: HttpClientExt + Clone + Default + MaybeSend + MaybeSync + 'static,
+    Ext: AnthropicCompatibleProvider + Clone + MaybeSend + MaybeSync + 'static,
 {
     type Response = CompletionResponse;
     type StreamingResponse = StreamingCompletionResponse;

--- a/crates/rig-core/src/providers/anthropic/model_listing.rs
+++ b/crates/rig-core/src/providers/anthropic/model_listing.rs
@@ -3,7 +3,7 @@ use crate::{
     http_client::{self, HttpClientExt},
     model::{Model, ModelList, ModelListingError},
     providers::anthropic::Client,
-    wasm_compat::{WasmCompatSend, WasmCompatSync},
+    wasm_compat::{MaybeSend, MaybeSync},
 };
 use serde::Deserialize;
 
@@ -36,7 +36,7 @@ pub struct AnthropicModelLister<H = reqwest::Client> {
 
 impl<H> ModelLister<H> for AnthropicModelLister<H>
 where
-    H: HttpClientExt + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + MaybeSend + MaybeSync + 'static,
 {
     type Client = Client<H>;
 

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -17,7 +17,7 @@ use crate::streaming::{
     self, RawStreamingChoice, RawStreamingToolCall, StreamingResult, ToolCallDeltaContent,
 };
 use crate::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
-use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use crate::wasm_compat::{MaybeSend, MaybeSync};
 use std::collections::HashMap;
 
 /// Build the Anthropic streaming request body.
@@ -217,7 +217,7 @@ impl GetTokenUsage for StreamingCompletionResponse {
 impl<Ext, T> GenericCompletionModel<Ext, T>
 where
     T: HttpClientExt + Clone + Default + 'static,
-    Ext: AnthropicCompatibleProvider + Clone + WasmCompatSend + WasmCompatSync + 'static,
+    Ext: AnthropicCompatibleProvider + Clone + MaybeSend + MaybeSync + 'static,
 {
     pub(crate) async fn stream(
         &self,

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -693,7 +693,7 @@ mod image_generation {
 
     impl<T> image_generation::ImageGenerationModel for ImageGenerationModel<T>
     where
-        T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+        T: HttpClientExt + Clone + Default + std::fmt::Debug + 'static,
     {
         type Response = ImageGenerationResponse;
 
@@ -785,7 +785,7 @@ mod audio_generation {
 
     impl<T> audio_generation::AudioGenerationModel for AudioGenerationModel<T>
     where
-        T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+        T: HttpClientExt + Clone + Default + std::fmt::Debug + 'static,
     {
         type Response = Bytes;
         type Client = Client<T>;

--- a/crates/rig-core/src/providers/chatgpt/auth/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/auth/mod.rs
@@ -5,6 +5,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+use crate::wasm_compat::{MaybeSend, MaybeSync};
+
 #[cfg(not(target_family = "wasm"))]
 mod native;
 #[cfg(target_family = "wasm")]
@@ -21,13 +23,18 @@ pub struct DeviceCodePrompt {
     pub user_code: String,
 }
 
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+type DeviceCodeCallback = dyn Fn(DeviceCodePrompt) + Send + Sync;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+type DeviceCodeCallback = dyn Fn(DeviceCodePrompt);
+
 #[derive(Clone, Default)]
-pub struct DeviceCodeHandler(Option<Arc<dyn Fn(DeviceCodePrompt) + Send + Sync>>);
+pub struct DeviceCodeHandler(Option<Arc<DeviceCodeCallback>>);
 
 impl DeviceCodeHandler {
     pub fn new<F>(handler: F) -> Self
     where
-        F: Fn(DeviceCodePrompt) + Send + Sync + 'static,
+        F: Fn(DeviceCodePrompt) + MaybeSend + MaybeSync + 'static,
     {
         Self(Some(Arc::new(handler)))
     }

--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -29,7 +29,7 @@ use crate::providers::openai::responses_api::{
 };
 use crate::streaming::StreamingCompletionResponse;
 use crate::telemetry::{CompletionOperation, CompletionSpanBuilder};
-use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use crate::wasm_compat::{MaybeSend, MaybeSync};
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use tracing::{Level, enabled};
@@ -266,7 +266,7 @@ impl<H> client::ClientBuilder<ChatGPTBuilder, crate::markers::Missing, H> {
 impl<H> ClientBuilder<H> {
     pub fn on_device_code<F>(self, handler: F) -> Self
     where
-        F: Fn(auth::DeviceCodePrompt) + Send + Sync + 'static,
+        F: Fn(auth::DeviceCodePrompt) + MaybeSend + MaybeSync + 'static,
     {
         self.over_ext(|mut ext| {
             ext.device_code_handler = auth::DeviceCodeHandler::new(handler);
@@ -339,7 +339,7 @@ pub struct ResponsesCompletionModel<H = reqwest::Client> {
 impl<H> ResponsesCompletionModel<H>
 where
     Client<H>: HttpClientExt + Clone + Debug + 'static,
-    H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + Default + Debug + MaybeSend + MaybeSync + 'static,
 {
     pub fn new(client: Client<H>, model: impl Into<String>) -> Self {
         Self {
@@ -480,7 +480,7 @@ where
 
 impl<H> Client<H>
 where
-    H: HttpClientExt + Clone + Debug + Default + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + Clone + Debug + Default + MaybeSend + MaybeSync + 'static,
 {
     pub async fn authorize(&self) -> Result<(), auth::AuthError> {
         self.ext().auth.auth_context().await.map(|_| ())
@@ -490,7 +490,7 @@ where
 impl<H> completion::CompletionModel for ResponsesCompletionModel<H>
 where
     Client<H>: HttpClientExt + Clone + Debug + 'static,
-    H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + Default + Debug + MaybeSend + MaybeSync + 'static,
 {
     type Response = responses_api::CompletionResponse;
     type StreamingResponse = responses_api::streaming::StreamingCompletionResponse;
@@ -541,7 +541,7 @@ where
 impl<H> ResponsesCompletionModel<H>
 where
     Client<H>: HttpClientExt + Clone + Debug + 'static,
-    H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + Default + Debug + MaybeSend + MaybeSync + 'static,
 {
     pub async fn stream(
         &self,

--- a/crates/rig-core/src/providers/cohere/client.rs
+++ b/crates/rig-core/src/providers/cohere/client.rs
@@ -101,7 +101,7 @@ pub enum ApiResponse<T> {
 
 impl<T> Client<T>
 where
-    T: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
+    T: HttpClientExt + Clone + MaybeSend + MaybeSync + 'static,
 {
     pub fn embeddings<D: Embed>(
         &self,

--- a/crates/rig-core/src/providers/cohere/embeddings.rs
+++ b/crates/rig-core/src/providers/cohere/embeddings.rs
@@ -67,7 +67,7 @@ pub struct EmbeddingModel<T = reqwest::Client> {
 
 impl<T> embeddings::EmbeddingModel for EmbeddingModel<T>
 where
-    T: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
+    T: HttpClientExt + Clone + MaybeSend + MaybeSync + 'static,
 {
     const MAX_DOCUMENTS: usize = 96;
     type Client = Client<T>;

--- a/crates/rig-core/src/providers/copilot/auth/mod.rs
+++ b/crates/rig-core/src/providers/copilot/auth/mod.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+use crate::wasm_compat::{MaybeSend, MaybeSync};
+
 #[cfg(not(target_family = "wasm"))]
 mod native;
 #[cfg(target_family = "wasm")]
@@ -19,13 +21,18 @@ pub struct DeviceCodePrompt {
     pub user_code: String,
 }
 
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+type DeviceCodeCallback = dyn Fn(DeviceCodePrompt) + Send + Sync;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+type DeviceCodeCallback = dyn Fn(DeviceCodePrompt);
+
 #[derive(Clone, Default)]
-pub struct DeviceCodeHandler(Option<Arc<dyn Fn(DeviceCodePrompt) + Send + Sync>>);
+pub struct DeviceCodeHandler(Option<Arc<DeviceCodeCallback>>);
 
 impl DeviceCodeHandler {
     pub fn new<F>(handler: F) -> Self
     where
-        F: Fn(DeviceCodePrompt) + Send + Sync + 'static,
+        F: Fn(DeviceCodePrompt) + MaybeSend + MaybeSync + 'static,
     {
         Self(Some(Arc::new(handler)))
     }

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -38,7 +38,7 @@ use crate::providers::openai;
 use crate::providers::openai::responses_api::{self, CompletionRequest as ResponsesRequest};
 use crate::streaming::{self, RawStreamingChoice, StreamingCompletionResponse};
 use crate::telemetry::{CompletionOperation, CompletionSpanBuilder};
-use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use crate::wasm_compat::{MaybeSend, MaybeSync};
 use async_stream::stream;
 use futures::StreamExt;
 use http::Request;
@@ -290,7 +290,7 @@ impl<H> client::ClientBuilder<CopilotBuilder, crate::markers::Missing, H> {
 impl<H> ClientBuilder<H> {
     pub fn on_device_code<F>(self, handler: F) -> Self
     where
-        F: Fn(auth::DeviceCodePrompt) + Send + Sync + 'static,
+        F: Fn(auth::DeviceCodePrompt) + MaybeSend + MaybeSync + 'static,
     {
         self.over_ext(|mut ext| {
             ext.device_code_handler = auth::DeviceCodeHandler::new(handler);
@@ -374,7 +374,7 @@ where
 
 impl<H> Client<H>
 where
-    H: HttpClientExt + Clone + Debug + Default + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + Clone + Debug + Default + MaybeSend + MaybeSync + 'static,
 {
     pub async fn authorize(&self) -> Result<(), auth::AuthError> {
         self.ext().auth.auth_context().await.map(|_| ())
@@ -731,7 +731,7 @@ pub struct CompletionModel<H = reqwest::Client> {
 impl<H> CompletionModel<H>
 where
     Client<H>: HttpClientExt + Clone + Debug + 'static,
-    H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + Default + Debug + MaybeSend + MaybeSync + 'static,
 {
     pub fn new(client: Client<H>, model: impl Into<String>) -> Self {
         Self {
@@ -1231,7 +1231,7 @@ where
 impl<H> completion::CompletionModel for CompletionModel<H>
 where
     Client<H>: HttpClientExt + Clone + Debug + 'static,
-    H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + Default + Debug + MaybeSend + MaybeSync + 'static,
 {
     type Response = CopilotCompletionResponse;
     type StreamingResponse = CopilotStreamingResponse;
@@ -1299,8 +1299,8 @@ where
 
 impl<H> embeddings::EmbeddingModel for EmbeddingModel<H>
 where
-    Client<H>: HttpClientExt + Clone + Debug + WasmCompatSend + WasmCompatSync + 'static,
-    H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
+    Client<H>: HttpClientExt + Clone + Debug + MaybeSend + MaybeSync + 'static,
+    H: Clone + Default + Debug + MaybeSend + MaybeSync + 'static,
 {
     const MAX_DOCUMENTS: usize = 1024;
     type Client = Client<H>;
@@ -1462,7 +1462,7 @@ pub struct CopilotModelLister<H = reqwest::Client> {
 
 impl<H> ModelLister<H> for CopilotModelLister<H>
 where
-    H: HttpClientExt + Clone + Debug + Default + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + Clone + Debug + Default + MaybeSend + MaybeSync + 'static,
 {
     type Client = Client<H>;
 

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -27,7 +27,7 @@ use crate::{
     OneOrMany,
     completion::{self, CompletionError},
     json_utils,
-    wasm_compat::{WasmCompatSend, WasmCompatSync},
+    wasm_compat::{MaybeSend, MaybeSync},
 };
 use serde::{Deserialize, Serialize};
 
@@ -435,7 +435,7 @@ pub struct DeepSeekModelLister<H = reqwest::Client> {
 
 impl<H> ModelLister<H> for DeepSeekModelLister<H>
 where
-    H: HttpClientExt + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + MaybeSend + MaybeSync + 'static,
 {
     type Client = Client<H>;
 

--- a/crates/rig-core/src/providers/doubleword/embedding.rs
+++ b/crates/rig-core/src/providers/doubleword/embedding.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 use crate::{
     embeddings::{self, EmbeddingError},
     http_client::{self, HttpClientExt},
-    wasm_compat::{WasmCompatSend, WasmCompatSync},
+    wasm_compat::{MaybeSend, MaybeSync},
 };
 
 use super::{Client, client::doubleword_api_types::ApiResponse};
@@ -48,7 +48,7 @@ pub struct EmbeddingModel<T = reqwest::Client> {
 
 impl<T> embeddings::EmbeddingModel for EmbeddingModel<T>
 where
-    T: HttpClientExt + Default + Clone + WasmCompatSend + WasmCompatSync + 'static,
+    T: HttpClientExt + Default + Clone + MaybeSend + MaybeSync + 'static,
 {
     // Conservative default; adjust to Doubleword's documented limit if it differs.
     const MAX_DOCUMENTS: usize = 1024;

--- a/crates/rig-core/src/providers/gemini/embedding.rs
+++ b/crates/rig-core/src/providers/gemini/embedding.rs
@@ -9,7 +9,7 @@ use super::{Client, client::ApiResponse};
 use crate::{
     embeddings::{self, EmbeddingError},
     http_client::HttpClientExt,
-    wasm_compat::WasmCompatSend,
+    wasm_compat::MaybeSend,
 };
 
 /// `gemini-embedding-001` embedding model (3072 dimensions by default)
@@ -74,7 +74,7 @@ where
     /// <https://ai.google.dev/api/embeddings#batch_embed_contents-SHELL>
     async fn embed_texts(
         &self,
-        documents: impl IntoIterator<Item = String> + WasmCompatSend,
+        documents: impl IntoIterator<Item = String> + MaybeSend,
     ) -> Result<Vec<embeddings::Embedding>, EmbeddingError> {
         let documents: Vec<String> = documents.into_iter().collect();
 

--- a/crates/rig-core/src/providers/gemini/image_generation.rs
+++ b/crates/rig-core/src/providers/gemini/image_generation.rs
@@ -49,7 +49,7 @@ impl TryFrom<GenerateContentResponse>
 
 impl<T> image_generation::ImageGenerationModel for ImageGenerationModel<T>
 where
-    T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+    T: HttpClientExt + Clone + Default + std::fmt::Debug + 'static,
 {
     type Response = GenerateContentResponse;
 

--- a/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
@@ -1,7 +1,6 @@
 use async_stream::stream;
-use futures::{Stream, StreamExt};
+use futures::StreamExt;
 use serde::{Deserialize, Serialize};
-use std::pin::Pin;
 use tracing::{Level, enabled};
 use tracing_futures::Instrument;
 
@@ -34,11 +33,11 @@ pub struct StreamingCompletionResponse {
 
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 pub type InteractionEventStream =
-    Pin<Box<dyn Stream<Item = Result<InteractionSseEvent, CompletionError>> + Send>>;
+    futures::stream::BoxStream<'static, Result<InteractionSseEvent, CompletionError>>;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub type InteractionEventStream =
-    Pin<Box<dyn Stream<Item = Result<InteractionSseEvent, CompletionError>>>>;
+    futures::stream::LocalBoxStream<'static, Result<InteractionSseEvent, CompletionError>>;
 
 impl GetTokenUsage for StreamingCompletionResponse {
     fn token_usage(&self) -> crate::completion::Usage {

--- a/crates/rig-core/src/providers/gemini/model_listing.rs
+++ b/crates/rig-core/src/providers/gemini/model_listing.rs
@@ -3,7 +3,7 @@ use crate::{
     http_client::{self, HttpClientExt},
     model::{Model, ModelList, ModelListingError},
     providers::gemini::{Client, InteractionsClient},
-    wasm_compat::{WasmCompatSend, WasmCompatSync},
+    wasm_compat::{MaybeSend, MaybeSync},
 };
 use serde::Deserialize;
 use std::{convert::TryFrom, fmt};
@@ -113,8 +113,8 @@ async fn list_all_models<Ext, H>(
     client: &client::Client<Ext, H>,
 ) -> Result<ModelList, ModelListingError>
 where
-    Ext: Provider + WasmCompatSend + WasmCompatSync + 'static,
-    H: HttpClientExt + WasmCompatSend + WasmCompatSync + 'static,
+    Ext: Provider + MaybeSend + MaybeSync + 'static,
+    H: HttpClientExt + MaybeSend + MaybeSync + 'static,
 {
     let mut all_models = Vec::new();
     let mut next_page_token: Option<String> = None;
@@ -157,7 +157,7 @@ pub struct GeminiModelLister<H = reqwest::Client> {
 
 impl<H> ModelLister<H> for GeminiModelLister<H>
 where
-    H: HttpClientExt + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + MaybeSend + MaybeSync + 'static,
 {
     type Client = Client<H>;
 
@@ -283,7 +283,7 @@ pub struct GeminiInteractionsModelLister<H = reqwest::Client> {
 
 impl<H> ModelLister<H> for GeminiInteractionsModelLister<H>
 where
-    H: HttpClientExt + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + MaybeSend + MaybeSync + 'static,
 {
     type Client = InteractionsClient<H>;
 

--- a/crates/rig-core/src/providers/gemini/transcription.rs
+++ b/crates/rig-core/src/providers/gemini/transcription.rs
@@ -10,7 +10,7 @@ use crate::{
         Blob, Content, GenerateContentRequest, GenerationConfig, Part, PartKind, Role,
     },
     transcription::{self, TranscriptionError},
-    wasm_compat::{WasmCompatSend, WasmCompatSync},
+    wasm_compat::{MaybeSend, MaybeSync},
 };
 
 use super::{Client, completion::gemini_api_types::GenerateContentResponse};
@@ -36,7 +36,7 @@ impl<T> TranscriptionModel<T> {
 
 impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
 where
-    T: HttpClientExt + WasmCompatSend + WasmCompatSync + Clone + 'static,
+    T: HttpClientExt + MaybeSend + MaybeSync + Clone + 'static,
 {
     type Response = GenerateContentResponse;
     type Client = Client<T>;

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -281,7 +281,7 @@ impl<T> TranscriptionModel<T> {
 }
 impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
 where
-    T: HttpClientExt + Clone + Send + std::fmt::Debug + Default + 'static,
+    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
 {
     type Response = TranscriptionResponse;
 

--- a/crates/rig-core/src/providers/huggingface/image_generation.rs
+++ b/crates/rig-core/src/providers/huggingface/image_generation.rs
@@ -47,7 +47,7 @@ impl<T> ImageGenerationModel<T> {
 
 impl<T> image_generation::ImageGenerationModel for ImageGenerationModel<T>
 where
-    T: HttpClientExt + Send + Clone + 'static,
+    T: HttpClientExt + Clone + 'static,
 {
     type Response = ImageGenerationResponse;
 

--- a/crates/rig-core/src/providers/huggingface/transcription.rs
+++ b/crates/rig-core/src/providers/huggingface/transcription.rs
@@ -3,7 +3,7 @@ use crate::providers::huggingface::Client;
 use crate::providers::huggingface::completion::ApiResponse;
 use crate::transcription;
 use crate::transcription::TranscriptionError;
-use crate::wasm_compat::WasmCompatSync;
+use crate::wasm_compat::MaybeSync;
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
 use serde::Deserialize;
@@ -49,7 +49,7 @@ impl<T> TranscriptionModel<T> {
 }
 impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
 where
-    T: HttpClientExt + Clone + WasmCompatSync + 'static,
+    T: HttpClientExt + Clone + MaybeSync + 'static,
 {
     type Response = TranscriptionResponse;
 

--- a/crates/rig-core/src/providers/hyperbolic.rs
+++ b/crates/rig-core/src/providers/hyperbolic.rs
@@ -262,7 +262,7 @@ mod image_generation {
 
     impl<T> image_generation::ImageGenerationModel for ImageGenerationModel<T>
     where
-        T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+        T: HttpClientExt + Clone + Default + std::fmt::Debug + 'static,
     {
         type Response = ImageGenerationResponse;
 
@@ -372,7 +372,7 @@ mod audio_generation {
 
     impl<T> audio_generation::AudioGenerationModel for AudioGenerationModel<T>
     where
-        T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+        T: HttpClientExt + Clone + Default + std::fmt::Debug + 'static,
     {
         type Response = AudioGenerationResponse;
         type Client = Client<T>;

--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
@@ -18,7 +18,7 @@ use crate::http_client::HttpClientExt;
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::json_utils;
 use crate::streaming::{self, RawStreamingChoice, RawStreamingToolCall, ToolCallDeltaContent};
-use crate::wasm_compat::WasmCompatSend;
+use crate::wasm_compat::MaybeSend;
 
 fn provider_response_from_compatible_sse_data(data: &str) -> Option<CompletionError> {
     let value = serde_json::from_str::<serde_json::Value>(data).ok()?;
@@ -155,10 +155,10 @@ where
         .collect()
 }
 
-pub(crate) trait CompatibleStreamProfile: WasmCompatSend {
-    type Usage: Clone + Default + GetTokenUsage + WasmCompatSend + 'static;
-    type Detail: WasmCompatSend + 'static;
-    type FinalResponse: Clone + Unpin + GetTokenUsage + WasmCompatSend + 'static;
+pub(crate) trait CompatibleStreamProfile: MaybeSend {
+    type Usage: Clone + Default + GetTokenUsage + MaybeSend + 'static;
+    type Detail: MaybeSend + 'static;
+    type FinalResponse: Clone + Unpin + GetTokenUsage + MaybeSend + 'static;
 
     fn normalize_chunk(&self, data: &str) -> NormalizedCompatibleChunk<Self::Usage, Self::Detail>;
 

--- a/crates/rig-core/src/providers/mistral/model_listing.rs
+++ b/crates/rig-core/src/providers/mistral/model_listing.rs
@@ -3,7 +3,7 @@ use crate::{
     http_client::{self, HttpClientExt},
     model::{Model, ModelList, ModelListingError},
     providers::mistral::Client,
-    wasm_compat::{WasmCompatSend, WasmCompatSync},
+    wasm_compat::{MaybeSend, MaybeSync},
 };
 use serde::Deserialize;
 
@@ -38,7 +38,7 @@ pub struct MistralModelLister<H = reqwest::Client> {
 
 impl<H> ModelLister<H> for MistralModelLister<H>
 where
-    H: HttpClientExt + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + MaybeSend + MaybeSync + 'static,
 {
     type Client = Client<H>;
 

--- a/crates/rig-core/src/providers/mistral/transcription.rs
+++ b/crates/rig-core/src/providers/mistral/transcription.rs
@@ -6,7 +6,7 @@ use crate::http_client::multipart::Part;
 use crate::http_client::{HttpClientExt, MultipartForm};
 use crate::providers::mistral::Client;
 use crate::transcription::{self, TranscriptionError};
-use crate::wasm_compat::WasmCompatSend;
+use crate::wasm_compat::MaybeSend;
 
 // ================================================================
 // Mistral Transcription API
@@ -98,7 +98,7 @@ pub struct TranscriptionModel<T = reqwest::Client> {
 
 impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + WasmCompatSend + 'static,
+    T: HttpClientExt + Clone + std::fmt::Debug + Default + MaybeSend + 'static,
 {
     type Response = MistralTranscriptionResponse;
     type Client = Client<T>;

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -55,7 +55,7 @@ use crate::{
     json_utils, message,
     message::{ImageDetail, Text},
     streaming,
-    wasm_compat::{WasmCompatSend, WasmCompatSync},
+    wasm_compat::{MaybeSend, MaybeSync},
 };
 use async_stream::try_stream;
 use bytes::Bytes;
@@ -658,7 +658,7 @@ impl NdjsonBuffer {
 
 impl<T> completion::CompletionModel for CompletionModel<T>
 where
-    T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+    T: HttpClientExt + Clone + Default + std::fmt::Debug + 'static,
 {
     type Response = CompletionResponse;
     type StreamingResponse = StreamingCompletionResponse;
@@ -880,7 +880,7 @@ pub struct OllamaModelLister<H = reqwest::Client> {
 
 impl<H> ModelLister<H> for OllamaModelLister<H>
 where
-    H: HttpClientExt + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + MaybeSend + MaybeSync + 'static,
 {
     type Client = Client<H>;
 

--- a/crates/rig-core/src/providers/openai/client.rs
+++ b/crates/rig-core/src/providers/openai/client.rs
@@ -5,7 +5,7 @@ use crate::{
         ProviderClient,
     },
     http_client::{self, HttpClientExt},
-    wasm_compat::{WasmCompatSend, WasmCompatSync},
+    wasm_compat::{MaybeSend, MaybeSync},
 };
 use serde::Deserialize;
 use std::fmt::Debug;
@@ -139,13 +139,7 @@ impl ProviderBuilder for OpenAICompletionsExtBuilder {
 
 impl<H> Client<H>
 where
-    H: HttpClientExt
-        + Clone
-        + std::fmt::Debug
-        + Default
-        + WasmCompatSend
-        + WasmCompatSync
-        + 'static,
+    H: HttpClientExt + Clone + std::fmt::Debug + Default + MaybeSend + MaybeSync + 'static,
 {
     /// Sets where Rig system instructions are placed in Responses requests for
     /// every completion model created from this client. Models capture the
@@ -209,13 +203,7 @@ impl Client<reqwest::Client> {
 
 impl<H> CompletionsClient<H>
 where
-    H: HttpClientExt
-        + Clone
-        + std::fmt::Debug
-        + Default
-        + WasmCompatSend
-        + WasmCompatSync
-        + 'static,
+    H: HttpClientExt + Clone + std::fmt::Debug + Default + MaybeSend + MaybeSync + 'static,
 {
     /// Create a Responses API client from this Completions API client.
     /// Useful for switching to the newer Responses API. A system-instructions

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -12,7 +12,7 @@ use crate::one_or_many::string_or_one_or_many;
 use crate::telemetry::{
     CompletionOperation, CompletionSpanBuilder, ProviderResponseExt, SpanCombinator,
 };
-use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use crate::wasm_compat::{MaybeSend, MaybeSync};
 use crate::{OneOrMany, completion, json_utils, message};
 use serde::{Deserialize, Serialize, Serializer};
 use std::convert::Infallible;
@@ -1443,8 +1443,8 @@ pub trait OpenAICompatibleProvider: crate::client::Provider {
         + Serialize
         + serde::de::DeserializeOwned
         + Unpin
-        + WasmCompatSend
-        + WasmCompatSync
+        + MaybeSend
+        + MaybeSync
         + 'static;
 
     /// The chat-completions payload this provider returns.
@@ -1452,8 +1452,8 @@ pub trait OpenAICompatibleProvider: crate::client::Provider {
         + Serialize
         + crate::telemetry::ProviderResponseExt<Usage: GetTokenUsage>
         + TryInto<completion::CompletionResponse<Self::Response>, Error = CompletionError>
-        + WasmCompatSend
-        + WasmCompatSync;
+        + MaybeSend
+        + MaybeSync;
 
     /// The request path for chat completions, resolved against the client
     /// base URL by [`Provider::build_uri`](crate::client::Provider::build_uri).
@@ -1903,16 +1903,15 @@ impl TryFrom<(String, CoreCompletionRequest)> for CompletionRequest {
 
 impl<Ext, H> completion::CompletionModel for GenericCompletionModel<Ext, H>
 where
-    crate::client::Client<Ext, H>:
-        HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
+    crate::client::Client<Ext, H>: HttpClientExt + Clone + MaybeSend + MaybeSync + 'static,
     Ext: crate::client::Provider
         + OpenAICompatibleProvider
         + crate::client::DebugExt
         + Clone
-        + WasmCompatSend
-        + WasmCompatSync
+        + MaybeSend
+        + MaybeSync
         + 'static,
-    H: Clone + Default + std::fmt::Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + Default + std::fmt::Debug + MaybeSend + MaybeSync + 'static,
 {
     type Response = Ext::Response;
     type StreamingResponse = StreamingCompletionResponse<Ext::StreamingUsage>;

--- a/crates/rig-core/src/providers/openai/completion/streaming.rs
+++ b/crates/rig-core/src/providers/openai/completion/streaming.rs
@@ -135,7 +135,7 @@ where
     Ext: crate::client::Provider
         + OpenAICompatibleProvider
         + Clone
-        + crate::wasm_compat::WasmCompatSend
+        + crate::wasm_compat::MaybeSend
         + 'static,
 {
     pub(crate) async fn stream(
@@ -241,12 +241,12 @@ struct OpenAICompatibleProfile<Ext = crate::providers::openai::OpenAICompletions
 
 impl<Ext, U> CompatibleStreamProfile for OpenAICompatibleProfile<Ext, U>
 where
-    Ext: OpenAICompatibleProvider + Clone + crate::wasm_compat::WasmCompatSend,
+    Ext: OpenAICompatibleProvider + Clone + crate::wasm_compat::MaybeSend,
     U: Clone
         + Default
         + GetTokenUsage
         + serde::de::DeserializeOwned
-        + crate::wasm_compat::WasmCompatSend
+        + crate::wasm_compat::MaybeSend
         + Unpin
         + 'static,
 {

--- a/crates/rig-core/src/providers/openai/embedding.rs
+++ b/crates/rig-core/src/providers/openai/embedding.rs
@@ -1,7 +1,7 @@
 use super::{client::ApiResponse, completion::Usage};
 use crate::embeddings::EmbeddingError;
 use crate::http_client::HttpClientExt;
-use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use crate::wasm_compat::{MaybeSend, MaybeSync};
 use crate::{embeddings, http_client};
 use serde::{Deserialize, Serialize};
 
@@ -137,8 +137,7 @@ fn model_dimensions_from_identifier(identifier: &str) -> Option<usize> {
 
 impl<Ext, H> embeddings::EmbeddingModel for GenericEmbeddingModel<Ext, H>
 where
-    crate::client::Client<Ext, H>:
-        HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
+    crate::client::Client<Ext, H>: HttpClientExt + Clone + MaybeSend + MaybeSync + 'static,
     Ext: OpenAIEmbeddingsCompatible + Clone + 'static,
 {
     const MAX_DOCUMENTS: usize = 1024;
@@ -366,10 +365,10 @@ mod tests {
         fn send<T, U>(
             &self,
             _req: Request<T>,
-        ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+        ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + MaybeSend + 'static
         where
-            T: Into<Bytes> + WasmCompatSend,
-            U: From<Bytes> + WasmCompatSend + 'static,
+            T: Into<Bytes> + MaybeSend,
+            U: From<Bytes> + MaybeSend + 'static,
         {
             future::ready(Err(http_client::Error::StreamEnded))
         }
@@ -377,9 +376,9 @@ mod tests {
         fn send_multipart<U>(
             &self,
             _req: Request<MultipartForm>,
-        ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+        ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + MaybeSend + 'static
         where
-            U: From<Bytes> + WasmCompatSend + 'static,
+            U: From<Bytes> + MaybeSend + 'static,
         {
             future::ready(Err(http_client::Error::StreamEnded))
         }
@@ -387,9 +386,9 @@ mod tests {
         fn send_streaming<T>(
             &self,
             _req: Request<T>,
-        ) -> impl Future<Output = http_client::Result<StreamingResponse>> + WasmCompatSend
+        ) -> impl Future<Output = http_client::Result<StreamingResponse>> + MaybeSend
         where
-            T: Into<Bytes> + WasmCompatSend,
+            T: Into<Bytes> + MaybeSend,
         {
             future::ready(Err(http_client::Error::StreamEnded))
         }

--- a/crates/rig-core/src/providers/openai/image_generation.rs
+++ b/crates/rig-core/src/providers/openai/image_generation.rs
@@ -70,7 +70,7 @@ impl<T> ImageGenerationModel<T> {
 
 impl<T> image_generation::ImageGenerationModel for ImageGenerationModel<T>
 where
-    T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+    T: HttpClientExt + Clone + Default + std::fmt::Debug + 'static,
 {
     type Response = ImageGenerationResponse;
 

--- a/crates/rig-core/src/providers/openai/model_listing.rs
+++ b/crates/rig-core/src/providers/openai/model_listing.rs
@@ -3,7 +3,7 @@ use crate::{
     http_client::{self, HttpClientExt},
     model::{Model, ModelList, ModelListingError},
     providers::openai::Client,
-    wasm_compat::{WasmCompatSend, WasmCompatSync},
+    wasm_compat::{MaybeSend, MaybeSync},
 };
 use serde::Deserialize;
 
@@ -36,7 +36,7 @@ pub struct OpenAIModelLister<H = reqwest::Client> {
 
 impl<H> ModelLister<H> for OpenAIModelLister<H>
 where
-    H: HttpClientExt + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + MaybeSend + MaybeSync + 'static,
 {
     type Client = Client<H>;
 

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -26,7 +26,7 @@ use crate::message::{
 use crate::one_or_many::string_or_one_or_many;
 use crate::telemetry::{CompletionOperation, CompletionSpanBuilder};
 
-use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use crate::wasm_compat::{MaybeSend, MaybeSync};
 use crate::{OneOrMany, completion, message};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{Map, Value};
@@ -2204,16 +2204,15 @@ pub enum OutputRole {
 
 impl<Ext, H> completion::CompletionModel for GenericResponsesCompletionModel<Ext, H>
 where
-    crate::client::Client<Ext, H>:
-        HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
+    crate::client::Client<Ext, H>: HttpClientExt + Clone + MaybeSend + MaybeSync + 'static,
     Ext: crate::client::Provider
         + ResponsesProviderExt
         + crate::client::DebugExt
         + Clone
-        + WasmCompatSend
-        + WasmCompatSync
+        + MaybeSend
+        + MaybeSync
         + 'static,
-    H: Clone + Default + std::fmt::Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + Default + std::fmt::Debug + MaybeSend + MaybeSync + 'static,
 {
     type Response = CompletionResponse;
     type StreamingResponse = StreamingCompletionResponse;

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -8,7 +8,7 @@ use crate::providers::openai::responses_api::{ReasoningSummary, ResponsesUsage};
 use crate::streaming;
 use crate::streaming::RawStreamingChoice;
 use crate::telemetry::{CompletionOperation, CompletionSpanBuilder};
-use crate::wasm_compat::WasmCompatSend;
+use crate::wasm_compat::MaybeSend;
 use async_stream::stream;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -606,7 +606,7 @@ pub(crate) fn stream_from_event_source<HttpClient, RequestBody>(
 ) -> streaming::StreamingCompletionResponse<StreamingCompletionResponse>
 where
     HttpClient: HttpClientExt + Clone + 'static,
-    RequestBody: Into<bytes::Bytes> + Clone + WasmCompatSend + 'static,
+    RequestBody: Into<bytes::Bytes> + Clone + MaybeSend + 'static,
 {
     stream_from_event_source_with_options(event_source, span, ResponsesStreamOptions::strict())
 }
@@ -618,7 +618,7 @@ pub(crate) fn stream_from_event_source_with_options<HttpClient, RequestBody>(
 ) -> streaming::StreamingCompletionResponse<StreamingCompletionResponse>
 where
     HttpClient: HttpClientExt + Clone + 'static,
-    RequestBody: Into<bytes::Bytes> + Clone + WasmCompatSend + 'static,
+    RequestBody: Into<bytes::Bytes> + Clone + MaybeSend + 'static,
 {
     let stream = stream! {
         let mut accumulator = RawChoiceAccumulator::new(ResponsesUsage::new());
@@ -851,10 +851,9 @@ pub enum SummaryPartChunkPart {
 
 impl<Ext, H> GenericResponsesCompletionModel<Ext, H>
 where
-    crate::client::Client<Ext, H>:
-        HttpClientExt + Clone + std::fmt::Debug + WasmCompatSend + 'static,
+    crate::client::Client<Ext, H>: HttpClientExt + Clone + std::fmt::Debug + MaybeSend + 'static,
     Ext: crate::client::Provider + super::ResponsesProviderExt + Clone + 'static,
-    H: Clone + Default + std::fmt::Debug + WasmCompatSend + 'static,
+    H: Clone + Default + std::fmt::Debug + MaybeSend + 'static,
 {
     pub(crate) async fn stream(
         &self,

--- a/crates/rig-core/src/providers/openai/responses_api/websocket.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/websocket.rs
@@ -9,7 +9,7 @@ use crate::http_client::HttpClientExt;
 use crate::providers::openai::responses_api::streaming::{
     ItemChunk, ResponseChunk, ResponseChunkKind, StreamingCompletionChunk,
 };
-use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use crate::wasm_compat::{MaybeSend, MaybeSync};
 use futures::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -237,13 +237,7 @@ impl<H> ResponsesWebSocketSessionBuilder<H> {
 
 impl<H> ResponsesWebSocketSessionBuilder<H>
 where
-    H: HttpClientExt
-        + Clone
-        + std::fmt::Debug
-        + Default
-        + WasmCompatSend
-        + WasmCompatSync
-        + 'static,
+    H: HttpClientExt + Clone + std::fmt::Debug + Default + MaybeSend + MaybeSync + 'static,
 {
     /// Opens the websocket session using the configured builder options.
     pub async fn connect(self) -> Result<ResponsesWebSocketSession<H>, CompletionError> {
@@ -277,13 +271,7 @@ pub struct ResponsesWebSocketSession<H = reqwest::Client> {
 
 impl<H> ResponsesWebSocketSession<H>
 where
-    H: HttpClientExt
-        + Clone
-        + std::fmt::Debug
-        + Default
-        + WasmCompatSend
-        + WasmCompatSync
-        + 'static,
+    H: HttpClientExt + Clone + std::fmt::Debug + Default + MaybeSend + MaybeSync + 'static,
 {
     async fn connect_with_timeouts(
         model: ResponsesCompletionModel<H>,

--- a/crates/rig-core/src/providers/openai/transcription.rs
+++ b/crates/rig-core/src/providers/openai/transcription.rs
@@ -48,7 +48,7 @@ impl<T> TranscriptionModel<T> {
 
 impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + Send + 'static,
+    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
 {
     type Response = TranscriptionResponse;
 

--- a/crates/rig-core/src/providers/openrouter/audio_generation.rs
+++ b/crates/rig-core/src/providers/openrouter/audio_generation.rs
@@ -3,7 +3,7 @@ use crate::audio_generation::{
 };
 use crate::http_client::{self, HttpClientExt};
 use crate::providers::openrouter::Client;
-use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use crate::wasm_compat::{MaybeSend, MaybeSync};
 use bytes::Bytes;
 use serde_json::json;
 
@@ -39,13 +39,7 @@ impl<T> AudioGenerationModel<T> {
 
 impl<T> audio_generation::AudioGenerationModel for AudioGenerationModel<T>
 where
-    T: HttpClientExt
-        + Clone
-        + std::fmt::Debug
-        + Default
-        + WasmCompatSend
-        + WasmCompatSync
-        + 'static,
+    T: HttpClientExt + Clone + std::fmt::Debug + Default + MaybeSend + MaybeSync + 'static,
 {
     type Response = Bytes;
     type Client = Client<T>;

--- a/crates/rig-core/src/providers/openrouter/model_listing.rs
+++ b/crates/rig-core/src/providers/openrouter/model_listing.rs
@@ -3,7 +3,7 @@ use crate::{
     http_client::{self, HttpClientExt},
     model::{Model, ModelList, ModelListingError},
     providers::openrouter::Client,
-    wasm_compat::{WasmCompatSend, WasmCompatSync},
+    wasm_compat::{MaybeSend, MaybeSync},
 };
 use serde::Deserialize;
 
@@ -43,7 +43,7 @@ pub struct OpenRouterModelLister<H = reqwest::Client> {
 
 impl<H> ModelLister<H> for OpenRouterModelLister<H>
 where
-    H: HttpClientExt + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + MaybeSend + MaybeSync + 'static,
 {
     type Client = Client<H>;
 

--- a/crates/rig-core/src/providers/openrouter/transcription.rs
+++ b/crates/rig-core/src/providers/openrouter/transcription.rs
@@ -2,7 +2,7 @@ use crate::http_client::HttpClientExt;
 use crate::providers::openrouter::Client;
 use crate::transcription;
 use crate::transcription::TranscriptionError;
-use crate::wasm_compat::WasmCompatSend;
+use crate::wasm_compat::MaybeSend;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
 use bytes::Bytes;
@@ -120,7 +120,7 @@ fn infer_format_from_filename(filename: &str) -> String {
 
 impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + WasmCompatSend + 'static,
+    T: HttpClientExt + Clone + std::fmt::Debug + Default + MaybeSend + 'static,
 {
     type Response = TranscriptionResponse;
     type Client = Client<T>;

--- a/crates/rig-core/src/providers/xai/completion.rs
+++ b/crates/rig-core/src/providers/xai/completion.rs
@@ -186,7 +186,7 @@ impl<T> CompletionModel<T> {
 
 impl<T> completion::CompletionModel for CompletionModel<T>
 where
-    T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+    T: HttpClientExt + Clone + Default + std::fmt::Debug + 'static,
 {
     type Response = CompletionResponse;
     type StreamingResponse = StreamingCompletionResponse;

--- a/crates/rig-core/src/providers/xai/image_generation.rs
+++ b/crates/rig-core/src/providers/xai/image_generation.rs
@@ -65,7 +65,7 @@ impl<T> ImageGenerationModel<T> {
 
 impl<T> image_generation::ImageGenerationModel for ImageGenerationModel<T>
 where
-    T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+    T: HttpClientExt + Clone + Default + std::fmt::Debug + 'static,
 {
     type Response = ImageGenerationResponse;
 

--- a/crates/rig-core/src/providers/xiaomimimo.rs
+++ b/crates/rig-core/src/providers/xiaomimimo.rs
@@ -30,7 +30,7 @@ use crate::model::{Model, ModelList, ModelListingError};
 use crate::providers::anthropic::client::{
     AnthropicBuilder as AnthropicCompatBuilder, AnthropicKey, finish_anthropic_builder,
 };
-use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use crate::wasm_compat::{MaybeSend, MaybeSync};
 
 /// OpenAI-compatible base URL.
 pub const API_BASE_URL: &str = "https://api.xiaomimimo.com/v1";
@@ -306,7 +306,7 @@ pub struct XiaomiMimoModelLister<H = reqwest::Client> {
 
 impl<H> ModelLister<H> for XiaomiMimoModelLister<H>
 where
-    H: HttpClientExt + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + MaybeSend + MaybeSync + 'static,
 {
     type Client = Client<H>;
 

--- a/crates/rig-core/src/rerank.rs
+++ b/crates/rig-core/src/rerank.rs
@@ -7,7 +7,7 @@
 use crate::{
     completion::Usage,
     http_client, provider_response,
-    wasm_compat::{WasmCompatSend, WasmCompatSync},
+    wasm_compat::{MaybeSend, MaybeSync},
 };
 use serde::{Deserialize, Serialize};
 
@@ -41,7 +41,7 @@ pub enum RerankError {
 crate::provider_response::impl_provider_response_helpers!(RerankError);
 
 /// Trait for reranking models that score documents by relevance to a query.
-pub trait RerankModel: WasmCompatSend + WasmCompatSync {
+pub trait RerankModel: MaybeSend + MaybeSync {
     /// The maximum number of documents that can be reranked in a single request.
     const MAX_DOCUMENTS: usize;
 
@@ -56,7 +56,7 @@ pub trait RerankModel: WasmCompatSend + WasmCompatSync {
         &self,
         query: &str,
         documents: Vec<String>,
-    ) -> impl std::future::Future<Output = Result<RerankResponse, RerankError>> + WasmCompatSend;
+    ) -> impl std::future::Future<Output = Result<RerankResponse, RerankError>> + MaybeSend;
 }
 
 /// A single reranked document result.

--- a/crates/rig-core/src/streaming.rs
+++ b/crates/rig-core/src/streaming.rs
@@ -221,12 +221,12 @@ impl From<RawStreamingToolCall> for ToolCall {
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 /// Provider stream of raw completion chunks on native targets.
 pub type StreamingResult<R> =
-    Pin<Box<dyn Stream<Item = Result<RawStreamingChoice<R>, CompletionError>> + Send>>;
+    futures::stream::BoxStream<'static, Result<RawStreamingChoice<R>, CompletionError>>;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 /// Provider stream of raw completion chunks on wasm targets.
 pub type StreamingResult<R> =
-    Pin<Box<dyn Stream<Item = Result<RawStreamingChoice<R>, CompletionError>>>>;
+    futures::stream::LocalBoxStream<'static, Result<RawStreamingChoice<R>, CompletionError>>;
 
 /// The response from a streaming completion request;
 /// message and response are populated at the end of the

--- a/crates/rig-core/src/test_utils/embeddings.rs
+++ b/crates/rig-core/src/test_utils/embeddings.rs
@@ -7,7 +7,7 @@ use crate::{
         Embedding, EmbeddingError, EmbeddingModel,
         embed::{EmbedError, TextEmbedder},
     },
-    wasm_compat::WasmCompatSend,
+    wasm_compat::MaybeSend,
 };
 
 /// A deterministic [`EmbeddingModel`] that returns a fixed vector for each input document.
@@ -29,7 +29,7 @@ impl EmbeddingModel for MockEmbeddingModel {
 
     async fn embed_texts(
         &self,
-        documents: impl IntoIterator<Item = String> + WasmCompatSend,
+        documents: impl IntoIterator<Item = String> + MaybeSend,
     ) -> Result<Vec<Embedding>, EmbeddingError> {
         Ok(documents
             .into_iter()

--- a/crates/rig-core/src/test_utils/http.rs
+++ b/crates/rig-core/src/test_utils/http.rs
@@ -12,7 +12,7 @@ use crate::{
     http_client::{
         self, HttpClientExt, LazyBody, MultipartForm, Request, Response, StreamingResponse,
     },
-    wasm_compat::WasmCompatSend,
+    wasm_compat::MaybeSend,
 };
 
 /// Request data captured by [`RecordingHttpClient`].
@@ -126,7 +126,7 @@ impl RecordingHttpClient {
         response: MockHttpResponse,
     ) -> http_client::Result<Response<LazyBody<U>>>
     where
-        U: From<Bytes> + WasmCompatSend + 'static,
+        U: From<Bytes> + MaybeSend + 'static,
     {
         let (status, response_body) = match response {
             MockHttpResponse::Success(response_body) => (http::StatusCode::OK, response_body),
@@ -149,10 +149,10 @@ impl HttpClientExt for RecordingHttpClient {
     fn send<T, U>(
         &self,
         req: Request<T>,
-    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + MaybeSend + 'static
     where
-        T: Into<Bytes> + WasmCompatSend,
-        U: From<Bytes> + WasmCompatSend + 'static,
+        T: Into<Bytes> + MaybeSend,
+        U: From<Bytes> + MaybeSend + 'static,
     {
         let response = self.response_guard().clone();
         let (parts, body) = req.into_parts();
@@ -164,9 +164,9 @@ impl HttpClientExt for RecordingHttpClient {
     fn send_multipart<U>(
         &self,
         req: Request<MultipartForm>,
-    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + MaybeSend + 'static
     where
-        U: From<Bytes> + WasmCompatSend + 'static,
+        U: From<Bytes> + MaybeSend + 'static,
     {
         let response = self.response_guard().clone();
         let (parts, _body) = req.into_parts();
@@ -178,9 +178,9 @@ impl HttpClientExt for RecordingHttpClient {
     fn send_streaming<T>(
         &self,
         _req: Request<T>,
-    ) -> impl Future<Output = http_client::Result<StreamingResponse>> + WasmCompatSend
+    ) -> impl Future<Output = http_client::Result<StreamingResponse>> + MaybeSend
     where
-        T: Into<Bytes> + WasmCompatSend,
+        T: Into<Bytes> + MaybeSend,
     {
         future::ready(Err(http_client::Error::InvalidStatusCode(
             http::StatusCode::NOT_IMPLEMENTED,
@@ -244,10 +244,10 @@ impl HttpClientExt for SequencedHttpClient {
     fn send<T, U>(
         &self,
         req: Request<T>,
-    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + MaybeSend + 'static
     where
-        T: Into<Bytes> + WasmCompatSend,
-        U: From<Bytes> + WasmCompatSend + 'static,
+        T: Into<Bytes> + MaybeSend,
+        U: From<Bytes> + MaybeSend + 'static,
     {
         let response = self.next_response();
         let (parts, body) = req.into_parts();
@@ -266,9 +266,9 @@ impl HttpClientExt for SequencedHttpClient {
     fn send_multipart<U>(
         &self,
         req: Request<MultipartForm>,
-    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + MaybeSend + 'static
     where
-        U: From<Bytes> + WasmCompatSend + 'static,
+        U: From<Bytes> + MaybeSend + 'static,
     {
         let response = self.next_response();
         let (parts, _body) = req.into_parts();
@@ -287,9 +287,9 @@ impl HttpClientExt for SequencedHttpClient {
     fn send_streaming<T>(
         &self,
         _req: Request<T>,
-    ) -> impl Future<Output = http_client::Result<StreamingResponse>> + WasmCompatSend
+    ) -> impl Future<Output = http_client::Result<StreamingResponse>> + MaybeSend
     where
-        T: Into<Bytes> + WasmCompatSend,
+        T: Into<Bytes> + MaybeSend,
     {
         future::ready(Err(http_client::Error::InvalidStatusCode(
             http::StatusCode::NOT_IMPLEMENTED,
@@ -310,10 +310,10 @@ impl HttpClientExt for MockStreamingClient {
     fn send<T, U>(
         &self,
         _req: Request<T>,
-    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + MaybeSend + 'static
     where
-        T: Into<Bytes> + WasmCompatSend,
-        U: From<Bytes> + WasmCompatSend + 'static,
+        T: Into<Bytes> + MaybeSend,
+        U: From<Bytes> + MaybeSend + 'static,
     {
         future::ready(Err(http_client::Error::InvalidStatusCode(
             http::StatusCode::NOT_IMPLEMENTED,
@@ -323,9 +323,9 @@ impl HttpClientExt for MockStreamingClient {
     fn send_multipart<U>(
         &self,
         _req: Request<MultipartForm>,
-    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + MaybeSend + 'static
     where
-        U: From<Bytes> + WasmCompatSend + 'static,
+        U: From<Bytes> + MaybeSend + 'static,
     {
         future::ready(Err(http_client::Error::InvalidStatusCode(
             http::StatusCode::NOT_IMPLEMENTED,
@@ -335,9 +335,9 @@ impl HttpClientExt for MockStreamingClient {
     fn send_streaming<T>(
         &self,
         _req: Request<T>,
-    ) -> impl Future<Output = http_client::Result<StreamingResponse>> + WasmCompatSend
+    ) -> impl Future<Output = http_client::Result<StreamingResponse>> + MaybeSend
     where
-        T: Into<Bytes> + WasmCompatSend,
+        T: Into<Bytes> + MaybeSend,
     {
         let sse_bytes = self.sse_bytes.clone();
         async move {
@@ -384,10 +384,10 @@ impl HttpClientExt for HttpErrorStreamingClient {
     fn send<T, U>(
         &self,
         _req: Request<T>,
-    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + MaybeSend + 'static
     where
-        T: Into<Bytes> + WasmCompatSend,
-        U: From<Bytes> + WasmCompatSend + 'static,
+        T: Into<Bytes> + MaybeSend,
+        U: From<Bytes> + MaybeSend + 'static,
     {
         future::ready(Err(http_client::Error::InvalidStatusCode(
             http::StatusCode::NOT_IMPLEMENTED,
@@ -397,9 +397,9 @@ impl HttpClientExt for HttpErrorStreamingClient {
     fn send_multipart<U>(
         &self,
         _req: Request<MultipartForm>,
-    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + MaybeSend + 'static
     where
-        U: From<Bytes> + WasmCompatSend + 'static,
+        U: From<Bytes> + MaybeSend + 'static,
     {
         future::ready(Err(http_client::Error::InvalidStatusCode(
             http::StatusCode::NOT_IMPLEMENTED,
@@ -409,9 +409,9 @@ impl HttpClientExt for HttpErrorStreamingClient {
     fn send_streaming<T>(
         &self,
         _req: Request<T>,
-    ) -> impl Future<Output = http_client::Result<StreamingResponse>> + WasmCompatSend
+    ) -> impl Future<Output = http_client::Result<StreamingResponse>> + MaybeSend
     where
-        T: Into<Bytes> + WasmCompatSend,
+        T: Into<Bytes> + MaybeSend,
     {
         let status = self.status;
         let body = self.body.clone();
@@ -443,10 +443,10 @@ impl HttpClientExt for SequencedStreamingHttpClient {
     fn send<T, U>(
         &self,
         _req: Request<T>,
-    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + MaybeSend + 'static
     where
-        T: Into<Bytes> + WasmCompatSend,
-        U: From<Bytes> + WasmCompatSend + 'static,
+        T: Into<Bytes> + MaybeSend,
+        U: From<Bytes> + MaybeSend + 'static,
     {
         future::ready(Err(http_client::Error::InvalidStatusCode(
             http::StatusCode::NOT_IMPLEMENTED,
@@ -456,9 +456,9 @@ impl HttpClientExt for SequencedStreamingHttpClient {
     fn send_multipart<U>(
         &self,
         _req: Request<MultipartForm>,
-    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + MaybeSend + 'static
     where
-        U: From<Bytes> + WasmCompatSend + 'static,
+        U: From<Bytes> + MaybeSend + 'static,
     {
         future::ready(Err(http_client::Error::InvalidStatusCode(
             http::StatusCode::NOT_IMPLEMENTED,
@@ -468,9 +468,9 @@ impl HttpClientExt for SequencedStreamingHttpClient {
     fn send_streaming<T>(
         &self,
         _req: Request<T>,
-    ) -> impl Future<Output = http_client::Result<StreamingResponse>> + WasmCompatSend
+    ) -> impl Future<Output = http_client::Result<StreamingResponse>> + MaybeSend
     where
-        T: Into<Bytes> + WasmCompatSend,
+        T: Into<Bytes> + MaybeSend,
     {
         let chunks = match self.chunks.lock() {
             Ok(mut guard) => guard.take(),

--- a/crates/rig-core/src/test_utils/memory.rs
+++ b/crates/rig-core/src/test_utils/memory.rs
@@ -8,7 +8,7 @@ use std::sync::{
 use crate::{
     completion::Message,
     memory::{ConversationMemory, InMemoryConversationMemory, MemoryError},
-    wasm_compat::WasmBoxedFuture,
+    wasm_compat::BoxFuture,
 };
 
 /// Memory backend that records load and append calls while delegating storage to
@@ -41,7 +41,7 @@ impl ConversationMemory for CountingMemory {
     fn load<'a>(
         &'a self,
         conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
+    ) -> BoxFuture<'a, Result<Vec<Message>, MemoryError>> {
         self.loads.fetch_add(1, Ordering::SeqCst);
         self.inner.load(conversation_id)
     }
@@ -50,15 +50,12 @@ impl ConversationMemory for CountingMemory {
         &'a self,
         conversation_id: &'a str,
         messages: Vec<Message>,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    ) -> BoxFuture<'a, Result<(), MemoryError>> {
         self.appends.fetch_add(1, Ordering::SeqCst);
         self.inner.append(conversation_id, messages)
     }
 
-    fn clear<'a>(
-        &'a self,
-        conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    fn clear<'a>(&'a self, conversation_id: &'a str) -> BoxFuture<'a, Result<(), MemoryError>> {
         self.inner.clear(conversation_id)
     }
 }
@@ -88,7 +85,7 @@ impl ConversationMemory for FailingMemory {
     fn load<'a>(
         &'a self,
         _conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
+    ) -> BoxFuture<'a, Result<Vec<Message>, MemoryError>> {
         let message = self.message.clone();
         Box::pin(async move { Err(MemoryError::backend(std::io::Error::other(message))) })
     }
@@ -97,14 +94,11 @@ impl ConversationMemory for FailingMemory {
         &'a self,
         _conversation_id: &'a str,
         _messages: Vec<Message>,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    ) -> BoxFuture<'a, Result<(), MemoryError>> {
         Box::pin(async { Ok(()) })
     }
 
-    fn clear<'a>(
-        &'a self,
-        _conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    fn clear<'a>(&'a self, _conversation_id: &'a str) -> BoxFuture<'a, Result<(), MemoryError>> {
         Box::pin(async { Ok(()) })
     }
 }
@@ -134,7 +128,7 @@ impl ConversationMemory for AppendFailingMemory {
     fn load<'a>(
         &'a self,
         _conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
+    ) -> BoxFuture<'a, Result<Vec<Message>, MemoryError>> {
         Box::pin(async { Ok(Vec::new()) })
     }
 
@@ -142,15 +136,12 @@ impl ConversationMemory for AppendFailingMemory {
         &'a self,
         _conversation_id: &'a str,
         _messages: Vec<Message>,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    ) -> BoxFuture<'a, Result<(), MemoryError>> {
         let message = self.message.clone();
         Box::pin(async move { Err(MemoryError::backend(std::io::Error::other(message))) })
     }
 
-    fn clear<'a>(
-        &'a self,
-        _conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    fn clear<'a>(&'a self, _conversation_id: &'a str) -> BoxFuture<'a, Result<(), MemoryError>> {
         Box::pin(async { Ok(()) })
     }
 }

--- a/crates/rig-core/src/test_utils/model_listing.rs
+++ b/crates/rig-core/src/test_utils/model_listing.rs
@@ -3,7 +3,7 @@
 use crate::{
     client::ModelLister,
     model::{Model, ModelList, ModelListingError},
-    wasm_compat::WasmCompatSend,
+    wasm_compat::MaybeSend,
 };
 
 /// A [`ModelLister`] that returns a preconfigured list of models.
@@ -27,8 +27,7 @@ impl ModelLister for MockModelLister {
 
     fn list_all(
         &self,
-    ) -> impl std::future::Future<Output = Result<ModelList, ModelListingError>> + WasmCompatSend
-    {
+    ) -> impl std::future::Future<Output = Result<ModelList, ModelListingError>> + MaybeSend {
         let models = self.models.clone();
         async move { Ok(ModelList::new(models)) }
     }

--- a/crates/rig-core/src/tool/portable.rs
+++ b/crates/rig-core/src/tool/portable.rs
@@ -10,21 +10,21 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     completion::ToolDefinition,
-    wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync},
+    wasm_compat::{BoxFuture, MaybeSend, MaybeSync},
 };
 
 use super::{IntoToolOutput, ToolExecutionError, ToolOutput};
 
 /// A context-free typed tool that can be executed by any Rig runtime.
-pub trait PortableTool: Sized + WasmCompatSend + WasmCompatSync {
+pub trait PortableTool: Sized + MaybeSend + MaybeSync {
     /// Unique registration and provider-facing name.
     const NAME: &'static str;
     /// Owned JSON arguments.
-    type Args: for<'de> Deserialize<'de> + WasmCompatSend + WasmCompatSync;
+    type Args: for<'de> Deserialize<'de> + MaybeSend + MaybeSync;
     /// Canonical model-visible output.
-    type Output: IntoToolOutput + WasmCompatSend;
+    type Output: IntoToolOutput + MaybeSend;
     /// Concrete author-facing failure.
-    type Error: std::error::Error + WasmCompatSend + WasmCompatSync + 'static;
+    type Error: std::error::Error + MaybeSend + MaybeSync + 'static;
 
     /// Model-facing description.
     fn description(&self) -> String;
@@ -41,17 +41,17 @@ pub trait PortableTool: Sized + WasmCompatSend + WasmCompatSync {
     fn call(
         &self,
         arguments: Self::Args,
-    ) -> impl Future<Output = Result<Self::Output, Self::Error>> + WasmCompatSend;
+    ) -> impl Future<Output = Result<Self::Output, Self::Error>> + MaybeSend;
 }
 
 /// A portable tool that can be embedded and reconstructed for discovery.
 pub trait PortableToolEmbedding: PortableTool {
     /// Failure returned while reconstructing the typed implementation.
-    type InitError: std::error::Error + WasmCompatSend + WasmCompatSync + 'static;
+    type InitError: std::error::Error + MaybeSend + MaybeSync + 'static;
     /// Serializable reconstruction data.
     type Context: for<'de> Deserialize<'de> + Serialize;
     /// Runtime initialization state supplied by the authoring integration.
-    type State: WasmCompatSend;
+    type State: MaybeSend;
 
     /// Documents used by a discovery implementation.
     fn embedding_docs(&self) -> Vec<String>;
@@ -62,16 +62,16 @@ pub trait PortableToolEmbedding: PortableTool {
 }
 
 trait PortableDynamicCallback:
-    Fn(serde_json::Value) -> WasmBoxedFuture<'static, Result<ToolOutput, ToolExecutionError>>
-    + WasmCompatSend
-    + WasmCompatSync
+    Fn(serde_json::Value) -> BoxFuture<'static, Result<ToolOutput, ToolExecutionError>>
+    + MaybeSend
+    + MaybeSync
 {
 }
 
 impl<F> PortableDynamicCallback for F where
-    F: Fn(serde_json::Value) -> WasmBoxedFuture<'static, Result<ToolOutput, ToolExecutionError>>
-        + WasmCompatSend
-        + WasmCompatSync
+    F: Fn(serde_json::Value) -> BoxFuture<'static, Result<ToolOutput, ToolExecutionError>>
+        + MaybeSend
+        + MaybeSync
 {
 }
 
@@ -104,11 +104,9 @@ impl PortableDynamicTool {
         callback: F,
     ) -> Self
     where
-        F: Fn(
-                serde_json::Value,
-            ) -> WasmBoxedFuture<'static, Result<ToolOutput, ToolExecutionError>>
-            + WasmCompatSend
-            + WasmCompatSync
+        F: Fn(serde_json::Value) -> BoxFuture<'static, Result<ToolOutput, ToolExecutionError>>
+            + MaybeSend
+            + MaybeSync
             + 'static,
     {
         Self {

--- a/crates/rig-core/src/tool/result.rs
+++ b/crates/rig-core/src/tool/result.rs
@@ -4,7 +4,7 @@ use std::{error::Error, sync::Arc};
 
 use crate::{
     tool::ToolOutput,
-    wasm_compat::{WasmCompatSend, WasmCompatSync},
+    wasm_compat::{MaybeSend, MaybeSync},
 };
 
 /// Normalized classification for a tool execution error.
@@ -186,7 +186,7 @@ impl ToolExecutionError {
     /// `ToolExecutionError` preserves its classification and presentation.
     pub fn from_error<E>(error: E) -> Self
     where
-        E: Error + WasmCompatSend + WasmCompatSync + 'static,
+        E: Error + MaybeSend + MaybeSync + 'static,
     {
         #[cfg(not(target_family = "wasm"))]
         {
@@ -262,7 +262,7 @@ impl ToolExecutionError {
     /// Preserve a concrete source for later downcasting.
     pub fn with_source<E>(mut self, source: E) -> Self
     where
-        E: Error + WasmCompatSend + WasmCompatSync + 'static,
+        E: Error + MaybeSend + MaybeSync + 'static,
     {
         self.source = Some(Arc::new(source));
         self
@@ -314,7 +314,7 @@ impl ToolExecutionError {
     /// Downcast the concrete source to `E`.
     pub fn downcast_ref<E>(&self) -> Option<&E>
     where
-        E: Error + WasmCompatSend + WasmCompatSync + 'static,
+        E: Error + MaybeSend + MaybeSync + 'static,
     {
         self.source.as_ref()?.downcast_ref::<E>()
     }
@@ -322,7 +322,7 @@ impl ToolExecutionError {
     /// Whether the concrete source has type `E`.
     pub fn is<E>(&self) -> bool
     where
-        E: Error + WasmCompatSend + WasmCompatSync + 'static,
+        E: Error + MaybeSend + MaybeSync + 'static,
     {
         self.downcast_ref::<E>().is_some()
     }

--- a/crates/rig-core/src/transcription.rs
+++ b/crates/rig-core/src/transcription.rs
@@ -2,7 +2,7 @@
 //! It provides traits, structs, and enums for generating audio transcription requests,
 //! handling transcription responses, and defining transcription models.
 use crate::markers::{Missing, Provided};
-use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use crate::wasm_compat::{MaybeSend, MaybeSync};
 use crate::{http_client, json_utils, provider_response};
 use std::io;
 use std::{fs, path::Path};
@@ -59,9 +59,9 @@ pub struct TranscriptionResponse<T> {
 /// Trait defining a transcription model that can be used to generate transcription requests.
 /// This trait is meant to be implemented by the user to define a custom transcription model,
 /// either from a third-party provider (e.g: OpenAI) or a local model.
-pub trait TranscriptionModel: Clone + WasmCompatSend + WasmCompatSync {
+pub trait TranscriptionModel: Clone + MaybeSend + MaybeSync {
     /// The raw response type returned by the underlying model.
-    type Response: WasmCompatSend + WasmCompatSync;
+    type Response: MaybeSend + MaybeSync;
     type Client;
 
     fn make(client: &Self::Client, model: impl Into<String>) -> Self;
@@ -72,7 +72,7 @@ pub trait TranscriptionModel: Clone + WasmCompatSend + WasmCompatSync {
         request: TranscriptionRequest,
     ) -> impl std::future::Future<
         Output = Result<TranscriptionResponse<Self::Response>, TranscriptionError>,
-    > + WasmCompatSend;
+    > + MaybeSend;
 
     /// Generates a transcription request builder for the given `file`
     fn transcription_request(&self) -> TranscriptionRequestBuilder<Self, Missing> {

--- a/crates/rig-core/src/vector_store/in_memory_store.rs
+++ b/crates/rig-core/src/vector_store/in_memory_store.rs
@@ -12,6 +12,7 @@ use crate::{
     OneOrMany,
     embeddings::{Embedding, EmbeddingModel, distance::VectorDistance},
     vector_store::request::Filter,
+    wasm_compat::{MaybeSend, MaybeSync},
 };
 
 use super::lsh::LSHIndex;
@@ -489,7 +490,7 @@ impl<M: EmbeddingModel, D: Serialize> InMemoryVectorIndex<M, D> {
     }
 }
 
-impl<M: EmbeddingModel + Sync, D: Serialize + Sync + Send + Eq> VectorStoreIndex
+impl<M: EmbeddingModel + MaybeSync, D: Serialize + MaybeSync + MaybeSend + Eq> VectorStoreIndex
     for InMemoryVectorIndex<M, D>
 {
     type Filter = Filter<serde_json::Value>;

--- a/crates/rig-core/src/vector_store/mod.rs
+++ b/crates/rig-core/src/vector_store/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     embeddings::{Embedding, EmbeddingError},
     tool::PortableTool,
     vector_store::request::{Filter, FilterError, SearchFilter},
-    wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync},
+    wasm_compat::{BoxFuture, MaybeSend, MaybeSync},
 };
 
 pub mod builder;
@@ -72,49 +72,48 @@ pub enum VectorStoreError {
 }
 
 /// Trait for inserting documents and embeddings into a vector store.
-pub trait InsertDocuments: WasmCompatSend + WasmCompatSync {
+pub trait InsertDocuments: MaybeSend + MaybeSync {
     /// Insert precomputed embeddings for each document.
-    fn insert_documents<Doc: Serialize + Embed + WasmCompatSend>(
+    fn insert_documents<Doc: Serialize + Embed + MaybeSend>(
         &self,
         documents: Vec<(Doc, OneOrMany<Embedding>)>,
-    ) -> impl std::future::Future<Output = Result<(), VectorStoreError>> + WasmCompatSend;
+    ) -> impl std::future::Future<Output = Result<(), VectorStoreError>> + MaybeSend;
 }
 
 /// Trait for querying a vector store by similarity.
-pub trait VectorStoreIndex: WasmCompatSend + WasmCompatSync {
+pub trait VectorStoreIndex: MaybeSend + MaybeSync {
     /// The filter type for this backend.
-    type Filter: SearchFilter + WasmCompatSend + WasmCompatSync;
+    type Filter: SearchFilter + MaybeSend + MaybeSync;
 
     /// Returns the top N most similar documents as `(score, id, document)` tuples.
-    fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
+    fn top_n<T: for<'a> Deserialize<'a> + MaybeSend>(
         &self,
         req: VectorSearchRequest<Self::Filter>,
-    ) -> impl std::future::Future<Output = Result<Vec<(f64, String, T)>, VectorStoreError>>
-    + WasmCompatSend;
+    ) -> impl std::future::Future<Output = Result<Vec<(f64, String, T)>, VectorStoreError>> + MaybeSend;
 
     /// Returns the top N most similar document IDs as `(score, id)` tuples.
     fn top_n_ids(
         &self,
         req: VectorSearchRequest<Self::Filter>,
-    ) -> impl std::future::Future<Output = Result<Vec<(f64, String)>, VectorStoreError>> + WasmCompatSend;
+    ) -> impl std::future::Future<Output = Result<Vec<(f64, String)>, VectorStoreError>> + MaybeSend;
 }
 
 /// Type-erased `top_n` result: `(score, id, document)` tuples as JSON values.
 pub type TopNResults = Result<Vec<(f64, String, Value)>, VectorStoreError>;
 
 /// Type-erased [`VectorStoreIndex`] for dynamic dispatch.
-pub trait VectorStoreIndexDyn: WasmCompatSend + WasmCompatSync {
+pub trait VectorStoreIndexDyn: MaybeSend + MaybeSync {
     /// Returns the top N documents for a JSON-serializable request.
     fn top_n<'a>(
         &'a self,
         req: VectorSearchRequest<Filter<serde_json::Value>>,
-    ) -> WasmBoxedFuture<'a, TopNResults>;
+    ) -> BoxFuture<'a, TopNResults>;
 
     /// Returns only the top N document IDs for a JSON-serializable request.
     fn top_n_ids<'a>(
         &'a self,
         req: VectorSearchRequest<Filter<serde_json::Value>>,
-    ) -> WasmBoxedFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>>;
+    ) -> BoxFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>>;
 }
 
 impl<I: VectorStoreIndex<Filter = F>, F> VectorStoreIndexDyn for I
@@ -122,8 +121,8 @@ where
     F: std::fmt::Debug
         + Clone
         + SearchFilter<Value = serde_json::Value>
-        + WasmCompatSend
-        + WasmCompatSync
+        + MaybeSend
+        + MaybeSync
         + Serialize
         + for<'de> Deserialize<'de>
         + 'static,
@@ -131,7 +130,7 @@ where
     fn top_n<'a>(
         &'a self,
         req: VectorSearchRequest<Filter<serde_json::Value>>,
-    ) -> WasmBoxedFuture<'a, TopNResults> {
+    ) -> BoxFuture<'a, TopNResults> {
         let req = req.map_filter(Filter::interpret);
 
         Box::pin(async move {
@@ -147,7 +146,7 @@ where
     fn top_n_ids<'a>(
         &'a self,
         req: VectorSearchRequest<Filter<serde_json::Value>>,
-    ) -> WasmBoxedFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>> {
+    ) -> BoxFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>> {
         let req = req.map_filter(Filter::interpret);
 
         Box::pin(self.top_n_ids(req))
@@ -190,10 +189,7 @@ pub struct VectorStoreOutput {
 
 impl<T, F> PortableTool for T
 where
-    F: SearchFilter<Value = serde_json::Value>
-        + WasmCompatSend
-        + WasmCompatSync
-        + for<'de> Deserialize<'de>,
+    F: SearchFilter<Value = serde_json::Value> + MaybeSend + MaybeSync + for<'de> Deserialize<'de>,
     T: VectorStoreIndex<Filter = F>,
 {
     const NAME: &'static str = "search_vector_store";
@@ -271,7 +267,7 @@ mod tests {
     impl VectorStoreIndex for TestIndex {
         type Filter = Filter<serde_json::Value>;
 
-        async fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
+        async fn top_n<T: for<'a> Deserialize<'a> + MaybeSend>(
             &self,
             req: VectorSearchRequest,
         ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {

--- a/crates/rig-core/src/wasm_compat.rs
+++ b/crates/rig-core/src/wasm_compat.rs
@@ -1,74 +1,81 @@
-use bytes::Bytes;
-use std::pin::Pin;
-
-use futures::Stream;
-
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-/// `Send` on native targets, a no-op marker on browser wasm.
-pub trait WasmCompatSend: Send {}
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-/// `Send` on native targets, a no-op marker on browser wasm.
-pub trait WasmCompatSend {}
+//! Target-conditional portability bounds for Rig's async public APIs.
+//!
+//! "Maybe" means target-conditional, not runtime-optional. On browser WASM
+//! (`all(target_arch = "wasm32", target_os = "unknown")`) the marker traits do
+//! not require thread-safety and [`BoxFuture`] is local. Every other target,
+//! including WASI, retains ordinary `Send`/`Sync` guarantees and sendable boxed
+//! futures.
 
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-impl<T> WasmCompatSend for T where T: Send {}
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-impl<T> WasmCompatSend for T {}
-
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-/// Streaming response bound that includes `Send` on native targets.
-pub trait WasmCompatSendStream:
-    Stream<Item = Result<Bytes, crate::http_client::Error>> + Send
-{
-    type InnerItem: Send;
-}
-
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-/// Streaming response bound without `Send` on browser wasm.
-pub trait WasmCompatSendStream: Stream<Item = Result<Bytes, crate::http_client::Error>> {
-    type InnerItem;
-}
-
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-impl<T> WasmCompatSendStream for T
-where
-    T: Stream<Item = Result<Bytes, crate::http_client::Error>> + Send,
-{
-    type InnerItem = Result<Bytes, crate::http_client::Error>;
-}
-
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-impl<T> WasmCompatSendStream for T
-where
-    T: Stream<Item = Result<Bytes, crate::http_client::Error>>,
-{
-    type InnerItem = Result<Bytes, crate::http_client::Error>;
-}
-
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-/// `Sync` on native targets, a no-op marker on browser wasm.
-pub trait WasmCompatSync: Sync {}
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-/// `Sync` on native targets, a no-op marker on browser wasm.
-pub trait WasmCompatSync {}
-
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-impl<T> WasmCompatSync for T where T: Sync {}
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-impl<T> WasmCompatSync for T {}
-
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-/// Boxed future type that includes `Send`, except on browser wasm.
+/// `Send` except on browser WASM, where this is a no-op marker.
 ///
-/// Gated to match [`WasmCompatSend`]/[`WasmCompatSync`] (and the streaming `Box`
-/// selection) — a `WasmBoxedFuture` returned by a `WasmCompatSend` bound (e.g.
-/// crate-private erased tool dispatch must drop `Send` under the same
-/// condition the marker relaxes it, or the two disagree on wasm.
-pub type WasmBoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+/// The relaxed target is exactly `wasm32-unknown-unknown`; this trait still
+/// requires `Send` on WASI and all other targets.
+pub trait MaybeSend: Send {}
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+/// `Send` except on browser WASM, where this is a no-op marker.
+///
+/// The relaxed target is exactly `wasm32-unknown-unknown`; this trait still
+/// requires `Send` on WASI and all other targets.
+pub trait MaybeSend {}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+impl<T> MaybeSend for T where T: Send {}
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl<T> MaybeSend for T {}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+/// `Sync` except on browser WASM, where this is a no-op marker.
+///
+/// The relaxed target is exactly `wasm32-unknown-unknown`; this trait still
+/// requires `Sync` on WASI and all other targets.
+pub trait MaybeSync: Sync {}
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+/// `Sync` except on browser WASM, where this is a no-op marker.
+///
+/// The relaxed target is exactly `wasm32-unknown-unknown`; this trait still
+/// requires `Sync` on WASI and all other targets.
+pub trait MaybeSync {}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+impl<T> MaybeSync for T where T: Sync {}
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl<T> MaybeSync for T {}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+/// A sendable boxed future on every target except browser WASM.
+///
+/// This is [`futures::future::BoxFuture`] on native, WASI, and other
+/// non-browser targets.
+pub use futures::future::BoxFuture;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-/// Boxed future type without `Send`, on browser wasm.
-pub type WasmBoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+/// A boxed future that may be non-`Send` on browser WASM.
+///
+/// This re-exports [`futures::future::LocalBoxFuture`] as `BoxFuture` exactly
+/// on `wasm32-unknown-unknown`.
+pub use futures::future::LocalBoxFuture as BoxFuture;
+
+// This module is compiled by an ordinary browser-WASM `cargo check`, so it
+// guards the relaxed marker and local-future contract without requiring a WASM
+// test runner.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+mod browser_wasm_contract {
+    use std::rc::Rc;
+
+    use super::{BoxFuture, MaybeSend, MaybeSync};
+
+    fn accepts_maybe_thread_safe<T: MaybeSend + MaybeSync>(_: &T) {}
+
+    #[allow(dead_code)]
+    fn accepts_rc_and_local_future() {
+        let state = Rc::new(());
+        accepts_maybe_thread_safe(&state);
+
+        let future: BoxFuture<'static, Rc<()>> = Box::pin(async move { state });
+        drop(future);
+    }
+}
 
 /// Error returned by [`timeout`] when the future does not complete in time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -133,10 +140,29 @@ macro_rules! if_not_wasm {
     };
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod tests {
-    use super::{Elapsed, timeout};
+    use super::{BoxFuture, Elapsed, MaybeSend, MaybeSync, timeout};
     use std::time::Duration;
+
+    fn maybe_send_implies_send<T: MaybeSend>() {
+        fn assert_send<T: Send>() {}
+        assert_send::<T>();
+    }
+
+    fn maybe_sync_implies_sync<T: MaybeSync>() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<T>();
+    }
+
+    #[test]
+    fn native_compatibility_types_retain_thread_safety() {
+        fn assert_send<T: Send>() {}
+
+        maybe_send_implies_send::<String>();
+        maybe_sync_implies_sync::<String>();
+        assert_send::<BoxFuture<'static, ()>>();
+    }
 
     #[tokio::test]
     async fn timeout_returns_ok_for_a_future_that_completes_in_time() {

--- a/crates/rig-gemini-grpc/src/embedding.rs
+++ b/crates/rig-gemini-grpc/src/embedding.rs
@@ -42,7 +42,7 @@ impl embeddings::EmbeddingModel for EmbeddingModel {
 
     async fn embed_texts(
         &self,
-        documents: impl IntoIterator<Item = String> + rig_core::wasm_compat::WasmCompatSend,
+        documents: impl IntoIterator<Item = String> + rig_core::wasm_compat::MaybeSend,
     ) -> Result<Vec<embeddings::Embedding>, EmbeddingError> {
         let documents_vec: Vec<String> = documents.into_iter().collect();
         let mut embeddings = Vec::new();

--- a/crates/rig-helixdb/src/lib.rs
+++ b/crates/rig-helixdb/src/lib.rs
@@ -12,7 +12,7 @@ use reqwest::{Client, StatusCode};
 use rig_core::{
     embeddings::EmbeddingModel,
     vector_store::{InsertDocuments, VectorStoreError, VectorStoreIndex, request::Filter},
-    wasm_compat::{WasmCompatSend, WasmCompatSync},
+    wasm_compat::{MaybeSend, MaybeSync},
 };
 use serde::{Deserialize, Serialize};
 
@@ -72,9 +72,9 @@ pub trait HelixDBClient {
         &self,
         endpoint: &str,
         data: &T,
-    ) -> impl Future<Output = Result<R, Self::Err>> + WasmCompatSend
+    ) -> impl Future<Output = Result<R, Self::Err>> + MaybeSend
     where
-        T: Serialize + WasmCompatSync,
+        T: Serialize + MaybeSync,
         R: for<'de> Deserialize<'de>;
 }
 
@@ -83,7 +83,7 @@ impl HelixDBClient for HelixDB {
 
     async fn query<T, R>(&self, endpoint: &str, data: &T) -> Result<R, HelixError>
     where
-        T: Serialize + WasmCompatSync,
+        T: Serialize + MaybeSync,
         R: for<'de> Deserialize<'de>,
     {
         let port = self.port.map(|port| format!(":{port}")).unwrap_or_default();
@@ -183,7 +183,7 @@ impl QueryInput {
 
 impl<C, E> HelixDBVectorStore<C, E>
 where
-    C: HelixDBClient + WasmCompatSend,
+    C: HelixDBClient + MaybeSend,
     E: EmbeddingModel,
 {
     /// Creates a new HelixDB vector store.
@@ -199,11 +199,11 @@ where
 
 impl<C, E> InsertDocuments for HelixDBVectorStore<C, E>
 where
-    C: HelixDBClient + WasmCompatSend + WasmCompatSync,
-    C::Err: std::error::Error + WasmCompatSend + WasmCompatSync + 'static,
-    E: EmbeddingModel + WasmCompatSend + WasmCompatSync,
+    C: HelixDBClient + MaybeSend + MaybeSync,
+    C::Err: std::error::Error + MaybeSend + MaybeSync + 'static,
+    E: EmbeddingModel + MaybeSend + MaybeSync,
 {
-    async fn insert_documents<Doc: Serialize + rig_core::Embed + WasmCompatSend>(
+    async fn insert_documents<Doc: Serialize + rig_core::Embed + MaybeSend>(
         &self,
         documents: Vec<(Doc, rig_core::OneOrMany<rig_core::embeddings::Embedding>)>,
     ) -> Result<(), VectorStoreError> {
@@ -245,13 +245,13 @@ where
 
 impl<C, E> VectorStoreIndex for HelixDBVectorStore<C, E>
 where
-    C: HelixDBClient + WasmCompatSend + WasmCompatSync,
-    C::Err: std::error::Error + WasmCompatSend + WasmCompatSync + 'static,
-    E: EmbeddingModel + WasmCompatSend + WasmCompatSync,
+    C: HelixDBClient + MaybeSend + MaybeSync,
+    C::Err: std::error::Error + MaybeSend + MaybeSync + 'static,
+    E: EmbeddingModel + MaybeSend + MaybeSync,
 {
     type Filter = HelixDBFilter;
 
-    async fn top_n<T: for<'a> serde::Deserialize<'a> + WasmCompatSend>(
+    async fn top_n<T: for<'a> serde::Deserialize<'a> + MaybeSend>(
         &self,
         req: rig_core::vector_store::VectorSearchRequest<HelixDBFilter>,
     ) -> Result<Vec<(f64, String, T)>, rig_core::vector_store::VectorStoreError> {

--- a/crates/rig-memory/src/lib.rs
+++ b/crates/rig-memory/src/lib.rs
@@ -53,14 +53,14 @@ pub use rig_core::memory::{
 
 use rig_core::completion::Message;
 use rig_core::message::UserContent;
-use rig_core::wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync};
+use rig_core::wasm_compat::{BoxFuture, MaybeSend, MaybeSync};
 
 /// A transformation applied to messages loaded from a [`ConversationMemory`].
 ///
 /// Policies typically truncate, summarize, or re-order history. They are
 /// pure, fallible message transformers: implementors that cannot fail should
 /// always return `Ok`.
-pub trait MemoryPolicy: WasmCompatSend + WasmCompatSync {
+pub trait MemoryPolicy: MaybeSend + MaybeSync {
     /// Transform `messages` into the history that should be returned to the
     /// agent. This is the required method — every policy must implement it.
     fn apply(&self, messages: Vec<Message>) -> Result<Vec<Message>, MemoryError>;
@@ -131,7 +131,7 @@ pub trait IntoFilter: MemoryPolicy + Sized + 'static {
     /// `tracing::warn!` is emitted, so a transient policy bug degrades
     /// gracefully (the model still sees the unfiltered history) instead of
     /// silently erasing context.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     fn into_filter(self) -> Box<dyn Fn(Vec<Message>) -> Vec<Message> + Send + Sync> {
         let policy = Arc::new(self);
         Box::new(move |msgs| {
@@ -152,7 +152,7 @@ pub trait IntoFilter: MemoryPolicy + Sized + 'static {
     /// `tracing::warn!` is emitted, so a transient policy bug degrades
     /// gracefully (the model still sees the unfiltered history) instead of
     /// silently erasing context.
-    #[cfg(target_family = "wasm")]
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     fn into_filter(self) -> Box<dyn Fn(Vec<Message>) -> Vec<Message>> {
         let policy = Arc::new(self);
         Box::new(move |msgs| {
@@ -234,14 +234,14 @@ impl MemoryPolicy for SlidingWindowMemory {
 /// Implementors should pick a counting strategy appropriate for their target
 /// provider (for example, `tiktoken-rs` for OpenAI). Counting must be cheap;
 /// it runs once per message on every memory load.
-pub trait TokenCounter: WasmCompatSend + WasmCompatSync {
+pub trait TokenCounter: MaybeSend + MaybeSync {
     /// Approximate the number of tokens contributed by `message`.
     fn count(&self, message: &Message) -> usize;
 }
 
 impl<F> TokenCounter for F
 where
-    F: Fn(&Message) -> usize + WasmCompatSend + WasmCompatSync,
+    F: Fn(&Message) -> usize + MaybeSend + MaybeSync,
 {
     fn count(&self, message: &Message) -> usize {
         (self)(message)
@@ -546,7 +546,7 @@ where
     fn load<'a>(
         &'a self,
         conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
+    ) -> BoxFuture<'a, Result<Vec<Message>, MemoryError>> {
         Box::pin(async move {
             let messages = self.inner.load(conversation_id).await?;
             self.policy.apply(messages)
@@ -557,14 +557,11 @@ where
         &'a self,
         conversation_id: &'a str,
         messages: Vec<Message>,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    ) -> BoxFuture<'a, Result<(), MemoryError>> {
         self.inner.append(conversation_id, messages)
     }
 
-    fn clear<'a>(
-        &'a self,
-        conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    fn clear<'a>(&'a self, conversation_id: &'a str) -> BoxFuture<'a, Result<(), MemoryError>> {
         self.inner.clear(conversation_id)
     }
 }
@@ -718,7 +715,7 @@ where
     fn load<'a>(
         &'a self,
         conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
+    ) -> BoxFuture<'a, Result<Vec<Message>, MemoryError>> {
         Box::pin(async move {
             let messages = self.inner.load(conversation_id).await?;
             let (kept, mut demoted) = self.policy.apply_with_demoted(messages)?;
@@ -814,14 +811,11 @@ where
         &'a self,
         conversation_id: &'a str,
         messages: Vec<Message>,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    ) -> BoxFuture<'a, Result<(), MemoryError>> {
         self.inner.append(conversation_id, messages)
     }
 
-    fn clear<'a>(
-        &'a self,
-        conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    fn clear<'a>(&'a self, conversation_id: &'a str) -> BoxFuture<'a, Result<(), MemoryError>> {
         Box::pin(async move {
             self.inner.clear(conversation_id).await?;
             self.forget(conversation_id);
@@ -1107,7 +1101,7 @@ where
     fn load<'a>(
         &'a self,
         conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
+    ) -> BoxFuture<'a, Result<Vec<Message>, MemoryError>> {
         Box::pin(async move {
             let messages = self.inner.load(conversation_id).await?;
             let (kept, demoted) = self.policy.apply_with_demoted(messages)?;
@@ -1257,14 +1251,11 @@ where
         &'a self,
         conversation_id: &'a str,
         messages: Vec<Message>,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    ) -> BoxFuture<'a, Result<(), MemoryError>> {
         self.inner.append(conversation_id, messages)
     }
 
-    fn clear<'a>(
-        &'a self,
-        conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+    fn clear<'a>(&'a self, conversation_id: &'a str) -> BoxFuture<'a, Result<(), MemoryError>> {
         Box::pin(async move {
             self.inner.clear(conversation_id).await?;
             self.forget(conversation_id);
@@ -1406,7 +1397,7 @@ impl Compactor for TemplateCompactor {
         _conversation_id: &'a str,
         evicted: &'a [Message],
         carry_over: Option<&'a Self::Artifact>,
-    ) -> WasmBoxedFuture<'a, Result<Self::Artifact, MemoryError>> {
+    ) -> BoxFuture<'a, Result<Self::Artifact, MemoryError>> {
         Box::pin(async move {
             let mut buf = String::new();
             buf.push_str(&self.header);
@@ -1914,7 +1905,7 @@ mod tests {
             &'a self,
             conversation_id: &'a str,
             messages: Vec<Message>,
-        ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+        ) -> BoxFuture<'a, Result<(), MemoryError>> {
             Box::pin(async move {
                 self.seen
                     .lock()
@@ -2003,7 +1994,7 @@ mod tests {
             &'a self,
             _conversation_id: &'a str,
             _messages: Vec<Message>,
-        ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+        ) -> BoxFuture<'a, Result<(), MemoryError>> {
             Box::pin(async move {
                 *self.calls.lock().unwrap() += 1;
                 Err(MemoryError::backend(std::io::Error::other("hook failed")))
@@ -2093,7 +2084,7 @@ mod tests {
             &'a self,
             _conversation_id: &'a str,
             _messages: Vec<Message>,
-        ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+        ) -> BoxFuture<'a, Result<(), MemoryError>> {
             let calls = self.calls.clone();
             let rendezvous = self.rendezvous.clone();
             let release = self.release.clone();
@@ -2311,7 +2302,7 @@ mod tests {
                 &'a self,
                 _conversation_id: &'a str,
                 _messages: Vec<Message>,
-            ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+            ) -> BoxFuture<'a, Result<(), MemoryError>> {
                 let release = Arc::new(tokio::sync::Notify::new());
                 self.releases.lock().unwrap().push(release.clone());
                 Box::pin(async move {
@@ -2565,7 +2556,7 @@ mod tests {
             _conversation_id: &'a str,
             evicted: &'a [Message],
             _carry_over: Option<&'a Self::Artifact>,
-        ) -> WasmBoxedFuture<'a, Result<Self::Artifact, MemoryError>> {
+        ) -> BoxFuture<'a, Result<Self::Artifact, MemoryError>> {
             Box::pin(async move {
                 let n = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                 if n == 0 {
@@ -2621,7 +2612,7 @@ mod tests {
             _conversation_id: &'a str,
             evicted: &'a [Message],
             carry_over: Option<&'a Self::Artifact>,
-        ) -> WasmBoxedFuture<'a, Result<Self::Artifact, MemoryError>> {
+        ) -> BoxFuture<'a, Result<Self::Artifact, MemoryError>> {
             Box::pin(async move {
                 self.log
                     .lock()
@@ -3031,7 +3022,7 @@ mod tests {
                 _conversation_id: &'a str,
                 _evicted: &'a [Message],
                 _carry_over: Option<&'a Self::Artifact>,
-            ) -> WasmBoxedFuture<'a, Result<Self::Artifact, MemoryError>> {
+            ) -> BoxFuture<'a, Result<Self::Artifact, MemoryError>> {
                 Box::pin(async move {
                     self.entered.store(true, Ordering::SeqCst);
                     self.release.notified().await;
@@ -3095,7 +3086,7 @@ mod tests {
                 _conversation_id: &'a str,
                 _evicted: &'a [Message],
                 _carry_over: Option<&'a Self::Artifact>,
-            ) -> WasmBoxedFuture<'a, Result<Self::Artifact, MemoryError>> {
+            ) -> BoxFuture<'a, Result<Self::Artifact, MemoryError>> {
                 Box::pin(async move {
                     self.entered.fetch_add(1, Ordering::SeqCst);
                     self.release.notified().await;
@@ -3167,7 +3158,7 @@ mod tests {
                 _conversation_id: &'a str,
                 _evicted: &'a [Message],
                 _carry_over: Option<&'a Self::Artifact>,
-            ) -> WasmBoxedFuture<'a, Result<Self::Artifact, MemoryError>> {
+            ) -> BoxFuture<'a, Result<Self::Artifact, MemoryError>> {
                 Box::pin(async move {
                     self.entered.fetch_add(1, Ordering::SeqCst);
                     self.rendezvous.notify_one();

--- a/crates/rig-milvus/Cargo.toml
+++ b/crates/rig-milvus/Cargo.toml
@@ -13,7 +13,6 @@ reqwest = { workspace = true, features = ["json"] }
 rig-core = { path = "../rig-core", version = "0.41.0", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
-uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/rig-milvus/src/lib.rs
+++ b/crates/rig-milvus/src/lib.rs
@@ -16,7 +16,7 @@ use rig_core::{
         InsertDocuments, TopNResults, VectorStoreError, VectorStoreIndex, VectorStoreIndexDyn,
         request::{Filter as CoreFilter, SearchFilter, VectorSearchRequest},
     },
-    wasm_compat::WasmBoxedFuture,
+    wasm_compat::{BoxFuture, MaybeSend, MaybeSync},
 };
 use serde::{Deserialize, Serialize};
 
@@ -171,9 +171,9 @@ where
 
 impl<Model> InsertDocuments for MilvusVectorStore<Model>
 where
-    Model: EmbeddingModel + Send + Sync,
+    Model: EmbeddingModel + MaybeSend + MaybeSync,
 {
-    async fn insert_documents<Doc: Serialize + Embed + Send>(
+    async fn insert_documents<Doc: Serialize + Embed + MaybeSend>(
         &self,
         documents: Vec<(Doc, OneOrMany<Embedding>)>,
     ) -> Result<(), VectorStoreError> {
@@ -238,7 +238,7 @@ where
 
     /// Search for the top `n` nearest neighbors to the given query within the Milvus vector store.
     /// Returns a vector of tuples containing the score, ID, and payload of the nearest neighbors.
-    async fn top_n<T: for<'a> Deserialize<'a> + Send>(
+    async fn top_n<T: for<'a> Deserialize<'a> + MaybeSend>(
         &self,
         req: VectorSearchRequest<Filter>,
     ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
@@ -321,12 +321,12 @@ where
 
 impl<M> VectorStoreIndexDyn for MilvusVectorStore<M>
 where
-    M: EmbeddingModel + Sync + Send,
+    M: EmbeddingModel + MaybeSync + MaybeSend,
 {
     fn top_n<'a>(
         &'a self,
         req: VectorSearchRequest<CoreFilter<serde_json::Value>>,
-    ) -> WasmBoxedFuture<'a, TopNResults> {
+    ) -> BoxFuture<'a, TopNResults> {
         Box::pin(async move {
             let req = req.try_map_filter(Filter::try_from)?;
             let results = <Self as VectorStoreIndex>::top_n::<serde_json::Value>(self, req).await?;
@@ -339,7 +339,7 @@ where
     fn top_n_ids<'a>(
         &'a self,
         req: VectorSearchRequest<CoreFilter<serde_json::Value>>,
-    ) -> WasmBoxedFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>> {
+    ) -> BoxFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>> {
         Box::pin(async move {
             let req = req.try_map_filter(Filter::try_from)?;
             let results = <Self as VectorStoreIndex>::top_n_ids(self, req).await?;

--- a/crates/rig-mongodb/src/lib.rs
+++ b/crates/rig-mongodb/src/lib.rs
@@ -16,7 +16,7 @@ use rig_core::{
         InsertDocuments, TopNResults, VectorStoreError, VectorStoreIndex, VectorStoreIndexDyn,
         request::{Filter, SearchFilter, VectorSearchRequest},
     },
-    wasm_compat::WasmBoxedFuture,
+    wasm_compat::BoxFuture,
 };
 use serde::{Deserialize, Serialize};
 
@@ -480,7 +480,7 @@ where
     fn top_n<'a>(
         &'a self,
         req: VectorSearchRequest<Filter<serde_json::Value>>,
-    ) -> WasmBoxedFuture<'a, TopNResults> {
+    ) -> BoxFuture<'a, TopNResults> {
         let req = req.map_filter(MongoDbSearchFilter::from);
 
         Box::pin(async move {
@@ -494,7 +494,7 @@ where
     fn top_n_ids<'a>(
         &'a self,
         req: VectorSearchRequest<Filter<serde_json::Value>>,
-    ) -> WasmBoxedFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>> {
+    ) -> BoxFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>> {
         let req = req.map_filter(MongoDbSearchFilter::from);
         Box::pin(async move {
             let results = <Self as VectorStoreIndex>::top_n_ids(self, req).await?;

--- a/crates/rig-scylladb/src/lib.rs
+++ b/crates/rig-scylladb/src/lib.rs
@@ -14,7 +14,7 @@ use rig_core::{
         InsertDocuments, TopNResults, VectorStoreError, VectorStoreIndex, VectorStoreIndexDyn,
         request::{Filter, FilterError, SearchFilter, VectorSearchRequest},
     },
-    wasm_compat::WasmBoxedFuture,
+    wasm_compat::BoxFuture,
 };
 use scylla::{
     client::{Compression, session::Session, session_builder::SessionBuilder},
@@ -559,7 +559,7 @@ where
     fn top_n<'a>(
         &'a self,
         req: VectorSearchRequest<Filter<serde_json::Value>>,
-    ) -> WasmBoxedFuture<'a, TopNResults> {
+    ) -> BoxFuture<'a, TopNResults> {
         Box::pin(async move {
             let req = req.try_map_filter(ScyllaSearchFilter::try_from)?;
             let results = <Self as VectorStoreIndex>::top_n::<serde_json::Value>(self, req).await?;
@@ -570,7 +570,7 @@ where
     fn top_n_ids<'a>(
         &'a self,
         req: VectorSearchRequest<Filter<serde_json::Value>>,
-    ) -> WasmBoxedFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>> {
+    ) -> BoxFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>> {
         Box::pin(async move {
             let req = req.try_map_filter(ScyllaSearchFilter::try_from)?;
             let results = <Self as VectorStoreIndex>::top_n_ids(self, req).await?;

--- a/crates/rig-sqlite/src/lib.rs
+++ b/crates/rig-sqlite/src/lib.rs
@@ -10,7 +10,7 @@
 use rig_core::embeddings::{Embedding, EmbeddingModel};
 use rig_core::vector_store::request::{FilterError, SearchFilter, VectorSearchRequest};
 use rig_core::vector_store::{InsertDocuments, VectorStoreError, VectorStoreIndex};
-use rig_core::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use rig_core::wasm_compat::{MaybeSend, MaybeSync};
 use rig_core::{Embed, OneOrMany};
 use rusqlite::OptionalExtension;
 use rusqlite::types::{Type, Value, ValueRef};
@@ -764,14 +764,10 @@ where
 
 impl<E, T> InsertDocuments for SqliteVectorStore<E, T>
 where
-    E: EmbeddingModel + Clone + WasmCompatSend + WasmCompatSync + 'static,
-    T: SqliteVectorStoreTable
-        + for<'de> Deserialize<'de>
-        + WasmCompatSend
-        + WasmCompatSync
-        + 'static,
+    E: EmbeddingModel + Clone + MaybeSend + MaybeSync + 'static,
+    T: SqliteVectorStoreTable + for<'de> Deserialize<'de> + MaybeSend + MaybeSync + 'static,
 {
-    async fn insert_documents<Doc: Serialize + Embed + WasmCompatSend>(
+    async fn insert_documents<Doc: Serialize + Embed + MaybeSend>(
         &self,
         documents: Vec<(Doc, OneOrMany<Embedding>)>,
     ) -> Result<(), VectorStoreError> {
@@ -5265,7 +5261,7 @@ mod tests {
 
         async fn embed_texts(
             &self,
-            texts: impl IntoIterator<Item = String> + WasmCompatSend,
+            texts: impl IntoIterator<Item = String> + MaybeSend,
         ) -> Result<Vec<Embedding>, EmbeddingError> {
             Ok(texts
                 .into_iter()

--- a/crates/rig-surrealdb/src/lib.rs
+++ b/crates/rig-surrealdb/src/lib.rs
@@ -16,7 +16,7 @@ use rig_core::{
         InsertDocuments, TopNResults, VectorStoreError, VectorStoreIndex, VectorStoreIndexDyn,
         request::{Filter, FilterError, SearchFilter, VectorSearchRequest},
     },
-    wasm_compat::WasmBoxedFuture,
+    wasm_compat::BoxFuture,
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use surrealdb::{
@@ -408,7 +408,7 @@ where
     fn top_n<'a>(
         &'a self,
         req: VectorSearchRequest<Filter<serde_json::Value>>,
-    ) -> WasmBoxedFuture<'a, TopNResults> {
+    ) -> BoxFuture<'a, TopNResults> {
         Box::pin(async move {
             let req = req.try_map_filter(SurrealSearchFilter::try_from)?;
             let results = <Self as VectorStoreIndex>::top_n::<serde_json::Value>(self, req).await?;
@@ -419,7 +419,7 @@ where
     fn top_n_ids<'a>(
         &'a self,
         req: VectorSearchRequest<Filter<serde_json::Value>>,
-    ) -> WasmBoxedFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>> {
+    ) -> BoxFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>> {
         Box::pin(async move {
             let req = req.try_map_filter(SurrealSearchFilter::try_from)?;
             <Self as VectorStoreIndex>::top_n_ids(self, req).await

--- a/crates/rig-vectorize/Cargo.toml
+++ b/crates/rig-vectorize/Cargo.toml
@@ -19,6 +19,9 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+uuid = { workspace = true, features = ["v4", "js"] }
+
 [dev-dependencies]
 anyhow = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/rig-vectorize/src/lib.rs
+++ b/crates/rig-vectorize/src/lib.rs
@@ -34,6 +34,7 @@ use client::{QueryRequest as ApiQueryRequest, VectorInput as ApiVectorInput};
 use rig_core::embeddings::EmbeddingModel;
 use rig_core::vector_store::request::VectorSearchRequest;
 use rig_core::vector_store::{InsertDocuments, VectorStoreError, VectorStoreIndex};
+use rig_core::wasm_compat::{MaybeSend, MaybeSync};
 use rig_core::{Embed, OneOrMany, embeddings::Embedding};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -79,11 +80,11 @@ impl<M> VectorizeVectorStore<M> {
 
 impl<M> VectorStoreIndex for VectorizeVectorStore<M>
 where
-    M: EmbeddingModel + Sync + Send,
+    M: EmbeddingModel + MaybeSync + MaybeSend,
 {
     type Filter = VectorizeFilter;
 
-    async fn top_n<T: for<'a> Deserialize<'a> + Send>(
+    async fn top_n<T: for<'a> Deserialize<'a> + MaybeSend>(
         &self,
         req: VectorSearchRequest<Self::Filter>,
     ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
@@ -152,9 +153,9 @@ where
 
 impl<M> InsertDocuments for VectorizeVectorStore<M>
 where
-    M: EmbeddingModel + Sync + Send,
+    M: EmbeddingModel + MaybeSync + MaybeSend,
 {
-    async fn insert_documents<Doc: Serialize + Embed + Send>(
+    async fn insert_documents<Doc: Serialize + Embed + MaybeSend>(
         &self,
         documents: Vec<(Doc, OneOrMany<Embedding>)>,
     ) -> Result<(), VectorStoreError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,26 @@
 
 pub use rig_core::*;
 
+// Compile this through the public facade on browser WASM. The equivalent
+// rig-core contract lives beside the compatibility definitions themselves.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+mod browser_wasm_compatibility_contract {
+    use std::rc::Rc;
+
+    use crate::wasm_compat::{BoxFuture, MaybeSend, MaybeSync};
+
+    fn accepts_maybe_thread_safe<T: MaybeSend + MaybeSync>(_: &T) {}
+
+    #[allow(dead_code)]
+    fn facade_accepts_rc_and_local_future() {
+        let state = Rc::new(());
+        accepts_maybe_thread_safe(&state);
+
+        let future: BoxFuture<'static, Rc<()>> = Box::pin(async move { state });
+        drop(future);
+    }
+}
+
 #[cfg(feature = "agent")]
 #[cfg_attr(docsrs, doc(cfg(feature = "agent")))]
 pub use rig_agent::{Agent, AgentBuilder, AgentRun, AgentRunner, ExtractionResponse};

--- a/tests/common/reasoning.rs
+++ b/tests/common/reasoning.rs
@@ -17,7 +17,7 @@ use rig::message::{
 };
 use rig::streaming::{StreamedAssistantContent, StreamedUserContent};
 use rig::tool::Tool;
-use rig::wasm_compat::WasmCompatSend;
+use rig::wasm_compat::MaybeSend;
 use serde::Deserialize;
 use serde_json::json;
 
@@ -54,7 +54,7 @@ where
 pub(crate) async fn run_reasoning_roundtrip_streaming<M>(agent: ReasoningRoundtripAgent<M>)
 where
     M: CompletionModel,
-    M::StreamingResponse: WasmCompatSend,
+    M::StreamingResponse: MaybeSend,
 {
     run_reasoning_roundtrip_streaming_with_final(agent, |_| {}).await;
 }
@@ -64,7 +64,7 @@ pub(crate) async fn run_reasoning_roundtrip_streaming_with_final<M, F>(
     mut inspect_final: F,
 ) where
     M: CompletionModel,
-    M::StreamingResponse: WasmCompatSend,
+    M::StreamingResponse: MaybeSend,
     F: FnMut(&M::StreamingResponse),
 {
     let turn1_prompt = Message::User {

--- a/tests/maybe_send.rs
+++ b/tests/maybe_send.rs
@@ -1,0 +1,26 @@
+#![cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+
+use rig::wasm_compat::{
+    BoxFuture as FacadeBoxFuture, MaybeSend as FacadeMaybeSend, MaybeSync as FacadeMaybeSync,
+};
+use rig_core::wasm_compat::{BoxFuture, MaybeSend, MaybeSync};
+
+fn core_markers_imply_thread_safety<T: MaybeSend + MaybeSync>() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<T>();
+}
+
+fn facade_markers_imply_thread_safety<T: FacadeMaybeSend + FacadeMaybeSync>() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<T>();
+}
+
+#[test]
+fn native_core_and_facade_exports_are_sendable() {
+    fn assert_send<T: Send>() {}
+
+    core_markers_imply_thread_safety::<String>();
+    facade_markers_imply_thread_safety::<String>();
+    assert_send::<BoxFuture<'static, ()>>();
+    assert_send::<FacadeBoxFuture<'static, ()>>();
+}


### PR DESCRIPTION
# Adopt MaybeSend portability vocabulary

## Description

This refactors Rig's cross-platform async portability vocabulary to conventional Rust naming while preserving the exact existing behavior.

- Rename `WasmCompatSend`, `WasmCompatSync`, and `WasmBoxedFuture` to `MaybeSend`, `MaybeSync`, and `BoxFuture`.
- Relax thread-safety only for `all(target_arch = "wasm32", target_os = "unknown")`; WASI and every other target retain real `Send`/`Sync` guarantees.
- Implement `BoxFuture` with `futures::future::BoxFuture` or `LocalBoxFuture`.
- Remove the HTTP-only stream marker in favor of target-specific `BoxStream`/`LocalBoxStream` aliases.
- Audit portable provider, tool, hook, memory, vector-store, erased-object, boxed-error, future, and stream bounds.
- Add core and root-facade compile contracts plus native regression coverage.
- Update public documentation, contributor guidance, migration notes, and the changelog.

This is intentionally a breaking API rename with no compatibility shims.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update

## Testing

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test`
- [x] `cargo check -p rig-core --target wasm32-unknown-unknown`
- [x] `cargo check -p rig-agent --target wasm32-unknown-unknown`
- [x] `cargo check -p rig --target wasm32-unknown-unknown`
- [x] `cargo doc --workspace --no-deps`
- [x] Targeted core/facade/rig-memory checks and stale-identifier audits

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented code where the target-specific behavior needs explanation
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the portability contract
- [x] New and existing unit tests pass locally with my changes

## Notes

A fresh independent review covered the complete diff. Its one finding—a stale compatibility name in a comment—was fixed, affected checks were rerun, and the final independent pass found no remaining actionable issues.

Two broader pre-existing target limitations remain outside this PR's scope:

- `rig-core --all-features` on browser WASM is blocked by `lopdf` → `getrandom` without `wasm_js`.
- WASI compilation is blocked earlier by existing Tokio feature and `socket2` target support.
