### PR TITLE
feat(openai): support server-side Responses compaction

### DIFF
--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -1032,6 +1032,7 @@ where
         let stream = tracing_futures::Instrument::instrument(
             stream! {
                 let mut final_usage = responses_api::ResponsesUsage::new();
+                let mut response_id = None;
                 let mut reasoning_metadata = None;
                 let mut reasoning_context = None;
                 let mut tool_calls: Vec<streaming::RawStreamingChoice<CopilotStreamingResponse>> = Vec::new();
@@ -1105,6 +1106,11 @@ where
                                         StreamingItemDoneOutput { item: responses_api::Output::Message(msg), .. } => {
                                             yield Ok(RawStreamingChoice::MessageId(msg.id.clone()));
                                         }
+                                        StreamingItemDoneOutput { item: responses_api::Output::Compaction(compaction), .. } => {
+                                            yield Ok(RawStreamingChoice::Unknown(
+                                                serde_json::Value::from(compaction),
+                                            ));
+                                        }
                                         // Surface an unmodeled output item (e.g. a hosted-tool result) to the consumer verbatim.
                                         StreamingItemDoneOutput { item: responses_api::Output::Unknown(value), .. } => {
                                             yield Ok(RawStreamingChoice::Unknown(value.clone()));
@@ -1142,6 +1148,7 @@ where
                                     responses_api::streaming::ResponseChunkKind::ResponseCompleted => {
                                         span.record("gen_ai.response.id", response.id.as_str());
                                         span.record("gen_ai.response.model", response.model.as_str());
+                                        response_id = Some(response.id);
                                         if let Some(usage) = response.usage {
                                             final_usage = usage;
                                         }
@@ -1214,6 +1221,7 @@ where
                 yield Ok(RawStreamingChoice::FinalResponse(
                     CopilotStreamingResponse::Responses(
                         responses_api::streaming::StreamingCompletionResponse {
+                            response_id,
                             usage: final_usage,
                             reasoning_metadata,
                             reasoning_context,

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -1637,6 +1637,9 @@ pub struct AdditionalParameters {
     /// Whether or not a given model task should run in the background (ie a detached process).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub background: Option<bool>,
+    /// Server-managed context controls such as automatic compaction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_management: Option<Vec<ContextManagement>>,
     /// The text response format. This is where you would add structured outputs (if you want them).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<TextConfig>,
@@ -1680,6 +1683,77 @@ pub struct AdditionalParameters {
     /// Whether or not to store the response for later retrieval by API.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub store: Option<bool>,
+}
+
+/// Server-managed context controls for the OpenAI Responses API.
+///
+/// Automatic compaction runs during a normal Responses request when the
+/// rendered token count crosses the configured threshold. When continuing with
+/// `previous_response_id`, send only the new input for each turn and do not
+/// manually prune the conversation.
+///
+/// # Example
+///
+/// ```no_run
+/// use rig_core::{
+///     client::{CompletionClient, ProviderClient},
+///     completion::CompletionModel,
+///     providers::openai::{self, responses_api::ContextManagement},
+/// };
+/// use serde_json::json;
+///
+/// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// let client = openai::Client::from_env()?;
+/// let model = client.completion_model("gpt-5.4");
+///
+/// let first = model
+///     .completion(
+///         model
+///             .completion_request("Begin a long task.")
+///             .additional_params(json!({
+///                 "context_management": [ContextManagement::compaction(200_000)],
+///                 "store": false,
+///             }))
+///             .build(),
+///     )
+///     .await?;
+///
+/// let second = model
+///     .completion(
+///         model
+///             .completion_request("Continue with the next step.")
+///             .additional_params(json!({
+///                 "context_management": [ContextManagement::compaction(200_000)],
+///                 "previous_response_id": first.raw_response.id,
+///                 "store": false,
+///             }))
+///             .build(),
+///     )
+///     .await?;
+/// # let _ = second;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContextManagement {
+    /// Compact the server-managed context after the optional token threshold is
+    /// crossed. When omitted, OpenAI selects the threshold.
+    Compaction {
+        /// Rendered token threshold that triggers automatic compaction.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        compact_threshold: Option<u64>,
+    },
+}
+
+impl ContextManagement {
+    /// Enables automatic server-side compaction at `compact_threshold`.
+    #[must_use]
+    pub const fn compaction(compact_threshold: u64) -> Self {
+        Self::Compaction {
+            compact_threshold: Some(compact_threshold),
+        }
+    }
 }
 
 fn deserialize_metadata<'de, D>(
@@ -1960,6 +2034,11 @@ pub enum Output {
         encrypted_content: Option<String>,
         status: Option<ToolStatus>,
     },
+    /// Opaque server-side compaction state returned by OpenAI.
+    ///
+    /// This item remains available in the raw provider response but is not
+    /// converted into Rig's provider-agnostic assistant conversation history.
+    Compaction(ResponseCompactionItem),
     /// Catch-all for output item types this version does not model. Holds the
     /// raw item object exactly as it appeared in the provider's `output[]`
     /// array, so hosted-tool payloads survive the typed decode.
@@ -2051,6 +2130,9 @@ impl Serialize for Output {
                 }
                 Ok(value)
             }
+            Output::Compaction(compaction) => {
+                return Value::from(compaction).serialize(serializer);
+            }
             Output::Unknown(value) => return value.serialize(serializer),
         };
         value
@@ -2081,6 +2163,9 @@ impl<'de> Deserialize<'de> for Output {
                 .map_err(serde::de::Error::custom),
             "reasoning" => serde_json::from_value::<ReasoningFields>(value)
                 .map(Output::from)
+                .map_err(serde::de::Error::custom),
+            "compaction" => serde_json::from_value(value)
+                .map(Output::Compaction)
                 .map_err(serde::de::Error::custom),
             _ => Ok(Output::Unknown(value)),
         }
@@ -2136,10 +2221,43 @@ impl From<Output> for Vec<completion::AssistantContent> {
                     },
                 )]
             }
+            Output::Compaction(_) => Vec::new(),
             Output::Unknown(_) => Vec::new(),
         };
 
         res
+    }
+}
+
+/// Opaque context state emitted by OpenAI automatic server-side compaction.
+///
+/// The encrypted content is provider state rather than a human-readable
+/// summary. When using `previous_response_id`, callers only need to carry the
+/// response ID forward; OpenAI retains this item in the response chain.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct ResponseCompactionItem {
+    /// Provider-assigned compaction item ID.
+    pub id: String,
+    /// Encrypted context state used by OpenAI for subsequent turns.
+    pub encrypted_content: String,
+    /// The component that created the compaction item, when supplied.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_by: Option<String>,
+}
+
+impl From<&ResponseCompactionItem> for Value {
+    fn from(item: &ResponseCompactionItem) -> Self {
+        let mut value = Map::new();
+        value.insert("type".to_string(), Value::String("compaction".to_string()));
+        value.insert("id".to_string(), Value::String(item.id.clone()));
+        value.insert(
+            "encrypted_content".to_string(),
+            Value::String(item.encrypted_content.clone()),
+        );
+        if let Some(created_by) = &item.created_by {
+            value.insert("created_by".to_string(), Value::String(created_by.clone()));
+        }
+        Value::Object(value)
     }
 }
 

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -4726,6 +4726,227 @@ mod tests {
         assert_eq!(json["error"]["code"], "invalid_value");
     }
 
