### PR TITLE
feat(agent): emit a live `ToolExecutionStarted` stream item when a tool call dispatches

### DIFF
--- a/crates/rig-agent/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-agent/src/agent/prompt_request/streaming.rs
@@ -68,10 +68,39 @@ pub enum MultiTurnStreamItem<R> {
     /// the [`FinalResponse`](Self::FinalResponse) rather than as a completed
     /// `ToolCall` item.
     StreamAssistantItem(StreamedAssistantContent<R>),
+    /// Live notification that Rig has **started executing** a tool call:
+    /// emitted at the call's actual start moment — immediately before its
+    /// `ToolCall` hook chain runs — so a consumer can show in-flight tool
+    /// activity while the body (or a slow steering hook) is still running. The
+    /// real-time counterpart of
+    /// [`ToolExecutionCommitted`](Self::ToolExecutionCommitted), which follows
+    /// only after the whole batch settles.
+    ///
+    /// Per call, the complete [`StreamedAssistantContent::ToolCall`] item
+    /// precedes this (a batch's are emitted up front, in call order) and the
+    /// `ToolExecutionCommitted` + `ToolResult` items follow it, still atomically
+    /// after batch settle in call order — every pre-existing item keeps its
+    /// position. Starts surface in call order sequentially, in start order
+    /// under `tool_concurrency`.
+    ///
+    /// Reports that dispatch **began**, not that the body ran: a hook-skipped
+    /// call still surfaces a start (followed by its `ToolResult` but no
+    /// commit), a call preresolved by invalid-call recovery emits nothing, and
+    /// a terminated batch may leave starts whose commit/result never follow.
+    ToolExecutionStarted {
+        /// Name of the tool being executed.
+        tool_name: String,
+        /// Rig-generated id correlating this start with the model tool call
+        /// ([`StreamedAssistantContent::ToolCall::internal_call_id`]), the
+        /// execution commit, and the resulting
+        /// [`StreamedUserContent::ToolResult`].
+        internal_call_id: String,
+    },
     /// Confirmation that Rig **executed and committed** a tool call. This is not
-    /// a real-time start notification: it is surfaced together with its
-    /// `ToolResult` only after the whole batch settles successfully. Use tool
-    /// hooks for live host-side start/result observation.
+    /// a real-time start notification — that is
+    /// [`ToolExecutionStarted`](Self::ToolExecutionStarted): it is surfaced
+    /// together with its `ToolResult` only after the whole batch settles
+    /// successfully.
     ///
     /// This item is emitted only for a tool whose body actually ran (it passed
     /// its `ToolCall` hook checks), never for a call dropped by a sibling's
@@ -331,8 +360,10 @@ where
     /// Execute up to `concurrency` of a turn's tool calls at once (1 by default,
     /// i.e. sequential). See [`AgentRunner::tool_concurrency`]: at any
     /// `concurrency` the stream emits the model's `ToolCall` items (call order),
-    /// then — atomically, after the whole tool batch settles successfully — the
-    /// per-tool `ToolExecutionCommitted` + `ToolResult` items in **call order** (not
+    /// then a live `ToolExecutionStarted` per call as it actually starts (call
+    /// order when sequential, start order when concurrent), then — atomically,
+    /// after the whole tool batch settles successfully — the per-tool
+    /// `ToolExecutionCommitted` + `ToolResult` items in **call order** (not
     /// completion order). The streamed message history is unchanged at any
     /// `concurrency`.
     pub fn tool_concurrency(mut self, concurrency: usize) -> Self {
@@ -679,7 +710,9 @@ where
 /// - The model tool-call events ([`StreamedAssistantContent::ToolCall`]) are
 ///   emitted up front — they report what the model emitted at turn commit.
 /// - Every tool then runs (sequentially at `tool_concurrency <= 1`, else
-///   concurrently bounded by it), with outcomes **collected, not surfaced**.
+///   concurrently bounded by it), with outcomes **collected, not surfaced** —
+///   except the live [`ToolExecutionStarted`](MultiTurnStreamItem::ToolExecutionStarted)
+///   item, surfaced immediately as each dispatched call starts.
 /// - On the first hook termination / fail-closed error the batch fails fast: no
 ///   new tool starts, not-yet-started concurrent siblings are dropped,
 ///   already-started ones are drained, and the deterministic lowest call-index
@@ -798,6 +831,13 @@ where
                     }
                     continue;
                 }
