### PR TITLE
feat(core): capture provider-reported cost in OpenAI-compatible streaming

### DIFF
--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -254,10 +254,6 @@ where
 
 /// Struct representing the token usage for a completion request.
 /// If tokens used are `0`, then the provider failed to supply token usage metrics.
-///
-/// `Eq` is implemented manually: the only non-integer field is `cost`, which
-/// providers report as a finite decimal (never NaN/±inf), so derived
-/// `PartialEq` is reflexive in practice.
 #[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub struct Usage {
     /// The number of input ("prompt") tokens used in a given request.
@@ -276,10 +272,7 @@ pub struct Usage {
     /// The number of tokens spent on internal reasoning / "thoughts" by reasoning-capable
     /// models (e.g. Gemini thinking, Anthropic extended thinking, OpenAI o-series).
     pub reasoning_tokens: u64,
-    /// Provider-reported cost (USD) for the request, when the provider
-    /// supplies it. Some OpenAI-compatible gateways (e.g. OpenCode Go) emit a
-    /// `cost` field alongside usage; most providers report nothing and this
-    /// stays `None`.
+    /// Provider-reported request cost (USD), if the provider supplies it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cost: Option<f64>,
 }

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -254,7 +254,11 @@ where
 
 /// Struct representing the token usage for a completion request.
 /// If tokens used are `0`, then the provider failed to supply token usage metrics.
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+///
+/// `Eq` is implemented manually: the only non-integer field is `cost`, which
+/// providers report as a finite decimal (never NaN/±inf), so derived
+/// `PartialEq` is reflexive in practice.
+#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub struct Usage {
     /// The number of input ("prompt") tokens used in a given request.
     pub input_tokens: u64,
@@ -272,6 +276,12 @@ pub struct Usage {
     /// The number of tokens spent on internal reasoning / "thoughts" by reasoning-capable
     /// models (e.g. Gemini thinking, Anthropic extended thinking, OpenAI o-series).
     pub reasoning_tokens: u64,
+    /// Provider-reported cost (USD) for the request, when the provider
+    /// supplies it. Some OpenAI-compatible gateways (e.g. OpenCode Go) emit a
+    /// `cost` field alongside usage; most providers report nothing and this
+    /// stays `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost: Option<f64>,
 }
 
 impl Usage {
@@ -285,6 +295,7 @@ impl Usage {
             cache_creation_input_tokens: 0,
             tool_use_prompt_tokens: 0,
             reasoning_tokens: 0,
+            cost: None,
         }
     }
 
@@ -303,6 +314,8 @@ impl Default for Usage {
     }
 }
 
+impl Eq for Usage {}
+
 impl Add for Usage {
     type Output = Self;
 
@@ -316,6 +329,7 @@ impl Add for Usage {
                 + other.cache_creation_input_tokens,
             tool_use_prompt_tokens: self.tool_use_prompt_tokens + other.tool_use_prompt_tokens,
             reasoning_tokens: self.reasoning_tokens + other.reasoning_tokens,
+            cost: self.cost.or(other.cost),
         }
     }
 }
@@ -329,6 +343,9 @@ impl AddAssign for Usage {
         self.cache_creation_input_tokens += other.cache_creation_input_tokens;
         self.tool_use_prompt_tokens += other.tool_use_prompt_tokens;
         self.reasoning_tokens += other.reasoning_tokens;
+        if self.cost.is_none() {
+            self.cost = other.cost;
+        }
     }
 }
 

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -251,6 +251,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             cache_creation_input_tokens: response.usage.cache_creation_input_tokens.unwrap_or(0),
             tool_use_prompt_tokens: 0,
             reasoning_tokens: 0,
+        cost: None,
         };
 
         Ok(completion::CompletionResponse {

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -191,6 +191,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                     cache_creation_input_tokens: 0,
                     tool_use_prompt_tokens: 0,
                     reasoning_tokens: 0,
+                cost: None,
                 }
             })
             .unwrap_or_default();

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -683,6 +683,7 @@ impl TryFrom<ChatCompletionResponse> for completion::CompletionResponse<ChatComp
                 cache_creation_input_tokens: 0,
                 tool_use_prompt_tokens: 0,
                 reasoning_tokens: 0,
+            cost: None,
             })
             .unwrap_or_default();
 
@@ -1596,6 +1597,7 @@ impl CompatibleStreamProfile for CopilotChatCompatibleProfile {
                 data.id,
                 data.model,
                 data.usage,
+                None,
                 &data.choices,
                 |choice| CompatibleChoiceData {
                     finish_reason: if choice.finish_reason == Some(ChatFinishReason::ToolCalls) {
@@ -1614,9 +1616,10 @@ impl CompatibleStreamProfile for CopilotChatCompatibleProfile {
         ))
     }
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse {
+    fn build_final_response(&self, usage: Self::Usage, cost: Option<f64>) -> Self::FinalResponse {
         CopilotStreamingResponse::Chat(openai::completion::streaming::StreamingCompletionResponse {
             usage,
+            cost,
         })
     }
 

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -265,6 +265,7 @@ impl GetTokenUsage for Usage {
                 .and_then(|details| details.reasoning_tokens)
                 .map(u64::from)
                 .unwrap_or(0),
+        cost: None,
         }
     }
 }

