### PR TITLE
feat(agent): resume a suspended AgentRun through the runner surface

### DIFF
--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -1,6 +1,6 @@
 use super::hook::{HookStack, RequestPatch};
 use super::prompt_request::{self, PromptRequest};
-use super::run::OutputMode;
+use super::run::{AgentRun, OutputMode};
 use super::runner::AgentRunner;
 use crate::{
     agent::prompt_request::streaming::StreamingPromptRequest,
@@ -619,6 +619,45 @@ where
     /// [`AgentRunner::add_hook`], then call [`AgentRunner::run`].
     pub fn runner(&self, prompt: impl Into<Message>) -> AgentRunner<M> {
         AgentRunner::from_agent(self, prompt)
+    }
+
+    /// Build an [`AgentRunner`] that continues a previously suspended
+    /// [`AgentRun`] — one serialized between steps, persisted, and restored
+    /// (possibly in another process) — with this agent's hooks, tool server,
+    /// memory, and telemetry. [`AgentRunner::run`] and [`AgentRunner::stream`]
+    /// share their drive loop with a fresh run, so a resumed run behaves
+    /// identically to one that was never suspended.
+    ///
+    /// The restored run supplies the loop state (prompt, history, pending tool
+    /// calls, budgets, aggregated usage); this agent supplies the environment
+    /// it resumes into and should be configured like the one that started the
+    /// run — pinned per-turn tool handles do not survive serialization, so
+    /// pending tool calls execute against this agent's current registry.
+    /// Conversation memory is never loaded for a resumed run (the run carries
+    /// its own history), but a configured backend still receives the completed
+    /// run's messages at the end. See the [`run`](crate::agent::run) module
+    /// docs for serialization caveats.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use rig_agent::{agent::run::AgentRun, prelude::*};
+    /// use rig_core::{client::ProviderClient, providers::openai};
+    ///
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// let openai = openai::Client::from_env()?;
+    /// let agent = openai.agent(openai::GPT_5_2).build();
+    ///
+    /// // A run suspended earlier (possibly by another process).
+    /// let json = std::fs::read_to_string("suspended-run.json")?;
+    /// let run: AgentRun = serde_json::from_str(&json)?;
+    ///
+    /// let response = agent.resume(run).run().await?;
+    /// println!("{}", response.output);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn resume(&self, run: AgentRun) -> AgentRunner<M> {
+        AgentRunner::resume(self, run)
     }
 
     /// Resolve the provider-facing tool definitions available for a prompt.

--- a/crates/rig-agent/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-agent/src/agent/prompt_request/streaming.rs
@@ -505,6 +505,9 @@ where
         // immediately following CallTools step. This keeps the sans-IO run state
         // serializable while pinning execution to the definitions sent that turn.
         let mut pending_tool_snapshot: Option<Arc<ToolRegistrySnapshot>> = None;
+        // Only a restored run may open on CallTools without a pinned snapshot;
+        // on any later step a missing snapshot is a driver bug.
+        let mut first_step = true;
 
         'outer: loop {
             let step = match run.next_step() {
@@ -612,13 +615,32 @@ where
                     pending_tool_snapshot = Some(turn_tool_snapshot);
                 }
                 AgentRunStep::CallTools { calls } => {
-                    let Some(tool_snapshot) = pending_tool_snapshot.take() else {
-                        store_error_usage(&runner, &run);
-                        yield Err(StreamingError::Completion(CompletionError::ResponseError(
-                            "agent requested tool execution without a prepared registry snapshot"
-                                .to_string(),
-                        )));
-                        break 'outer;
+                    // A restored run's pinned handles did not survive serialization:
+                    // its opening batch binds to the current registry instead.
+                    let tool_snapshot = match pending_tool_snapshot.take() {
+                        Some(tool_snapshot) => tool_snapshot,
+                        None if first_step => {
+                            match runner.tool_server_handle.snapshot_tool_defs(None).await {
+                                Ok(tool_snapshot) => Arc::new(tool_snapshot),
+                                Err(_) => {
+                                    store_error_usage(&runner, &run);
+                                    yield Err(StreamingError::Completion(
+                                        CompletionError::RequestError(
+                                            "Failed to get tool definitions".into(),
+                                        ),
+                                    ));
+                                    break 'outer;
+                                }
+                            }
+                        }
+                        None => {
+                            store_error_usage(&runner, &run);
+                            yield Err(StreamingError::Completion(CompletionError::ResponseError(
+                                "agent requested tool execution without a prepared registry snapshot"
+                                    .to_string(),
+                            )));
+                            break 'outer;
+                        }
                     };
                     let mut tool_stream = source.run_tool_calls(
                         &runner,
@@ -668,6 +690,7 @@ where
                     break 'outer;
                 }
             }
+            first_step = false;
         }
     }
 }
