### PR TITLE
feat(openai): surface finish_reason on chat-completions streaming final responses

### DIFF
--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -1557,6 +1557,18 @@ enum ChatFinishReason {
     Other(String),
 }
 
+impl From<&ChatFinishReason> for CompatibleFinishReason {
+    fn from(reason: &ChatFinishReason) -> Self {
+        match reason {
+            ChatFinishReason::ToolCalls => Self::ToolCalls,
+            ChatFinishReason::Stop => Self::Stop,
+            ChatFinishReason::ContentFilter => Self::ContentFilter,
+            ChatFinishReason::Length => Self::Length,
+            ChatFinishReason::Other(other) => Self::Other(other.clone()),
+        }
+    }
+}
+
 #[derive(Deserialize, Debug)]
 struct ChatStreamingChoice {
     delta: ChatStreamingDelta,
@@ -1598,11 +1610,7 @@ impl CompatibleStreamProfile for CopilotChatCompatibleProfile {
                 data.usage,
                 &data.choices,
                 |choice| CompatibleChoiceData {
-                    finish_reason: if choice.finish_reason == Some(ChatFinishReason::ToolCalls) {
-                        CompatibleFinishReason::ToolCalls
-                    } else {
-                        CompatibleFinishReason::Other
-                    },
+                    finish_reason: choice.finish_reason.as_ref().map(Into::into),
                     text: choice.delta.content.clone(),
                     reasoning: choice.delta.reasoning_content.clone(),
                     tool_calls: openai_chat_completions_compatible::tool_call_chunks(
@@ -1614,9 +1622,14 @@ impl CompatibleStreamProfile for CopilotChatCompatibleProfile {
         ))
     }
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse {
+    fn build_final_response(
+        &self,
+        usage: Self::Usage,
+        finish_reason: Option<CompatibleFinishReason>,
+    ) -> Self::FinalResponse {
         CopilotStreamingResponse::Chat(openai::completion::streaming::StreamingCompletionResponse {
             usage,
+            finish_reason: finish_reason.map(Into::into),
         })
     }
 
@@ -2256,6 +2269,46 @@ mod tests {
             stream.next().await.is_none(),
             "chat stream should terminate immediately after a transport error"
         );
+    }
+
+    #[tokio::test]
+    async fn chat_stream_surfaces_finish_reason_on_final_response() {
+        let http_client = MockStreamingClient {
+            sse_bytes: sse_bytes_from_data_lines([
+                "{\"choices\":[{\"delta\":{\"content\":\"Hel\"},\"finish_reason\":null}],\"usage\":null}",
+                "{\"choices\":[{\"delta\":{},\"finish_reason\":\"length\"}],\"usage\":null}",
+                "{\"choices\":[],\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":3,\"total_tokens\":10}}",
+                "[DONE]",
+            ]),
+        };
+        let client = Client::builder()
+            .api_key("copilot-token")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model("gpt-4o");
+        let request = model.completion_request("hello").build();
+        let mut stream = model.stream(request).await.expect("stream should start");
+
+        let mut final_response = None;
+        while let Some(item) = stream.next().await {
+            if let StreamedAssistantContent::Final(response) =
+                item.expect("stream item should be ok")
+            {
+                final_response = Some(response);
+            }
+        }
+
+        let super::CopilotStreamingResponse::Chat(response) =
+            final_response.expect("expected a final response")
+        else {
+            panic!("chat streaming should yield a chat final response");
+        };
+        assert_eq!(
+            response.finish_reason,
+            Some(crate::providers::openai::completion::streaming::FinishReason::Length)
+        );
+        assert_eq!(response.usage.total_tokens, 10);
     }
 
     #[test]

--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
@@ -41,10 +41,15 @@ fn provider_response_from_compatible_sse_data(data: &str) -> Option<CompletionEr
     Some(crate::provider_response::completion_error_from_body(data))
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+// `ToolCalls` also drives the shared state machine (it flushes pending tool
+// calls); `Other` preserves nonstandard values some compatible gateways emit.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CompatibleFinishReason {
     ToolCalls,
-    Other,
+    Stop,
+    Length,
+    ContentFilter,
+    Other(String),
 }
 
 #[derive(Debug, Clone)]
@@ -82,7 +87,7 @@ impl CompatibleToolCallChunk {
 
 #[derive(Debug, Clone)]
 pub(crate) struct CompatibleChoice<D> {
-    pub(crate) finish_reason: CompatibleFinishReason,
+    pub(crate) finish_reason: Option<CompatibleFinishReason>,
     pub(crate) text: Option<String>,
     pub(crate) reasoning: Option<String>,
     pub(crate) tool_calls: Vec<CompatibleToolCallChunk>,
@@ -91,7 +96,7 @@ pub(crate) struct CompatibleChoice<D> {
 
 #[derive(Debug, Clone)]
 pub(crate) struct CompatibleChoiceData<T, D> {
-    pub(crate) finish_reason: CompatibleFinishReason,
+    pub(crate) finish_reason: Option<CompatibleFinishReason>,
     pub(crate) text: Option<String>,
     pub(crate) reasoning: Option<String>,
     pub(crate) tool_calls: Vec<T>,
@@ -162,7 +167,11 @@ pub(crate) trait CompatibleStreamProfile: WasmCompatSend {
 
     fn normalize_chunk(&self, data: &str) -> NormalizedCompatibleChunk<Self::Usage, Self::Detail>;
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse;
+    fn build_final_response(
+        &self,
+        usage: Self::Usage,
+        finish_reason: Option<CompatibleFinishReason>,
+    ) -> Self::FinalResponse;
 
     fn uses_distinct_tool_call_eviction(&self) -> bool {
         false
@@ -231,6 +240,7 @@ where
     let stream = stream! {
         let mut tool_calls: HashMap<usize, RawStreamingToolCall> = HashMap::new();
         let mut final_usage = None;
+        let mut final_finish_reason: Option<CompatibleFinishReason> = None;
         let mut terminated_with_error = false;
 
         while let Some(event_result) = event_source.next().await {
@@ -273,6 +283,11 @@ where
                     let Some(choice) = chunk.choice else {
                         continue;
                     };
+
+                    // Keep the most recent finish reason for the final response.
+                    if let Some(reason) = choice.finish_reason.as_ref() {
+                        final_finish_reason = Some(reason.clone());
+                    }
 
                     for incoming in choice.tool_calls {
                         if let Some(existing) = tool_calls.get(&incoming.index)
@@ -351,7 +366,7 @@ where
                         yield Ok(RawStreamingChoice::Message(content));
                     }
 
-                    if choice.finish_reason == CompatibleFinishReason::ToolCalls {
+                    if choice.finish_reason == Some(CompatibleFinishReason::ToolCalls) {
                         for tool_call in take_finalized_tool_calls(
                             &mut tool_calls,
                             DroppedToolCallContext::ToolCallsFinishReason,
@@ -387,7 +402,7 @@ where
         let final_usage = final_usage.unwrap_or_default();
         record_usage(&span, &final_usage);
         yield Ok(RawStreamingChoice::FinalResponse(
-            profile.build_final_response(final_usage),
+            profile.build_final_response(final_usage, final_finish_reason),
         ));
     }
     .instrument(instrument_span);

--- a/crates/rig-core/src/providers/openai/completion/streaming.rs
+++ b/crates/rig-core/src/providers/openai/completion/streaming.rs
@@ -86,7 +86,8 @@ struct StreamingDelta {
     reasoning_details: Vec<serde_json::Value>,
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+/// Finish reason reported on a Chat Completions streaming choice.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum FinishReason {
     ToolCalls,
@@ -95,6 +96,33 @@ pub enum FinishReason {
     Length,
     #[serde(untagged)]
     Other(String), // This will handle the deprecated function_call
+}
+
+impl From<&FinishReason> for CompatibleFinishReason {
+    fn from(reason: &FinishReason) -> Self {
+        match reason {
+            FinishReason::ToolCalls => Self::ToolCalls,
+            FinishReason::Stop => Self::Stop,
+            FinishReason::ContentFilter => Self::ContentFilter,
+            FinishReason::Length => Self::Length,
+            // `function_call` is the deprecated pre-tools finish reason some
+            // compatible providers still emit for tool calls.
+            FinishReason::Other(other) if other == "function_call" => Self::ToolCalls,
+            FinishReason::Other(other) => Self::Other(other.clone()),
+        }
+    }
+}
+
+impl From<CompatibleFinishReason> for FinishReason {
+    fn from(reason: CompatibleFinishReason) -> Self {
+        match reason {
+            CompatibleFinishReason::ToolCalls => Self::ToolCalls,
+            CompatibleFinishReason::Stop => Self::Stop,
+            CompatibleFinishReason::ContentFilter => Self::ContentFilter,
+            CompatibleFinishReason::Length => Self::Length,
+            CompatibleFinishReason::Other(other) => Self::Other(other),
+        }
+    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -118,6 +146,10 @@ struct StreamingCompletionChunk<U = Usage> {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct StreamingCompletionResponse<U = Usage> {
     pub usage: U,
+    /// The last `finish_reason` observed on the stream, if any; the deprecated
+    /// `function_call` value is normalized to [`FinishReason::ToolCalls`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<FinishReason>,
 }
 
 impl<U> GetTokenUsage for StreamingCompletionResponse<U>
@@ -273,15 +305,7 @@ where
                 data.usage,
                 &data.choices,
                 |choice| CompatibleChoiceData {
-                    // `function_call` is the deprecated pre-tools finish reason
-                    // some compatible providers still emit for tool calls.
-                    finish_reason: match &choice.finish_reason {
-                        Some(FinishReason::ToolCalls) => CompatibleFinishReason::ToolCalls,
-                        Some(FinishReason::Other(other)) if other == "function_call" => {
-                            CompatibleFinishReason::ToolCalls
-                        }
-                        _ => CompatibleFinishReason::Other,
-                    },
+                    finish_reason: choice.finish_reason.as_ref().map(Into::into),
                     text: choice.delta.content.clone(),
                     reasoning: choice
                         .delta
@@ -297,8 +321,15 @@ where
         ))
     }
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse {
-        StreamingCompletionResponse { usage }
+    fn build_final_response(
+        &self,
+        usage: Self::Usage,
+        finish_reason: Option<CompatibleFinishReason>,
+    ) -> Self::FinalResponse {
+        StreamingCompletionResponse {
+            usage,
+            finish_reason: finish_reason.map(Into::into),
+        }
     }
 
     fn decorate_tool_call(
@@ -614,6 +645,149 @@ mod tests {
         let usage = final_usage.expect("expected a final response with usage");
         assert_eq!(usage.prompt_tokens, 10);
         assert_eq!(usage.total_tokens, 15);
+    }
+
+    async fn final_response_for_stream(
+        data_lines: Vec<String>,
+    ) -> StreamingCompletionResponse<Usage> {
+        use crate::test_utils::MockStreamingClient;
+        use futures::StreamExt;
+
+        let client = MockStreamingClient {
+            sse_bytes: sse_bytes_from_data_lines(data_lines),
+        };
+
+        let req = http::Request::builder()
+            .method("POST")
+            .uri("http://localhost/v1/chat/completions")
+            .body(Vec::new())
+            .unwrap();
+
+        let mut stream = send_compatible_streaming_request(client, req)
+            .await
+            .unwrap();
+
+        let mut final_response = None;
+        while let Some(chunk) = stream.next().await {
+            if let streaming::StreamedAssistantContent::Final(res) = chunk.unwrap() {
+                final_response = Some(res);
+            }
+        }
+
+        final_response.expect("expected a final response")
+    }
+
+    #[tokio::test]
+    async fn test_streaming_finish_reason_survives_final_response() {
+        for (wire, expected) in [
+            ("stop", FinishReason::Stop),
+            ("length", FinishReason::Length),
+            ("content_filter", FinishReason::ContentFilter),
+        ] {
+            let res = final_response_for_stream(vec![
+                "{\"choices\":[{\"delta\":{\"content\":\"Hello\",\"tool_calls\":[]},\"finish_reason\":null}],\"usage\":null}".to_owned(),
+                format!("{{\"choices\":[{{\"delta\":{{}},\"finish_reason\":\"{wire}\"}}],\"usage\":null}}"),
+                "{\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}".to_owned(),
+                "[DONE]".to_owned(),
+            ])
+            .await;
+
+            assert_eq!(
+                res.finish_reason,
+                Some(expected),
+                "finish_reason {wire:?} should survive to the final response"
+            );
+            assert_eq!(res.usage.prompt_tokens, 10);
+            assert_eq!(res.usage.total_tokens, 15);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_streaming_tool_calls_finish_reason_survives_final_response() {
+        let res = final_response_for_stream(vec![
+            "{\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_123\",\"function\":{\"name\":\"ping\",\"arguments\":\"{}\"}}]},\"finish_reason\":null}],\"usage\":null}".to_owned(),
+            "{\"choices\":[{\"delta\":{\"tool_calls\":[]},\"finish_reason\":\"tool_calls\"}],\"usage\":null}".to_owned(),
+            "{\"choices\":[],\"usage\":{\"prompt_tokens\":20,\"completion_tokens\":10,\"total_tokens\":30}}".to_owned(),
+            "[DONE]".to_owned(),
+        ])
+        .await;
+
+        assert_eq!(res.finish_reason, Some(FinishReason::ToolCalls));
+    }
+
+    #[tokio::test]
+    async fn test_streaming_deprecated_function_call_finish_reason_normalizes_to_tool_calls() {
+        let res = final_response_for_stream(vec![
+            "{\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_123\",\"function\":{\"name\":\"ping\",\"arguments\":\"{}\"}}]},\"finish_reason\":null}],\"usage\":null}".to_owned(),
+            "{\"choices\":[{\"delta\":{\"tool_calls\":[]},\"finish_reason\":\"function_call\"}],\"usage\":null}".to_owned(),
+            "[DONE]".to_owned(),
+        ])
+        .await;
+
+        assert_eq!(res.finish_reason, Some(FinishReason::ToolCalls));
+    }
+
+    #[tokio::test]
+    async fn test_streaming_nonstandard_finish_reason_is_preserved() {
+        // Some compatible gateways emit finish reasons outside the OpenAI set
+        // (e.g. DeepSeek's `insufficient_system_resource`).
+        let res = final_response_for_stream(vec![
+            "{\"choices\":[{\"delta\":{\"content\":\"Hello\",\"tool_calls\":[]},\"finish_reason\":null}],\"usage\":null}".to_owned(),
+            "{\"choices\":[{\"delta\":{},\"finish_reason\":\"insufficient_system_resource\"}],\"usage\":null}".to_owned(),
+            "[DONE]".to_owned(),
+        ])
+        .await;
+
+        assert_eq!(
+            res.finish_reason,
+            Some(FinishReason::Other(
+                "insufficient_system_resource".to_owned()
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_streaming_without_finish_reason_yields_none() {
+        let res = final_response_for_stream(vec![
+            "{\"choices\":[{\"delta\":{\"content\":\"Hello\",\"tool_calls\":[]}}],\"usage\":null}"
+                .to_owned(),
+            "{\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}".to_owned(),
+            "[DONE]".to_owned(),
+        ])
+        .await;
+
+        assert!(res.finish_reason.is_none());
+    }
+
+    #[test]
+    fn test_streaming_response_finish_reason_serde_is_backward_compatible() {
+        // Payloads serialized before the field existed still deserialize.
+        let legacy = r#"{"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}"#;
+        let response: StreamingCompletionResponse = serde_json::from_str(legacy).unwrap();
+        assert!(response.finish_reason.is_none());
+
+        // `None` keeps the serialized form unchanged.
+        let serialized = serde_json::to_value(&response).unwrap();
+        assert!(serialized.get("finish_reason").is_none());
+
+        // Standard and nonstandard reasons round-trip.
+        for (reason, wire) in [
+            (FinishReason::Length, serde_json::json!("length")),
+            (
+                FinishReason::Other("expired".to_owned()),
+                serde_json::json!("expired"),
+            ),
+        ] {
+            let response = StreamingCompletionResponse::<Usage> {
+                usage: Usage::new(),
+                finish_reason: Some(reason.clone()),
+            };
+            let serialized = serde_json::to_value(&response).unwrap();
+            assert_eq!(serialized["finish_reason"], wire);
+            let deserialized: StreamingCompletionResponse =
+                serde_json::from_value(serialized).unwrap();
+            assert_eq!(deserialized.finish_reason, Some(reason));
+        }
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/test_utils/internal_streaming_profiles.rs
+++ b/crates/rig-core/src/test_utils/internal_streaming_profiles.rs
@@ -20,7 +20,7 @@ fn test_chunk(choice: CompatibleChoice<()>) -> CompatibleChunk<MockResponse, ()>
 }
 
 fn tool_call_choice(
-    finish_reason: CompatibleFinishReason,
+    finish_reason: Option<CompatibleFinishReason>,
     tool_calls: Vec<CompatibleToolCallChunk>,
 ) -> CompatibleChoice<()> {
     CompatibleChoice {
@@ -61,7 +61,7 @@ impl CompatibleStreamProfile for ErrorAfterPendingToolCallProfile {
     ) -> Result<Option<CompatibleChunk<Self::Usage, Self::Detail>>, CompletionError> {
         match data {
             "start" => Ok(Some(test_chunk(tool_call_choice(
-                CompatibleFinishReason::Other,
+                None,
                 vec![tool_call_chunk(0, Some("call_123"), Some("ping"), Some(""))],
             )))),
             "bad" => Err(CompletionError::ProviderError(
@@ -71,7 +71,11 @@ impl CompatibleStreamProfile for ErrorAfterPendingToolCallProfile {
         }
     }
 
-    fn build_final_response(&self, _usage: Self::Usage) -> Self::FinalResponse {
+    fn build_final_response(
+        &self,
+        _usage: Self::Usage,
+        _finish_reason: Option<CompatibleFinishReason>,
+    ) -> Self::FinalResponse {
         MockResponse::new()
     }
 }
@@ -91,7 +95,7 @@ impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
     ) -> Result<Option<CompatibleChunk<Self::Usage, Self::Detail>>, CompletionError> {
         let choice = match data {
             "first_start" => Some(tool_call_choice(
-                CompatibleFinishReason::Other,
+                None,
                 vec![tool_call_chunk(
                     0,
                     Some("call_aaa"),
@@ -100,7 +104,7 @@ impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
                 )],
             )),
             "first_args" => Some(tool_call_choice(
-                CompatibleFinishReason::Other,
+                None,
                 vec![tool_call_chunk(0, None, None, Some("{\"query\":\"one\"}"))],
             )),
             // A partial (still-streaming) argument fragment: the accumulator
@@ -108,11 +112,11 @@ impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
             // `{...}` object. If the first call is evicted at this point, its
             // arguments are a non-object string — the exact #1958 leak condition.
             "first_args_partial" => Some(tool_call_choice(
-                CompatibleFinishReason::Other,
+                None,
                 vec![tool_call_chunk(0, None, None, Some("{\"query\":"))],
             )),
             "second_start" => Some(tool_call_choice(
-                CompatibleFinishReason::Other,
+                None,
                 vec![tool_call_chunk(
                     0,
                     Some("call_bbb"),
@@ -121,11 +125,11 @@ impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
                 )],
             )),
             "second_args" => Some(tool_call_choice(
-                CompatibleFinishReason::Other,
+                None,
                 vec![tool_call_chunk(0, None, None, Some("{\"query\":\"two\"}"))],
             )),
             "finish" => Some(tool_call_choice(
-                CompatibleFinishReason::ToolCalls,
+                Some(CompatibleFinishReason::ToolCalls),
                 Vec::new(),
             )),
             _ => None,
@@ -134,7 +138,11 @@ impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
         Ok(choice.map(test_chunk))
     }
 
-    fn build_final_response(&self, _usage: Self::Usage) -> Self::FinalResponse {
+    fn build_final_response(
+        &self,
+        _usage: Self::Usage,
+        _finish_reason: Option<CompatibleFinishReason>,
+    ) -> Self::FinalResponse {
         MockResponse::new()
     }
 
@@ -158,7 +166,7 @@ impl CompatibleStreamProfile for FinishReasonCleanupProfile {
     ) -> Result<Option<CompatibleChunk<Self::Usage, Self::Detail>>, CompletionError> {
         let choice = match data {
             "start" => Some(tool_call_choice(
-                CompatibleFinishReason::Other,
+                None,
                 vec![tool_call_chunk(
                     0,
                     Some("call_123"),
@@ -167,7 +175,7 @@ impl CompatibleStreamProfile for FinishReasonCleanupProfile {
                 )],
             )),
             "finish" => Some(tool_call_choice(
-                CompatibleFinishReason::ToolCalls,
+                Some(CompatibleFinishReason::ToolCalls),
                 Vec::new(),
             )),
             _ => None,
@@ -176,7 +184,11 @@ impl CompatibleStreamProfile for FinishReasonCleanupProfile {
         Ok(choice.map(test_chunk))
     }
 
-    fn build_final_response(&self, _usage: Self::Usage) -> Self::FinalResponse {
+    fn build_final_response(
+        &self,
+        _usage: Self::Usage,
+        _finish_reason: Option<CompatibleFinishReason>,
+    ) -> Self::FinalResponse {
         MockResponse::new()
     }
 }

--- a/tests/cassettes/openai/completions_api/completions_api_stream_surfaces_length_finish_reason.yaml
+++ b/tests/cassettes/openai/completions_api/completions_api_stream_surfaces_length_finish_reason.yaml
@@ -1,0 +1,36 @@
+when:
+  path: /v1/chat/completions
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"max_tokens":6,"messages":[{"content":"Write a long story about a lighthouse keeper.","role":"user"}],"model":"gpt-4o","stream":true,"stream_options":{"include_usage":true}}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    data: {"choices":[{"delta":{"content":"","refusal":null,"role":"assistant"},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"gpt-4o-2024-08-06","obfuscation":"obfuscation_REDACTED_1","object":"chat.completion.chunk","service_tier":"default","system_fingerprint":"fp_REDACTED_1","usage":null}
+
+    data: {"choices":[{"delta":{"content":"The"},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"gpt-4o-2024-08-06","obfuscation":"obfuscation_REDACTED_2","object":"chat.completion.chunk","service_tier":"default","system_fingerprint":"fp_REDACTED_1","usage":null}
+
+    data: {"choices":[{"delta":{"content":" lighthouse"},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"gpt-4o-2024-08-06","obfuscation":"obfuscation_REDACTED_3","object":"chat.completion.chunk","service_tier":"default","system_fingerprint":"fp_REDACTED_1","usage":null}
+
+    data: {"choices":[{"delta":{"content":" keeper"},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"gpt-4o-2024-08-06","obfuscation":"obfuscation_REDACTED_4","object":"chat.completion.chunk","service_tier":"default","system_fingerprint":"fp_REDACTED_1","usage":null}
+
+    data: {"choices":[{"delta":{"content":" watched"},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"gpt-4o-2024-08-06","obfuscation":"obfuscation_REDACTED_5","object":"chat.completion.chunk","service_tier":"default","system_fingerprint":"fp_REDACTED_1","usage":null}
+
+    data: {"choices":[{"delta":{"content":" the"},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"gpt-4o-2024-08-06","obfuscation":"obfuscation_REDACTED_6","object":"chat.completion.chunk","service_tier":"default","system_fingerprint":"fp_REDACTED_1","usage":null}
+
+    data: {"choices":[{"delta":{"content":" storm"},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"gpt-4o-2024-08-06","obfuscation":"obfuscation_REDACTED_7","object":"chat.completion.chunk","service_tier":"default","system_fingerprint":"fp_REDACTED_1","usage":null}
+
+    data: {"choices":[{"delta":{},"finish_reason":"length","index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"gpt-4o-2024-08-06","obfuscation":"obfuscation_REDACTED_8","object":"chat.completion.chunk","service_tier":"default","system_fingerprint":"fp_REDACTED_1","usage":null}
+
+    data: {"choices":[],"created":0,"id":"chatcmpl-REDACTED_1","model":"gpt-4o-2024-08-06","obfuscation":"obfuscation_REDACTED_9","object":"chat.completion.chunk","service_tier":"default","system_fingerprint":"fp_REDACTED_1","usage":{"completion_tokens":6,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":0,"rejected_prediction_tokens":0},"prompt_tokens":16,"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0},"total_tokens":22}}
+
+    data: [DONE]
+

--- a/tests/providers/openai/cassette/completions_api.rs
+++ b/tests/providers/openai/cassette/completions_api.rs
@@ -272,3 +272,44 @@ async fn completions_api_raw_followup_uses_tool_result_without_new_tool_calls() 
     )
     .await;
 }
+
+#[tokio::test]
+async fn completions_api_stream_surfaces_length_finish_reason() {
+    use futures::StreamExt;
+    use rig::providers::openai::completion::streaming::FinishReason;
+    use rig::streaming::StreamedAssistantContent;
+
+    with_openai_completions_cassette(
+        "completions_api/completions_api_stream_surfaces_length_finish_reason",
+        |client| async move {
+            let model = client.completion_model(openai::GPT_4O);
+            let request = model
+                .completion_request("Write a long story about a lighthouse keeper.")
+                .max_tokens(6)
+                .build();
+
+            let mut stream = model
+                .stream(request)
+                .await
+                .expect("raw completions api stream should start");
+
+            let mut final_response = None;
+            while let Some(item) = stream.next().await {
+                if let StreamedAssistantContent::Final(response) =
+                    item.expect("stream item should be ok")
+                {
+                    final_response = Some(response);
+                }
+            }
+
+            let final_response = final_response.expect("stream should yield a final response");
+            assert_eq!(
+                final_response.finish_reason,
+                Some(FinishReason::Length),
+                "a max_tokens truncation must surface `length` on the streaming final response"
+            );
+            assert_eq!(final_response.usage.total_tokens, 22);
+        },
+    )
+    .await;
+}


### PR DESCRIPTION
Fixes #2248.

Refs #2090, #2235.

The OpenAI Chat Completions streaming path parses each choice's `finish_reason`,
uses it once to decide when to flush pending tool calls, and then drops it. The
streaming `StreamingCompletionResponse` carried `usage` and nothing else, so a
`max_tokens` truncation was indistinguishable from a natural stop — the same gap
#2236 closes for Anthropic, and the one its notes explicitly left open for the
OpenAI-compatible side. The non-streaming response keeps the value
(`choices[].finish_reason` on the raw response); only streaming consumers lose it.

Reproduce with any streaming completion capped by `max_tokens`: the final
response reports normal-looking usage and no signal that the output was cut off.
A consumer that must refuse to act on a truncated response has nothing to branch
on without re-parsing provider SSE itself.

## What this does

`StreamingCompletionResponse` gains the field:

```rust
pub struct StreamingCompletionResponse<U = Usage> {
    pub usage: U,
    #[serde(skip_serializing_if = "Option::is_none")]
    pub finish_reason: Option<FinishReason>,   // added
}
```

`FinishReason` is the typed enum this module already deserializes from the wire
(`ToolCalls`, `Stop`, `ContentFilter`, `Length`, `Other(String)`); it now derives
`Clone`, `Serialize`, and `Eq` so it can live on the response.

Internally, the shared compatible-stream state machine
(`providers/internal/openai_chat_completions_compatible.rs`) previously
normalized finish reasons into `CompatibleFinishReason { ToolCalls, Other }`,
which conflated "stopped for length", "stopped naturally", and "no finish reason
on this chunk". The enum now carries the full set, the choice field is
`Option<CompatibleFinishReason>` so absence is distinct from nonstandard, the
loop tracks the last streamed reason, and `build_final_response` receives it.

Because the state machine is shared, the fix lands in one place for:

- OpenAI's chat-completions dialect (`.completions_api()`), and every provider
  driving completions through `GenericCompletionModel` (Azure, Groq, DeepSeek,
  Mistral, OpenRouter, Together, Moonshot, MiniMax, Z.ai, Hugging Face,
  Perplexity, and the other compatible providers);
- Copilot chat, whose profile previously collapsed everything except
  `tool_calls` — it now surfaces the same typed value.

Two mapping details, both pinned by tests: the deprecated `function_call` wire
value keeps its existing tool-calls semantics and surfaces as
`FinishReason::ToolCalls`; nonstandard values some gateways emit (e.g.
DeepSeek's `insufficient_system_resource`) survive verbatim as
`Other(String)`.

## Design choice

This mirrors #1776, which added `finish_reason` to Gemini's streaming response
type, and #2236, which does the same for Anthropic: the provider-native typed
value on the provider's streaming final response. It deliberately does **not**
touch the generic `CompletionResponse` / `streaming::StreamingCompletionResponse`
types — #2090 tracks a normalized cross-provider `FinishReason`, and the variant
set there is still open. Once that lands, this field is exactly the input the
OpenAI-family mapping needs.

Alternatives considered:

- **Normalized enum on the generic response** — rejected here as #2090's design
  discussion; doing it per-provider first matches how `Usage` grew.
- **Raw `Option<String>`** — rejected; the typed enum already exists on the wire
  path and `Other(String)` preserves fidelity for nonstandard values.
- **Capturing inside each profile** — not possible; profiles are stateless by
  design, so the value has to flow through the shared loop.

## Compatibility

Additive. The field is `Option`, skipped when `None` on serialization, and
`Option` fields default on deserialization, so payloads persisted before this
change round-trip unchanged, and payloads written by this change deserialize
under older readers that ignore unknown fields. The reshaped
`CompatibleFinishReason` and the `build_final_response` signature are
`pub(crate)`. No public API is removed or changed in shape.

## Tests

Unit tests in `providers/openai/completion/streaming.rs`:

- `stop` / `length` / `content_filter` each survive to the final response, with
  usage intact;
- `tool_calls` surfaces as `ToolCalls`; deprecated `function_call` normalizes to
  `ToolCalls`;
- nonstandard `insufficient_system_resource` is preserved as `Other`;
- a stream with no finish reason yields `None`;
- serde round-trip: legacy payloads without the field deserialize, `None` keeps
  the serialized form unchanged, standard and nonstandard reasons round-trip.

Copilot: `chat_stream_surfaces_finish_reason_on_final_response` pins the typed
value through `CopilotStreamingResponse::Chat`.

Cassette: `completions_api_stream_surfaces_length_finish_reason` replays a
`max_tokens`-truncated chat-completions stream and asserts `Length` on the final
response. The fixture is authored in scrubbed cassette form (it passes the
cassette-safety scan and the registered-scenario check).

The tests are load-bearing, not incidentally green: reverting only the surface
(`finish_reason: None` at the final-response construction site) turns four of
them red.

Verified locally on the pinned toolchain:

- `cargo fmt --check`
- `cargo clippy -p rig-core --all-targets --all-features` — clean
- `cargo test -p rig-core --lib` — 952 passed
- `cargo test -p rig --all-features --test openai` — 130 passed
- `cargo test -p rig --all-features --test copilot` — 67 passed
- full cassette suites for groq, deepseek, mistral, openrouter, perplexity,
  doubleword, llamafile, chatgpt — all green