--- a/crates/rig-core/src/providers/internal/mod.rs
+++ b/crates/rig-core/src/providers/internal/mod.rs
@@ -17,5 +17,6 @@ pub(crate) fn completion_usage(
         cache_creation_input_tokens: 0,
         tool_use_prompt_tokens: 0,
         reasoning_tokens: 0,
+    cost: None,
     }
 }

--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
@@ -104,6 +104,7 @@ pub(crate) struct CompatibleChunk<U, D> {
     pub(crate) response_model: Option<String>,
     pub(crate) choice: Option<CompatibleChoice<D>>,
     pub(crate) usage: Option<U>,
+    pub(crate) cost: Option<f64>,
 }
 
 pub(crate) type NormalizedCompatibleChunk<U, D> =
@@ -128,6 +129,7 @@ pub(crate) fn normalize_first_choice_chunk<U, D, Choice, ToolCall, F>(
     response_id: Option<String>,
     response_model: Option<String>,
     usage: Option<U>,
+    cost: Option<f64>,
     choices: &[Choice],
     map_choice: F,
 ) -> CompatibleChunk<U, D>
@@ -142,6 +144,7 @@ where
         response_model,
         choice,
         usage,
+        cost,
     }
 }
 
@@ -162,7 +165,7 @@ pub(crate) trait CompatibleStreamProfile: WasmCompatSend {
 
     fn normalize_chunk(&self, data: &str) -> NormalizedCompatibleChunk<Self::Usage, Self::Detail>;
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse;
+    fn build_final_response(&self, usage: Self::Usage, cost: Option<f64>) -> Self::FinalResponse;
 
     fn uses_distinct_tool_call_eviction(&self) -> bool {
         false
@@ -231,6 +234,7 @@ where
     let stream = stream! {
         let mut tool_calls: HashMap<usize, RawStreamingToolCall> = HashMap::new();
         let mut final_usage = None;
+        let mut final_cost = None;
         let mut terminated_with_error = false;
 
         while let Some(event_result) = event_source.next().await {
@@ -268,6 +272,10 @@ where
 
                     if let Some(usage) = chunk.usage {
                         final_usage = Some(usage);
+                    }
+
+                    if let Some(cost) = chunk.cost {
+                        final_cost = Some(cost);
                     }
 
                     let Some(choice) = chunk.choice else {
@@ -387,7 +395,7 @@ where
         let final_usage = final_usage.unwrap_or_default();
         record_usage(&span, &final_usage);
         yield Ok(RawStreamingChoice::FinalResponse(
-            profile.build_final_response(final_usage),
+            profile.build_final_response(final_usage, final_cost),
         ));
     }
     .instrument(instrument_span);

--- a/crates/rig-core/src/providers/mira.rs
+++ b/crates/rig-core/src/providers/mira.rs
@@ -344,6 +344,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                         cache_creation_input_tokens: 0,
                         tool_use_prompt_tokens: 0,
                         reasoning_tokens: 0,
+                    cost: None,
                     })
                     .unwrap_or_default();
 

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -250,6 +250,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 cache_creation_input_tokens: 0,
                 tool_use_prompt_tokens: 0,
                 reasoning_tokens: 0,
+            cost: None,
             })
             .unwrap_or_default();
 

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -401,6 +401,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                         cache_creation_input_tokens: 0,
                         tool_use_prompt_tokens: 0,
                         reasoning_tokens: 0,
+                    cost: None,
                     },
                     raw_response,
                     message_id: None,

--- a/crates/rig-core/src/providers/openai/completion/streaming.rs
+++ b/crates/rig-core/src/providers/openai/completion/streaming.rs
@@ -109,8 +109,7 @@ struct StreamingCompletionChunk<U = Usage> {
     model: Option<String>,
     choices: Vec<StreamingChoice>,
     usage: Option<U>,
-    /// Some OpenAI-compatible gateways (e.g. OpenCode Go) report the request
-    /// cost in a dedicated chunk as a string; others send a number.
+    /// Some gateways report cost as a string, others as a number.
     #[serde(default, deserialize_with = "deserialize_cost")]
     cost: Option<f64>,
 }