@@ -1504,7 +1527,7 @@ where
     /// hook handling with the blocking [`run`](AgentRunner::run) via
     /// `drive_agent`, so the two behave identically apart from the streamed
     /// delta events.
-    pub async fn stream(self) -> StreamingResult<M::StreamingResponse> {
+    pub async fn stream(mut self) -> StreamingResult<M::StreamingResponse> {
         let (agent_span, created_agent_span) = acquire_agent_span(
             self.agent_name_or_default(),
             self.preamble.as_deref(),
@@ -1520,25 +1543,29 @@ where
         // When the caller passes explicit history, memory is fully bypassed for
         // this request (no load AND no save). Otherwise, if a memory backend and
         // conversation id are both configured, load prior history.
-        let (history_override, memory_handle) = match &self.chat_history {
-            Some(_) => (None, None),
-            None => match (&self.memory, &self.conversation_id) {
-                (Some(memory), Some(id)) => match memory.load(id).await {
-                    Ok(loaded) => (Some(loaded), Some((memory.clone(), id.clone()))),
-                    Err(err) => {
-                        let stream = async_stream::stream! {
-                            yield Err(StreamingError::from(err));
-                        };
-                        // Instrument under the agent span like the success path so
-                        // a load failure stays tied to invoke_agent.
-                        return Box::pin(stream.instrument(agent_span));
-                    }
+        let (history_override, memory_handle) = if self.restored_run.is_some() {
+            (None, self.resume_memory_handle())
+        } else {
+            match &self.chat_history {
+                Some(_) => (None, None),
+                None => match (&self.memory, &self.conversation_id) {
+                    (Some(memory), Some(id)) => match memory.load(id).await {
+                        Ok(loaded) => (Some(loaded), Some((memory.clone(), id.clone()))),
+                        Err(err) => {
+                            let stream = async_stream::stream! {
+                                yield Err(StreamingError::from(err));
+                            };
+                            // Instrument under the agent span like the success path so
+                            // a load failure stays tied to invoke_agent.
+                            return Box::pin(stream.instrument(agent_span));
+                        }
+                    },
+                    _ => (None, None),
                 },
-                _ => (None, None),
-            },
+            }
         };
 
-        let run = self.build_run(history_override);
+        let run = self.take_run(history_override);
         let source = StreamingTurnSource::new(
             &self.hooks,
             self.agent_name_or_default().to_string(),

--- a/crates/rig-agent/src/agent/run/mod.rs
+++ b/crates/rig-agent/src/agent/run/mod.rs
@@ -16,11 +16,13 @@
 //! Because the machine never awaits anything, it is runtime-agnostic and the
 //! whole run state is `Serialize + Deserialize`: a driver can serialize a run
 //! between steps (for example while tool calls are pending), persist it, and
-//! resume it later in another process. Note that serialized run state embeds
-//! the full conversation accumulated so far — persisting it inherits whatever
-//! sensitivity the conversation content has — and the serialization format
-//! carries no cross-version stability guarantee yet: resume with the same rig
-//! version that suspended the run.
+//! resume it later in another process — by continuing to drive it by hand, or
+//! by handing it back to the full agent driver with
+//! [`Agent::resume`](crate::agent::Agent::resume). Note that serialized run
+//! state embeds the full conversation accumulated so far — persisting it
+//! inherits whatever sensitivity the conversation content has — and the
+//! serialization format carries no cross-version stability guarantee yet:
+//! resume with the same rig version that suspended the run.
 //!
 //! `AgentRun` deliberately contains no model, tool registry, memory backend, or
 //! hook stack. Hand-driving it is a low-level provider integration: the caller
@@ -484,6 +486,32 @@ impl AgentRun {
     /// and tool results), excluding the input history.
     pub fn messages(&self) -> &[Message] {
         &self.new_messages
+    }
+
+    /// The run's total model-call budget.
+    pub(crate) fn max_turns_limit(&self) -> usize {
+        self.max_turns
+    }
+
+    /// The run's invalid tool-call retry budget.
+    pub(crate) fn invalid_tool_call_retry_limit(&self) -> usize {
+        self.max_invalid_tool_call_retries
+    }
+
+    /// The tool-choice policy stored on the run.
+    pub(crate) fn tool_choice(&self) -> Option<&ToolChoice> {
+        self.tool_choice.as_ref()
+    }
+
+    /// Replace the tool-choice policy, used when a resuming runner re-applies
+    /// its loop overrides to a restored run.
+    pub(crate) fn set_tool_choice(&mut self, tool_choice: Option<ToolChoice>) {
+        self.tool_choice = tool_choice;
+    }
+
+    /// The prompt message that started the run.
+    pub(crate) fn initial_prompt(&self) -> Option<&Message> {
+        self.new_messages.first()
     }
 
     /// Canonical content for the accepted model turn awaiting advancement.

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -226,6 +226,9 @@ where
     pub(crate) conversation_id: Option<String>,
     pub(crate) hooks: HookStack,
     pub(crate) error_usage: Option<Arc<Mutex<Usage>>>,
+    /// A restored run to continue instead of building a fresh one. Set by
+    /// [`resume`](Self::resume).
+    pub(crate) restored_run: Option<AgentRun>,
 }
 
 impl<M> AgentRunner<M>
@@ -262,7 +265,27 @@ where
             conversation_id: agent.default_conversation_id.clone(),
             hooks: agent.hooks.clone(),
             error_usage: None,
+            restored_run: None,
         }
+    }
+
+    /// Build a runner that continues a previously suspended [`AgentRun`],
+    /// seeding it with the agent's default hook stack and the run's own
+    /// turn/retry budgets and tool-choice policy, so builder overrides such as
+    /// [`max_turns`](Self::max_turns) default to the suspended values. Prefer
+    /// [`Agent::resume`](crate::agent::Agent::resume), which documents the
+    /// resume semantics.
+    pub fn resume(agent: &Agent<M>, run: AgentRun) -> Self {
+        let prompt = run
+            .initial_prompt()
+            .cloned()
+            .unwrap_or_else(|| Message::user(String::new()));
+        let mut runner = Self::from_agent(agent, prompt);
+        runner.max_turns = run.max_turns_limit();
+        runner.max_invalid_tool_call_retries = run.invalid_tool_call_retry_limit();
+        runner.tool_choice = run.tool_choice().cloned();
+        runner.restored_run = Some(run);
+        runner
     }
 
     /// Append a hook to the stack (on top of any the agent already carries).
@@ -506,6 +529,31 @@ where
         match &self.output_tool_name {
             Some(name) => run.with_output_tool_name(name.clone()),
             None => run,
+        }
+    }
+
+    /// The run to drive: the restored run when resuming (with this runner's
+    /// loop overrides re-applied), otherwise a freshly built one.
+    pub(crate) fn take_run(&mut self, history_override: Option<Vec<Message>>) -> AgentRun {
+        match self.restored_run.take() {
+            Some(run) => {
+                let mut run = run
+                    .max_turns(self.max_turns)
+                    .max_invalid_tool_call_retries(self.max_invalid_tool_call_retries);
+                run.set_tool_choice(self.tool_choice.clone());
+                run
+            }
+            None => self.build_run(history_override),
+        }
+    }
+
+    /// Memory participation for a resumed run: never load (the run's history
+    /// is authoritative); a configured backend still gets the completed run's
+    /// messages at `Done`, which the suspending process never appended.
+    pub(crate) fn resume_memory_handle(&self) -> Option<(Arc<dyn ConversationMemory>, String)> {
+        match (&self.memory, &self.conversation_id) {
+            (Some(memory), Some(id)) => Some((memory.clone(), id.clone())),
+            _ => None,
         }
     }
 }
@@ -1115,7 +1163,7 @@ where
     /// Drive the agent loop to completion, returning the aggregated
     /// [`PromptResponse`]. Hooks fire at every observable point; the first hook
     /// to terminate cancels the run.
-    pub async fn run(self) -> Result<PromptResponse, PromptError> {
+    pub async fn run(mut self) -> Result<PromptResponse, PromptError> {
         let (agent_span, created_agent_span) = acquire_agent_span(
             self.agent_name_or_default(),
             self.preamble.as_deref(),
@@ -1131,18 +1179,22 @@ where
         // When the caller passes explicit history, memory is fully bypassed for
         // this run (no load AND no save). Otherwise, if a memory backend and
         // conversation id are both configured, load prior history.
-        let (history_override, memory_handle) = match &self.chat_history {
-            Some(_) => (None, None),
-            None => match (&self.memory, &self.conversation_id) {
-                (Some(memory), Some(id)) => {
-                    let loaded = memory.load(id).await?;
-                    (Some(loaded), Some((memory.clone(), id.clone())))
-                }
-                _ => (None, None),
-            },
+        let (history_override, memory_handle) = if self.restored_run.is_some() {
+            (None, self.resume_memory_handle())
+        } else {
+            match &self.chat_history {
+                Some(_) => (None, None),
+                None => match (&self.memory, &self.conversation_id) {
+                    (Some(memory), Some(id)) => {
+                        let loaded = memory.load(id).await?;
+                        (Some(loaded), Some((memory.clone(), id.clone())))
+                    }
+                    _ => (None, None),
+                },
+            }
         };
 
-        let run = self.build_run(history_override);
+        let run = self.take_run(history_override);
 
         // Fold the shared engine to its final response. The blocking surface
         // uses a unary model transport and ignores the intermediate items the
@@ -10187,5 +10239,218 @@ mod migrated_tests {
         ));
         assert_eq!(stop_calls.load(SeqCst), 1);
         assert_eq!(after_stop_calls.load(SeqCst), 0);
+    }
+
+    mod resume {
+        use super::*;
+        use crate::agent::run::{AgentRun, AgentRunStep, ModelTurn, ModelTurnOutcome};
+        use crate::test_utils::CountingMemory;
+        use rig_core::memory::ConversationMemory;
+        use std::collections::BTreeSet;
+
+        /// Hand-drive a run to its tool boundary (one pending `add` call) and
+        /// serialize it to JSON, as a persisting host does before suspending.
+        fn suspended_mid_tool_batch(max_turns: usize) -> String {
+            let mut run = AgentRun::new("add 2 and 3").max_turns(max_turns);
+            let step = run.next_step().expect("first step");
+            assert!(matches!(step, AgentRunStep::CallModel { turn: 1, .. }));
+
+            let mut usage = Usage::new();
+            usage.input_tokens = 7;
+            usage.output_tokens = 3;
+            usage.total_tokens = 10;
+            let tool_names: BTreeSet<String> = ["add".to_string()].into();
+            let outcome = run
+                .model_response(ModelTurn::new(
+                    None,
+                    OneOrMany::one(AssistantContent::ToolCall(MessageToolCall::new(
+                        "tc1".to_string(),
+                        ToolFunction::new("add".to_string(), json!({"x": 2, "y": 3})),
+                    ))),
+                    usage,
+                    tool_names.clone(),
+                    tool_names,
+                ))
+                .expect("model turn should be accepted");
+            assert!(matches!(outcome, ModelTurnOutcome::Continue { .. }));
+
+            let step = run.next_step().expect("tool step");
+            assert!(matches!(step, AgentRunStep::CallTools { .. }));
+            serde_json::to_string(&run).expect("run should serialize to JSON")
+        }
+
+        /// A run serialized at its tool boundary, restored from JSON, completes
+        /// through the public runner surface: the pending tool executes through
+        /// the live tool server, hooks fire on the resumed leg, and usage
+        /// aggregates across the suspend/resume boundary.
+        #[tokio::test]
+        async fn resumed_mid_tool_batch_run_completes_with_hooks() {
+            let snapshot = suspended_mid_tool_batch(3);
+
+            let run: AgentRun = serde_json::from_str(&snapshot).expect("run should deserialize");
+            let mut resumed_usage = Usage::new();
+            resumed_usage.input_tokens = 5;
+            resumed_usage.output_tokens = 2;
+            resumed_usage.total_tokens = 7;
+            let model = MockCompletionModel::from_turns([
+                MockTurn::text("the answer is 5").with_usage(resumed_usage)
+            ]);
+            let hook = RecordingHook::default();
+            let agent = AgentBuilder::new(model.clone()).tool(MockAddTool).build();
+
+            let response = agent
+                .resume(run)
+                .add_hook(hook.clone())
+                .run()
+                .await
+                .expect("resumed run should complete");
+
+            assert_eq!(response.output, "the answer is 5");
+            assert_eq!(hook.tool_results(), vec!["5".to_string()]);
+            assert_eq!(
+                hook.shared_events(),
+                vec![
+                    StepEventKind::ToolCall,
+                    StepEventKind::ToolResult,
+                    StepEventKind::CompletionCall,
+                ]
+            );
+            // Only the post-resume model call reached the live model.
+            assert_eq!(model.request_count(), 1);
+            // Usage spans the suspending and resuming processes.
+            assert_eq!(response.usage.input_tokens, 12);
+            assert_eq!(response.usage.output_tokens, 5);
+            // Full history: prompt, tool call, tool result, final text.
+            let messages = response.messages.as_deref().unwrap_or_default();
+            assert_eq!(messages.len(), 4);
+        }
+
+        /// Resuming seeds the runner with the suspended run's own turn budget;
+        /// the runner's builder methods still override it before driving.
+        #[tokio::test]
+        async fn resume_seeds_and_overrides_the_suspended_turn_budget() {
+            // Suspended with a budget of one, already spent on the recorded call.
+            let snapshot = suspended_mid_tool_batch(1);
+
+            let run: AgentRun = serde_json::from_str(&snapshot).expect("run should deserialize");
+            let agent = AgentBuilder::new(MockCompletionModel::default())
+                .tool(MockAddTool)
+                .build();
+            let err = agent
+                .resume(run)
+                .run()
+                .await
+                .expect_err("the exhausted budget should be preserved");
+            assert!(matches!(
+                err,
+                PromptError::MaxTurnsError { max_turns: 1, .. }
+            ));
+
+            // The same snapshot resumes to completion once the budget is raised.
+            let run: AgentRun = serde_json::from_str(&snapshot).expect("run should deserialize");
+            let agent = AgentBuilder::new(MockCompletionModel::text("done"))
+                .tool(MockAddTool)
+                .build();
+            let response = agent
+                .resume(run)
+                .max_turns(2)
+                .run()
+                .await
+                .expect("the raised budget should let the run finish");
+            assert_eq!(response.output, "done");
+        }
+
+        /// A resumed run never loads conversation memory — the restored run
+        /// carries its own history — but a configured backend still receives
+        /// the completed run's messages at the end.
+        #[tokio::test]
+        async fn resumed_run_appends_to_memory_without_loading() {
+            let snapshot = suspended_mid_tool_batch(3);
+            let run: AgentRun = serde_json::from_str(&snapshot).expect("run should deserialize");
+
+            let memory = CountingMemory::default();
+            let agent = AgentBuilder::new(MockCompletionModel::text("the answer is 5"))
+                .tool(MockAddTool)
+                .memory(memory.clone())
+                .conversation("resumed")
+                .build();
+
+            let response = agent.resume(run).run().await.expect("resumed run");
+
+            assert_eq!(memory.load_count(), 0, "resume must not load memory");
+            assert_eq!(memory.append_count(), 1, "completion must append once");
+            let stored = memory
+                .inner()
+                .load("resumed")
+                .await
+                .expect("stored history");
+            assert_eq!(Some(stored), response.messages);
+        }
+
+        /// Resuming a run serialized before its first model call behaves like a
+        /// run that was never suspended.
+        #[tokio::test]
+        async fn resume_at_the_model_boundary_runs_like_a_new_run() {
+            let snapshot = serde_json::to_string(&AgentRun::new("hi").max_turns(2))
+                .expect("run should serialize to JSON");
+
+            let run: AgentRun = serde_json::from_str(&snapshot).expect("run should deserialize");
+            let model = MockCompletionModel::text("hello");
+            let agent = AgentBuilder::new(model.clone()).build();
+            let response = agent.resume(run).run().await.expect("resumed run");
+
+            assert_eq!(response.output, "hello");
+            assert_eq!(model.request_count(), 1);
+        }
+
+        /// A restored run resumes through `stream()` as well: the pending
+        /// tool's result surfaces as a stream item, hooks fire on the resumed
+        /// leg, and the run ends with a final response.
+        #[tokio::test]
+        async fn resumed_run_streams_tool_activity_and_final_response() {
+            let snapshot = suspended_mid_tool_batch(3);
+            let run: AgentRun = serde_json::from_str(&snapshot).expect("run should deserialize");
+
+            let model = MockCompletionModel::from_stream_turns([vec![
+                MockStreamEvent::text("the answer is 5"),
+                MockStreamEvent::final_response_with_total_tokens(0),
+            ]]);
+            let hook = RecordingHook::default();
+            let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+            let mut stream = agent.resume(run).add_hook(hook.clone()).stream().await;
+
+            let mut saw_tool_result = false;
+            let mut final_response = None;
+            while let Some(item) = stream.next().await {
+                match item.expect("stream item") {
+                    MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
+                        ..
+                    }) => {
+                        saw_tool_result = true;
+                    }
+                    MultiTurnStreamItem::FinalResponse(response) => {
+                        final_response = Some(response);
+                    }
+                    _ => {}
+                }
+            }
+
+            assert!(
+                saw_tool_result,
+                "the resumed tool batch should surface its result"
+            );
+            let final_response = final_response.expect("final response");
+            assert_eq!(final_response.output(), "the answer is 5");
+            assert_eq!(hook.tool_results(), vec!["5".to_string()]);
+            assert_eq!(
+                hook.shared_events(),
+                vec![
+                    StepEventKind::ToolCall,
+                    StepEventKind::ToolResult,
+                    StepEventKind::CompletionCall,
+                ]
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixes #2244.

Related: #2116 (checkpoint / interrupt–resume operations), #2118 (interactive coding-agent roadmap). Complementary to #2121, which adds safe-boundary checkpoint capture for *manually driven* runs and explicitly lists runner-level durable checkpoint resumption as remaining work — this PR is that piece for the current runner, kept small and additive.

## Motivation

`AgentRun` is a sans-IO, `Serialize + Deserialize` state machine, and its module docs advertise exactly the workflow servers need: serialize a run between steps (for example while tool calls are pending), persist it, and resume it later in another process. The capture half of that story works today by hand-driving `next_step()` / `model_response()` / `tool_results()`.

The resume half is currently missing: the high-level driver (`AgentRunner::run` / `stream`) builds its `AgentRun` internally and has no way to accept a restored one. Anyone resuming a persisted run must hand-write the entire drive loop for the resume leg — and thereby loses the runner's hook stack, tool-server dispatch (including retrieval and MCP-registered tools), conversation-memory append, telemetry spans, and structured-output handling. In practice a process restart, migration, or approval-gate suspension leaves the second half of the run without those integrations.

This PR closes the loop with one additive entry point:

```rust
let run: AgentRun = serde_json::from_str(&persisted)?;
let response = agent.resume(run).run().await?;      // or .stream().await
```

## Design

**Public surface (additive only):**

- `Agent::resume(run: AgentRun) -> AgentRunner<M>` — mirrors `Agent::runner(prompt)`.
- `AgentRunner::resume(agent, run)` — mirrors `AgentRunner::from_agent(agent, prompt)`.

Everything else on the runner keeps working: `add_hook`, `max_turns`, `tool_concurrency`, `conversation` / `without_memory`, and both `run()` and `stream()`.

**One drive loop, not a fork.** `run()` and `stream()` already share the single engine (`drive_agent`), which takes an `AgentRun` as input. Resume reuses that seam: the runner carries an optional restored run, and both surfaces drive it through the identical loop, so hooks, tool execution, fail-closed semantics, memory append, and telemetry behave exactly as they do for a run that was never suspended. No second driver exists to drift.

**Division of authority.** The restored run is authoritative for loop state: prompt, accumulated history, pending tool calls, turn budget, invalid-tool-call retry budget, tool choice, and aggregated usage (a resumed run's final usage spans both processes). The agent is authoritative for the environment the run resumes into: model, hooks, tool server, preamble, request parameters, structured-output configuration, and memory. The run's budgets and tool-choice policy seed the runner on `resume()`, so builder overrides default to the suspended values and can still be changed before driving — e.g. `agent.resume(run).max_turns(extended)` deliberately raises an exhausted budget.

**Mid-tool-batch re-entry.** A run restored in the pending-tools state re-enters the drive loop directly on `CallTools` (the state machine already re-emits the pending calls idempotently, preserving `internal_call_id`s). Within one process the engine pins each turn's tool batch to the registry snapshot advertised to the model; those pinned handles cannot survive serialization, so a resumed batch takes a fresh snapshot and binds to the tool server's *current* registry. This is only permitted on the first step of a resumed drive — for every later step, a missing snapshot remains the driver-bug error it is today.

**Memory semantics.** Resume never *loads* conversation memory (the restored run carries its own history — loading would corrupt it), but a configured backend still receives the completed run's messages at `Done`, exactly once across the suspend/resume boundary: the suspending process never reached `Done`, so it never appended. `without_memory()` opts out, as usual.

## Alternatives considered

- **Making the private drive loop public** so callers can drive a restored run themselves. Rejected: it exposes a large internal surface (`TurnSource`, snapshot threading, span shaping) that would freeze implementation details into API, and every caller would still have to reassemble hooks/memory/telemetry correctly. `resume()` keeps one blessed driver.
- **A free-standing `resume(agent, run)` function.** Equivalent power, but the runner-builder shape is the repo's idiom and gives the override story (`max_turns`, `add_hook`, …) for free.
- **Re-pinning the original turn's tool definitions on mid-batch resume.** Not achievable — tool executors are not serializable — so the limitation is documented rather than worked around. The behavior (current-registry dispatch) is documented instead; the run still validates calls against the tool names that were advertised on the suspended turn.
- **Blocking memory append on resume** (treating a restored run like caller-supplied explicit history, which bypasses memory entirely). Rejected: the restored run's messages are precisely this conversation's new messages, and appending once at completion is what would have happened without the interruption; skipping it would silently drop the exchange from memory.

## Serialization caveats (documented on `Agent::resume` and the `run` module)

- Run state embeds the full conversation accumulated so far; persisting it inherits the conversation's sensitivity.
- The format is JSON-tolerant (serde defaults absorb absent fields) but carries **no cross-version stability guarantee yet**: resume with the same rig version that suspended the run.
- Runs must be suspended at a step boundary (the state observed between `next_step()` calls, e.g. pending tool calls). A run snapshotted while a model response was outstanding cannot be advanced and fails with the existing protocol error.
- The resuming agent should be configured equivalently to the one that started the run (tools, output mode, preamble); the run does not carry the environment.

## Test coverage

New tests in `rig-agent` (all synthetic — `MockCompletionModel`, `MockAddTool`, `CountingMemory`; no network):

- `resumed_mid_tool_batch_run_completes_with_hooks` — hand-drive a run to its tool boundary, serialize to JSON, drop it, restore, and resume via `agent.resume(run).run()`: the pending tool executes through the live tool server, `ToolCall`/`ToolResult`/`CompletionCall` hooks fire on the resumed leg, usage aggregates across the boundary, and the final history contains the pre-suspension turn.
- `resumed_run_streams_tool_activity_and_final_response` — the same restored run through `stream()`: tool result surfaces as a stream item, hooks fire, final response arrives.
- `resume_seeds_and_overrides_the_suspended_turn_budget` — an exhausted budget is preserved by default (`MaxTurnsError`) and extendable via `.max_turns()` before driving.
- `resumed_run_appends_to_memory_without_loading` — zero loads, exactly one append, stored history equals the response messages.
- `resume_at_the_model_boundary_runs_like_a_new_run` — a run serialized before its first model call resumes indistinguishably from a fresh run.

Validation: `cargo fmt --check`, `cargo clippy -p rig-agent --all-targets --all-features` (clean), `cargo test -p rig-agent --all-features` (492 lib tests + doctests, green) on the repo toolchain (1.94.0).