+                // Live start: yielded before the tool future is even built.
+                if forward_items {
+                    yield Ok(MultiTurnStreamItem::ToolExecutionStarted {
+                        tool_name: tool_call.function.name.clone(),
+                        internal_call_id: internal_call_id.clone(),
+                    });
+                }
                 let outcome = run_single_tool(
                     runner,
                     hook_ctx,
@@ -834,9 +874,25 @@ where
             // runs) once any sibling terminates — avoiding the Semantic-Kernel
             // fail-open — while already-in-flight siblings are drained so the
             // lowest call-index terminator wins and no task is left detached.
+            enum BatchEvent<T> {
+                Started {
+                    tool_name: String,
+                    internal_call_id: String,
+                },
+                Settled(usize, Option<T>),
+            }
             let terminating = Arc::new(std::sync::atomic::AtomicBool::new(false));
-            let unordered = stream::iter(prepared.into_iter().enumerate())
-                .map(|(index, call)| {
+            let (started_tx, started_rx) = futures::channel::mpsc::unbounded();
+            let tasks: Vec<_> = prepared
+                .into_iter()
+                .enumerate()
+                .map(|(index, call)| (index, call, started_tx.clone()))
+                .collect();
+            // Each task owns one sender clone, so the channel — and the merged
+            // drain below — closes exactly when the last task settles.
+            drop(started_tx);
+            let unordered = stream::iter(tasks)
+                .map(|(index, call, started_tx)| {
                     let PreparedToolCall { tool_call, preresolved_result, internal_call_id, span } = call;
                     let tool_snapshot = &tool_snapshot;
                     let full_history_for_errors = &full_history_for_errors;
@@ -855,6 +911,13 @@ where
                         // `None` marks a dropped (never-started) sibling.
                         if terminating.load(std::sync::atomic::Ordering::SeqCst) {
                             return (index, None);
+                        }
+                        if forward_items {
+                            // A failed send means the drain is gone with the stream.
+                            let _ = started_tx.unbounded_send((
+                                tool_call.function.name.clone(),
+                                internal_call_id.clone(),
+                            ));
                         }
                         let outcome = run_single_tool(
                             runner,
@@ -883,9 +946,29 @@ where
                     .instrument(span)
                 })
                 .buffer_unordered(runner.concurrency);
-            futures::pin_mut!(unordered);
+            let merged = stream::select(
+                started_rx.map(|(tool_name, internal_call_id)| BatchEvent::Started {
+                    tool_name,
+                    internal_call_id,
+                }),
+                unordered.map(|(index, outcome)| BatchEvent::Settled(index, outcome)),
+            );
+            futures::pin_mut!(merged);
 
-            while let Some((index, outcome)) = unordered.next().await {
+            while let Some(event) = merged.next().await {
+                let (index, outcome) = match event {
+                    BatchEvent::Started {
+                        tool_name,
+                        internal_call_id,
+                    } => {
+                        yield Ok(MultiTurnStreamItem::ToolExecutionStarted {
+                            tool_name,
+                            internal_call_id,
+                        });
+                        continue;
+                    }
+                    BatchEvent::Settled(index, outcome) => (index, outcome),
+                };
                 // A dropped sibling records nothing.
                 let result = match outcome {
                     Some(result) => result,
@@ -2267,11 +2350,13 @@ mod migrated_tests {
             true,
         );
 
+        let mut saw_start = false;
         let mut saw_commit = false;
         let mut saw_result = false;
         let mut saw_error = false;
         while let Some(item) = stream.next().await {
             match item {
+                Ok(MultiTurnStreamItem::ToolExecutionStarted { .. }) => saw_start = true,
                 Ok(MultiTurnStreamItem::ToolExecutionCommitted { .. }) => saw_commit = true,
                 Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
                     ..
@@ -2284,6 +2369,11 @@ mod migrated_tests {
         assert!(
             saw_error,
             "the mismatched result must fail run-state commit"
+        );
+        assert!(
+            saw_start,
+            "the live start was surfaced before the batch failed to commit — \
+             a terminated batch may leave starts without commit/result items"
         );
         assert!(!saw_commit, "a failed run-state commit cannot be announced");
         assert!(!saw_result, "an uncommitted result cannot be surfaced");

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -453,7 +453,9 @@ where
     /// per-tool side effects interleave even though the final history does not.
     ///
     /// For the streaming path: the driver emits *all* of a turn's `ToolCall`
-    /// stream items eagerly (in call order) when the model turn commits, then —
+    /// stream items eagerly (in call order) when the model turn commits, then a
+    /// live `ToolExecutionStarted` item per dispatched call as it actually
+    /// starts (call order when sequential, start order when concurrent), then —
     /// only after the whole tool batch settles successfully — surfaces the
     /// per-tool `ToolExecutionCommitted` and `ToolResult` stream items in **call
     /// order** (never completion order), for the tools whose body actually ran.
@@ -4617,10 +4619,11 @@ mod migrated_tests {
 
     /// The stream-item taxonomy and ordering: the driver emits *all* of a turn's
     /// **model** tool-call items ([`StreamedAssistantContent::ToolCall`], one per
-    /// call the model made) first, then — after the whole tool batch settles —
-    /// the per-tool **execution** items (`ToolExecutionCommitted` then the
-    /// `ToolResult`) in call order. This holds identically at every concurrency
-    /// (the batch is atomic on both the sequential and concurrent paths).
+    /// call the model made) first, then a live `ToolExecutionStarted` per call as
+    /// it dispatches, then — after the whole tool batch settles — the per-tool
+    /// **execution** items (`ToolExecutionCommitted` then the `ToolResult`) in
+    /// call order. This holds identically at every concurrency (the batch is
+    /// atomic on both the sequential and concurrent paths).
     #[tokio::test]
     async fn stream_emits_model_tool_calls_then_atomic_execution_items() {
         async fn markers(concurrency: usize) -> Vec<&'static str> {
@@ -4649,6 +4652,7 @@ mod migrated_tests {
                     MultiTurnStreamItem::StreamAssistantItem(
                         StreamedAssistantContent::ToolCall { .. },
                     ) => markers.push("model-call"),
+                    MultiTurnStreamItem::ToolExecutionStarted { .. } => markers.push("exec-start"),
                     MultiTurnStreamItem::ToolExecutionCommitted { .. } => {
                         markers.push("exec-commit")
                     }
@@ -4661,11 +4665,13 @@ mod migrated_tests {
             markers
         }
 
-        // Both surfaces: all model tool calls first, then per-tool (start, result)
-        // in call order, surfaced atomically after the batch settles.
+        // All model tool calls first, then a live start per call, then —
+        // atomically after the batch settles — per-tool (commit, result).
         let expected = vec![
             "model-call",
             "model-call",
+            "exec-start",
+            "exec-start",
             "exec-commit",
             "result",
             "exec-commit",
@@ -4673,6 +4679,177 @@ mod migrated_tests {
         ];
         assert_eq!(markers(1).await, expected);
         assert_eq!(markers(4).await, expected);
+    }
+
+    /// A tool that completes only after the stream consumer releases its gate —
+    /// proving `ToolExecutionStarted` is live: the consumer must observe the
+    /// start while the tool body is still pending, or the run deadlocks.
+    #[derive(Clone)]
+    struct ConsumerGatedTool {
+        gate: Arc<tokio::sync::Notify>,
+    }
+
+    impl Tool for ConsumerGatedTool {
+        const NAME: &'static str = "add";
+        type Error = MockToolError;
+        type Args = MockOperationArgs;
+        type Output = i32;
+
+        fn description(&self) -> String {
+            MockAddTool.description()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            MockAddTool.parameters()
+        }
+
+        async fn call(
+            &self,
+            _context: &mut ToolContext,
+            _args: Self::Args,
+        ) -> Result<Self::Output, Self::Error> {
+            self.gate.notified().await;
+            Ok(0)
+        }
+    }
+
+    /// `ToolExecutionStarted` is a **live** stream item: the gated tool
+    /// completes only when the consumer reacts to the start, so a driver that
+    /// surfaced it after execution (or not at all) would deadlock — the timeout
+    /// turns that into a clean failure. Also pins the `internal_call_id`
+    /// correlation across the model `ToolCall` item, the commit, and the result.
+    #[tokio::test]
+    async fn stream_emits_tool_execution_started_live_while_tool_runs() {
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call("tc1", "add", json!({"x": 1, "y": 2})),
+                MockStreamEvent::final_response_with_total_tokens(0),
+            ],
+            vec![
+                MockStreamEvent::text("done"),
+                MockStreamEvent::final_response_with_total_tokens(0),
+            ],
+        ]);
+        let mut stream = AgentBuilder::new(model)
+            .tool(ConsumerGatedTool { gate: gate.clone() })
+            .build()
+            .runner("go")
+            .max_turns(3)
+            .stream()
+            .await;
+
+        let mut model_call_ids = Vec::new();
+        let mut started = Vec::new();
+        let mut committed_ids = Vec::new();
+        let mut result_ids = Vec::new();
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while let Some(item) = stream.next().await {
+                match item.unwrap_or_else(|err| panic!("stream item errored: {err}")) {
+                    MultiTurnStreamItem::StreamAssistantItem(
+                        StreamedAssistantContent::ToolCall {
+                            internal_call_id, ..
+                        },
+                    ) => model_call_ids.push(internal_call_id),
+                    MultiTurnStreamItem::ToolExecutionStarted {
+                        tool_name,
+                        internal_call_id,
+                    } => {
+                        assert!(
+                            committed_ids.is_empty() && result_ids.is_empty(),
+                            "a start item must precede every commit/result item"
+                        );
+                        started.push((tool_name, internal_call_id));
+                        // Receiving the start live is what unblocks the tool.
+                        gate.notify_one();
+                    }
+                    MultiTurnStreamItem::ToolExecutionCommitted {
+                        internal_call_id, ..
+                    } => committed_ids.push(internal_call_id),
+                    MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
+                        internal_call_id,
+                        ..
+                    }) => result_ids.push(internal_call_id),
+                    _ => {}
+                }
+            }
+        })
+        .await
+        .expect("the start item must be surfaced while the tool is still running");
+
+        assert_eq!(started.len(), 1, "one start per executed tool call");
+        let (tool_name, started_id) = &started[0];
+        assert_eq!(tool_name, "add");
+        assert_eq!(model_call_ids, vec![started_id.clone()]);
+        assert_eq!(committed_ids, vec![started_id.clone()]);
+        assert_eq!(result_ids, vec![started_id.clone()]);
+    }
+
+    /// The concurrent tool path surfaces `ToolExecutionStarted` live as well:
+    /// every call is gated on its own start being consumed, so the batch can
+    /// only settle if each start reaches the consumer mid-execution. Starts
+    /// precede every commit/result item and pair with them one-to-one by id.
+    #[tokio::test]
+    async fn stream_emits_tool_execution_started_live_under_concurrency() {
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call("tc1", "add", json!({"x": 1, "y": 0})),
+                MockStreamEvent::tool_call("tc2", "add", json!({"x": 2, "y": 0})),
+                MockStreamEvent::final_response_with_total_tokens(0),
+            ],
+            vec![
+                MockStreamEvent::text("done"),
+                MockStreamEvent::final_response_with_total_tokens(0),
+            ],
+        ]);
+        let mut stream = AgentBuilder::new(model)
+            .tool(ConsumerGatedTool { gate: gate.clone() })
+            .build()
+            .runner("go")
+            .max_turns(3)
+            .tool_concurrency(2)
+            .stream()
+            .await;
+
+        let mut started_ids = Vec::new();
+        let mut committed_ids = Vec::new();
+        let mut result_ids = Vec::new();
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while let Some(item) = stream.next().await {
+                match item.unwrap_or_else(|err| panic!("stream item errored: {err}")) {
+                    MultiTurnStreamItem::ToolExecutionStarted {
+                        internal_call_id, ..
+                    } => {
+                        assert!(
+                            committed_ids.is_empty() && result_ids.is_empty(),
+                            "every start item must precede the batch's commit/result items"
+                        );
+                        started_ids.push(internal_call_id);
+                        gate.notify_one();
+                    }
+                    MultiTurnStreamItem::ToolExecutionCommitted {
+                        internal_call_id, ..
+                    } => committed_ids.push(internal_call_id),
+                    MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
+                        internal_call_id,
+                        ..
+                    }) => result_ids.push(internal_call_id),
+                    _ => {}
+                }
+            }
+        })
+        .await
+        .expect("start items must be surfaced while the concurrent tools are still running");
+
+        assert_eq!(started_ids.len(), 2, "one start per executed tool call");
+        // Starts pair with the (call-ordered) commit/result ids in any start order.
+        let mut paired = started_ids.clone();
+        paired.sort();
+        let mut committed_sorted = committed_ids.clone();
+        committed_sorted.sort();
+        assert_eq!(paired, committed_sorted);
+        assert_eq!(committed_ids, result_ids);
     }
 
     /// Terminates from the `x == 1` tool's result, but only *after* the slow