--- a/crates/rig-core/src/providers/openai/completion/streaming.rs
+++ b/crates/rig-core/src/providers/openai/completion/streaming.rs
@@ -109,6 +109,28 @@ struct StreamingCompletionChunk<U = Usage> {
     model: Option<String>,
     choices: Vec<StreamingChoice>,
     usage: Option<U>,
+    /// Some OpenAI-compatible gateways (e.g. OpenCode Go) report the request
+    /// cost in a dedicated chunk as a string; others send a number.
+    #[serde(default, deserialize_with = "deserialize_cost")]
+    cost: Option<f64>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum CostValue {
+    Number(f64),
+    String(String),
+}
+
+fn deserialize_cost<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(match Option::<CostValue>::deserialize(deserializer)? {
+        Some(CostValue::Number(n)) => Some(n),
+        Some(CostValue::String(s)) => s.trim().parse().ok(),
+        None => None,
+    })
 }
 
 /// Final streaming response. `U` is the provider's streaming usage payload
@@ -118,6 +140,9 @@ struct StreamingCompletionChunk<U = Usage> {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct StreamingCompletionResponse<U = Usage> {
     pub usage: U,
+    /// Provider-reported request cost (USD), when the provider supplies it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost: Option<f64>,
 }
 
 impl<U> GetTokenUsage for StreamingCompletionResponse<U>
@@ -125,7 +150,9 @@ where
     U: GetTokenUsage,
 {
     fn token_usage(&self) -> crate::completion::Usage {
-        self.usage.token_usage()
+        let mut usage = self.usage.token_usage();
+        usage.cost = self.cost;
+        usage
     }
 }
 
@@ -271,6 +298,7 @@ where
                 data.id,
                 data.model,
                 data.usage,
+                data.cost,
                 &data.choices,
                 |choice| CompatibleChoiceData {
                     // `function_call` is the deprecated pre-tools finish reason
@@ -297,8 +325,8 @@ where
         ))
     }
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse {
-        StreamingCompletionResponse { usage }
+    fn build_final_response(&self, usage: Self::Usage, cost: Option<f64>) -> Self::FinalResponse {
+        StreamingCompletionResponse { usage, cost }
     }
 
     fn decorate_tool_call(
@@ -577,6 +605,61 @@ mod tests {
                 .unwrap(),
             "ation\":\"NYC\"}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_streaming_captures_provider_reported_cost() {
+        use crate::test_utils::MockStreamingClient;
+        use futures::StreamExt;
+
+        // OpenCode Go emits a final usage chunk followed by a dedicated
+        // `inference-cost` chunk carrying `cost` as a string.
+        let client = MockStreamingClient {
+            sse_bytes: sse_bytes_from_data_lines([
+                "{\"choices\":[{\"delta\":{\"content\":\"Hello\",\"tool_calls\":[]}}],\"usage\":null}",
+                "{\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}",
+                "{\"choices\":[],\"cost\":\"0.00006972\"}",
+                "[DONE]",
+            ]),
+        };
+
+        let req = http::Request::builder()
+            .method("POST")
+            .uri("http://localhost/v1/chat/completions")
+            .body(Vec::new())
+            .unwrap();
+
+        let mut stream = send_compatible_streaming_request(client, req)
+            .await
+            .unwrap();
+
+        let mut final_response = None;
+        while let Some(chunk) = stream.next().await {
+            if let streaming::StreamedAssistantContent::Final(res) = chunk.unwrap() {
+                final_response = Some(res);
+                break;
+            }
+        }
+
+        let response = final_response.expect("expected a final streaming response");
+        assert_eq!(response.cost, Some(0.00006972));
+        assert_eq!(response.token_usage().cost, Some(0.00006972));
+        assert_eq!(response.token_usage().input_tokens, 10);
+    }
+
+    #[test]
+    fn test_streaming_chunk_parses_cost_string_or_number() {
+        let chunk: StreamingCompletionChunk =
+            serde_json::from_str(r#"{"choices":[],"cost":"0.00006972"}"#).unwrap();
+        assert_eq!(chunk.cost, Some(0.00006972));
+
+        let chunk: StreamingCompletionChunk =
+            serde_json::from_str(r#"{"choices":[],"cost":0.001}"#).unwrap();
+        assert_eq!(chunk.cost, Some(0.001));
+
+        let chunk: StreamingCompletionChunk =
+            serde_json::from_str(r#"{"choices":[],"usage":null}"#).unwrap();
+        assert_eq!(chunk.cost, None);
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/openai/embedding.rs
+++ b/crates/rig-core/src/providers/openai/embedding.rs
@@ -254,6 +254,7 @@ where
                             cache_creation_input_tokens: 0,
                             tool_use_prompt_tokens: 0,
                             reasoning_tokens: 0,
+                        cost: None,
                         },
                         None if Ext::REQUIRES_USAGE => {
                             return Err(EmbeddingError::MissingUsage {

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -978,6 +978,7 @@ impl GetTokenUsage for ResponsesUsage {
                 .as_ref()
                 .map(|details| details.reasoning_tokens)
                 .unwrap_or(0),
+        cost: None,
         }
     }
 }

--- a/crates/rig-core/src/providers/openrouter/client.rs
+++ b/crates/rig-core/src/providers/openrouter/client.rs
@@ -135,6 +135,7 @@ impl GetTokenUsage for Usage {
             cache_creation_input_tokens: cache_creation,
             tool_use_prompt_tokens: 0,
             reasoning_tokens: 0,
+        cost: None,
         }
     }
 }

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -724,6 +724,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                     cache_creation_input_tokens: cache_creation,
                     tool_use_prompt_tokens: 0,
                     reasoning_tokens: 0,
+                cost: None,
                 }
             })
             .unwrap_or_default();

--- a/crates/rig-core/src/providers/voyageai.rs
+++ b/crates/rig-core/src/providers/voyageai.rs
@@ -243,6 +243,7 @@ where
                         cache_creation_input_tokens: 0,
                         tool_use_prompt_tokens: 0,
                         reasoning_tokens: 0,
+                    cost: None,
                     };
 
                     let embeddings = response