+    #[tokio::test]
+    async fn responses_compaction_preserves_raw_state_and_chains_new_input() {
+        use crate::client::CompletionClient;
+        use crate::completion::CompletionModel;
+        use crate::providers::openai::Client;
+        use crate::test_utils::{MockHttpResponse, SequencedHttpClient};
+
+        let first_response = json!({
+            "id": "resp_compacted_1",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "model": "gpt-5.4",
+            "output": [
+                {
+                    "type": "compaction",
+                    "id": "cmp_1",
+                    "encrypted_content": "encrypted-state",
+                    "created_by": "server"
+                },
+                {
+                    "type": "message",
+                    "id": "msg_1",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{
+                        "type": "output_text",
+                        "text": "First answer",
+                        "annotations": []
+                    }]
+                }
+            ]
+        })
+        .to_string();
+        let second_response = json!({
+            "id": "resp_compacted_2",
+            "object": "response",
+            "created_at": 1,
+            "status": "completed",
+            "model": "gpt-5.4",
+            "output": [{
+                "type": "message",
+                "id": "msg_2",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{
+                    "type": "output_text",
+                    "text": "Second answer",
+                    "annotations": []
+                }]
+            }]
+        })
+        .to_string();
+        let http_client = SequencedHttpClient::new([
+            MockHttpResponse::success(first_response),
+            MockHttpResponse::success(second_response),
+        ]);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client.clone())
+            .build()
+            .expect("client should build");
+        let model = client.completion_model("gpt-5.4");
+
+        let first = model
+            .completion(
+                model
+                    .completion_request("Begin the task")
+                    .additional_params(json!({
+                        "context_management": [ContextManagement::compaction(200_000)],
+                        "store": false
+                    }))
+                    .build(),
+            )
+            .await
+            .expect("first response should complete");
+
+        assert!(first.choice.iter().any(|content| {
+            matches!(
+                content,
+                completion::AssistantContent::Text(text) if text.text == "First answer"
+            )
+        }));
+        assert!(matches!(
+            first.raw_response.output.first(),
+            Some(Output::Compaction(ResponseCompactionItem {
+                id,
+                encrypted_content,
+                created_by: Some(created_by),
+            })) if id == "cmp_1"
+                && encrypted_content == "encrypted-state"
+                && created_by == "server"
+        ));
+
+        let first_response_id = first.raw_response.id.clone();
+        model
+            .completion(
+                model
+                    .completion_request("Continue with the next step")
+                    .additional_params(json!({
+                        "context_management": [ContextManagement::compaction(200_000)],
+                        "previous_response_id": first_response_id,
+                        "store": false
+                    }))
+                    .build(),
+            )
+            .await
+            .expect("second response should complete");
+
+        let requests = http_client.requests();
+        assert_eq!(requests.len(), 2);
+        assert!(
+            requests
+                .iter()
+                .all(|request| request.uri.ends_with("/responses"))
+        );
+
+        let first_request: Value =
+            serde_json::from_slice(&requests[0].body).expect("first request should be JSON");
+        let second_request: Value =
+            serde_json::from_slice(&requests[1].body).expect("second request should be JSON");
+        let expected_context_management =
+            json!([{ "type": "compaction", "compact_threshold": 200_000 }]);
+
+        assert_eq!(
+            first_request["context_management"],
+            expected_context_management
+        );
+        assert_eq!(
+            second_request["context_management"],
+            expected_context_management
+        );
+        assert_eq!(first_request["store"], false);
+        assert_eq!(second_request["store"], false);
+        assert!(first_request.get("previous_response_id").is_none());
+        assert_eq!(second_request["previous_response_id"], "resp_compacted_1");
+        assert_eq!(
+            second_request["input"]
+                .as_array()
+                .expect("input should be an array")
+                .len(),
+            1
+        );
+        assert_eq!(
+            second_request["input"][0]["content"][0]["text"],
+            "Continue with the next step"
+        );
+    }
+
+    #[test]
+    fn context_management_serializes_and_survives_request_conversion() {
+        let compaction = ContextManagement::compaction(200_000);
+        assert_eq!(
+            serde_json::to_value(&compaction).expect("compaction should serialize"),
+            json!({
+                "type": "compaction",
+                "compact_threshold": 200_000
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(ContextManagement::Compaction {
+                compact_threshold: None
+            })
+            .expect("compaction without a threshold should serialize"),
+            json!({ "type": "compaction" })
+        );
+
+        let mut request = request_with_preamble("You are concise.");
+        request.additional_params = Some(json!({
+            "context_management": [compaction],
+            "store": false
+        }));
+        let request = CompletionRequest::try_from(("gpt-5.4".to_string(), request))
+            .expect("request should convert");
+        let serialized = serde_json::to_value(request).expect("request should serialize");
+
+        assert_eq!(
+            serialized["context_management"],
+            json!([{
+                "type": "compaction",
+                "compact_threshold": 200_000
+            }])
+        );
+        assert_eq!(serialized["store"], false);
+    }
+
+    #[test]
+    fn output_compaction_round_trips_value_equal() {
+        for item in [
+            json!({
+                "type": "compaction",
+                "id": "cmp_1",
+                "encrypted_content": "encrypted-state",
+                "created_by": "server"
+            }),
+            json!({
+                "type": "compaction",
+                "id": "cmp_2",
+                "encrypted_content": "encrypted-state"
+            }),
+        ] {
+            let output: Output =
+                serde_json::from_value(item.clone()).expect("compaction should deserialize");
+            assert!(matches!(output, Output::Compaction(_)));
+            assert_eq!(
+                serde_json::to_value(output).expect("compaction should serialize"),
+                item
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_compaction_output_errors() {
+        let result: Result<Output, _> = serde_json::from_value(json!({
+            "type": "compaction",
+            "id": "cmp_1"
+        }));
+
+        assert!(result.is_err());
+    }
+
     #[test]
     fn output_unknown_preserves_hosted_tool_payload() {
         let item = json!({
@@ -4980,6 +5201,14 @@ mod tests {
             serde_json::from_value(json!({ "type": "reasoning", "id": "r1", "summary": [] }))
                 .expect("reasoning item should decode");
         assert!(matches!(reasoning, Output::Reasoning { .. }));
+
+        let compaction: Output = serde_json::from_value(json!({
+            "type": "compaction",
+            "id": "cmp_1",
+            "encrypted_content": "encrypted-state"
+        }))
+        .expect("compaction item should decode");
+        assert!(matches!(compaction, Output::Compaction(_)));
     }
 
     #[test]

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -1170,6 +1170,38 @@ mod tests {
     }
 
     #[test]
+    fn compaction_output_item_surfaces_as_raw_unknown_choice() {
+        let item = json!({
+            "type": "compaction",
+            "id": "cmp_1",
+            "encrypted_content": "encrypted-state",
+            "created_by": "server"
+        });
+        let body = format!(
+            "data: {}\n",
+            json!({
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "sequence_number": 1,
+                "item": item,
+            })
+        );
+
+        let choices = raw_choices_from_sse_body(&body, ResponsesUsage::new())
+            .expect("sse body should decode");
+
+        let compaction = choices.iter().find_map(|choice| match choice {
+            RawStreamingChoice::Unknown(value)
+                if value.get("type").and_then(serde_json::Value::as_str) == Some("compaction") =>
+            {
+                Some(value)
+            }
+            _ => None,
+        });
+        assert_eq!(compaction, Some(&item));
+    }
+
+    #[test]
     fn reasoning_done_item_without_encrypted_emits_summary_only() {
         let summary = vec![ReasoningSummary::SummaryText {
             text: "only summary".to_string(),
@@ -1588,10 +1620,11 @@ mod tests {
             "response": response,
         });
 
-        let usage = final_response_from_event(event).await.usage;
-        assert_eq!(usage.input_tokens, 10);
-        assert_eq!(usage.output_tokens, 5);
-        assert_eq!(usage.total_tokens, 15);
+        let response = final_response_from_event(event).await;
+        assert_eq!(response.response_id.as_deref(), Some("resp_123"));
+        assert_eq!(response.usage.input_tokens, 10);
+        assert_eq!(response.usage.output_tokens, 5);
+        assert_eq!(response.usage.total_tokens, 15);
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -37,6 +37,12 @@ pub enum StreamingCompletionChunk {
 /// The final streaming response from the OpenAI Responses API.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct StreamingCompletionResponse {
+    /// Provider-assigned response ID from the terminal response event.
+    ///
+    /// Pass this as `previous_response_id` on the next request when using
+    /// response-ID chaining, including automatic server-side compaction.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_id: Option<String>,
     /// Token usage
     pub usage: ResponsesUsage,
     /// The complete object-shaped reasoning metadata from the terminal response event.
@@ -218,6 +224,7 @@ pub(crate) fn parse_sse_completion_body(
 }
 
 struct RawChoiceAccumulator {
+    response_id: Option<String>,
     final_usage: ResponsesUsage,
     reasoning_metadata: Option<serde_json::Map<String, serde_json::Value>>,
     reasoning_context: Option<String>,
@@ -228,6 +235,7 @@ struct RawChoiceAccumulator {
 impl RawChoiceAccumulator {
     fn new(initial_usage: ResponsesUsage) -> Self {
         Self {
+            response_id: None,
             final_usage: initial_usage,
             reasoning_metadata: None,
             reasoning_context: None,
@@ -318,6 +326,7 @@ impl RawChoiceAccumulator {
     ) -> Result<(), CompletionError> {
         match kind {
             ResponseChunkKind::ResponseCompleted => {
+                self.response_id = Some(response.id);
                 if let Some(usage) = response.usage {
                     self.final_usage = usage;
                 }
@@ -378,6 +387,11 @@ impl RawChoiceAccumulator {
             Output::Message(message) => {
                 immediate.push(streaming::RawStreamingChoice::MessageId(message.id));
             }
+            Output::Compaction(compaction) => {
+                immediate.push(streaming::RawStreamingChoice::Unknown(
+                    serde_json::Value::from(&compaction),
+                ));
+            }
             // An unmodeled output item (e.g. a hosted-tool result such as
             // `web_search_call`) arriving on `response.output_item.done`. Surface
             // the raw item to stream consumers, mirroring how the non-streaming
@@ -393,6 +407,7 @@ impl RawChoiceAccumulator {
         choices.append(&mut self.tool_calls);
         choices.push(RawStreamingChoice::FinalResponse(
             StreamingCompletionResponse {
+                response_id: self.response_id,
                 usage: self.final_usage,
                 reasoning_metadata: self.reasoning_metadata,
                 reasoning_context: self.reasoning_context,

--- a/crates/rig-core/src/providers/openai/responses_api/websocket.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/websocket.rs
@@ -262,6 +262,51 @@ where
 /// turns can automatically chain via `previous_response_id` unless the request
 /// explicitly sets a different one.
 ///
+/// Automatic compaction composes with that chaining behavior. Configure
+/// `context_management` on each request and send only the new turn input:
+///
+/// ```no_run
+/// use rig_core::{
+///     client::{CompletionClient, ProviderClient},
+///     completion::CompletionModel,
+///     providers::openai::{self, responses_api::ContextManagement},
+/// };
+/// use serde_json::json;
+///
+/// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// let client = openai::Client::from_env()?;
+/// let model = client.completion_model("gpt-5.4");
+/// let mut session = client.responses_websocket("gpt-5.4").await?;
+///
+/// session
+///     .completion(
+///         model
+///             .completion_request("Begin a long task.")
+///             .additional_params(json!({
+///                 "context_management": [ContextManagement::compaction(200_000)],
+///                 "store": false,
+///             }))
+///             .build(),
+///     )
+///     .await?;
+///
+/// session
+///     .completion(
+///         model
+///             .completion_request("Continue with the next step.")
+///             .additional_params(json!({
+///                 "context_management": [ContextManagement::compaction(200_000)],
+///                 "store": false,
+///             }))
+///             .build(),
+///     )
+///     .await?;
+///
+/// session.close().await?;
+/// # Ok(())
+/// # }
+/// ```
+///
 /// Call [`ResponsesWebSocketSession::close`] when you are finished with the
 /// session so the websocket can complete a close handshake cleanly.
 pub struct ResponsesWebSocketSession<H = reqwest::Client> {

--- a/crates/rig-core/src/providers/openai/responses_api/websocket.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/websocket.rs
@@ -878,7 +878,8 @@ mod tests {
     use crate::client::CompletionClient;
     use crate::completion::CompletionModel;
     use crate::providers::openai::responses_api::{
-        CompletionResponse, ResponseError, ResponseObject, ResponseStatus, ResponsesUsage,
+        CompletionResponse, ContextManagement, ResponseError, ResponseObject, ResponseStatus,
+        ResponsesUsage,
     };
     use futures::{SinkExt, StreamExt};
     use serde_json::json;
@@ -1397,6 +1398,140 @@ mod tests {
         assert_eq!(second.id, "resp_2");
         assert_eq!(session.previous_response_id(), Some("resp_2"));
 
+        server.await.expect("server task should finish");
+    }
+
+    #[tokio::test]
+    async fn compaction_requests_chain_only_after_successful_websocket_turns() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let address = listener.local_addr().expect("listener should have address");
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("server should accept");
+            let mut socket = accept_async(stream)
+                .await
+                .expect("server should upgrade websocket");
+
+            let turns = [
+                ("first", "resp_1", ResponseStatus::Completed),
+                ("second", "resp_incomplete", ResponseStatus::Incomplete),
+                ("third", "resp_3", ResponseStatus::Completed),
+            ];
+
+            for (index, (prompt, response_id, status)) in turns.into_iter().enumerate() {
+                let request = socket
+                    .next()
+                    .await
+                    .expect("request should exist")
+                    .expect("request should be valid");
+                let payload: serde_json::Value =
+                    serde_json::from_str(&request.into_text().expect("request should be text"))
+                        .expect("request should be JSON");
+
+                assert_eq!(payload["type"], "response.create");
+                assert_eq!(
+                    payload["context_management"],
+                    json!([{
+                        "type": "compaction",
+                        "compact_threshold": 200_000
+                    }])
+                );
+                assert_eq!(payload["store"], false);
+                assert_eq!(
+                    payload["input"]
+                        .as_array()
+                        .expect("input should be an array")
+                        .len(),
+                    1
+                );
+                assert_eq!(payload["input"][0]["content"][0]["text"], prompt);
+
+                match index {
+                    1 => assert_eq!(payload["previous_response_id"], "resp_1"),
+                    0 | 2 => assert!(
+                        payload.get("previous_response_id").is_none(),
+                        "turn {index} should not carry a stale response ID"
+                    ),
+                    _ => unreachable!("test only defines three turns"),
+                }
+
+                let event_type = match &status {
+                    ResponseStatus::Completed => "response.completed",
+                    ResponseStatus::Incomplete => "response.incomplete",
+                    _ => unreachable!("test only uses terminal statuses"),
+                };
+                let response = serde_json::to_value(CompletionResponse {
+                    id: response_id.to_string(),
+                    status,
+                    ..sample_response(ResponseStatus::Completed)
+                })
+                .expect("response should serialize");
+
+                socket
+                    .send(Message::text(
+                        json!({
+                            "type": event_type,
+                            "sequence_number": index + 1,
+                            "response": response,
+                        })
+                        .to_string(),
+                    ))
+                    .await
+                    .expect("terminal event should send");
+            }
+        });
+
+        let base_url = format!("http://{address}/v1");
+        let client = crate::providers::openai::Client::builder()
+            .api_key("test-key")
+            .base_url(&base_url)
+            .build()
+            .expect("client should build");
+        let model = client.completion_model("gpt-5.4");
+        let mut session = client
+            .responses_websocket("gpt-5.4")
+            .await
+            .expect("session should connect");
+
+        for prompt in ["first", "second", "third"] {
+            session
+                .send(
+                    model
+                        .completion_request(prompt)
+                        .additional_params(json!({
+                            "context_management": [ContextManagement::compaction(200_000)],
+                            "store": false
+                        }))
+                        .build(),
+                )
+                .await
+                .expect("request should send");
+
+            if prompt == "second" {
+                session
+                    .wait_for_completed_response()
+                    .await
+                    .expect_err("incomplete response should fail");
+                assert_eq!(session.previous_response_id(), None);
+            } else {
+                let response = session
+                    .wait_for_completed_response()
+                    .await
+                    .expect("completed response should succeed");
+                assert_eq!(
+                    response.id,
+                    if prompt == "first" {
+                        "resp_1"
+                    } else {
+                        "resp_3"
+                    }
+                );
+            }
+        }
+
+        assert_eq!(session.previous_response_id(), Some("resp_3"));
         server.await.expect("server task should finish");
     }
 


### PR DESCRIPTION
Adds support for [OpenAI Responses API server-side compaction](https://developers.openai.com/api/docs/guides/compaction)

- Adds `context_management` request support.
- Preserves compaction output items without adding them to conversation history.
- Exposes response IDs for streaming continuation.
- Supports automatic response-ID chaining in WebSocket sessions.
- Adds deterministic HTTP, streaming, and WebSocket coverage.