@@ -5389,12 +5566,14 @@ mod migrated_tests {
             .stream()
             .await;
 
+        let mut exec_starts = 0;
         let mut exec_commits = 0;
         let mut results = 0;
         let mut final_response = None;
         let mut stream = stream;
         while let Some(item) = stream.next().await {
             match item.unwrap_or_else(|err| panic!("stream item errored: {err}")) {
+                MultiTurnStreamItem::ToolExecutionStarted { .. } => exec_starts += 1,
                 MultiTurnStreamItem::ToolExecutionCommitted { .. } => exec_commits += 1,
                 MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult { .. }) => {
                     results += 1
@@ -5405,6 +5584,10 @@ mod migrated_tests {
         }
 
         assert_eq!(calls.load(SeqCst), 0, "a skipped tool's body never runs");
+        assert_eq!(
+            exec_starts, 1,
+            "the call dispatched (its hook chain ran), so its start is surfaced"
+        );
         assert_eq!(
             exec_commits, 0,
             "a hook-skipped tool produces no execution-commit"

--- a/crates/rig-agent/src/test_utils/model_conformance.rs
+++ b/crates/rig-agent/src/test_utils/model_conformance.rs
@@ -1828,6 +1828,7 @@ where
                 final_response = Some(response);
             }
             MultiTurnStreamItem::StreamAssistantItem(_)
+            | MultiTurnStreamItem::ToolExecutionStarted { .. }
             | MultiTurnStreamItem::ToolExecutionCommitted { .. }
             | MultiTurnStreamItem::ModelTurnRetried { .. } => {}
         }


### PR DESCRIPTION
Fixes #2246.

## Semver

`MultiTurnStreamItem` is `#[non_exhaustive]`, so adding the variant is a **minor, non-breaking**
change: downstream `match`es already carry a wildcard arm, and existing consumers see the new
item fall into it. Every pre-existing stream item keeps its exact position and payload — the new
item is purely additive to the sequence. Serialized form follows the enum's existing tagged
convention (`"type": "toolExecutionStarted"`).

## Motivation

The multi-turn stream currently has no **live** tool-execution signal.
`ToolExecutionCommitted` + `ToolResult` are (deliberately) surfaced only after the whole tool
batch settles, so a streaming consumer that wants to render "running tool X…" — a chat UI, an
AG-UI/SSE bridge mapping onto a `TOOL_CALL_*` lifecycle, or any progress surface — has to
register an `on_tool_call` hook and re-merge that side channel into its own stream, re-deriving
correlation that the stream already carries. Hooks remain the right place for *steering*; this
PR gives pure observers a first-class stream item instead.

## What this adds

A new `MultiTurnStreamItem::ToolExecutionStarted { tool_name, internal_call_id }`, emitted at
each tool call's **actual start moment** — immediately before its `ToolCall` hook chain runs —
one per dispatched call, not per batch. It carries the same rig-generated `internal_call_id`
consumers already receive on the model `ToolCall` item, `ToolExecutionCommitted`, and the
`ToolResult`, so the full start ⟷ commit ⟷ result lifecycle correlates with the ids they
already track.

### Ordering contract (documented on the variant)

Per tool call, keyed by `internal_call_id`:

1. the model's complete `StreamedAssistantContent::ToolCall` items — up front for the whole
   batch, in call order (unchanged);
2. `ToolExecutionStarted` — live, as each call actually starts: call order on the sequential
   path, start order under `tool_concurrency > 1`;
3. after the whole batch settles successfully — `ToolExecutionCommitted` + `ToolResult`, in
   call order (unchanged, still atomic all-or-nothing).

The item reports that **dispatch began**, not that the body ran:

- a call whose `ToolCall` hook returns `Skip` still surfaces a start (its hook chain ran, which
  matters for slow approval-style hooks) but no `ToolExecutionCommitted`;
- a call preresolved by invalid-tool-call recovery never dispatches and emits nothing;
- a batch that terminates may leave starts without commit/result items (batch atomicity is
  unchanged).

## Implementation

Both surfaces share `drive_tool_calls`, so the change lives there and behaves identically for
local and MCP-backed tools (both dispatch through the same registry snapshot / hook pipeline);
the blocking surface is untouched (`forward_items: false` still builds no items).

- **Sequential path**: the item is yielded directly before `run_single_tool` is awaited, so a
  consumer observes it before the tool body is even constructed.
- **Concurrent path** (`buffer_unordered`): each task reports its start through an unbounded
  side channel the moment it dispatches (after the fail-fast `terminating` check, so dropped
  siblings emit nothing), and the drain loop is a `stream::select` merge of that channel with
  the settled-outcome stream — starts surface live while tools are still running, and the
  channel closes exactly when the last task settles (each task owns one sender clone), so the
  merged drain terminates as before. Outcome collection, fail-fast semantics, and the
  atomic-after-settle commit are untouched.

## Tests

All in `rig-agent`'s existing streaming/loop test style (mock model turns, no network):

- `stream_emits_tool_execution_started_live_while_tool_runs` — **liveness**: the tool body
  completes only when the consumer reacts to the start item on the stream; a driver that
  surfaced the start after execution would deadlock (timeout-guarded). Also pins correlation:
  the start's `internal_call_id` equals the model `ToolCall` item's, the commit's, and the
  result's.
- `stream_emits_tool_execution_started_live_under_concurrency` — same liveness proof on the
  `buffer_unordered` path with every call gated on its own start being consumed; asserts every
  start precedes the batch's commit/result items and start ids pair 1:1 with commit/result ids.
- `stream_emits_model_tool_calls_then_atomic_execution_items` — extended taxonomy/ordering
  fixture now asserts the full marker sequence (model-calls → starts → commit/result pairs) at
  concurrency 1 and 4.
- `stream_hook_skip_surfaces_result_without_execution_commit` — extended: a hook-skipped call
  surfaces a start and a result but no commit.
- `execution_commit_items_are_not_emitted_when_run_commit_fails` — extended: a failed batch
  commit surfaces no commit/result items, while the already-emitted live start documents the
  starts-without-results terminal case.

Cassettes: not applicable (no provider behavior change).

`cargo fmt --check`, `cargo clippy -p rig-agent --all-features --all-targets`, and
`cargo test -p rig-agent --all-features` (489 passed) are green on the workspace toolchain.