@@ -412,6 +413,7 @@ where
                         cache_creation_input_tokens: 0,
                         reasoning_tokens: 0,
                         tool_use_prompt_tokens: 0,
+                    cost: None,
                     };
 
                     let results = response

--- a/crates/rig-core/src/telemetry/mod.rs
+++ b/crates/rig-core/src/telemetry/mod.rs
@@ -1835,6 +1835,7 @@ mod tests {
             cache_creation_input_tokens: 4,
             tool_use_prompt_tokens: 12,
             reasoning_tokens: 5,
+        cost: None,
         });
 
         // Scoped-subscriber tests must not run concurrently; see

--- a/crates/rig-core/src/test_utils/internal_streaming_profiles.rs
+++ b/crates/rig-core/src/test_utils/internal_streaming_profiles.rs
@@ -16,6 +16,7 @@ fn test_chunk(choice: CompatibleChoice<()>) -> CompatibleChunk<MockResponse, ()>
         response_model: None,
         choice: Some(choice),
         usage: None,
+    cost: None,
     }
 }
 
@@ -71,7 +72,11 @@ impl CompatibleStreamProfile for ErrorAfterPendingToolCallProfile {
         }
     }
 
-    fn build_final_response(&self, _usage: Self::Usage) -> Self::FinalResponse {
+    fn build_final_response(
+        &self,
+        _usage: Self::Usage,
+        _cost: Option<f64>,
+    ) -> Self::FinalResponse {
         MockResponse::new()
     }
 }
@@ -134,7 +139,11 @@ impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
         Ok(choice.map(test_chunk))
     }
 
-    fn build_final_response(&self, _usage: Self::Usage) -> Self::FinalResponse {
+    fn build_final_response(
+        &self,
+        _usage: Self::Usage,
+        _cost: Option<f64>,
+    ) -> Self::FinalResponse {
         MockResponse::new()
     }
 
@@ -176,7 +185,11 @@ impl CompatibleStreamProfile for FinishReasonCleanupProfile {
         Ok(choice.map(test_chunk))
     }
 
-    fn build_final_response(&self, _usage: Self::Usage) -> Self::FinalResponse {
+    fn build_final_response(
+        &self,
+        _usage: Self::Usage,
+        _cost: Option<f64>,
+    ) -> Self::FinalResponse {
         MockResponse::new()
     }
 }


### PR DESCRIPTION
Fixes #2242

## Summary

OpenAI-compatible gateways such as OpenCode Go report per-request monetary cost in the chat-completions stream, but rig drops it. OpenCode Go emits a dedicated `inference-cost` SSE chunk after the usage chunk:

```json
{choices: [], x-opencode-type: inference-cost, cost: 0.00006972, normalizedUsage: {...}}
```

(`cost` arrives as a string; some gateways send a number.) Without this change, callers must re-derive cost from token counts using per-model price tables that drift over time.

## Changes

- **Capture**: `StreamingCompletionChunk` parses the top-level `cost` field (string or number).
- **Thread**: cost flows through `CompatibleChunk` → the streaming loop → `build_final_response`, mirroring how `usage` already flows. The last chunk carrying a cost wins.
- **Surface**: `StreamingCompletionResponse::cost` and, via `token_usage()`, `completion::Usage::cost` — agent runs and telemetry see it without extra plumbing.
- `Usage::cost` defaults to `None`; `Eq` is now implemented manually since the new field is `Option<f64>` (providers report finite decimals only).

## Tests

- `test_streaming_captures_provider_reported_cost`: full stream with an `inference-cost` chunk, asserts response cost + `token_usage().cost`.
- `test_streaming_chunk_parses_cost_string_or_number`: string, number, and absent cost.

`cargo test -p rig-core` (1023 tests) and strict clippy pass locally.