### PR TITLE
fix(anthropic): surface streaming stop_reason and message_delta input_tokens

### DIFF
--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -313,9 +313,20 @@ where
                                             // cache_creation_input_tokens and cache_read_input_tokens
                                             // are cumulative totals on message_delta.usage per the
                                             // Anthropic streaming API spec — use them directly.
+                                            // Prefer `message_delta.usage.input_tokens` when the
+                                            // provider supplies it. Anthropic itself reports input
+                                            // usage on `message_start`, but Anthropic-compatible
+                                            // gateways (e.g. OpenRouter) send `input_tokens: 0`
+                                            // there and the real count on `message_delta`. Reading
+                                            // `message_start` alone silently yields a zero prompt
+                                            // count against those providers, which breaks any
+                                            // consumer that sizes its context from input tokens.
                                             let usage = PartialUsage {
                                                  output_tokens: usage.output_tokens,
-                                                 input_tokens: usize::try_from(input_tokens).ok(),
+                                                 input_tokens: usage
+                                                     .input_tokens
+                                                     .filter(|v| *v > 0)
+                                                     .or_else(|| usize::try_from(input_tokens).ok()),
                                                  cache_creation_input_tokens: usage.cache_creation_input_tokens,
                                                  cache_read_input_tokens: usage.cache_read_input_tokens
                                             };

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -196,6 +196,12 @@ struct ThinkingState {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StreamingCompletionResponse {
     pub usage: PartialUsage,
+    /// Anthropic `message_delta.stop_reason` (`"end_turn"`, `"tool_use"`,
+    /// `"max_tokens"`, `"stop_sequence"`). Surfaced so consumers can
+    /// distinguish a `max_tokens` truncation from a normal stop — the
+    /// streaming API otherwise drops it.
+    #[serde(default)]
+    pub stop_reason: Option<String>,
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
@@ -283,6 +289,7 @@ where
             let mut sse_stream = Box::pin(stream);
             let mut input_tokens = 0;
             let mut final_usage = None;
+            let mut final_stop_reason: Option<String> = None;
 
             let mut text_content = String::new();
 
@@ -316,6 +323,7 @@ where
                                             let span = tracing::Span::current();
                                             span.record_token_usage(&usage);
                                             final_usage = Some(usage);
+                                            final_stop_reason = delta.stop_reason.clone();
                                             break;
                                         }
                                     }
@@ -354,7 +362,8 @@ where
             sse_stream.close();
 
             yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
-                usage: final_usage.unwrap_or_default()
+                usage: final_usage.unwrap_or_default(),
+                stop_reason: final_stop_reason.clone(),
             }))
         }.instrument(span));
 
@@ -1619,6 +1628,7 @@ mod tests {
 
             yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
                 usage: PartialUsage::default(),
+                stop_reason: None,
             }));
         };
 
@@ -1764,6 +1774,7 @@ mod tests {
 
             yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
                 usage: PartialUsage::default(),
+                stop_reason: None,
             }));
         };
 

--- a/tests/cassettes/anthropic/streaming/streaming_metadata_from_message_delta.yaml
+++ b/tests/cassettes/anthropic/streaming/streaming_metadata_from_message_delta.yaml
@@ -1,0 +1,36 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":64000,"messages":[{"content":[{"text":"In one short paragraph, explain what a solar eclipse is.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You are a concise assistant. Answer directly in plain text.","type":"text"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    event: message_start
+    data: {"message":{"content":[],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":0,"output_tokens":1,"service_tier":"standard"}},"type":"message_start"}
+
+    event: content_block_start
+    data: {"content_block":{"text":"","type":"text"},"index":0,"type":"content_block_start"}
+
+    event: content_block_delta
+    data: {"delta":{"text":"A solar eclipse happens when the Moon passes between the Earth and the Sun.","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":0,"type":"content_block_stop"}
+
+    event: message_delta
+    data: {"delta":{"stop_details":null,"stop_reason":"max_tokens","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":9,"output_tokens":17}}
+
+    event: message_stop
+    data: {"type":"message_stop"}
+

--- a/tests/providers/anthropic/cassette/streaming.rs
+++ b/tests/providers/anthropic/cassette/streaming.rs
@@ -30,3 +30,47 @@ async fn streaming_smoke() {
     })
     .await;
 }
+
+/// Regression: the streaming final response must carry the metadata Anthropic
+/// puts on `message_delta`.
+///
+/// Two things used to be dropped. `stop_reason` never reached the consumer at
+/// all, so a `max_tokens` truncation was indistinguishable from a normal stop.
+/// And `input_tokens` was read only from `message_start`, which
+/// Anthropic-compatible gateways report as `0`, hiding the real prompt size
+/// that the provider sends on `message_delta`.
+///
+/// The cassette reproduces exactly that shape: `message_start` carries
+/// `input_tokens: 0` while `message_delta` carries `stop_reason: "max_tokens"`
+/// and `input_tokens: 9`.
+#[tokio::test]
+async fn streaming_metadata_from_message_delta() {
+    with_anthropic_cassette(
+        "streaming/streaming_metadata_from_message_delta",
+        |client| async move {
+            let agent = client
+                .agent(anthropic::completion::CLAUDE_SONNET_4_6)
+                .preamble(STREAMING_PREAMBLE)
+                .build();
+
+            let mut stream = agent.stream_prompt(STREAMING_PROMPT).await;
+            let (response, provider_final): (_, anthropic::streaming::StreamingCompletionResponse) =
+                collect_stream_final_response_and_provider_final(&mut stream)
+                    .await
+                    .expect("streaming prompt should succeed");
+
+            assert_nonempty_response(&response);
+            assert_eq!(
+                provider_final.stop_reason.as_deref(),
+                Some("max_tokens"),
+                "stop_reason from message_delta must reach the consumer"
+            );
+            assert_eq!(
+                provider_final.usage.input_tokens,
+                Some(9),
+                "input_tokens must come from message_delta when the provider sends it there"
+            );
+        },
+    )
+    .await;
+}


### PR DESCRIPTION
Fixes #2235

The Anthropic streaming provider parses two pieces of metadata off the wire and
then drops them before the consumer can see them. This surfaces both, without
changing behaviour against Anthropic proper.

## 1. Surface `stop_reason` on the streaming response

`message_delta.delta.stop_reason` was read only to decide when to break out of
the SSE loop; the value was discarded. `StreamingCompletionResponse` carried
`usage` and nothing else, so a `max_tokens` truncation was indistinguishable
from a normal `end_turn`.

```rust
pub struct StreamingCompletionResponse {
    pub usage: PartialUsage,
    #[serde(default)]
    pub stop_reason: Option<String>,   // added
}
```

The value is captured in the same block that already builds `final_usage`, and
filled in at the `FinalResponse` construction site. The two test-fixture
construction sites get `None`.

This matters for consumers that must refuse to act on a truncated response — a
tool call cut mid-arguments has to be declined, and `stop_reason` is the only
signal that says so.

## 2. Prefer `message_delta.usage.input_tokens` when the provider sends it

`input_tokens` was captured at `message_start` only, and `message_delta`'s
`usage.input_tokens` was ignored even though `PartialUsage` already models the
field. Anthropic reports input usage on `message_start`, so this worked against
the real API — but Anthropic-compatible gateways do not all behave that way.
OpenRouter's Anthropic Messages endpoint sends:

```
message_start  {"input_tokens": 0, "output_tokens": 0, ...}
message_delta  {"input_tokens": 9, "output_tokens": 4, ...}
```

which yielded a silent `Usage { input_tokens: 0 }` — worse than a missing value,
because a consumer sizing its context window from input tokens sees zero and
never acts.

```rust
input_tokens: usage
    .input_tokens
    .filter(|v| *v > 0)
    .or_else(|| usize::try_from(input_tokens).ok()),
```

**Behaviour against Anthropic proper is unchanged**: `PartialUsage.input_tokens`
is `#[serde(default)] Option<usize>`, and Anthropic's `message_delta` payload
does not carry the field, so the expression always falls through to the
`message_start` value there.

## Tests

`streaming_metadata_from_message_delta` — a cassette-backed regression covering
both changes in one recorded interaction: `message_start` reports
`input_tokens: 0` while `message_delta` carries `stop_reason: "max_tokens"` and
`input_tokens: 9`.

I verified the test is load-bearing rather than incidentally green: reverting
the `input_tokens` change alone turns it red with `left: Some(0), right: Some(9)`,
and reverting the `stop_reason` change removes the field the test reads.

`cargo test -p rig --test anthropic` → 109 passed / 0 failed.
`cargo clippy -p rig-core --all-targets` → clean.

## Notes

- The OpenAI-compatible side has the same gap for finish reasons
  (`CompatibleFinishReason { ToolCalls, Other }` is `pub(crate)` and `length` is
  lost at `providers/openai/completion/streaming.rs`). I left it out to keep this
  PR focused on the provider where a typed `stop_reason` already exists on the
  response object. Happy to open a separate issue for it if that is wanted.
- The two changes are in adjacent lines of the same function and share a root
  cause — the final response not carrying what `message_delta` reported. If you
  would rather review them separately I can split the PR.
