### PR TITLE
refactor(agent): support hook-driven runtime model routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - *(agent)* Add opaque `ModelHandle` values with between-run replacement,
-  per-run overrides, and per-model-call routing across heterogeneous providers.
+  per-run default overrides, and hook-driven per-model-call routing across
+  heterogeneous providers.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- *(agent)* Add opaque `ModelHandle` values with between-run replacement,
+  per-run overrides, and per-model-call routing across heterogeneous providers.
+
+### Changed
+
+- *(agent)* [**breaking**] Make the classic high-level agent, runner, prompt,
+  extraction, and streaming surfaces independent of concrete model types;
+  normalize high-level provider stream finals to `AgentStreamFinal` while
+  retaining typed direct `CompletionModel` APIs.
+
 ## [0.41.0](https://github.com/0xPlaygrounds/rig/compare/v0.40.0...v0.41.0) - 2026-07-28
 
 ### Added

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -55,16 +55,21 @@ only its tool typestate parameter. Custom provider models still implement
 raw unary and streaming responses.
 
 Use `Agent::set_model` or `set_model_handle` to replace the default for later
-runs, `.using_model(handle)` for one run, and `.select_model(...)` to route at
-each model-call boundary. A runner snapshots the agent default when it is
-created. Selection after a fixed override takes precedence; a later fixed
-override clears the selector. In-flight calls never rebind, while retries and
-post-tool calls may select again.
+runs and `.using_model(handle)` to replace one run's default candidate. Route
+at each model-call boundary by implementing synchronous
+`AgentHook::on_model_select` and returning `ModelSelectionAction::Select`.
+Selection hooks chain in registration order, the last selection wins, and a
+stop is terminal. A runner snapshots the agent default and hook stack when it
+is created. In-flight calls never rebind, while retries and post-tool calls may
+select again. `using_model` changes the initial candidate without suppressing
+routing hooks; append an unconditional selecting hook last when one run must
+force a model. Blocking and streaming prompts share the same routing lifecycle.
 
 For extraction, use
 `extractor.using_model(handle).extract(...)` (or `using_model_value(model)`) to
-pin one extraction, including all of its retries. Later calls through the
-extractor still use its original default.
+change one extraction's default candidate, including all of its retries.
+Routing hooks may replace that candidate. Later calls through the extractor
+still use its original default.
 
 High-level stream types no longer expose the provider streaming-response type.
 Provider final events become `AgentStreamFinal`, with the original final

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -11,6 +11,7 @@ above it, in order. Each one is self-contained.
 
 | You are on | Start at |
 | --- | --- |
+| 0.41 | [0.41 → unreleased](#041--unreleased) |
 | 0.40 | [0.40 → 0.41](#040--041) |
 | 0.39 | [0.39 → 0.40](#039--040) |
 | 0.38 | [0.38 → 0.39](#038--039) |
@@ -26,6 +27,54 @@ above it, in order. Each one is self-contained.
 **Everyone should read [Silent behavior changes](#silent-behavior-changes)
 first.** Those are the changes that leave your code compiling and make it do
 something different — the ones a compiler upgrade will not point at.
+
+---
+
+## 0.41 → unreleased
+
+### High-level agent values no longer carry a model type parameter
+
+The classic runtime now erases a `CompletionModel` into an opaque
+`ModelHandle` when the model enters an agent. Remove the model parameter from
+long-lived high-level types:
+
+```rust,ignore
+// Before
+fn build_agent() -> Agent<MyModel> { /* ... */ }
+let agents: Vec<Agent<MyModel>> = vec![agent];
+
+// After
+fn build_agent() -> Agent { /* ... */ }
+let agents: Vec<Agent> = vec![first_provider_agent, second_provider_agent];
+```
+
+The same change applies to `AgentRunner`, `PromptRequest`, streaming request
+and item types, `Extractor<T>`, and `ExtractorBuilder<T>`. `AgentBuilder` keeps
+only its tool typestate parameter. Custom provider models still implement
+`CompletionModel`, and direct low-level calls continue to return their typed
+raw unary and streaming responses.
+
+Use `Agent::set_model` or `set_model_handle` to replace the default for later
+runs, `.using_model(handle)` for one run, and `.select_model(...)` to route at
+each model-call boundary. A runner snapshots the agent default when it is
+created. Selection after a fixed override takes precedence; a later fixed
+override clears the selector. In-flight calls never rebind, while retries and
+post-tool calls may select again.
+
+For extraction, use
+`extractor.using_model(handle).extract(...)` (or `using_model_value(model)`) to
+pin one extraction, including all of its retries. Later calls through the
+extractor still use its original default.
+
+High-level stream types no longer expose the provider streaming-response type.
+Provider final events become `AgentStreamFinal`, with the original final
+serialized in `raw_response` and its reported `usage` preserved. If code needs
+the provider's typed final, call `CompletionModel::stream` directly.
+
+`ModelHandle` is live behavior, not configuration, and therefore has no serde
+implementation. Persist your own provider/model key and resolve it to a handle
+when the process starts. Provider-specific `additional_params` are not assumed
+to be portable when a run switches providers.
 
 ---
 

--- a/crates/rig-agent/CHANGELOG.md
+++ b/crates/rig-agent/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add opaque, cloneable `ModelHandle` values plus default replacement,
-  per-run override, and per-call selection APIs.
-- Add run-local extractor model overrides that remain fixed across retries.
+  per-run default override, and hook-driven per-call selection.
+- Add run-local extractor default-model overrides used across retries.
 
 ### Changed
 

--- a/crates/rig-agent/CHANGELOG.md
+++ b/crates/rig-agent/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- Add opaque, cloneable `ModelHandle` values plus default replacement,
+  per-run override, and per-call selection APIs.
+- Add run-local extractor model overrides that remain fixed across retries.
+
+### Changed
+
+- [**breaking**] Remove concrete model parameters from long-lived classic
+  runtime types and normalize high-level stream finals to `AgentStreamFinal`.
+  Direct provider-model completion and streaming APIs remain typed.
+
 ## [0.41.0](https://github.com/0xPlaygrounds/rig/compare/rig-agent-v0.0.0...rig-agent-v0.41.0) - 2026-07-28
 
 ### Added

--- a/crates/rig-agent/README.md
+++ b/crates/rig-agent/README.md
@@ -19,6 +19,50 @@ let agent = client.agent(openai::GPT_5_2).build();
 let answer = agent.prompt("Explain ownership briefly.").await?;
 ```
 
+## Runtime model routing
+
+High-level agents are concrete values: the provider model is erased once into
+an opaque, cloneable `ModelHandle`. Provider authors still implement the typed
+`CompletionModel` trait, and direct `completion` or `stream` calls retain their
+provider-specific raw response types.
+
+Replace the default on one agent value with `set_model` or
+`set_model_handle`, pin one prompt with `using_model`, or select before every
+model call with `select_model`. Selection occurs only at a model-call boundary;
+the selected handle prepares and executes that attempt and cannot change while
+its future or stream is in flight. Retries and calls after tool execution are
+new boundaries and may select another handle.
+
+Extractors support the same run-local choice through
+`extractor.using_model(handle).extract(...)` or `using_model_value(model)`.
+That handle remains fixed across the extraction's retries, and the extractor's
+default is unchanged for later calls.
+
+```rust,ignore
+let fast = ModelHandle::named("fast", fast_model);
+let strong = ModelHandle::named("strong", strong_model);
+let agent = AgentBuilder::from_model_handle(fast.clone())
+    .tool(search_tool)
+    .build();
+
+let answer = agent
+    .prompt("Research, then synthesize")
+    .max_turns(3)
+    .select_model(move |context| {
+        if context.turn == 1 { fast.clone() } else { strong.clone() }
+    })
+    .await?;
+```
+
+Handles contain live clients and callbacks, so they are deliberately not
+serializable; persist an application model identifier and resolve it to a
+handle at runtime. Clones share the retained model safely, while replacing an
+agent clone has ordinary value semantics. Concurrent runs keep independent
+default and selector snapshots. High-level agent streams normalize typed
+provider finals to `AgentStreamFinal { usage, raw_response }`; direct model
+streams remain typed. See the credential-free
+`runtime_model_routing` example for a complete two-model tool round trip.
+
 Portable tools implement `rig_core::tool::PortableTool` and work in both runtimes.
 Classic tools that need mutable per-call state implement
 `rig_agent::tool::Tool` and receive `&mut ToolContext`.

--- a/crates/rig-agent/README.md
+++ b/crates/rig-agent/README.md
@@ -27,18 +27,48 @@ an opaque, cloneable `ModelHandle`. Provider authors still implement the typed
 provider-specific raw response types.
 
 Replace the default on one agent value with `set_model` or
-`set_model_handle`, pin one prompt with `using_model`, or select before every
-model call with `select_model`. Selection occurs only at a model-call boundary;
+`set_model_handle`, or change one run's default candidate with `using_model`.
+Implement `AgentHook::on_model_select` to route before every model call. Model
+selection hooks chain in registration order, with the last selection winning
+and a stop terminating the run. Selection occurs only at a model-call boundary;
 the selected handle prepares and executes that attempt and cannot change while
 its future or stream is in flight. Retries and calls after tool execution are
 new boundaries and may select another handle.
 
+Hooks attached through `AgentBuilder::add_hook` apply to every later runner
+from that agent; hooks appended to a prompt or runner apply only to that run.
+`using_model` changes the run's initial candidate but does not suppress routing
+hooks. To force a model, omit routing hooks or append a final hook that always
+selects it. Blocking and streaming prompts share this lifecycle: `Stop`
+cancels before request preparation and provider execution, and dropping an
+in-flight attempt still cancels it by dropping its retained future or stream.
+
 Extractors support the same run-local choice through
 `extractor.using_model(handle).extract(...)` or `using_model_value(model)`.
-That handle remains fixed across the extraction's retries, and the extractor's
-default is unchanged for later calls.
+That handle is the initial candidate for each extraction retry, routing hooks
+may replace it, and the extractor's default is unchanged for later calls.
 
 ```rust,ignore
+#[derive(Clone)]
+struct RouteModels {
+    fast: ModelHandle,
+    strong: ModelHandle,
+}
+
+impl AgentHook for RouteModels {
+    fn on_model_select(
+        &self,
+        context: &HookContext,
+        _event: ModelSelection<'_>,
+    ) -> ModelSelectionAction {
+        if context.turn() == 1 {
+            ModelSelectionAction::select(self.fast.clone())
+        } else {
+            ModelSelectionAction::select(self.strong.clone())
+        }
+    }
+}
+
 let fast = ModelHandle::named("fast", fast_model);
 let strong = ModelHandle::named("strong", strong_model);
 let agent = AgentBuilder::from_model_handle(fast.clone())
@@ -48,17 +78,20 @@ let agent = AgentBuilder::from_model_handle(fast.clone())
 let answer = agent
     .prompt("Research, then synthesize")
     .max_turns(3)
-    .select_model(move |context| {
-        if context.turn == 1 { fast.clone() } else { strong.clone() }
+    .add_hook(RouteModels {
+        fast: fast.clone(),
+        strong: strong.clone(),
     })
     .await?;
 ```
 
-Handles contain live clients and callbacks, so they are deliberately not
-serializable; persist an application model identifier and resolve it to a
-handle at runtime. Clones share the retained model safely, while replacing an
-agent clone has ordinary value semantics. Concurrent runs keep independent
-default and selector snapshots. High-level agent streams normalize typed
+Handles and routing hooks contain live clients, callbacks, and policy state, so
+handles, hook stacks, and hook actions are deliberately not serializable;
+persist an application model identifier and resolve it to a handle at runtime.
+Clones share the retained model safely, while replacing an agent clone has
+ordinary value semantics. Concurrent runs keep independent default and
+hook-stack snapshots; explicitly synchronized state captured by a hook follows
+that hook's own clone semantics. High-level agent streams normalize typed
 provider finals to `AgentStreamFinal { usage, raw_response }`; direct model
 streams remain typed. See the credential-free
 `runtime_model_routing` example for a complete two-model tool round trip.

--- a/crates/rig-agent/examples/runtime_model_routing.rs
+++ b/crates/rig-agent/examples/runtime_model_routing.rs
@@ -3,7 +3,7 @@
 //! The first scripted model calls a search tool. After Rig commits the tool
 //! result to provider-neutral history, the second scripted model writes the
 //! final answer. Real applications can put handles from different providers in
-//! the same map and apply the same selection policy.
+//! the same map and apply the same hook policy.
 
 use std::convert::Infallible;
 
@@ -11,6 +11,7 @@ use anyhow::Result;
 use futures::stream;
 use rig_agent::{
     AgentBuilder, ModelHandle,
+    agent::{AgentHook, HookContext, ModelSelection, ModelSelectionAction},
     completion::{
         CompletionError, CompletionModel, CompletionRequest, CompletionResponse, GetTokenUsage,
         Prompt, Usage,
@@ -194,6 +195,26 @@ impl Tool for Search {
     }
 }
 
+#[derive(Clone)]
+struct RouteModels {
+    fast: ModelHandle,
+    strong: ModelHandle,
+}
+
+impl AgentHook for RouteModels {
+    fn on_model_select(
+        &self,
+        context: &HookContext,
+        _event: ModelSelection<'_>,
+    ) -> ModelSelectionAction {
+        if context.turn() == 1 {
+            ModelSelectionAction::select(self.fast.clone())
+        } else {
+            ModelSelectionAction::select(self.strong.clone())
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let fast = ModelHandle::named("fast", FastResearchModel);
@@ -205,12 +226,9 @@ async fn main() -> Result<()> {
     let answer = agent
         .prompt("Research this, then synthesize a careful answer")
         .max_turns(2)
-        .select_model(move |context| {
-            if context.turn == 1 {
-                fast.clone()
-            } else {
-                strong.clone()
-            }
+        .add_hook(RouteModels {
+            fast: fast.clone(),
+            strong: strong.clone(),
         })
         .await?;
 

--- a/crates/rig-agent/examples/runtime_model_routing.rs
+++ b/crates/rig-agent/examples/runtime_model_routing.rs
@@ -1,0 +1,219 @@
+//! Route one agent across two concrete model types without credentials.
+//!
+//! The first scripted model calls a search tool. After Rig commits the tool
+//! result to provider-neutral history, the second scripted model writes the
+//! final answer. Real applications can put handles from different providers in
+//! the same map and apply the same selection policy.
+
+use std::convert::Infallible;
+
+use anyhow::Result;
+use futures::stream;
+use rig_agent::{
+    AgentBuilder, ModelHandle,
+    completion::{
+        CompletionError, CompletionModel, CompletionRequest, CompletionResponse, GetTokenUsage,
+        Prompt, Usage,
+    },
+    streaming::{RawStreamingChoice, StreamingCompletionResponse},
+    tool::{Tool, ToolContext},
+};
+use rig_core::{
+    OneOrMany,
+    message::{AssistantContent, ToolCall, ToolFunction},
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ScriptedRawResponse {
+    model: String,
+    usage: Usage,
+}
+
+impl GetTokenUsage for ScriptedRawResponse {
+    fn token_usage(&self) -> Usage {
+        self.usage
+    }
+}
+
+fn usage(total_tokens: u64) -> Usage {
+    Usage {
+        total_tokens,
+        ..Usage::new()
+    }
+}
+
+fn response(
+    model: &'static str,
+    choice: AssistantContent,
+    total_tokens: u64,
+) -> CompletionResponse<ScriptedRawResponse> {
+    let usage = usage(total_tokens);
+    CompletionResponse {
+        choice: OneOrMany::one(choice),
+        usage,
+        raw_response: ScriptedRawResponse {
+            model: model.to_owned(),
+            usage,
+        },
+        message_id: Some(format!("{model}-message")),
+    }
+}
+
+#[derive(Clone)]
+struct FastResearchModel;
+
+impl CompletionModel for FastResearchModel {
+    type Response = ScriptedRawResponse;
+    type StreamingResponse = ScriptedRawResponse;
+    type Client = ();
+
+    fn make(_client: &Self::Client, _model: impl Into<String>) -> Self {
+        Self
+    }
+
+    async fn completion(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        Ok(response(
+            "fast",
+            AssistantContent::ToolCall(ToolCall::new(
+                "search-1".to_owned(),
+                ToolFunction::new(
+                    "search".to_owned(),
+                    serde_json::json!({"query": "runtime model routing"}),
+                ),
+            )),
+            3,
+        ))
+    }
+
+    async fn stream(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        let usage = usage(3);
+        Ok(StreamingCompletionResponse::stream(Box::pin(stream::iter(
+            [
+                Ok(RawStreamingChoice::ToolCall(
+                    rig_agent::streaming::RawStreamingToolCall::new(
+                        "search-1".to_owned(),
+                        "search".to_owned(),
+                        serde_json::json!({"query": "runtime model routing"}),
+                    ),
+                )),
+                Ok(RawStreamingChoice::FinalResponse(ScriptedRawResponse {
+                    model: "fast".to_owned(),
+                    usage,
+                })),
+            ],
+        ))))
+    }
+}
+
+#[derive(Clone)]
+struct StrongSynthesisModel;
+
+impl CompletionModel for StrongSynthesisModel {
+    type Response = ScriptedRawResponse;
+    type StreamingResponse = ScriptedRawResponse;
+    type Client = ();
+
+    fn make(_client: &Self::Client, _model: impl Into<String>) -> Self {
+        Self
+    }
+
+    async fn completion(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        let saw_tool_result = request.chat_history.iter().any(|message| {
+            matches!(message, rig_core::message::Message::User { content }
+                if content.iter().any(|item| matches!(item, rig_core::message::UserContent::ToolResult(_))))
+        });
+        let answer = if saw_tool_result {
+            "The strong model synthesized the committed search result."
+        } else {
+            "The tool result was missing."
+        };
+        Ok(response("strong", AssistantContent::text(answer), 5))
+    }
+
+    async fn stream(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        let usage = usage(5);
+        Ok(StreamingCompletionResponse::stream(Box::pin(stream::iter(
+            [
+                Ok(RawStreamingChoice::Message(
+                    "The strong model synthesized the committed search result.".to_owned(),
+                )),
+                Ok(RawStreamingChoice::FinalResponse(ScriptedRawResponse {
+                    model: "strong".to_owned(),
+                    usage,
+                })),
+            ],
+        ))))
+    }
+}
+
+#[derive(Deserialize)]
+struct SearchArgs {
+    query: String,
+}
+
+#[derive(Clone)]
+struct Search;
+
+impl Tool for Search {
+    const NAME: &'static str = "search";
+    type Args = SearchArgs;
+    type Output = String;
+    type Error = Infallible;
+
+    fn description(&self) -> String {
+        "Return deterministic research evidence".to_owned()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"]
+        })
+    }
+
+    async fn call(
+        &self,
+        _context: &mut ToolContext,
+        args: Self::Args,
+    ) -> Result<Self::Output, Self::Error> {
+        Ok(format!("evidence for {}", args.query))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let fast = ModelHandle::named("fast", FastResearchModel);
+    let strong = ModelHandle::named("strong", StrongSynthesisModel);
+
+    let agent = AgentBuilder::from_model_handle(fast.clone())
+        .tool(Search)
+        .build();
+    let answer = agent
+        .prompt("Research this, then synthesize a careful answer")
+        .max_turns(2)
+        .select_model(move |context| {
+            if context.turn == 1 {
+                fast.clone()
+            } else {
+                strong.clone()
+            }
+        })
+        .await?;
+
+    println!("{answer}");
+    Ok(())
+}

--- a/crates/rig-agent/src/agent/builder.rs
+++ b/crates/rig-agent/src/agent/builder.rs
@@ -23,7 +23,7 @@ use crate::{
 #[cfg_attr(docsrs, doc(cfg(feature = "rmcp")))]
 use crate::tool::rmcp::McpTool as RmcpTool;
 
-use super::{Agent, OutputMode};
+use super::{Agent, ModelHandle, OutputMode};
 
 struct DynamicContext<I> {
     samples: usize,
@@ -145,16 +145,13 @@ pub struct WithBuilderTools {
 /// # Ok(())
 /// # }
 /// ```
-pub struct AgentBuilder<M, ToolState = NoToolConfig>
-where
-    M: CompletionModel,
-{
+pub struct AgentBuilder<ToolState = NoToolConfig> {
     /// Name of the agent used for logging and debugging
     name: Option<String>,
     /// Agent description. Primarily useful when using sub-agents as part of an agent workflow and converting agents to other formats.
     description: Option<String>,
     /// Completion model (e.g.: OpenAI's gpt-3.5-turbo-1106, Cohere's command-r)
-    model: M,
+    model: ModelHandle,
     /// System prompt
     preamble: Option<String>,
     /// Context documents always available to the agent
@@ -185,10 +182,7 @@ where
     default_conversation_id: Option<String>,
 }
 
-impl<M, ToolState> AgentBuilder<M, ToolState>
-where
-    M: CompletionModel,
-{
+impl<ToolState> AgentBuilder<ToolState> {
     /// Set the name of the agent
     pub fn name(mut self, name: &str) -> Self {
         self.name = Some(name.into());
@@ -355,12 +349,17 @@ where
     }
 }
 
-impl<M> AgentBuilder<M, NoToolConfig>
-where
-    M: CompletionModel,
-{
+impl AgentBuilder<NoToolConfig> {
     /// Create a new agent builder with the given model
-    pub fn new(model: M) -> Self {
+    pub fn new<M>(model: M) -> Self
+    where
+        M: CompletionModel + 'static,
+    {
+        Self::from_model_handle(ModelHandle::new(model))
+    }
+
+    /// Create an agent builder from an already-erased runtime model handle.
+    pub fn from_model_handle(model: ModelHandle) -> Self {
         Self {
             name: None,
             description: None,
@@ -383,10 +382,7 @@ where
     }
 }
 
-impl<M> AgentBuilder<M, NoToolConfig>
-where
-    M: CompletionModel,
-{
+impl AgentBuilder<NoToolConfig> {
     /// Set a pre-existing ToolServerHandle for the agent.
     ///
     /// After calling this method, tool-adding methods (`.tool()`, `.dynamic_tool()`, etc.)
@@ -395,7 +391,7 @@ where
     pub fn tool_server_handle(
         self,
         handle: ToolServerHandle,
-    ) -> AgentBuilder<M, WithToolServerHandle> {
+    ) -> AgentBuilder<WithToolServerHandle> {
         AgentBuilder {
             name: self.name,
             description: self.description,
@@ -421,7 +417,7 @@ where
     ///
     /// This transitions the builder to the `WithBuilderTools` state, where
     /// additional tools can be added but `tool_server_handle()` is no longer available.
-    pub fn tool<T>(self, tool: T) -> AgentBuilder<M, WithBuilderTools>
+    pub fn tool<T>(self, tool: T) -> AgentBuilder<WithBuilderTools>
     where
         T: Tool + 'static,
     {
@@ -452,7 +448,7 @@ where
     }
 
     /// Add one runtime-defined tool to the agent.
-    pub fn dynamic_tool(self, tool: DynamicTool) -> AgentBuilder<M, WithBuilderTools> {
+    pub fn dynamic_tool(self, tool: DynamicTool) -> AgentBuilder<WithBuilderTools> {
         self.dynamic_tools(vec![tool])
     }
 
@@ -460,7 +456,7 @@ where
     pub fn portable_dynamic_tool(
         self,
         tool: PortableDynamicTool,
-    ) -> AgentBuilder<M, WithBuilderTools> {
+    ) -> AgentBuilder<WithBuilderTools> {
         self.dynamic_tool(DynamicTool::from_portable(tool))
     }
 
@@ -468,7 +464,7 @@ where
     ///
     /// This is useful when tool definitions and callbacks are constructed at runtime.
     /// Transitions the builder to the `WithBuilderTools` state.
-    pub fn dynamic_tools(self, tools: Vec<DynamicTool>) -> AgentBuilder<M, WithBuilderTools> {
+    pub fn dynamic_tools(self, tools: Vec<DynamicTool>) -> AgentBuilder<WithBuilderTools> {
         let tools = ToolSet::from_dynamic_tools(tools);
 
         AgentBuilder {
@@ -507,7 +503,7 @@ where
         self,
         tool: rmcp::model::Tool,
         client: rmcp::service::ServerSink,
-    ) -> AgentBuilder<M, WithBuilderTools> {
+    ) -> AgentBuilder<WithBuilderTools> {
         self.rmcp_tool_with_timeout(tool, client, crate::tool::rmcp::DEFAULT_MCP_TOOL_TIMEOUT)
     }
 
@@ -524,7 +520,7 @@ where
         tool: rmcp::model::Tool,
         client: rmcp::service::ServerSink,
         timeout: impl Into<Option<std::time::Duration>>,
-    ) -> AgentBuilder<M, WithBuilderTools> {
+    ) -> AgentBuilder<WithBuilderTools> {
         self.with_rmcp_toolset(build_rmcp_tools(vec![tool], client, timeout.into()))
     }
 
@@ -540,7 +536,7 @@ where
         self,
         tools: Vec<rmcp::model::Tool>,
         client: rmcp::service::ServerSink,
-    ) -> AgentBuilder<M, WithBuilderTools> {
+    ) -> AgentBuilder<WithBuilderTools> {
         self.rmcp_tools_with_timeout(tools, client, crate::tool::rmcp::DEFAULT_MCP_TOOL_TIMEOUT)
     }
 
@@ -558,17 +554,14 @@ where
         tools: Vec<rmcp::model::Tool>,
         client: rmcp::service::ServerSink,
         timeout: impl Into<Option<std::time::Duration>>,
-    ) -> AgentBuilder<M, WithBuilderTools> {
+    ) -> AgentBuilder<WithBuilderTools> {
         self.with_rmcp_toolset(build_rmcp_tools(tools, client, timeout.into()))
     }
 
     /// Transition into the `WithBuilderTools` state carrying the given built
     /// MCP tools.
     #[cfg(all(feature = "rmcp", not(target_family = "wasm")))]
-    fn with_rmcp_toolset(
-        self,
-        built: Vec<(String, RmcpTool)>,
-    ) -> AgentBuilder<M, WithBuilderTools> {
+    fn with_rmcp_toolset(self, built: Vec<(String, RmcpTool)>) -> AgentBuilder<WithBuilderTools> {
         AgentBuilder {
             name: self.name,
             description: self.description,
@@ -607,7 +600,7 @@ where
         sample: usize,
         index: impl VectorStoreIndexDyn + Send + Sync + 'static,
         toolset: ToolSet,
-    ) -> AgentBuilder<M, WithBuilderTools> {
+    ) -> AgentBuilder<WithBuilderTools> {
         let mut tools = ToolSet::default();
         tools.add_retrievable_tools(toolset);
         AgentBuilder {
@@ -637,13 +630,13 @@ where
     /// Build the agent with no tools configured.
     ///
     /// An empty `ToolServer` will be created for the agent.
-    pub fn build(self) -> Agent<M> {
+    pub fn build(self) -> Agent {
         let tool_server_handle = ToolServer::new().run();
 
         Agent {
             name: self.name,
             description: self.description,
-            model: Arc::new(self.model),
+            model: self.model,
             preamble: self.preamble,
             static_context: self.static_context,
             temperature: self.temperature,
@@ -662,16 +655,13 @@ where
     }
 }
 
-impl<M> AgentBuilder<M, WithToolServerHandle>
-where
-    M: CompletionModel,
-{
+impl AgentBuilder<WithToolServerHandle> {
     /// Build the agent using the pre-configured ToolServerHandle.
-    pub fn build(self) -> Agent<M> {
+    pub fn build(self) -> Agent {
         Agent {
             name: self.name,
             description: self.description,
-            model: Arc::new(self.model),
+            model: self.model,
             preamble: self.preamble,
             static_context: self.static_context,
             temperature: self.temperature,
@@ -690,10 +680,7 @@ where
     }
 }
 
-impl<M> AgentBuilder<M, WithBuilderTools>
-where
-    M: CompletionModel,
-{
+impl AgentBuilder<WithBuilderTools> {
     /// Add another static tool to the agent.
     pub fn tool<T>(mut self, tool: T) -> Self
     where
@@ -781,7 +768,7 @@ where
     /// A new `ToolServer` will be created containing all tools added via
     /// `.tool()`, `.dynamic_tool()`, `.dynamic_tools()`, and
     /// `.retrieved_tools()`.
-    pub fn build(self) -> Agent<M> {
+    pub fn build(self) -> Agent {
         let tool_server_handle = ToolServer::new()
             .add_tools(self.tool_state.tools)
             .add_retrieval_indexes(self.tool_state.retrieval_indexes)
@@ -790,7 +777,7 @@ where
         Agent {
             name: self.name,
             description: self.description,
-            model: Arc::new(self.model),
+            model: self.model,
             preamble: self.preamble,
             static_context: self.static_context,
             temperature: self.temperature,

--- a/crates/rig-agent/src/agent/builder.rs
+++ b/crates/rig-agent/src/agent/builder.rs
@@ -336,10 +336,11 @@ impl<ToolState> AgentBuilder<ToolState> {
     /// Attach a default hook to the agent. Each call appends to the agent's hook
     /// stack; hooks run for every prompt request (unless more are added per
     /// request) in registration order. How their results compose is
-    /// event-dependent: `CompletionCall` request patches accumulate and merge,
-    /// `ToolCall`/`ToolResult` rewrites chain, while model-turn steering and
-    /// observe-only/recovery events use first-non-`Continue`-wins. See the
-    /// [`hook`](crate::agent::hook) module docs.
+    /// event-dependent: model selections and `ToolCall`/`ToolResult` rewrites
+    /// chain, `CompletionCall` request patches accumulate and merge, while
+    /// model-turn steering and observe-only/recovery events use
+    /// first-non-`Continue`-wins. See the [`hook`](crate::agent::hook) module
+    /// docs.
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where
         H: AgentHook + 'static,

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -1,12 +1,13 @@
 use super::hook::{HookStack, RequestPatch};
+use super::model::ModelHandle;
 use super::prompt_request::{self, PromptRequest};
 use super::run::OutputMode;
 use super::runner::AgentRunner;
 use crate::{
     agent::prompt_request::streaming::StreamingPromptRequest,
     completion::{
-        Chat, CompletionError, CompletionModel, CompletionRequestBuilder, Document, GetTokenUsage,
-        Message, Prompt, PromptError, ToolDefinition, TypedPrompt,
+        Chat, CompletionError, CompletionModel, CompletionRequestBuilder, Document, Message,
+        Prompt, PromptError, ToolDefinition, TypedPrompt,
     },
     json_utils,
     streaming::{StreamingChat, StreamingPrompt},
@@ -19,8 +20,11 @@ use super::UNKNOWN_AGENT_NAME;
 
 /// A prepared completion request plus the executable Rig tool names advertised
 /// to the provider for this turn.
-pub(crate) struct PreparedCompletionRequest<M: CompletionModel> {
-    pub(crate) builder: CompletionRequestBuilder<M>,
+pub(crate) struct PreparedModelAttempt {
+    /// Exact model snapshot selected before capability-sensitive preparation.
+    pub(crate) model: ModelHandle,
+    /// Fully built provider-neutral request executed by `model`.
+    pub(crate) request: crate::completion::CompletionRequest,
     /// Exact implementations behind this turn's provider definitions.
     pub(crate) tool_snapshot: Arc<ToolRegistrySnapshot>,
     pub(crate) executable_tool_names: BTreeSet<String>,
@@ -215,8 +219,8 @@ pub(crate) fn allowed_tool_names_for_choice(
 /// Helper function to build a completion request from agent components while
 /// preserving the executable Rig tool names sent to the provider.
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
-    model: &Arc<M>,
+pub(crate) async fn build_prepared_completion_request(
+    model: &ModelHandle,
     prompt: Message,
     chat_history: &[Message],
     preamble: Option<&str>,
@@ -233,7 +237,7 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
     output_tool_description: Option<&str>,
     augment_output_preamble: bool,
     request_patch: Option<&RequestPatch>,
-) -> Result<PreparedCompletionRequest<M>, CompletionError> {
+) -> Result<PreparedModelAttempt, CompletionError> {
     // Apply a per-turn request patch (the merged patch from every `CompletionCall`
     // hook): each set field replaces the agent's configured value for this turn,
     // unset fields inherit it, `additional_params` is shallow-merged, and
@@ -466,8 +470,7 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
         });
     }
 
-    let mut completion_request = model
-        .completion_request(prompt)
+    let mut completion_request = CompletionRequestBuilder::without_model(prompt)
         .messages(chat_history)
         .temperature_opt(temperature)
         .max_tokens_opt(max_tokens)
@@ -512,8 +515,9 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
         allowed_tool_names.insert(name.clone());
     }
 
-    Ok(PreparedCompletionRequest {
-        builder: completion_request,
+    Ok(PreparedModelAttempt {
+        model: model.clone(),
+        request: completion_request.build(),
         tool_snapshot: Arc::new(tool_snapshot),
         executable_tool_names,
         allowed_tool_names,
@@ -548,16 +552,13 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
 /// ```
 #[derive(Clone)]
 #[non_exhaustive]
-pub struct Agent<M>
-where
-    M: CompletionModel,
-{
+pub struct Agent {
     /// Name of the agent used for logging and debugging
     pub(crate) name: Option<String>,
     /// Agent description. Primarily useful when using sub-agents as part of an agent workflow and converting agents to other formats.
     pub(crate) description: Option<String>,
     /// Completion model (e.g.: OpenAI's gpt-3.5-turbo-1106, Cohere's command-r)
-    pub(crate) model: Arc<M>,
+    pub(crate) model: ModelHandle,
     /// System prompt
     pub(crate) preamble: Option<String>,
     /// Context documents always available to the agent
@@ -596,10 +597,7 @@ where
     pub(crate) default_conversation_id: Option<String>,
 }
 
-impl<M> Agent<M>
-where
-    M: CompletionModel,
-{
+impl Agent {
     /// Returns the configured agent name.
     pub fn name(&self) -> Option<&str> {
         self.name.as_deref()
@@ -617,8 +615,44 @@ where
     /// Build a hook-aware [`AgentRunner`] for this agent, seeded with the
     /// agent's default hook stack. Attach more hooks with
     /// [`AgentRunner::add_hook`], then call [`AgentRunner::run`].
-    pub fn runner(&self, prompt: impl Into<Message>) -> AgentRunner<M> {
+    pub fn runner(&self, prompt: impl Into<Message>) -> AgentRunner {
         AgentRunner::from_agent(self, prompt)
+    }
+
+    /// Returns the agent's current default model handle.
+    pub fn model_handle(&self) -> &ModelHandle {
+        &self.model
+    }
+
+    /// Replace the default model used by runners created after this call.
+    ///
+    /// Existing runners retain their model snapshot, and replacing one cloned
+    /// agent does not mutate another clone.
+    pub fn set_model_handle(&mut self, model: ModelHandle) {
+        self.model = model;
+    }
+
+    /// Erase and install a typed completion model as this agent's new default.
+    pub fn set_model<M>(&mut self, model: M)
+    where
+        M: CompletionModel + 'static,
+    {
+        self.set_model_handle(ModelHandle::new(model));
+    }
+
+    /// Return this agent with a replacement default model handle.
+    pub fn with_model_handle(mut self, model: ModelHandle) -> Self {
+        self.set_model_handle(model);
+        self
+    }
+
+    /// Return this agent with an erased typed model as its new default.
+    pub fn with_model<M>(mut self, model: M) -> Self
+    where
+        M: CompletionModel + 'static,
+    {
+        self.set_model(model);
+        self
     }
 
     /// Resolve the provider-facing tool definitions available for a prompt.
@@ -641,37 +675,28 @@ where
 //  - https://github.com/rust-lang/rust/issues/121718 (refining_impl_trait)
 
 #[allow(refining_impl_trait)]
-impl<M> Prompt for Agent<M>
-where
-    M: CompletionModel + 'static,
-{
+impl Prompt for Agent {
     fn prompt(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-    ) -> PromptRequest<prompt_request::Standard, M> {
+    ) -> PromptRequest<prompt_request::Standard> {
         PromptRequest::from_agent(self, prompt)
     }
 }
 
 #[allow(refining_impl_trait)]
-impl<M> Prompt for &Agent<M>
-where
-    M: CompletionModel + 'static,
-{
+impl Prompt for &Agent {
     #[tracing::instrument(skip(self, prompt), fields(agent_name = self.name_or_default()))]
     fn prompt(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-    ) -> PromptRequest<prompt_request::Standard, M> {
-        PromptRequest::from_agent(*self, prompt)
+    ) -> PromptRequest<prompt_request::Standard> {
+        PromptRequest::from_agent(self, prompt)
     }
 }
 
 #[allow(refining_impl_trait)]
-impl<M> Chat for Agent<M>
-where
-    M: CompletionModel + 'static,
-{
+impl Chat for Agent {
     #[tracing::instrument(skip(self, prompt, chat_history), fields(agent_name = self.name_or_default()))]
     async fn chat(
         &self,
@@ -691,34 +716,23 @@ where
     }
 }
 
-impl<M> StreamingPrompt<M, M::StreamingResponse> for Agent<M>
-where
-    M: CompletionModel + 'static,
-    M::StreamingResponse: GetTokenUsage,
-{
-    fn stream_prompt(
-        &self,
-        prompt: impl Into<Message> + WasmCompatSend,
-    ) -> StreamingPromptRequest<M> {
-        StreamingPromptRequest::<M>::from_agent(self, prompt)
+impl StreamingPrompt for Agent {
+    fn stream_prompt(&self, prompt: impl Into<Message> + WasmCompatSend) -> StreamingPromptRequest {
+        StreamingPromptRequest::from_agent(self, prompt)
     }
 }
 
-impl<M> StreamingChat<M, M::StreamingResponse> for Agent<M>
-where
-    M: CompletionModel + 'static,
-    M::StreamingResponse: GetTokenUsage,
-{
+impl StreamingChat for Agent {
     fn stream_chat<I, T>(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
         chat_history: I,
-    ) -> StreamingPromptRequest<M>
+    ) -> StreamingPromptRequest
     where
         I: IntoIterator<Item = T>,
         T: Into<Message>,
     {
-        StreamingPromptRequest::<M>::from_agent(self, prompt).history(chat_history)
+        StreamingPromptRequest::from_agent(self, prompt).history(chat_history)
     }
 }
 
@@ -727,12 +741,9 @@ use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 
 #[allow(refining_impl_trait)]
-impl<M> TypedPrompt for Agent<M>
-where
-    M: CompletionModel + 'static,
-{
+impl TypedPrompt for Agent {
     type TypedRequest<T>
-        = TypedPromptRequest<T, prompt_request::Standard, M>
+        = TypedPromptRequest<T, prompt_request::Standard>
     where
         T: JsonSchema + DeserializeOwned + WasmCompatSend + 'static;
 
@@ -771,7 +782,7 @@ where
     fn prompt_typed<T>(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-    ) -> TypedPromptRequest<T, prompt_request::Standard, M>
+    ) -> TypedPromptRequest<T, prompt_request::Standard>
     where
         T: JsonSchema + DeserializeOwned + WasmCompatSend,
     {
@@ -780,23 +791,20 @@ where
 }
 
 #[allow(refining_impl_trait)]
-impl<M> TypedPrompt for &Agent<M>
-where
-    M: CompletionModel + 'static,
-{
+impl TypedPrompt for &Agent {
     type TypedRequest<T>
-        = TypedPromptRequest<T, prompt_request::Standard, M>
+        = TypedPromptRequest<T, prompt_request::Standard>
     where
         T: JsonSchema + DeserializeOwned + WasmCompatSend + 'static;
 
     fn prompt_typed<T>(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-    ) -> TypedPromptRequest<T, prompt_request::Standard, M>
+    ) -> TypedPromptRequest<T, prompt_request::Standard>
     where
         T: JsonSchema + DeserializeOwned + WasmCompatSend,
     {
-        TypedPromptRequest::from_agent(*self, prompt)
+        TypedPromptRequest::from_agent(self, prompt)
     }
 }
 

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -627,7 +627,8 @@ impl Agent {
     /// Replace the default model used by runners created after this call.
     ///
     /// Existing runners retain their model snapshot, and replacing one cloned
-    /// agent does not mutate another clone.
+    /// agent does not mutate another clone. Model-selection hooks may replace
+    /// the captured default at each model-call boundary.
     pub fn set_model_handle(&mut self, model: ModelHandle) {
         self.model = model;
     }
@@ -641,6 +642,8 @@ impl Agent {
     }
 
     /// Return this agent with a replacement default model handle.
+    ///
+    /// Model-selection hooks may replace this default for individual calls.
     pub fn with_model_handle(mut self, model: ModelHandle) -> Self {
         self.set_model_handle(model);
         self

--- a/crates/rig-agent/src/agent/hook.rs
+++ b/crates/rig-agent/src/agent/hook.rs
@@ -8,12 +8,13 @@
 //! message IDs. Use the direct completion or streaming APIs when a hook-like
 //! integration needs the provider's typed raw response.
 //!
-//! Hooks run in registration order through [`HookStack`]. Completion-call
-//! [`RequestPatch`] values accumulate and merge; tool-call argument rewrites and
-//! tool-result presentation rewrites chain into later hooks. A
-//! [`ModelTurnAction::Retry`] or stop action short-circuits the remaining hooks
-//! for that event. Nested stacks obey the same rules as flat stacks, including
-//! preserving an argument rewrite when an inner stack later skips or stops.
+//! Hooks run in registration order through [`HookStack`]. Model selections,
+//! tool-call argument rewrites, and tool-result presentation rewrites chain into
+//! later hooks; completion-call [`RequestPatch`] values accumulate and merge.
+//! A [`ModelTurnAction::Retry`] or stop action short-circuits the remaining
+//! hooks for that event. Nested stacks obey the same rules as flat stacks,
+//! including preserving an argument rewrite when an inner stack later skips or
+//! stops.
 //!
 //! Register observe-only hooks before steering hooks when every observation is
 //! required: a steering stop intentionally prevents later observers from
@@ -126,6 +127,7 @@ use rig_core::{
 };
 
 use crate::{
+    agent::model::ModelHandle,
     completion::{Document, Usage},
     json_utils,
     tool::{ToolContext, ToolOutput, ToolResult},
@@ -393,6 +395,26 @@ pub struct CompletionCall<'a> {
     pub history: &'a [Message],
     /// One-based model-call index.
     pub turn: usize,
+}
+
+/// Model-selection event resolved before request preparation.
+///
+/// The runner default is the first candidate. A [`HookStack`] threads every
+/// [`ModelSelectionAction::Select`] into later hooks in registration order, so
+/// `selected_model` always reflects all earlier decisions for this event.
+#[derive(Clone, Copy)]
+#[non_exhaustive]
+pub struct ModelSelection<'a> {
+    /// Prompt for the pending model call.
+    pub prompt: &'a Message,
+    /// Canonical history visible to the pending model call.
+    pub history: &'a [Message],
+    /// Model selected for the preceding model attempt in this run, if any.
+    pub previous_model: Option<&'a ModelHandle>,
+    /// Runner default used as the initial candidate for this call.
+    pub default_model: &'a ModelHandle,
+    /// Candidate after all earlier model-selection hooks.
+    pub selected_model: &'a ModelHandle,
 }
 
 /// Canonical non-streaming completion response event.
@@ -722,6 +744,35 @@ impl RequestPatch {
     }
 }
 
+/// Action for model-selection hooks.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum ModelSelectionAction {
+    /// Keep the candidate supplied to this hook.
+    Continue,
+    /// Replace the candidate and pass it to later hooks.
+    Select(ModelHandle),
+    /// Stop the run before request preparation or model execution.
+    Stop(String),
+}
+
+impl ModelSelectionAction {
+    /// Keeps the current model candidate.
+    pub fn continue_run() -> Self {
+        Self::Continue
+    }
+
+    /// Selects `model` and passes it to later hooks.
+    pub fn select(model: ModelHandle) -> Self {
+        Self::Select(model)
+    }
+
+    /// Stops the run before the pending model attempt.
+    pub fn stop(reason: impl Into<String>) -> Self {
+        Self::Stop(reason.into())
+    }
+}
+
 /// Action for completion-call hooks.
 #[derive(Debug, Clone, PartialEq)]
 pub enum CompletionCallAction {
@@ -915,6 +966,20 @@ impl ObservationAction {
 
 /// Per-run lifecycle observer and steerer.
 pub trait AgentHook: WasmCompatSend + WasmCompatSync {
+    /// Selects the model for the pending model-call boundary.
+    ///
+    /// Selection is synchronous and operates only on already-constructed
+    /// [`ModelHandle`] values. In a [`HookStack`], selections are passed to
+    /// later hooks in registration order; the last selection wins and a stop
+    /// is terminal. The default action keeps the current candidate.
+    fn on_model_select(
+        &self,
+        _ctx: &HookContext,
+        _event: ModelSelection<'_>,
+    ) -> ModelSelectionAction {
+        ModelSelectionAction::Continue
+    }
+
     /// Runs before a completion request is sent.
     ///
     /// Return a per-turn patch, continue without one, or stop the run. Patches
@@ -1038,6 +1103,7 @@ impl AgentHook for () {
 }
 
 trait DynAgentHook: WasmCompatSend + WasmCompatSync {
+    fn model_select(&self, ctx: &HookContext, event: ModelSelection<'_>) -> ModelSelectionAction;
     fn completion_call<'a>(
         &'a self,
         ctx: &'a HookContext,
@@ -1090,6 +1156,10 @@ impl<H> DynAgentHook for H
 where
     H: AgentHook,
 {
+    fn model_select(&self, ctx: &HookContext, event: ModelSelection<'_>) -> ModelSelectionAction {
+        self.on_model_select(ctx, event)
+    }
+
     fn completion_call<'a>(
         &'a self,
         ctx: &'a HookContext,
@@ -1165,6 +1235,10 @@ where
 }
 
 /// Ordered composable hook stack.
+///
+/// Model selections chain in registration order: each hook sees the candidate
+/// selected by earlier hooks, the last selection wins, and a stop is terminal.
+/// Nested stacks preserve the same composition semantics.
 #[derive(Clone, Default)]
 pub struct HookStack {
     hooks: Vec<Arc<dyn DynAgentHook>>,
@@ -1250,6 +1324,32 @@ where
 }
 
 impl AgentHook for HookStack {
+    fn on_model_select(
+        &self,
+        ctx: &HookContext,
+        event: ModelSelection<'_>,
+    ) -> ModelSelectionAction {
+        let mut selected = None;
+        for hook in &self.hooks {
+            let action = {
+                let selected_model = selected.as_ref().unwrap_or(event.selected_model);
+                hook.model_select(
+                    ctx,
+                    ModelSelection {
+                        selected_model,
+                        ..event
+                    },
+                )
+            };
+            match action {
+                ModelSelectionAction::Continue => {}
+                ModelSelectionAction::Select(model) => selected = Some(model),
+                stop @ ModelSelectionAction::Stop(_) => return stop,
+            }
+        }
+        selected.map_or(ModelSelectionAction::Continue, ModelSelectionAction::Select)
+    }
+
     async fn on_completion_call(
         &self,
         ctx: &HookContext,
@@ -1608,6 +1708,231 @@ mod migrated_tests {
 
     fn ctx() -> HookContext {
         HookContext::new(false, Some("test-agent".to_string()))
+    }
+
+    fn model(label: &str) -> ModelHandle {
+        ModelHandle::named(label, crate::test_utils::MockCompletionModel::default())
+    }
+
+    enum RouteDecision {
+        Continue,
+        Select(ModelHandle),
+        Stop,
+    }
+
+    type RouteLog = Arc<Mutex<Vec<(&'static str, Option<String>)>>>;
+
+    struct RouteRecorder {
+        label: &'static str,
+        log: RouteLog,
+        decision: RouteDecision,
+    }
+
+    impl AgentHook for RouteRecorder {
+        fn on_model_select(
+            &self,
+            _ctx: &HookContext,
+            event: ModelSelection<'_>,
+        ) -> ModelSelectionAction {
+            self.log
+                .lock()
+                .expect("route log")
+                .push((self.label, event.selected_model.label().map(str::to_owned)));
+            match &self.decision {
+                RouteDecision::Continue => ModelSelectionAction::continue_run(),
+                RouteDecision::Select(model) => ModelSelectionAction::select(model.clone()),
+                RouteDecision::Stop => ModelSelectionAction::stop("routing stopped"),
+            }
+        }
+    }
+
+    fn model_selection<'a>(
+        prompt: &'a Message,
+        default_model: &'a ModelHandle,
+    ) -> ModelSelection<'a> {
+        ModelSelection {
+            prompt,
+            history: &[],
+            previous_model: None,
+            default_model,
+            selected_model: default_model,
+        }
+    }
+
+    #[test]
+    fn model_selections_chain_in_registration_order_and_last_wins() {
+        let default = model("default");
+        let first = model("first");
+        let last = model("last");
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let mut stack = HookStack::with(RouteRecorder {
+            label: "continue",
+            log: log.clone(),
+            decision: RouteDecision::Continue,
+        });
+        stack.push(RouteRecorder {
+            label: "first",
+            log: log.clone(),
+            decision: RouteDecision::Select(first),
+        });
+        stack.push(RouteRecorder {
+            label: "last",
+            log: log.clone(),
+            decision: RouteDecision::Select(last),
+        });
+        let prompt = Message::user("route");
+
+        let action = stack.on_model_select(&ctx(), model_selection(&prompt, &default));
+
+        let ModelSelectionAction::Select(selected) = action else {
+            panic!("stack should select the last candidate");
+        };
+        assert_eq!(selected.label(), Some("last"));
+        assert_eq!(
+            log.lock().expect("route log").as_slice(),
+            &[
+                ("continue", Some("default".to_owned())),
+                ("first", Some("default".to_owned())),
+                ("last", Some("first".to_owned())),
+            ]
+        );
+    }
+
+    #[test]
+    fn model_selection_stop_short_circuits_later_hooks() {
+        let default = model("default");
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let mut stack = HookStack::with(RouteRecorder {
+            label: "stop",
+            log: log.clone(),
+            decision: RouteDecision::Stop,
+        });
+        stack.push(RouteRecorder {
+            label: "later",
+            log: log.clone(),
+            decision: RouteDecision::Select(model("later")),
+        });
+        let prompt = Message::user("route");
+
+        assert!(matches!(
+            stack.on_model_select(&ctx(), model_selection(&prompt, &default)),
+            ModelSelectionAction::Stop(reason) if reason == "routing stopped"
+        ));
+        assert_eq!(
+            log.lock().expect("route log").as_slice(),
+            &[("stop", Some("default".to_owned()))]
+        );
+    }
+
+    #[test]
+    fn nested_model_selection_stacks_preserve_candidate_chaining() {
+        let default = model("default");
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let inner = HookStack::with(RouteRecorder {
+            label: "inner",
+            log: log.clone(),
+            decision: RouteDecision::Select(model("inner")),
+        });
+        let mut outer = HookStack::with(RouteRecorder {
+            label: "outer-before",
+            log: log.clone(),
+            decision: RouteDecision::Select(model("outer")),
+        });
+        outer.push(inner);
+        outer.push(RouteRecorder {
+            label: "outer-after",
+            log: log.clone(),
+            decision: RouteDecision::Continue,
+        });
+        let prompt = Message::user("route");
+
+        let action = outer.on_model_select(&ctx(), model_selection(&prompt, &default));
+
+        let ModelSelectionAction::Select(selected) = action else {
+            panic!("nested stack should preserve the inner selection");
+        };
+        assert_eq!(selected.label(), Some("inner"));
+        assert_eq!(
+            log.lock().expect("route log").as_slice(),
+            &[
+                ("outer-before", Some("default".to_owned())),
+                ("inner", Some("outer".to_owned())),
+                ("outer-after", Some("inner".to_owned())),
+            ]
+        );
+    }
+
+    #[test]
+    fn nested_model_selection_stack_without_a_selection_preserves_outer_candidate() {
+        let default = model("default");
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let inner = HookStack::with(RouteRecorder {
+            label: "inner-continue",
+            log: log.clone(),
+            decision: RouteDecision::Continue,
+        });
+        let mut outer = HookStack::with(RouteRecorder {
+            label: "outer-select",
+            log: log.clone(),
+            decision: RouteDecision::Select(model("outer")),
+        });
+        outer.push(inner);
+        outer.push(RouteRecorder {
+            label: "outer-after",
+            log: log.clone(),
+            decision: RouteDecision::Continue,
+        });
+        let prompt = Message::user("route");
+
+        let action = outer.on_model_select(&ctx(), model_selection(&prompt, &default));
+
+        let ModelSelectionAction::Select(selected) = action else {
+            panic!("outer selection should survive a continuing nested stack");
+        };
+        assert_eq!(selected.label(), Some("outer"));
+        assert_eq!(
+            log.lock().expect("route log").as_slice(),
+            &[
+                ("outer-select", Some("default".to_owned())),
+                ("inner-continue", Some("outer".to_owned())),
+                ("outer-after", Some("outer".to_owned())),
+            ]
+        );
+    }
+
+    #[test]
+    fn nested_model_selection_stop_short_circuits_the_outer_stack() {
+        let default = model("default");
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let inner = HookStack::with(RouteRecorder {
+            label: "inner-stop",
+            log: log.clone(),
+            decision: RouteDecision::Stop,
+        });
+        let mut outer = HookStack::with(RouteRecorder {
+            label: "outer-before",
+            log: log.clone(),
+            decision: RouteDecision::Select(model("outer")),
+        });
+        outer.push(inner);
+        outer.push(RouteRecorder {
+            label: "outer-after",
+            log: log.clone(),
+            decision: RouteDecision::Select(model("unreachable")),
+        });
+        let prompt = Message::user("route");
+
+        assert!(matches!(
+            outer.on_model_select(&ctx(), model_selection(&prompt, &default)),
+            ModelSelectionAction::Stop(reason) if reason == "routing stopped"
+        ));
+        assert_eq!(
+            log.lock().expect("route log").as_slice(),
+            &[
+                ("outer-before", Some("default".to_owned())),
+                ("inner-stop", Some("outer".to_owned())),
+            ]
+        );
     }
 
     struct ToolRecorder {
@@ -2256,6 +2581,7 @@ mod migrated_tests {
 
     #[test]
     fn action_types_are_event_specific() {
+        fn model_selection(_: ModelSelectionAction) {}
         fn completion(_: CompletionCallAction) {}
         fn model_turn(_: ModelTurnAction) {}
         fn retry_request(_: RetryRequest) {}
@@ -2263,6 +2589,7 @@ mod migrated_tests {
         fn result(_: ToolResultAction) {}
         fn invalid(_: InvalidToolCallAction) {}
         fn observation(_: ObservationAction) {}
+        model_selection(ModelSelectionAction::continue_run());
         completion(CompletionCallAction::continue_run());
         model_turn(ModelTurnAction::retry_with_feedback("try again"));
         retry_request(RetryRequest::Repeat);

--- a/crates/rig-agent/src/agent/mod.rs
+++ b/crates/rig-agent/src/agent/mod.rs
@@ -117,12 +117,12 @@ pub use completion::Agent;
 pub use hook::CompletionCall as CompletionCallEvent;
 pub use hook::{
     AgentHook, CompletionCallAction, CompletionResponse as CompletionResponseEvent, HookContext,
-    HookStack, InvalidToolCallAction, InvalidToolCallContext, ModelTurnAction, ModelTurnFinished,
-    ObservationAction, RequestPatch, RetryRequest, RunId, Scratchpad, StepEventKind,
-    StreamResponseFinish, TextDelta, ToolCall, ToolCallAction, ToolCallDelta, ToolResultAction,
-    ToolResultEvent,
+    HookStack, InvalidToolCallAction, InvalidToolCallContext, ModelSelection, ModelSelectionAction,
+    ModelTurnAction, ModelTurnFinished, ObservationAction, RequestPatch, RetryRequest, RunId,
+    Scratchpad, StepEventKind, StreamResponseFinish, TextDelta, ToolCall, ToolCallAction,
+    ToolCallDelta, ToolResultAction, ToolResultEvent,
 };
-pub use model::{AgentStreamFinal, ModelHandle, ModelSelectionContext};
+pub use model::{AgentStreamFinal, ModelHandle};
 pub use prompt_request::streaming::{
     MultiTurnStreamItem, StreamingError, StreamingPromptRequest, StreamingResult, stream_to_stdout,
 };

--- a/crates/rig-agent/src/agent/mod.rs
+++ b/crates/rig-agent/src/agent/mod.rs
@@ -102,6 +102,7 @@
 mod builder;
 mod completion;
 pub mod hook;
+pub mod model;
 pub(crate) mod prompt_request;
 pub mod run;
 pub mod runner;
@@ -121,11 +122,13 @@ pub use hook::{
     StreamResponseFinish, TextDelta, ToolCall, ToolCallAction, ToolCallDelta, ToolResultAction,
     ToolResultEvent,
 };
+pub use model::{AgentStreamFinal, ModelHandle, ModelSelectionContext};
 pub use prompt_request::streaming::{
     MultiTurnStreamItem, StreamingError, StreamingPromptRequest, StreamingResult, stream_to_stdout,
 };
 pub use prompt_request::{
-    CompletionCall, PromptRequest, PromptResponse, TypedPromptRequest, TypedPromptResponse,
+    CompletionCall, Extended, PromptRequest, PromptResponse, PromptType, Standard,
+    TypedPromptRequest, TypedPromptResponse,
 };
 pub use rig_core::message::Text;
 pub use run::{AgentRun, AgentRunStep, ModelTurn, ModelTurnOutcome, OutputMode, PendingToolCall};

--- a/crates/rig-agent/src/agent/model.rs
+++ b/crates/rig-agent/src/agent/model.rs
@@ -26,9 +26,9 @@ use futures::{Stream, StreamExt};
 use rig_core::{
     OneOrMany,
     completion::{CompletionError, CompletionModel, CompletionRequest, GetTokenUsage, Usage},
-    message::{AssistantContent, Message},
+    message::AssistantContent,
     streaming::{StreamedAssistantContent, StreamingCompletionResponse},
-    wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync},
+    wasm_compat::WasmBoxedFuture,
 };
 use serde::{Deserialize, Serialize};
 
@@ -50,55 +50,6 @@ pub struct AgentStreamFinal {
 impl GetTokenUsage for AgentStreamFinal {
     fn token_usage(&self) -> Usage {
         self.usage
-    }
-}
-
-/// Borrowed inputs supplied to a run-local model selector before a model call.
-///
-/// Selection happens once for each `AgentRunStep::CallModel`, before request
-/// preparation. The selected handle is then bound to that attempt, so it cannot
-/// change while a unary future or provider stream is in flight.
-pub struct ModelSelectionContext<'a> {
-    /// One-based model-call index reported by the agent run state machine.
-    pub turn: usize,
-    /// Prompt for the pending model call.
-    pub prompt: &'a Message,
-    /// Canonical history visible to the pending model call.
-    pub history: &'a [Message],
-    /// Whether the run is using the streaming surface.
-    pub is_streaming: bool,
-    /// Handle selected for the previous model call in this run, if any.
-    pub previous_model: Option<&'a ModelHandle>,
-    /// Run-local default handle used when no selector is installed.
-    pub default_model: &'a ModelHandle,
-}
-
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-type SelectorCallback = dyn for<'a> Fn(ModelSelectionContext<'a>) -> ModelHandle + Send + Sync;
-
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-type SelectorCallback = dyn for<'a> Fn(ModelSelectionContext<'a>) -> ModelHandle;
-
-#[derive(Clone)]
-pub(crate) struct ModelSelector {
-    callback: Arc<SelectorCallback>,
-}
-
-impl ModelSelector {
-    pub(crate) fn new<F>(selector: F) -> Self
-    where
-        F: for<'a> Fn(ModelSelectionContext<'a>) -> ModelHandle
-            + WasmCompatSend
-            + WasmCompatSync
-            + 'static,
-    {
-        Self {
-            callback: Arc::new(selector),
-        }
-    }
-
-    pub(crate) fn select(&self, context: ModelSelectionContext<'_>) -> ModelHandle {
-        (self.callback)(context)
     }
 }
 

--- a/crates/rig-agent/src/agent/model.rs
+++ b/crates/rig-agent/src/agent/model.rs
@@ -1,0 +1,407 @@
+//! Runtime model handles for the concrete agent facade.
+//!
+//! Provider authors continue to implement [`CompletionModel`] with typed unary
+//! and streaming responses. [`ModelHandle`] erases that implementation once,
+//! when it enters the high-level agent runtime, so an [`Agent`](super::Agent)
+//! can replace or route models without changing its Rust type.
+//!
+//! Routing observes ten invariants: one selection occurs per `CallModel` step;
+//! preparation reads that selection's capabilities; the same handle executes
+//! the prepared request; in-flight work cannot be rebound; dropping a call
+//! drops its retained future or stream; retries select anew; accepted tool calls
+//! stay with their turn; history remains provider-neutral; concurrent runs own
+//! independent routing snapshots; and replacing an agent clone has value
+//! semantics. Provider-specific `additional_params` are not guaranteed to be
+//! portable between providers and retain each provider's existing validation
+//! and error behavior.
+
+use std::{
+    fmt,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use futures::{Stream, StreamExt};
+use rig_core::{
+    OneOrMany,
+    completion::{CompletionError, CompletionModel, CompletionRequest, GetTokenUsage, Usage},
+    message::{AssistantContent, Message},
+    streaming::{StreamedAssistantContent, StreamingCompletionResponse},
+    wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync},
+};
+use serde::{Deserialize, Serialize};
+
+/// A provider-neutral final event on the high-level agent streaming surface.
+///
+/// Direct [`CompletionModel::stream`] calls still expose the provider's typed
+/// streaming response. Agent streams normalize only the provider-final event so
+/// callers can switch providers between model-call boundaries without changing
+/// the stream's Rust type.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[non_exhaustive]
+pub struct AgentStreamFinal {
+    /// Token usage reported by the provider final response.
+    pub usage: Usage,
+    /// The provider final response serialized as JSON.
+    pub raw_response: serde_json::Value,
+}
+
+impl GetTokenUsage for AgentStreamFinal {
+    fn token_usage(&self) -> Usage {
+        self.usage
+    }
+}
+
+/// Borrowed inputs supplied to a run-local model selector before a model call.
+///
+/// Selection happens once for each `AgentRunStep::CallModel`, before request
+/// preparation. The selected handle is then bound to that attempt, so it cannot
+/// change while a unary future or provider stream is in flight.
+pub struct ModelSelectionContext<'a> {
+    /// One-based model-call index reported by the agent run state machine.
+    pub turn: usize,
+    /// Prompt for the pending model call.
+    pub prompt: &'a Message,
+    /// Canonical history visible to the pending model call.
+    pub history: &'a [Message],
+    /// Whether the run is using the streaming surface.
+    pub is_streaming: bool,
+    /// Handle selected for the previous model call in this run, if any.
+    pub previous_model: Option<&'a ModelHandle>,
+    /// Run-local default handle used when no selector is installed.
+    pub default_model: &'a ModelHandle,
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+type SelectorCallback = dyn for<'a> Fn(ModelSelectionContext<'a>) -> ModelHandle + Send + Sync;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+type SelectorCallback = dyn for<'a> Fn(ModelSelectionContext<'a>) -> ModelHandle;
+
+#[derive(Clone)]
+pub(crate) struct ModelSelector {
+    callback: Arc<SelectorCallback>,
+}
+
+impl ModelSelector {
+    pub(crate) fn new<F>(selector: F) -> Self
+    where
+        F: for<'a> Fn(ModelSelectionContext<'a>) -> ModelHandle
+            + WasmCompatSend
+            + WasmCompatSync
+            + 'static,
+    {
+        Self {
+            callback: Arc::new(selector),
+        }
+    }
+
+    pub(crate) fn select(&self, context: ModelSelectionContext<'_>) -> ModelHandle {
+        (self.callback)(context)
+    }
+}
+
+pub(crate) struct ModelCompletion {
+    pub(crate) choice: OneOrMany<AssistantContent>,
+    pub(crate) usage: Usage,
+    pub(crate) message_id: Option<String>,
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+type CompleteCallback = dyn Fn(CompletionRequest) -> WasmBoxedFuture<'static, Result<ModelCompletion, CompletionError>>
+    + Send
+    + Sync;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+type CompleteCallback =
+    dyn Fn(CompletionRequest) -> WasmBoxedFuture<'static, Result<ModelCompletion, CompletionError>>;
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+type StreamCallback = dyn Fn(CompletionRequest) -> WasmBoxedFuture<'static, Result<ModelStream, CompletionError>>
+    + Send
+    + Sync;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+type StreamCallback =
+    dyn Fn(CompletionRequest) -> WasmBoxedFuture<'static, Result<ModelStream, CompletionError>>;
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+type CapabilityCallback = dyn Fn() -> bool + Send + Sync;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+type CapabilityCallback = dyn Fn() -> bool;
+
+struct ModelDriver {
+    complete: Arc<CompleteCallback>,
+    open_stream: Arc<StreamCallback>,
+    composes_native_output_with_tools: Arc<CapabilityCallback>,
+    label: Option<String>,
+}
+
+/// A cloneable, opaque handle to live completion-model behavior.
+///
+/// The handle is the boundary between typed provider authoring and Rig's
+/// concrete high-level agent facade. It is intentionally not serializable:
+/// captured clients, credentials, transports, and callbacks are live process
+/// state. Applications that need persistent model selection should serialize a
+/// separate identifier and resolve it to a handle at runtime.
+///
+/// Cloning is cheap and shares the retained model through an [`Arc`]. Replacing
+/// a handle on one cloned agent has value semantics and does not mutate other
+/// agent clones. Each in-flight attempt owns its own handle clone, preserving
+/// cancellation-by-drop without detached work.
+///
+/// The absence of serde implementations is intentional:
+///
+/// ```compile_fail
+/// use rig_agent::ModelHandle;
+///
+/// fn requires_serialize<T: serde::Serialize>() {}
+/// requires_serialize::<ModelHandle>();
+/// ```
+///
+/// ```compile_fail
+/// use rig_agent::ModelHandle;
+///
+/// fn requires_deserialize<T: for<'de> serde::Deserialize<'de>>() {}
+/// requires_deserialize::<ModelHandle>();
+/// ```
+#[derive(Clone)]
+pub struct ModelHandle {
+    inner: Arc<ModelDriver>,
+}
+
+impl ModelHandle {
+    /// Erase a typed completion model into a runtime model handle.
+    pub fn new<M>(model: M) -> Self
+    where
+        M: CompletionModel + 'static,
+    {
+        Self::from_parts(None, model)
+    }
+
+    /// Erase a typed completion model and attach a diagnostic label.
+    ///
+    /// Labels are for logs and routing diagnostics only. They are not stable
+    /// provider identities and are not serialized.
+    pub fn named<M>(label: impl Into<String>, model: M) -> Self
+    where
+        M: CompletionModel + 'static,
+    {
+        Self::from_parts(Some(label.into()), model)
+    }
+
+    fn from_parts<M>(label: Option<String>, model: M) -> Self
+    where
+        M: CompletionModel + 'static,
+    {
+        let model = Arc::new(model);
+
+        let complete_model = model.clone();
+        let complete: Arc<CompleteCallback> = Arc::new(move |request| {
+            let model = complete_model.clone();
+            Box::pin(async move {
+                let response = model.completion(request).await?;
+                Ok(ModelCompletion {
+                    choice: response.choice,
+                    usage: response.usage,
+                    message_id: response.message_id,
+                })
+            })
+        });
+
+        let stream_model = model.clone();
+        let open_stream: Arc<StreamCallback> = Arc::new(move |request| {
+            let model = stream_model.clone();
+            Box::pin(async move {
+                let stream = model.stream(request).await?;
+                Ok(ModelStream::new(stream))
+            })
+        });
+
+        let capability_model = model;
+        let composes_native_output_with_tools: Arc<CapabilityCallback> =
+            Arc::new(move || capability_model.composes_native_output_with_tools());
+
+        Self {
+            inner: Arc::new(ModelDriver {
+                complete,
+                open_stream,
+                composes_native_output_with_tools,
+                label,
+            }),
+        }
+    }
+
+    /// Returns the optional diagnostic label attached to this handle.
+    pub fn label(&self) -> Option<&str> {
+        self.inner.label.as_deref()
+    }
+
+    pub(crate) fn complete(
+        &self,
+        request: CompletionRequest,
+    ) -> WasmBoxedFuture<'static, Result<ModelCompletion, CompletionError>> {
+        (self.inner.complete)(request)
+    }
+
+    pub(crate) fn open_stream(
+        &self,
+        request: CompletionRequest,
+    ) -> WasmBoxedFuture<'static, Result<ModelStream, CompletionError>> {
+        (self.inner.open_stream)(request)
+    }
+
+    pub(crate) fn composes_native_output_with_tools(&self) -> bool {
+        (self.inner.composes_native_output_with_tools)()
+    }
+}
+
+impl fmt::Debug for ModelHandle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ModelHandle")
+            .field("label", &self.label())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+trait ErasedModelStream: Send {
+    fn poll_next_erased(
+        self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<Option<Result<StreamedAssistantContent<AgentStreamFinal>, CompletionError>>>;
+
+    fn choice(&self) -> &OneOrMany<AssistantContent>;
+
+    fn message_id(&self) -> Option<&str>;
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+trait ErasedModelStream {
+    fn poll_next_erased(
+        self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<Option<Result<StreamedAssistantContent<AgentStreamFinal>, CompletionError>>>;
+
+    fn choice(&self) -> &OneOrMany<AssistantContent>;
+
+    fn message_id(&self) -> Option<&str>;
+}
+
+struct TypedModelStream<R>
+where
+    R: Clone + Unpin + GetTokenUsage,
+{
+    inner: StreamingCompletionResponse<R>,
+}
+
+impl<R> ErasedModelStream for TypedModelStream<R>
+where
+    R: Clone + Unpin + rig_core::wasm_compat::WasmCompatSend + GetTokenUsage + Serialize + 'static,
+{
+    fn poll_next_erased(
+        self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<Option<Result<StreamedAssistantContent<AgentStreamFinal>, CompletionError>>> {
+        let this = self.get_mut();
+        match this.inner.poll_next_unpin(context) {
+            Poll::Ready(Some(Ok(item))) => Poll::Ready(Some(map_stream_item(item))),
+            Poll::Ready(Some(Err(error))) => Poll::Ready(Some(Err(error))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn choice(&self) -> &OneOrMany<AssistantContent> {
+        &self.inner.choice
+    }
+
+    fn message_id(&self) -> Option<&str> {
+        self.inner.message_id.as_deref()
+    }
+}
+
+fn map_stream_item<R>(
+    item: StreamedAssistantContent<R>,
+) -> Result<StreamedAssistantContent<AgentStreamFinal>, CompletionError>
+where
+    R: Clone + Unpin + GetTokenUsage + Serialize,
+{
+    Ok(match item {
+        StreamedAssistantContent::Text(text) => StreamedAssistantContent::Text(text),
+        StreamedAssistantContent::ToolCall {
+            tool_call,
+            internal_call_id,
+        } => StreamedAssistantContent::ToolCall {
+            tool_call,
+            internal_call_id,
+        },
+        StreamedAssistantContent::ToolCallDelta {
+            id,
+            internal_call_id,
+            content,
+        } => StreamedAssistantContent::ToolCallDelta {
+            id,
+            internal_call_id,
+            content,
+        },
+        StreamedAssistantContent::Reasoning(reasoning) => {
+            StreamedAssistantContent::Reasoning(reasoning)
+        }
+        StreamedAssistantContent::ReasoningDelta { id, reasoning } => {
+            StreamedAssistantContent::ReasoningDelta { id, reasoning }
+        }
+        StreamedAssistantContent::Final(response) => {
+            StreamedAssistantContent::Final(AgentStreamFinal {
+                usage: response.token_usage(),
+                raw_response: serde_json::to_value(response)?,
+            })
+        }
+        StreamedAssistantContent::Unknown(value) => StreamedAssistantContent::Unknown(value),
+    })
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+type BoxedErasedModelStream = Pin<Box<dyn ErasedModelStream + Send>>;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+type BoxedErasedModelStream = Pin<Box<dyn ErasedModelStream>>;
+
+pub(crate) struct ModelStream {
+    inner: BoxedErasedModelStream,
+}
+
+impl ModelStream {
+    fn new<R>(stream: StreamingCompletionResponse<R>) -> Self
+    where
+        R: Clone
+            + Unpin
+            + rig_core::wasm_compat::WasmCompatSend
+            + GetTokenUsage
+            + Serialize
+            + 'static,
+    {
+        Self {
+            inner: Box::pin(TypedModelStream { inner: stream }),
+        }
+    }
+
+    pub(crate) fn choice(&self) -> &OneOrMany<AssistantContent> {
+        self.inner.as_ref().get_ref().choice()
+    }
+
+    pub(crate) fn message_id(&self) -> Option<&str> {
+        self.inner.as_ref().get_ref().message_id()
+    }
+}
+
+impl Stream for ModelStream {
+    type Item = Result<StreamedAssistantContent<AgentStreamFinal>, CompletionError>;
+
+    fn poll_next(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.get_mut().inner.as_mut().poll_next_erased(context)
+    }
+}

--- a/crates/rig-agent/src/agent/prompt_request/mod.rs
+++ b/crates/rig-agent/src/agent/prompt_request/mod.rs
@@ -170,33 +170,21 @@ macro_rules! forward_prompt_setters {
             self
         }
 
-        /// Pin every model call in this run to an opaque model handle.
+        /// Set the default model candidate for this run.
         ///
-        /// This clears a selector installed earlier. Installing a selector
-        /// afterwards restores per-call routing with this handle as its default.
+        /// This does not suppress registered model-selection hooks, which may
+        /// replace this candidate before each model call.
         pub fn using_model(mut self, model: $crate::agent::ModelHandle) -> Self {
             self.$recv = self.$recv.using_model(model);
             self
         }
 
-        /// Erase and pin a typed completion model for this run.
+        /// Erase and set a typed default model for this run.
         pub fn using_model_value<M>(mut self, model: M) -> Self
         where
             M: crate::completion::CompletionModel + 'static,
         {
             self.$recv = self.$recv.using_model_value(model);
-            self
-        }
-
-        /// Select a model before each model call in this run.
-        pub fn select_model<F>(mut self, selector: F) -> Self
-        where
-            F: for<'a> Fn($crate::agent::ModelSelectionContext<'a>) -> $crate::agent::ModelHandle
-                + rig_core::wasm_compat::WasmCompatSend
-                + rig_core::wasm_compat::WasmCompatSync
-                + 'static,
-        {
-            self.$recv = self.$recv.select_model(selector);
             self
         }
     };
@@ -285,10 +273,11 @@ where
 
     /// Append a hook for this request (on top of any the agent already carries).
     /// Hooks run in registration order; how their results compose is
-    /// event-dependent (`CompletionCall` request patches accumulate and merge,
-    /// `ToolCall`/`ToolResult` rewrites chain, while model-turn steering and
-    /// observe-only/recovery events use first-non-`Continue`-wins). See the
-    /// [`hook`](crate::agent::hook) module docs.
+    /// event-dependent (model selections and `ToolCall`/`ToolResult` rewrites
+    /// chain, `CompletionCall` request patches accumulate and merge, while
+    /// model-turn steering and observe-only/recovery events use
+    /// first-non-`Continue`-wins). See the [`hook`](crate::agent::hook) module
+    /// docs.
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where
         H: AgentHook + 'static,
@@ -782,7 +771,8 @@ where
     }
 
     /// Append a hook to this request's hook stack (on top of any the agent
-    /// already carries).
+    /// already carries). Model-selection hooks may replace this request's
+    /// default model candidate before each model call.
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where
         H: AgentHook + 'static,

--- a/crates/rig-agent/src/agent/prompt_request/mod.rs
+++ b/crates/rig-agent/src/agent/prompt_request/mod.rs
@@ -8,7 +8,7 @@ use rig_core::{
 };
 
 use crate::{
-    completion::{CompletionModel, Message, PromptError, Usage},
+    completion::{Message, PromptError, Usage},
     tool::{ToolContext, ToolOutput},
 };
 use serde::{Deserialize, Serialize};
@@ -169,6 +169,36 @@ macro_rules! forward_prompt_setters {
             self.$recv = self.$recv.max_invalid_tool_call_retries(retries);
             self
         }
+
+        /// Pin every model call in this run to an opaque model handle.
+        ///
+        /// This clears a selector installed earlier. Installing a selector
+        /// afterwards restores per-call routing with this handle as its default.
+        pub fn using_model(mut self, model: $crate::agent::ModelHandle) -> Self {
+            self.$recv = self.$recv.using_model(model);
+            self
+        }
+
+        /// Erase and pin a typed completion model for this run.
+        pub fn using_model_value<M>(mut self, model: M) -> Self
+        where
+            M: crate::completion::CompletionModel + 'static,
+        {
+            self.$recv = self.$recv.using_model_value(model);
+            self
+        }
+
+        /// Select a model before each model call in this run.
+        pub fn select_model<F>(mut self, selector: F) -> Self
+        where
+            F: for<'a> Fn($crate::agent::ModelSelectionContext<'a>) -> $crate::agent::ModelHandle
+                + rig_core::wasm_compat::WasmCompatSend
+                + rig_core::wasm_compat::WasmCompatSync
+                + 'static,
+        {
+            self.$recv = self.$recv.select_model(selector);
+            self
+        }
     };
 }
 pub(crate) use forward_prompt_setters;
@@ -206,24 +236,20 @@ impl PromptType for Extended {}
 /// one model call. Use [`.max_turns()`](Self::max_turns) to override the agent's
 /// configured or implicit budget; a tool call followed by a model-authored final
 /// answer generally requires at least two model calls.
-pub struct PromptRequest<S, M>
+pub struct PromptRequest<S>
 where
     S: PromptType,
-    M: CompletionModel,
 {
     /// The hook-aware driver this request configures and runs.
-    pub(crate) runner: AgentRunner<M>,
+    pub(crate) runner: AgentRunner,
     /// Phantom data to track the type of the request (Standard vs Extended).
     state: PhantomData<S>,
 }
 
-impl<M> PromptRequest<Standard, M>
-where
-    M: CompletionModel,
-{
+impl PromptRequest<Standard> {
     /// Create a new PromptRequest from an agent, cloning the agent's data and
     /// default hook stack.
-    pub fn from_agent(agent: &Agent<M>, prompt: impl Into<Message>) -> Self {
+    pub fn from_agent(agent: &Agent, prompt: impl Into<Message>) -> Self {
         PromptRequest {
             runner: AgentRunner::from_agent(agent, prompt),
             state: PhantomData,
@@ -231,10 +257,9 @@ where
     }
 }
 
-impl<S, M> PromptRequest<S, M>
+impl<S> PromptRequest<S>
 where
     S: PromptType,
-    M: CompletionModel,
 {
     /// Enable returning extended details for responses (includes aggregated token usage
     /// and the full message history accumulated during the agent loop).
@@ -242,7 +267,7 @@ where
     /// Note: This changes the type of the response from `.send` to return a `PromptResponse` struct
     /// instead of a simple `String`. This is useful for tracking token usage across multiple turns
     /// of conversation and inspecting the full message exchange.
-    pub fn extended_details(self) -> PromptRequest<Extended, M> {
+    pub fn extended_details(self) -> PromptRequest<Extended> {
         PromptRequest {
             runner: self.runner,
             state: PhantomData,
@@ -279,10 +304,7 @@ where
 /// Due to: [RFC 2515](https://github.com/rust-lang/rust/issues/63063), we have to use a `BoxFuture`
 ///  for the `IntoFuture` implementation. In the future, we should be able to use `impl Future<...>`
 ///  directly via the associated type.
-impl<M> IntoFuture for PromptRequest<Standard, M>
-where
-    M: CompletionModel + 'static,
-{
+impl IntoFuture for PromptRequest<Standard> {
     type Output = Result<String, PromptError>;
     type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
 
@@ -291,10 +313,7 @@ where
     }
 }
 
-impl<M> IntoFuture for PromptRequest<Extended, M>
-where
-    M: CompletionModel + 'static,
-{
+impl IntoFuture for PromptRequest<Extended> {
     type Output = Result<PromptResponse, PromptError>;
     type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
 
@@ -303,10 +322,7 @@ where
     }
 }
 
-impl<M> PromptRequest<Standard, M>
-where
-    M: CompletionModel,
-{
+impl PromptRequest<Standard> {
     async fn send(self) -> Result<String, PromptError> {
         self.extended_details().send().await.map(|resp| resp.output)
     }
@@ -675,10 +691,7 @@ pub(crate) fn assistant_text_from_choice(choice: &OneOrMany<AssistantContent>) -
         .collect()
 }
 
-impl<M> PromptRequest<Extended, M>
-where
-    M: CompletionModel,
-{
+impl PromptRequest<Extended> {
     async fn send(self) -> Result<PromptResponse, PromptError> {
         self.runner.run().await
     }
@@ -708,25 +721,23 @@ use serde::de::DeserializeOwned;
 ///     .max_turns(3)
 ///     .await?;
 /// ```
-pub struct TypedPromptRequest<T, S, M>
+pub struct TypedPromptRequest<T, S>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
     S: PromptType,
-    M: CompletionModel,
 {
-    inner: PromptRequest<S, M>,
+    inner: PromptRequest<S>,
     _phantom: std::marker::PhantomData<T>,
 }
 
-impl<T, M> TypedPromptRequest<T, Standard, M>
+impl<T> TypedPromptRequest<T, Standard>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
-    M: CompletionModel,
 {
     /// Create a new TypedPromptRequest from an agent.
     ///
     /// This automatically sets the output schema based on the type parameter `T`.
-    pub fn from_agent(agent: &Agent<M>, prompt: impl Into<Message>) -> Self {
+    pub fn from_agent(agent: &Agent, prompt: impl Into<Message>) -> Self {
         let mut inner = PromptRequest::from_agent(agent, prompt);
         // Override the output schema with the schema for T
         inner.runner.output_schema = Some(schema_for!(T));
@@ -744,18 +755,17 @@ where
     }
 }
 
-impl<T, S, M> TypedPromptRequest<T, S, M>
+impl<T, S> TypedPromptRequest<T, S>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
     S: PromptType,
-    M: CompletionModel,
 {
     /// Enable returning extended details for responses (includes aggregated token usage).
     ///
     /// Note: This changes the type of the response from `.send()` to return a `TypedPromptResponse<T>` struct
     /// instead of just `T`. This is useful for tracking token usage across multiple turns
     /// of conversation.
-    pub fn extended_details(self) -> TypedPromptRequest<T, Extended, M> {
+    pub fn extended_details(self) -> TypedPromptRequest<T, Extended> {
         TypedPromptRequest {
             inner: self.inner.extended_details(),
             _phantom: std::marker::PhantomData,
@@ -807,10 +817,9 @@ fn deserialize_structured_output<T: DeserializeOwned>(text: &str) -> Result<T, s
     }
 }
 
-impl<T, M> TypedPromptRequest<T, Standard, M>
+impl<T> TypedPromptRequest<T, Standard>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
-    M: CompletionModel,
 {
     /// Send the typed prompt request and deserialize the response.
     async fn send(self) -> Result<T, StructuredOutputError> {
@@ -825,10 +834,9 @@ where
     }
 }
 
-impl<T, M> TypedPromptRequest<T, Extended, M>
+impl<T> TypedPromptRequest<T, Extended>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
-    M: CompletionModel,
 {
     /// Send the typed prompt request with extended details and deserialize the response.
     async fn send(self) -> Result<TypedPromptResponse<T>, StructuredOutputError> {
@@ -844,10 +852,9 @@ where
     }
 }
 
-impl<T, M> IntoFuture for TypedPromptRequest<T, Standard, M>
+impl<T> IntoFuture for TypedPromptRequest<T, Standard>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend + 'static,
-    M: CompletionModel + 'static,
 {
     type Output = Result<T, StructuredOutputError>;
     type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
@@ -857,10 +864,9 @@ where
     }
 }
 
-impl<T, M> IntoFuture for TypedPromptRequest<T, Extended, M>
+impl<T> IntoFuture for TypedPromptRequest<T, Extended>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend + 'static,
-    M: CompletionModel + 'static,
 {
     type Output = Result<TypedPromptResponse<T>, StructuredOutputError>;
     type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
@@ -1450,7 +1456,7 @@ mod tests {
             MockTurn::text("should not be requested"),
         ]);
         let recorded = model.clone();
-        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+        let agent = AgentBuilder::new(model.clone()).tool(MockAddTool).build();
 
         let err = agent
             .prompt("use the tool")
@@ -1678,7 +1684,7 @@ mod tests {
             MockTurn::tool_call("tool_call_1", "default_api", json!({"x": 2, "y": 3})),
             MockTurn::text("done"),
         ]);
-        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+        let agent = AgentBuilder::new(model.clone()).tool(MockAddTool).build();
 
         let response = agent
             .prompt("add")
@@ -2300,7 +2306,7 @@ mod tests {
                 .with_usage(first_call_usage),
             MockTurn::text("").with_usage(second_call_usage),
         ]);
-        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+        let agent = AgentBuilder::new(model.clone()).tool(MockAddTool).build();
 
         let response = agent
             .prompt("do tool work")
@@ -2370,7 +2376,7 @@ mod tests {
                     AssistantContent::Text(text) if text.text.is_empty()
                 ))
         )));
-        let requests = agent.model.requests();
+        let requests = model.requests();
         assert_eq!(requests.len(), 2);
         validate_follow_up_tool_history(&requests[1]);
     }

--- a/crates/rig-agent/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-agent/src/agent/prompt_request/streaming.rs
@@ -5,7 +5,7 @@ use rig_core::{
 };
 
 use crate::{
-    agent::completion::{PreparedCompletionRequest, build_prepared_completion_request},
+    agent::completion::{PreparedModelAttempt, build_prepared_completion_request},
     agent::hook::{
         AgentHook, HookContext, HookStack, InvalidToolCallAction, ModelTurnFinished, StepEventKind,
         StreamResponseFinish, TextDelta, ToolCallDelta,
@@ -20,7 +20,7 @@ use crate::{
         append_run_messages, build_chat_span, new_execute_tool_span, observe_action,
         resolve_completion_call, resolve_model_turn_action, run_single_tool,
     },
-    completion::GetTokenUsage,
+    agent::{AgentStreamFinal, ModelSelectionContext},
     streaming::{StreamedAssistantContent, StreamedUserContent, ToolCallDeltaContent},
     tool::{ToolContext, server::ToolRegistrySnapshot},
 };
@@ -32,7 +32,7 @@ use tracing_futures::Instrument;
 use super::{CompletionCall, PromptResponse, forward_prompt_setters};
 use crate::{
     agent::Agent,
-    completion::{CompletionError, CompletionModel, PromptError},
+    completion::{CompletionError, PromptError},
 };
 use rig_core::message::{Message, Text};
 
@@ -41,17 +41,16 @@ use rig_core::message::{Message, Text};
 // predicate, so keep the two in step: a bare `target_arch = "wasm32"` would
 // also drop `Send` on WASI, where `rig-core` still requires it.
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-pub type StreamingResult<R> =
-    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>> + Send>>;
+pub type StreamingResult =
+    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem, StreamingError>> + Send>>;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-pub type StreamingResult<R> =
-    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>>>>;
+pub type StreamingResult = Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem, StreamingError>>>>;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(tag = "type", rename_all = "camelCase")]
 #[non_exhaustive]
-pub enum MultiTurnStreamItem<R> {
+pub enum MultiTurnStreamItem {
     /// A streamed assistant content item — the content the **model emitted**:
     /// text/reasoning deltas, tool-call deltas, and, when the model turn is
     /// committed, the complete [`StreamedAssistantContent::ToolCall`] for each
@@ -67,7 +66,7 @@ pub enum MultiTurnStreamItem<R> {
     /// which finalizes the run directly — its structured result is surfaced in
     /// the [`FinalResponse`](Self::FinalResponse) rather than as a completed
     /// `ToolCall` item.
-    StreamAssistantItem(StreamedAssistantContent<R>),
+    StreamAssistantItem(StreamedAssistantContent<AgentStreamFinal>),
     /// Confirmation that Rig **executed and committed** a tool call. This is not
     /// a real-time start notification: it is surfaced together with its
     /// `ToolResult` only after the whole batch settles successfully. Use tool
@@ -143,8 +142,8 @@ fn final_response_from_content(
     response
 }
 
-impl<R> MultiTurnStreamItem<R> {
-    pub(crate) fn stream_item(item: StreamedAssistantContent<R>) -> Self {
+impl MultiTurnStreamItem {
+    pub(crate) fn stream_item(item: StreamedAssistantContent<AgentStreamFinal>) -> Self {
         Self::StreamAssistantItem(item)
     }
 
@@ -190,16 +189,13 @@ impl<R> MultiTurnStreamItem<R> {
 
 /// Drain a provider stream abandoned by invalid tool-call recovery so the
 /// reported usage for the recovered completion call is not lost.
-async fn drain_stream_usage<R>(
-    stream: &mut crate::streaming::StreamingCompletionResponse<R>,
-) -> Result<crate::completion::Usage, StreamingError>
-where
-    R: Clone + Unpin + GetTokenUsage,
-{
+async fn drain_stream_usage(
+    stream: &mut crate::agent::model::ModelStream,
+) -> Result<crate::completion::Usage, StreamingError> {
     while let Some(content) = stream.next().await {
         match content {
             Ok(StreamedAssistantContent::Final(final_resp)) => {
-                return Ok(final_resp.token_usage());
+                return Ok(final_resp.usage);
             }
             Ok(_) => {}
             Err(err) => return Err(err.into()),
@@ -288,28 +284,21 @@ impl From<rig_core::memory::MemoryError> for StreamingError {
 /// one model call. Use [`.max_turns()`](Self::max_turns) to override the agent's
 /// configured or implicit budget; a tool call followed by a model-authored final
 /// answer generally requires at least two model calls.
-pub struct StreamingPromptRequest<M>
-where
-    M: CompletionModel,
-{
+pub struct StreamingPromptRequest {
     /// The hook-aware driver this streaming request configures and runs.
-    runner: AgentRunner<M>,
+    runner: AgentRunner,
 }
 
-impl<M> StreamingPromptRequest<M>
-where
-    M: CompletionModel + 'static,
-    <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetTokenUsage,
-{
+impl StreamingPromptRequest {
     /// Create a new `StreamingPromptRequest` from an agent, including its
     /// default hooks.
-    pub fn new(agent: Arc<Agent<M>>, prompt: impl Into<Message>) -> StreamingPromptRequest<M> {
+    pub fn new(agent: Arc<Agent>, prompt: impl Into<Message>) -> StreamingPromptRequest {
         Self::from_agent(agent.as_ref(), prompt)
     }
 
     /// Create a new StreamingPromptRequest from an agent, cloning the agent's
     /// data and default hook stack.
-    pub fn from_agent(agent: &Agent<M>, prompt: impl Into<Message>) -> StreamingPromptRequest<M> {
+    pub fn from_agent(agent: &Agent, prompt: impl Into<Message>) -> StreamingPromptRequest {
         StreamingPromptRequest {
             runner: AgentRunner::from_agent(agent, prompt),
         }
@@ -356,7 +345,7 @@ where
 
     forward_prompt_setters!(runner);
 
-    async fn send(self) -> StreamingResult<M::StreamingResponse> {
+    async fn send(self) -> StreamingResult {
         self.runner.stream().await
     }
 }
@@ -366,12 +355,12 @@ where
 /// per-step future leaking into the engine's own (`Send`) inference.
 // Same browser-wasm predicate as `StreamingResult` above, for the same reason.
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-pub(crate) type DriveStream<'a, R> =
-    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>> + Send + 'a>>;
+pub(crate) type DriveStream<'a> =
+    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem, StreamingError>> + Send + 'a>>;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-pub(crate) type DriveStream<'a, R> =
-    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>> + 'a>>;
+pub(crate) type DriveStream<'a> =
+    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem, StreamingError>> + 'a>>;
 
 /// One item emitted by the shared engine [`drive_agent`].
 ///
@@ -384,11 +373,11 @@ pub(crate) type DriveStream<'a, R> =
 // which the streaming path is specifically tuned to avoid. `Done` is yielded
 // once per run, so the wasted space on that rare variant is irrelevant.
 #[allow(clippy::large_enum_variant)]
-pub(crate) enum DriveItem<R> {
+pub(crate) enum DriveItem {
     /// An intermediate stream item (assistant delta, tool call/result, a
     /// per-call `CompletionCall`, or — last, for the streaming surface — the
     /// final response item).
-    Item(MultiTurnStreamItem<R>),
+    Item(MultiTurnStreamItem),
     /// The run finished; carries the canonical response the blocking fold
     /// returns. The streaming surface has already received the final item as the
     /// preceding `Item` and ignores this.
@@ -402,18 +391,12 @@ pub(crate) enum DriveItem<R> {
 /// genuinely divergent pieces are behind this trait. Invalid-tool-call recovery
 /// is one of them — it lives inside each source's `run_model_turn` (end-of-turn
 /// for blocking, mid-stream for streaming), not in `drive_agent`.
-pub(crate) trait TurnSource<M>: WasmCompatSend
-where
-    M: CompletionModel,
-{
-    /// The raw provider response carried on per-delta stream items.
-    type Raw: WasmCompatSend;
-
+pub(crate) trait TurnSource: WasmCompatSend {
     /// Build this medium's per-turn `chat` span (name + parenting + any
     /// `follows_from` chaining differ between blocking and streaming).
     fn open_chat_span(
         &self,
-        runner: &AgentRunner<M>,
+        runner: &AgentRunner,
         effective_preamble: Option<&str>,
     ) -> tracing::Span;
 
@@ -423,25 +406,25 @@ where
     #[allow(clippy::too_many_arguments)]
     fn run_model_turn<'a>(
         &'a mut self,
-        runner: &'a AgentRunner<M>,
+        runner: &'a AgentRunner,
         hook_ctx: &'a HookContext,
         run: &'a mut AgentRun,
-        prepared: PreparedCompletionRequest<M>,
+        prepared: PreparedModelAttempt,
         chat_span: tracing::Span,
         agent_span: &'a tracing::Span,
         prompt: Message,
-    ) -> DriveStream<'a, Self::Raw>;
+    ) -> DriveStream<'a>;
 
     /// Execute a turn's tool calls, feeding the results into the machine and
     /// yielding any intermediate items.
     fn run_tool_calls<'a>(
         &'a self,
-        runner: &'a AgentRunner<M>,
+        runner: &'a AgentRunner,
         hook_ctx: &'a HookContext,
         run: &'a mut AgentRun,
         calls: Vec<PendingToolCall>,
         tool_snapshot: Arc<ToolRegistrySnapshot>,
-    ) -> DriveStream<'a, Self::Raw>;
+    ) -> DriveStream<'a>;
 
     /// Record run-level telemetry onto the agent span at `Done`. Gated on
     /// `created_agent_span` so a caller-supplied outer span is never polluted.
@@ -454,7 +437,7 @@ where
 
     /// Build the final stream item surfaced at `Done`, or `None` when the
     /// surface discards it (the blocking fold) so the engine skips the work.
-    fn final_item(&self, response: &PromptResponse) -> Option<MultiTurnStreamItem<Self::Raw>>;
+    fn final_item(&self, response: &PromptResponse) -> Option<MultiTurnStreamItem>;
 }
 
 /// Convert a [`StreamingError`] back into a [`PromptError`] for the blocking
@@ -467,10 +450,7 @@ pub(crate) fn streaming_error_into_prompt(err: StreamingError) -> PromptError {
     }
 }
 
-pub(crate) fn store_error_usage<M>(runner: &AgentRunner<M>, run: &AgentRun)
-where
-    M: CompletionModel,
-{
+pub(crate) fn store_error_usage(runner: &AgentRunner, run: &AgentRun) {
     if let Some(usage) = &runner.error_usage {
         *usage.lock().unwrap_or_else(|error| error.into_inner()) = run.usage();
     }
@@ -483,18 +463,17 @@ where
 /// medium-specific model call, tool execution, span shaping and finalization to
 /// a [`TurnSource`]. The streaming surface forwards the yielded [`DriveItem`]s;
 /// the blocking surface folds them to `Done`.
-pub(crate) fn drive_agent<M, S>(
-    runner: AgentRunner<M>,
+pub(crate) fn drive_agent<S>(
+    runner: AgentRunner,
     mut source: S,
     mut run: AgentRun,
     agent_span: tracing::Span,
     created_agent_span: bool,
     memory_handle: Option<(Arc<dyn rig_core::memory::ConversationMemory>, String)>,
     is_streaming: bool,
-) -> impl Stream<Item = Result<DriveItem<S::Raw>, StreamingError>>
+) -> impl Stream<Item = Result<DriveItem, StreamingError>>
 where
-    M: CompletionModel,
-    S: TurnSource<M>,
+    S: TurnSource,
 {
     async_stream::stream! {
         // Run-scoped hook context: minted once, shared by every hook event on
@@ -505,6 +484,8 @@ where
         // immediately following CallTools step. This keeps the sans-IO run state
         // serializable while pinning execution to the definitions sent that turn.
         let mut pending_tool_snapshot: Option<Arc<ToolRegistrySnapshot>> = None;
+        // Live routing state stays in the driver, not the serde `AgentRun`.
+        let mut previous_model = None;
 
         'outer: loop {
             let step = match run.next_step() {
@@ -523,6 +504,24 @@ where
                         tracing::info!("Current conversation Turns: {}/{}", turn, runner.max_turns);
                     }
                     hook_ctx.set_turn(turn);
+
+                    // Select exactly once at the model-call boundary. The
+                    // resulting handle is cloned into the prepared attempt and
+                    // used for both capability inspection and execution.
+                    let selected_model = runner.model_selector.as_ref().map_or_else(
+                        || runner.model.clone(),
+                        |selector| {
+                            selector.select(ModelSelectionContext {
+                                turn,
+                                prompt: &prompt,
+                                history: &history,
+                                is_streaming,
+                                previous_model: previous_model.as_ref(),
+                                default_model: &runner.model,
+                            })
+                        },
+                    );
+                    previous_model = Some(selected_model.clone());
 
                     let request_patch =
                         match resolve_completion_call(&runner.hooks, &hook_ctx, &prompt, &history, turn).await {
@@ -549,7 +548,7 @@ where
                     // consistent even if the per-turn tool set changes (#1928).
                     let committed_output_tool = run.output_tool_name().map(str::to_owned);
                     let mut prepared = match build_prepared_completion_request(
-                        &runner.model,
+                        &selected_model,
                         prompt.clone(),
                         &history,
                         runner.preamble.as_deref(),
@@ -579,9 +578,9 @@ where
                     run.set_output_tool_name(prepared.output_tool_name.clone());
                     let turn_tool_snapshot = prepared.tool_snapshot.clone();
                     if runner.record_telemetry_content {
-                        let input_messages = prepared.builder.messages_for_telemetry();
+                        let input_messages = prepared.request.messages_for_telemetry();
                         rig_core::telemetry::record_model_input(&chat_span, &input_messages, true);
-                        prepared.builder = prepared.builder.record_content_telemetry(false);
+                        prepared.request.record_telemetry_content = false;
                     }
 
                     let mut turn_stream = source.run_model_turn(
@@ -695,18 +694,16 @@ where
 /// but the collect/commit and fail-fast behavior is identical, so `run()` and
 /// `stream()` return the same terminal reason. `chain_tool_span` lets the
 /// blocking surface chain spans into its linear `follows_from` sequence.
-pub(crate) fn drive_tool_calls<'a, M, R, F>(
-    runner: &'a AgentRunner<M>,
+pub(crate) fn drive_tool_calls<'a, F>(
+    runner: &'a AgentRunner,
     hook_ctx: &'a HookContext,
     run: &'a mut AgentRun,
     calls: Vec<PendingToolCall>,
     tool_snapshot: Arc<ToolRegistrySnapshot>,
     chain_tool_span: F,
     forward_items: bool,
-) -> DriveStream<'a, R>
+) -> DriveStream<'a>
 where
-    M: CompletionModel,
-    R: WasmCompatSend + 'a,
     F: Fn(tracing::Span) -> tracing::Span + WasmCompatSend + 'a,
 {
     // Per-call working state: a stable internal_call_id and the execute span,
@@ -925,7 +922,7 @@ where
         // turn) but is still committed. Every non-dropped slot is filled; a
         // dropped slot only occurs after a termination, handled above.
         let mut committed: Vec<UserContent> = Vec::with_capacity(call_count);
-        let mut surface_items: Vec<MultiTurnStreamItem<R>> =
+        let mut surface_items: Vec<MultiTurnStreamItem> =
             Vec::with_capacity(call_count.saturating_mul(2));
         for slot in collected {
             let CollectedToolResult { content, internal_call_id, surface } = match slot {
@@ -1023,16 +1020,10 @@ impl StreamingTurnSource {
     }
 }
 
-impl<M> TurnSource<M> for StreamingTurnSource
-where
-    M: CompletionModel,
-    <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetTokenUsage,
-{
-    type Raw = M::StreamingResponse;
-
+impl TurnSource for StreamingTurnSource {
     fn open_chat_span(
         &self,
-        runner: &AgentRunner<M>,
+        runner: &AgentRunner,
         effective_preamble: Option<&str>,
     ) -> tracing::Span {
         build_chat_span!(runner, effective_preamble, "chat_streaming", "chat")
@@ -1040,18 +1031,18 @@ where
 
     fn run_model_turn<'a>(
         &'a mut self,
-        runner: &'a AgentRunner<M>,
+        runner: &'a AgentRunner,
         hook_ctx: &'a HookContext,
         run: &'a mut AgentRun,
-        prepared: PreparedCompletionRequest<M>,
+        prepared: PreparedModelAttempt,
         chat_span: tracing::Span,
         agent_span: &'a tracing::Span,
         current_prompt: Message,
-    ) -> DriveStream<'a, M::StreamingResponse> {
+    ) -> DriveStream<'a> {
         Box::pin(async_stream::stream! {
             let mut stream = match prepared
-                .builder
-                .stream()
+                .model
+                .open_stream(prepared.request)
                 .instrument(chat_span.clone())
                 .await
             {
@@ -1220,7 +1211,7 @@ where
                             }
                         }
                         StreamedTurnEvent::InvalidToolCall(invalid) => {
-                            let partial = assembler.partial_turn(stream.message_id.clone());
+                            let partial = assembler.partial_turn(stream.message_id().map(str::to_owned));
                             // Gated on `has_hooks`: building the diagnostic context
                             // clones the chat history, so an empty stack skips it and
                             // fails fast — identical to the blocking path.
@@ -1318,8 +1309,11 @@ where
                 }
             }
 
-            let final_turn_content = stream.choice.clone();
-            let streamed_turn = assembler.finish(stream.message_id.clone(), &final_turn_content);
+            let final_turn_content = stream.choice().clone();
+            let streamed_turn = assembler.finish(
+                stream.message_id().map(str::to_owned),
+                &final_turn_content,
+            );
             if pending_final.is_some()
                 && !turn_recovered
                 && let Some(reason) = observe_action(
@@ -1430,12 +1424,12 @@ where
 
     fn run_tool_calls<'a>(
         &'a self,
-        runner: &'a AgentRunner<M>,
+        runner: &'a AgentRunner,
         hook_ctx: &'a HookContext,
         run: &'a mut AgentRun,
         calls: Vec<PendingToolCall>,
         tool_snapshot: Arc<ToolRegistrySnapshot>,
-    ) -> DriveStream<'a, M::StreamingResponse> {
+    ) -> DriveStream<'a> {
         // The streaming surface chains nothing onto its tool spans, and forwards
         // the ToolCall/ToolResult items to the consumer.
         drive_tool_calls(
@@ -1460,10 +1454,7 @@ where
         }
     }
 
-    fn final_item(
-        &self,
-        response: &PromptResponse,
-    ) -> Option<MultiTurnStreamItem<M::StreamingResponse>> {
+    fn final_item(&self, response: &PromptResponse) -> Option<MultiTurnStreamItem> {
         // Tool output mode (#1928): when the finishing turn made the output-tool
         // call, surface the run's structured output as the final content.
         let final_choice = finalize_streamed_choice(&self.last_final_choice, &response.output)
@@ -1490,11 +1481,7 @@ where
     }
 }
 
-impl<M> AgentRunner<M>
-where
-    M: CompletionModel + 'static,
-    <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetTokenUsage,
-{
+impl AgentRunner {
     /// Drive the agent loop, streaming assistant content, tool activity, and a
     /// final response. Hooks fire at every observable point, including streamed
     /// text and tool-call deltas. Returns the stream after loading any
@@ -1504,7 +1491,7 @@ where
     /// hook handling with the blocking [`run`](AgentRunner::run) via
     /// `drive_agent`, so the two behave identically apart from the streamed
     /// delta events.
-    pub async fn stream(self) -> StreamingResult<M::StreamingResponse> {
+    pub async fn stream(self) -> StreamingResult {
         let (agent_span, created_agent_span) = acquire_agent_span(
             self.agent_name_or_default(),
             self.preamble.as_deref(),
@@ -1570,12 +1557,8 @@ where
     }
 }
 
-impl<M> IntoFuture for StreamingPromptRequest<M>
-where
-    M: CompletionModel + 'static,
-    <M as CompletionModel>::StreamingResponse: WasmCompatSend,
-{
-    type Output = StreamingResult<M::StreamingResponse>; // what `.await` returns
+impl IntoFuture for StreamingPromptRequest {
+    type Output = StreamingResult; // what `.await` returns
     type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
@@ -1591,8 +1574,8 @@ where
 /// metadata is returned on the [`PromptResponse`] via accessors such as
 /// [`PromptResponse::completion_calls`]. A model-turn retry prints a visible
 /// boundary because text already written to stdout cannot be retracted.
-pub async fn stream_to_stdout<R>(
-    stream: &mut StreamingResult<R>,
+pub async fn stream_to_stdout(
+    stream: &mut StreamingResult,
 ) -> Result<PromptResponse, std::io::Error> {
     let mut final_res = PromptResponse::empty();
     print!("Response: ");
@@ -1646,8 +1629,8 @@ mod migrated_tests {
     use crate::streaming::{StreamingPrompt, ToolCallDeltaContent};
     use crate::test_utils::{
         AppendFailingMemory, FailingMemory, MockAddTool, MockBarrierTool, MockCompletionModel,
-        MockContextProbeTool, MockResponse, MockStreamEvent, MockSubtractTool, MockToolError,
-        MockTurn, SessionId,
+        MockContextProbeTool, MockStreamEvent, MockSubtractTool, MockToolError, MockTurn,
+        SessionId,
     };
     use crate::tool::{Tool, ToolContext};
     use futures::{StreamExt, TryStreamExt};
@@ -2257,7 +2240,7 @@ mod migrated_tests {
 
         let hook_context = HookContext::new(true, None);
         hook_context.set_turn(1);
-        let mut stream = drive_tool_calls::<MockCompletionModel, MockResponse, _>(
+        let mut stream = drive_tool_calls(
             &runner,
             &hook_context,
             &mut run,
@@ -2441,7 +2424,7 @@ mod migrated_tests {
     }
 
     async fn assert_stream_usage_recorded_on_chat_spans(
-        agent: crate::agent::Agent<MockCompletionModel>,
+        agent: crate::agent::Agent,
         prompt: &str,
         max_turns: usize,
         expected_usages: &[Usage],
@@ -3038,7 +3021,7 @@ mod migrated_tests {
 
     #[test]
     fn completion_calls_stream_item_serializes_and_deserializes_expected_shape() {
-        let item: MultiTurnStreamItem<MockResponse> =
+        let item: MultiTurnStreamItem =
             MultiTurnStreamItem::CompletionCall(CompletionCall::new(2, usage(3, 4)));
 
         let value = serde_json::to_value(&item).expect("serialize completion call event");
@@ -3060,7 +3043,7 @@ mod migrated_tests {
             })
         );
 
-        let item: MultiTurnStreamItem<MockResponse> =
+        let item: MultiTurnStreamItem =
             serde_json::from_value(value).expect("deserialize completion call event");
         match item {
             MultiTurnStreamItem::CompletionCall(call_usage) => {
@@ -3069,7 +3052,7 @@ mod migrated_tests {
             other => panic!("expected completion call event, got {other:?}"),
         }
 
-        let item: MultiTurnStreamItem<MockResponse> =
+        let item: MultiTurnStreamItem =
             MultiTurnStreamItem::CompletionCall(CompletionCall::new(3, Usage::new()));
         let value = serde_json::to_value(&item).expect("serialize missing usage event");
 
@@ -3094,7 +3077,7 @@ mod migrated_tests {
 
         // Stream items serialized before the Option encoding was dropped used
         // `"usage": null`; they must still deserialize.
-        let legacy: MultiTurnStreamItem<MockResponse> = serde_json::from_value(serde_json::json!({
+        let legacy: MultiTurnStreamItem = serde_json::from_value(serde_json::json!({
             "type": "completionCall",
             "call_index": 3,
             "usage": null
@@ -3110,16 +3093,15 @@ mod migrated_tests {
 
     #[test]
     fn final_response_serializes_completion_calls_with_missing_usage() {
-        let item: MultiTurnStreamItem<MockResponse> =
-            MultiTurnStreamItem::final_response_with_completion_calls(
-                OneOrMany::one(AssistantContent::text("done")),
-                usage(3, 4),
-                vec![
-                    CompletionCall::new(0, Usage::new()),
-                    CompletionCall::new(1, usage(3, 4)),
-                ],
-                None,
-            );
+        let item: MultiTurnStreamItem = MultiTurnStreamItem::final_response_with_completion_calls(
+            OneOrMany::one(AssistantContent::text("done")),
+            usage(3, 4),
+            vec![
+                CompletionCall::new(0, Usage::new()),
+                CompletionCall::new(1, usage(3, 4)),
+            ],
+            None,
+        );
 
         if let MultiTurnStreamItem::FinalResponse(response) = &item {
             assert_eq!(response.requests(), 2);

--- a/crates/rig-agent/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-agent/src/agent/prompt_request/streaming.rs
@@ -5,10 +5,12 @@ use rig_core::{
 };
 
 use crate::{
+    agent::AgentStreamFinal,
     agent::completion::{PreparedModelAttempt, build_prepared_completion_request},
     agent::hook::{
-        AgentHook, HookContext, HookStack, InvalidToolCallAction, ModelTurnFinished, StepEventKind,
-        StreamResponseFinish, TextDelta, ToolCallDelta,
+        AgentHook, HookContext, HookStack, InvalidToolCallAction, ModelSelection,
+        ModelSelectionAction, ModelTurnFinished, StepEventKind, StreamResponseFinish, TextDelta,
+        ToolCallDelta,
     },
     agent::prompt_request::{assistant_text_from_choice, is_empty_assistant_turn},
     agent::run::{
@@ -20,7 +22,6 @@ use crate::{
         append_run_messages, build_chat_span, new_execute_tool_span, observe_action,
         resolve_completion_call, resolve_model_turn_action, run_single_tool,
     },
-    agent::{AgentStreamFinal, ModelSelectionContext},
     streaming::{StreamedAssistantContent, StreamedUserContent, ToolCallDeltaContent},
     tool::{ToolContext, server::ToolRegistrySnapshot},
 };
@@ -331,9 +332,10 @@ impl StreamingPromptRequest {
 
     /// Append a hook to this request's hook stack (on top of any the agent
     /// already carries). Hooks run in registration order; how their results
-    /// compose is event-dependent (`CompletionCall` request patches accumulate
-    /// and merge, `ToolCall`/`ToolResult` rewrites chain, while model-turn
-    /// steering and observe-only/recovery events use first-non-`Continue`-wins). See the
+    /// compose is event-dependent (model selections and
+    /// `ToolCall`/`ToolResult` rewrites chain, `CompletionCall` request patches
+    /// accumulate and merge, while model-turn steering and
+    /// observe-only/recovery events use first-non-`Continue`-wins). See the
     /// [`hook`](crate::agent::hook) module docs.
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where
@@ -505,22 +507,27 @@ where
                     }
                     hook_ctx.set_turn(turn);
 
-                    // Select exactly once at the model-call boundary. The
+                    // Resolve routing once at the model-call boundary. The
                     // resulting handle is cloned into the prepared attempt and
                     // used for both capability inspection and execution.
-                    let selected_model = runner.model_selector.as_ref().map_or_else(
-                        || runner.model.clone(),
-                        |selector| {
-                            selector.select(ModelSelectionContext {
-                                turn,
-                                prompt: &prompt,
-                                history: &history,
-                                is_streaming,
-                                previous_model: previous_model.as_ref(),
-                                default_model: &runner.model,
-                            })
+                    let selected_model = match runner.hooks.on_model_select(
+                        &hook_ctx,
+                        ModelSelection {
+                            prompt: &prompt,
+                            history: &history,
+                            previous_model: previous_model.as_ref(),
+                            default_model: &runner.model,
+                            selected_model: &runner.model,
                         },
-                    );
+                    ) {
+                        ModelSelectionAction::Continue => runner.model.clone(),
+                        ModelSelectionAction::Select(model) => model,
+                        ModelSelectionAction::Stop(reason) => {
+                            store_error_usage(&runner, &run);
+                            yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
+                            break 'outer;
+                        }
+                    };
                     previous_model = Some(selected_model.clone());
 
                     let request_patch =

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -13,8 +13,7 @@
 //!
 //! ```rust,no_run
 //! # use rig_agent::Agent;
-//! # use rig_core::completion::CompletionModel;
-//! # async fn example<M: CompletionModel + 'static>(agent: Agent<M>) -> Result<(), Box<dyn std::error::Error>> {
+//! # async fn example(agent: Agent) -> Result<(), Box<dyn std::error::Error>> {
 //! let response = agent
 //!     .runner("What is 2 + 2?")
 //!     .max_turns(3)
@@ -34,13 +33,14 @@ use futures::StreamExt;
 use tracing::{Instrument, info_span, span::Id};
 
 use super::{
-    completion::{Agent, PreparedCompletionRequest},
+    completion::{Agent, PreparedModelAttempt},
     hook::{
         AgentHook, CompletionCall, CompletionCallAction,
         CompletionResponse as CompletionResponseEvent, HookContext, HookStack,
         InvalidToolCallAction, ModelTurnAction, ModelTurnFinished, ObservationAction, RequestPatch,
         ToolCall as ToolCallEvent, ToolCallAction, ToolResultAction, ToolResultEvent,
     },
+    model::{ModelHandle, ModelSelectionContext, ModelSelector},
     prompt_request::{
         PromptResponse,
         streaming::{
@@ -195,15 +195,15 @@ pub(crate) fn completion_call_decision(action: CompletionCallAction) -> Completi
 /// the same events, so they behave identically apart from the streamed delta
 /// events the medium adds.
 #[non_exhaustive]
-pub struct AgentRunner<M>
-where
-    M: CompletionModel,
-{
+pub struct AgentRunner {
     pub(crate) prompt: Message,
     pub(crate) chat_history: Option<Vec<Message>>,
     pub(crate) max_turns: usize,
     pub(crate) max_invalid_tool_call_retries: usize,
-    pub(crate) model: Arc<M>,
+    pub(crate) model: ModelHandle,
+    /// Optional per-call selector. When present it takes precedence over the
+    /// run-local fixed/default model at each `CallModel` boundary.
+    pub(crate) model_selector: Option<ModelSelector>,
     pub(crate) agent_name: Option<String>,
     pub(crate) preamble: Option<String>,
     pub(crate) static_context: Vec<Document>,
@@ -228,19 +228,17 @@ where
     pub(crate) error_usage: Option<Arc<Mutex<Usage>>>,
 }
 
-impl<M> AgentRunner<M>
-where
-    M: CompletionModel,
-{
+impl AgentRunner {
     /// Build a runner from an agent, seeding it with the agent's default hook
     /// stack. Prefer [`Agent::runner`].
-    pub fn from_agent(agent: &Agent<M>, prompt: impl Into<Message>) -> Self {
+    pub fn from_agent(agent: &Agent, prompt: impl Into<Message>) -> Self {
         Self {
             prompt: prompt.into(),
             chat_history: None,
             max_turns: agent.default_max_turns.unwrap_or(1),
             max_invalid_tool_call_retries: 0,
             model: agent.model.clone(),
+            model_selector: None,
             agent_name: agent.name.clone(),
             preamble: agent.preamble.clone(),
             static_context: agent.static_context.clone(),
@@ -280,15 +278,48 @@ where
     }
 }
 
-impl<M> AgentRunner<M>
-where
-    M: CompletionModel,
-{
+impl AgentRunner {
     /// Set the total model-call budget, including the initial call and every
     /// retry or continuation. Zero emits no model calls; one permits only the
     /// initial call. Exceeding the budget returns [`PromptError::MaxTurnsError`].
     pub fn max_turns(mut self, max_turns: usize) -> Self {
         self.max_turns = max_turns;
+        self
+    }
+
+    /// Pin every model attempt in this run to `model`.
+    ///
+    /// This clears any selector installed earlier. Calling [`Self::select_model`]
+    /// afterwards installs per-call routing again, with this handle as the
+    /// selector context's `default_model`.
+    pub fn using_model(mut self, model: ModelHandle) -> Self {
+        self.model = model;
+        self.model_selector = None;
+        self
+    }
+
+    /// Erase and pin a typed completion model for this run.
+    pub fn using_model_value<M>(self, model: M) -> Self
+    where
+        M: CompletionModel + 'static,
+    {
+        self.using_model(ModelHandle::new(model))
+    }
+
+    /// Select a model synchronously before every model call in this run.
+    ///
+    /// The selector runs exactly once per `AgentRunStep::CallModel`, including
+    /// calls after tools and retries. Its returned handle is bound to request
+    /// preparation and execution for that attempt. Installing a selector after
+    /// [`Self::using_model`] gives the selector precedence.
+    pub fn select_model<F>(mut self, selector: F) -> Self
+    where
+        F: for<'a> Fn(ModelSelectionContext<'a>) -> ModelHandle
+            + rig_core::wasm_compat::WasmCompatSend
+            + rig_core::wasm_compat::WasmCompatSync
+            + 'static,
+    {
+        self.model_selector = Some(ModelSelector::new(selector));
         self
     }
 
@@ -660,17 +691,14 @@ pub(crate) struct ToolCallOutcome {
 /// Records `gen_ai.tool.*` on the current span;
 /// `error_history` builds a cancellation error if a hook terminates the run.
 /// Returns whether the tool body executed via [`ToolCallOutcome::execution`].
-pub(crate) async fn run_single_tool<M>(
-    runner: &AgentRunner<M>,
+pub(crate) async fn run_single_tool(
+    runner: &AgentRunner,
     ctx: &HookContext,
     tool_snapshot: &ToolRegistrySnapshot,
     tool_call: &ToolCall,
     internal_call_id: &str,
     error_history: &[Message],
-) -> Result<ToolCallOutcome, PromptError>
-where
-    M: CompletionModel,
-{
+) -> Result<ToolCallOutcome, PromptError> {
     let hooks = &runner.hooks;
     let tool_context = &runner.tool_context;
     let record_content = runner.record_telemetry_content;
@@ -896,15 +924,10 @@ impl UnaryTurnSource {
     }
 }
 
-impl<M> TurnSource<M> for UnaryTurnSource
-where
-    M: CompletionModel,
-{
-    type Raw = M::Response;
-
+impl TurnSource for UnaryTurnSource {
     fn open_chat_span(
         &self,
-        runner: &AgentRunner<M>,
+        runner: &AgentRunner,
         effective_preamble: Option<&str>,
     ) -> tracing::Span {
         let chat_span = build_chat_span!(runner, effective_preamble, "chat", "chat");
@@ -913,16 +936,21 @@ where
 
     fn run_model_turn<'a>(
         &'a mut self,
-        runner: &'a AgentRunner<M>,
+        runner: &'a AgentRunner,
         hook_ctx: &'a HookContext,
         run: &'a mut AgentRun,
-        prepared: PreparedCompletionRequest<M>,
+        prepared: PreparedModelAttempt,
         chat_span: tracing::Span,
         _agent_span: &'a tracing::Span,
         current_prompt: Message,
-    ) -> DriveStream<'a, M::Response> {
+    ) -> DriveStream<'a> {
         Box::pin(async_stream::stream! {
-            let resp = match prepared.builder.send().instrument(chat_span.clone()).await {
+            let resp = match prepared
+                .model
+                .complete(prepared.request)
+                .instrument(chat_span.clone())
+                .await
+            {
                 Ok(resp) => resp,
                 Err(err) => {
                     yield Err(StreamingError::from(err));
@@ -1050,12 +1078,12 @@ where
 
     fn run_tool_calls<'a>(
         &'a self,
-        runner: &'a AgentRunner<M>,
+        runner: &'a AgentRunner,
         hook_ctx: &'a HookContext,
         run: &'a mut AgentRun,
         calls: Vec<PendingToolCall>,
         tool_snapshot: Arc<ToolRegistrySnapshot>,
-    ) -> DriveStream<'a, M::Response> {
+    ) -> DriveStream<'a> {
         // The blocking surface chains tool spans into its linear `follows_from`
         // sequence (chat -> tool -> chat), and discards the yielded items, so it
         // skips building them.
@@ -1088,17 +1116,14 @@ where
         }
     }
 
-    fn final_item(&self, _response: &PromptResponse) -> Option<MultiTurnStreamItem<M::Response>> {
+    fn final_item(&self, _response: &PromptResponse) -> Option<MultiTurnStreamItem> {
         // The blocking surface folds the engine and discards the final item, so
         // building it (an extra full-response clone) is skipped entirely.
         None
     }
 }
 
-impl<M> AgentRunner<M>
-where
-    M: CompletionModel,
-{
+impl AgentRunner {
     pub(crate) async fn run_with_error_usage(
         mut self,
     ) -> (Result<PromptResponse, PromptError>, Usage) {
@@ -4387,8 +4412,8 @@ mod migrated_tests {
 
     /// Drive a stream to completion, panicking on any stream error, and return
     /// its final response.
-    async fn drive_to_final_response<R: Send + 'static>(
-        mut stream: crate::agent::prompt_request::streaming::StreamingResult<R>,
+    async fn drive_to_final_response(
+        mut stream: crate::agent::prompt_request::streaming::StreamingResult,
     ) -> crate::agent::prompt_request::PromptResponse {
         let mut final_response = None;
         while let Some(item) = stream.next().await {

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -40,7 +40,7 @@ use super::{
         InvalidToolCallAction, ModelTurnAction, ModelTurnFinished, ObservationAction, RequestPatch,
         ToolCall as ToolCallEvent, ToolCallAction, ToolResultAction, ToolResultEvent,
     },
-    model::{ModelHandle, ModelSelectionContext, ModelSelector},
+    model::ModelHandle,
     prompt_request::{
         PromptResponse,
         streaming::{
@@ -201,9 +201,6 @@ pub struct AgentRunner {
     pub(crate) max_turns: usize,
     pub(crate) max_invalid_tool_call_retries: usize,
     pub(crate) model: ModelHandle,
-    /// Optional per-call selector. When present it takes precedence over the
-    /// run-local fixed/default model at each `CallModel` boundary.
-    pub(crate) model_selector: Option<ModelSelector>,
     pub(crate) agent_name: Option<String>,
     pub(crate) preamble: Option<String>,
     pub(crate) static_context: Vec<Document>,
@@ -238,7 +235,6 @@ impl AgentRunner {
             max_turns: agent.default_max_turns.unwrap_or(1),
             max_invalid_tool_call_retries: 0,
             model: agent.model.clone(),
-            model_selector: None,
             agent_name: agent.name.clone(),
             preamble: agent.preamble.clone(),
             static_context: agent.static_context.clone(),
@@ -265,10 +261,11 @@ impl AgentRunner {
 
     /// Append a hook to the stack (on top of any the agent already carries).
     /// Hooks run in registration order; how their results compose is
-    /// event-dependent (`CompletionCall` request patches accumulate and merge,
-    /// `ToolCall`/`ToolResult` rewrites chain, while model-turn steering and
-    /// observe-only/recovery events use their event-specific terminal action). See the
-    /// [`hook`](crate::agent::hook) module docs.
+    /// event-dependent (model selections and `ToolCall`/`ToolResult` rewrites
+    /// chain, `CompletionCall` request patches accumulate and merge, while
+    /// model-turn steering and observe-only/recovery events use their
+    /// event-specific terminal action). See the [`hook`](crate::agent::hook)
+    /// module docs.
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where
         H: AgentHook + 'static,
@@ -287,40 +284,22 @@ impl AgentRunner {
         self
     }
 
-    /// Pin every model attempt in this run to `model`.
+    /// Set the default model candidate for this run.
     ///
-    /// This clears any selector installed earlier. Calling [`Self::select_model`]
-    /// afterwards installs per-call routing again, with this handle as the
-    /// selector context's `default_model`.
+    /// This does not suppress registered model-selection hooks, which may
+    /// replace the candidate before each model call. Append an unconditional
+    /// selecting hook last when the run must always use one model.
     pub fn using_model(mut self, model: ModelHandle) -> Self {
         self.model = model;
-        self.model_selector = None;
         self
     }
 
-    /// Erase and pin a typed completion model for this run.
+    /// Erase and set a typed default model for this run.
     pub fn using_model_value<M>(self, model: M) -> Self
     where
         M: CompletionModel + 'static,
     {
         self.using_model(ModelHandle::new(model))
-    }
-
-    /// Select a model synchronously before every model call in this run.
-    ///
-    /// The selector runs exactly once per `AgentRunStep::CallModel`, including
-    /// calls after tools and retries. Its returned handle is bound to request
-    /// preparation and execution for that attempt. Installing a selector after
-    /// [`Self::using_model`] gives the selector precedence.
-    pub fn select_model<F>(mut self, selector: F) -> Self
-    where
-        F: for<'a> Fn(ModelSelectionContext<'a>) -> ModelHandle
-            + rig_core::wasm_compat::WasmCompatSend
-            + rig_core::wasm_compat::WasmCompatSync
-            + 'static,
-    {
-        self.model_selector = Some(ModelSelector::new(selector));
-        self
     }
 
     /// Set the typed context cloned for every tool dispatch in this run.

--- a/crates/rig-agent/src/agent/tool.rs
+++ b/crates/rig-agent/src/agent/tool.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::{
     agent::Agent,
-    completion::{CompletionModel, Prompt},
+    completion::Prompt,
     tool::{DynamicTool, ToolExecutionError, ToolOutput},
 };
 use schemars::{JsonSchema, schema_for};
@@ -17,7 +17,7 @@ struct AgentToolArgs {
 
 const DEFAULT_AGENT_TOOL_NAME: &str = "agent_tool";
 
-impl<M: CompletionModel + 'static> Agent<M> {
+impl Agent {
     /// Convert this agent into a runtime-defined tool.
     ///
     /// The configured agent name becomes the tool name. Unnamed agents use
@@ -64,8 +64,8 @@ impl<M: CompletionModel + 'static> Agent<M> {
     }
 }
 
-impl<M: CompletionModel + 'static> From<Agent<M>> for DynamicTool {
-    fn from(agent: Agent<M>) -> Self {
+impl From<Agent> for DynamicTool {
+    fn from(agent: Agent) -> Self {
         agent.into_tool()
     }
 }

--- a/crates/rig-agent/src/client.rs
+++ b/crates/rig-agent/src/client.rs
@@ -23,12 +23,15 @@ use rig_core::wasm_compat::{WasmCompatSend, WasmCompatSync};
 /// the full `completion_model` + `agent` + `extractor` surface.
 pub trait AgentClientExt: rig_core::client::completion::CompletionClient {
     /// Construct a classic agent builder for `model`.
-    fn agent(&self, model: impl Into<String>) -> AgentBuilder<Self::CompletionModel> {
+    fn agent(&self, model: impl Into<String>) -> AgentBuilder
+    where
+        Self::CompletionModel: 'static,
+    {
         AgentBuilder::new(self.completion_model(model))
     }
 
     /// Construct a classic typed extractor builder for `model`.
-    fn extractor<T>(&self, model: impl Into<String>) -> ExtractorBuilder<Self::CompletionModel, T>
+    fn extractor<T>(&self, model: impl Into<String>) -> ExtractorBuilder<T>
     where
         T: JsonSchema
             + for<'de> Deserialize<'de>
@@ -36,6 +39,7 @@ pub trait AgentClientExt: rig_core::client::completion::CompletionClient {
             + WasmCompatSend
             + WasmCompatSync
             + 'static,
+        Self::CompletionModel: 'static,
     {
         ExtractorBuilder::new(self.completion_model(model))
     }
@@ -46,7 +50,10 @@ impl<C: rig_core::client::completion::CompletionClient> AgentClientExt for C {}
 /// Adds classic agent construction to every portable completion model.
 pub trait AgentModelExt: rig_core::completion::CompletionModel + Sized {
     /// Convert this model into a classic agent builder.
-    fn into_agent_builder(self) -> AgentBuilder<Self> {
+    fn into_agent_builder(self) -> AgentBuilder
+    where
+        Self: 'static,
+    {
         AgentBuilder::new(self)
     }
 }

--- a/crates/rig-agent/src/extractor.rs
+++ b/crates/rig-agent/src/extractor.rs
@@ -82,10 +82,11 @@ where
     retries: u64,
 }
 
-/// A single extraction run pinned to a runtime-selected model.
+/// A single extraction run with an overridden default model.
 ///
-/// The selected model is used for every retry in this run. The originating
-/// [`Extractor`]'s default model is unchanged.
+/// The model is the initial candidate for every retry in this run;
+/// model-selection hooks may replace it. The originating [`Extractor`]'s
+/// default model is unchanged.
 #[must_use = "an extraction override does nothing until an extract method is awaited"]
 pub struct ExtractorRun<'a, T>
 where
@@ -99,15 +100,16 @@ impl<T> Extractor<T>
 where
     T: JsonSchema + for<'a> Deserialize<'a> + WasmCompatSend + WasmCompatSync,
 {
-    /// Pin a different model for this extractor's subsequent attempts.
+    /// Set a different default model for this extractor's subsequent attempts.
     pub fn with_model_handle(mut self, model: ModelHandle) -> Self {
         self.agent.set_model_handle(model);
         self
     }
 
-    /// Pin a model to one extraction run without changing this extractor.
+    /// Set one extraction run's default model without changing this extractor.
     ///
-    /// Every retry initiated through the returned run uses the same handle.
+    /// Every retry starts from this handle, which model-selection hooks may
+    /// replace before request preparation.
     pub fn using_model(&self, model: ModelHandle) -> ExtractorRun<'_, T> {
         ExtractorRun {
             extractor: self,
@@ -115,7 +117,7 @@ where
         }
     }
 
-    /// Erase and pin a typed completion model to one extraction run.
+    /// Erase and set a typed default model for one extraction run.
     pub fn using_model_value<M>(&self, model: M) -> ExtractorRun<'_, T>
     where
         M: CompletionModel + 'static,

--- a/crates/rig-agent/src/extractor.rs
+++ b/crates/rig-agent/src/extractor.rs
@@ -42,7 +42,7 @@ use rig_core::{
 };
 
 use crate::{
-    agent::{Agent, AgentBuilder, AgentHook, OutputMode},
+    agent::{Agent, AgentBuilder, AgentHook, ModelHandle, OutputMode},
     completion::{CompletionError, CompletionModel, PromptError, Usage},
 };
 
@@ -73,21 +73,56 @@ pub enum ExtractionError {
 }
 
 /// Extractor for structured data from text
-pub struct Extractor<M, T>
+pub struct Extractor<T>
 where
-    M: CompletionModel,
     T: JsonSchema + for<'a> Deserialize<'a> + WasmCompatSend + WasmCompatSync,
 {
-    agent: Agent<M>,
+    agent: Agent,
     _t: PhantomData<T>,
     retries: u64,
 }
 
-impl<M, T> Extractor<M, T>
+/// A single extraction run pinned to a runtime-selected model.
+///
+/// The selected model is used for every retry in this run. The originating
+/// [`Extractor`]'s default model is unchanged.
+#[must_use = "an extraction override does nothing until an extract method is awaited"]
+pub struct ExtractorRun<'a, T>
 where
-    M: CompletionModel,
+    T: JsonSchema + for<'de> Deserialize<'de> + WasmCompatSend + WasmCompatSync,
+{
+    extractor: &'a Extractor<T>,
+    model: ModelHandle,
+}
+
+impl<T> Extractor<T>
+where
     T: JsonSchema + for<'a> Deserialize<'a> + WasmCompatSend + WasmCompatSync,
 {
+    /// Pin a different model for this extractor's subsequent attempts.
+    pub fn with_model_handle(mut self, model: ModelHandle) -> Self {
+        self.agent.set_model_handle(model);
+        self
+    }
+
+    /// Pin a model to one extraction run without changing this extractor.
+    ///
+    /// Every retry initiated through the returned run uses the same handle.
+    pub fn using_model(&self, model: ModelHandle) -> ExtractorRun<'_, T> {
+        ExtractorRun {
+            extractor: self,
+            model,
+        }
+    }
+
+    /// Erase and pin a typed completion model to one extraction run.
+    pub fn using_model_value<M>(&self, model: M) -> ExtractorRun<'_, T>
+    where
+        M: CompletionModel + 'static,
+    {
+        self.using_model(ModelHandle::new(model))
+    }
+
     /// Attempts to extract data from the given text with a number of retries.
     ///
     /// The function will retry the extraction if the initial attempt fails or
@@ -98,7 +133,7 @@ where
         &self,
         text: impl Into<Message> + WasmCompatSend,
     ) -> Result<T, ExtractionError> {
-        let (data, _usage) = self.retry_extract(text.into(), vec![]).await?;
+        let (data, _usage) = self.retry_extract(text.into(), vec![], None).await?;
         Ok(data)
     }
 
@@ -113,7 +148,7 @@ where
         text: impl Into<Message> + WasmCompatSend,
         chat_history: Vec<Message>,
     ) -> Result<T, ExtractionError> {
-        let (data, _usage) = self.retry_extract(text.into(), chat_history).await?;
+        let (data, _usage) = self.retry_extract(text.into(), chat_history, None).await?;
         Ok(data)
     }
 
@@ -134,7 +169,7 @@ where
         &self,
         text: impl Into<Message> + WasmCompatSend,
     ) -> Result<ExtractionResponse<T>, ExtractionError> {
-        let (data, usage) = self.retry_extract(text.into(), vec![]).await?;
+        let (data, usage) = self.retry_extract(text.into(), vec![], None).await?;
         Ok(ExtractionResponse { data, usage })
     }
 
@@ -157,7 +192,7 @@ where
         text: impl Into<Message> + WasmCompatSend,
         chat_history: Vec<Message>,
     ) -> Result<ExtractionResponse<T>, ExtractionError> {
-        let (data, usage) = self.retry_extract(text.into(), chat_history).await?;
+        let (data, usage) = self.retry_extract(text.into(), chat_history, None).await?;
         Ok(ExtractionResponse { data, usage })
     }
 
@@ -170,6 +205,7 @@ where
         &self,
         text: Message,
         chat_history: Vec<Message>,
+        model: Option<&ModelHandle>,
     ) -> Result<(T, Usage), ExtractionError> {
         let mut last_error = None;
         let mut usage = Usage::new();
@@ -179,7 +215,9 @@ where
                 "Attempting to extract JSON. Retries left: {retries}",
                 retries = self.retries - i
             );
-            let (result, attempt_usage) = self.extract_json_with_usage(&text, &chat_history).await;
+            let (result, attempt_usage) = self
+                .extract_json_with_usage(&text, &chat_history, model)
+                .await;
             usage += attempt_usage;
             match result {
                 Ok(data) => return Ok((data, usage)),
@@ -205,11 +243,16 @@ where
         &self,
         text: &Message,
         messages: &[Message],
+        model: Option<&ModelHandle>,
     ) -> (Result<T, ExtractionError>, Usage) {
-        let (result, error_usage) = self
+        let mut runner = self
             .agent
             .runner(text.clone())
-            .history(messages.iter().cloned())
+            .history(messages.iter().cloned());
+        if let Some(model) = model {
+            runner = runner.using_model(model.clone());
+        }
+        let (result, error_usage) = runner
             .max_turns(1)
             .output_tool(
                 SUBMIT_TOOL_NAME,
@@ -248,25 +291,86 @@ where
     }
 }
 
-/// Builder for the Extractor
-pub struct ExtractorBuilder<M, T>
+impl<T> ExtractorRun<'_, T>
 where
-    M: CompletionModel,
+    T: JsonSchema + for<'de> Deserialize<'de> + WasmCompatSend + WasmCompatSync,
+{
+    /// Extract structured data with the run-local model.
+    pub async fn extract(
+        &self,
+        text: impl Into<Message> + WasmCompatSend,
+    ) -> Result<T, ExtractionError> {
+        let (data, _usage) = self
+            .extractor
+            .retry_extract(text.into(), vec![], Some(&self.model))
+            .await?;
+        Ok(data)
+    }
+
+    /// Extract structured data with chat history and the run-local model.
+    pub async fn extract_with_chat_history(
+        &self,
+        text: impl Into<Message> + WasmCompatSend,
+        chat_history: Vec<Message>,
+    ) -> Result<T, ExtractionError> {
+        let (data, _usage) = self
+            .extractor
+            .retry_extract(text.into(), chat_history, Some(&self.model))
+            .await?;
+        Ok(data)
+    }
+
+    /// Extract structured data and usage with the run-local model.
+    pub async fn extract_with_usage(
+        &self,
+        text: impl Into<Message> + WasmCompatSend,
+    ) -> Result<ExtractionResponse<T>, ExtractionError> {
+        let (data, usage) = self
+            .extractor
+            .retry_extract(text.into(), vec![], Some(&self.model))
+            .await?;
+        Ok(ExtractionResponse { data, usage })
+    }
+
+    /// Extract structured data with chat history and usage using the run-local model.
+    pub async fn extract_with_chat_history_with_usage(
+        &self,
+        text: impl Into<Message> + WasmCompatSend,
+        chat_history: Vec<Message>,
+    ) -> Result<ExtractionResponse<T>, ExtractionError> {
+        let (data, usage) = self
+            .extractor
+            .retry_extract(text.into(), chat_history, Some(&self.model))
+            .await?;
+        Ok(ExtractionResponse { data, usage })
+    }
+}
+
+/// Builder for the Extractor
+pub struct ExtractorBuilder<T>
+where
     T: JsonSchema + for<'a> Deserialize<'a> + Serialize + WasmCompatSend + WasmCompatSync + 'static,
 {
-    agent_builder: AgentBuilder<M>,
+    agent_builder: AgentBuilder,
     _t: PhantomData<T>,
     retries: Option<u64>,
 }
 
-impl<M, T> ExtractorBuilder<M, T>
+impl<T> ExtractorBuilder<T>
 where
-    M: CompletionModel,
     T: JsonSchema + for<'a> Deserialize<'a> + Serialize + WasmCompatSend + WasmCompatSync + 'static,
 {
-    pub fn new(model: M) -> Self {
+    pub fn new<M>(model: M) -> Self
+    where
+        M: CompletionModel + 'static,
+    {
+        Self::from_model_handle(ModelHandle::new(model))
+    }
+
+    /// Create an extractor builder from an opaque runtime model handle.
+    pub fn from_model_handle(model: ModelHandle) -> Self {
         Self {
-            agent_builder: AgentBuilder::new(model)
+            agent_builder: AgentBuilder::from_model_handle(model)
                 .preamble("\
                     You are an AI assistant whose purpose is to extract structured data from the provided text.\n\
                     You will have access to a `submit` function that defines the structure of the data to extract from the provided text.\n\
@@ -343,7 +447,7 @@ where
     }
 
     /// Build the Extractor
-    pub fn build(self) -> Extractor<M, T> {
+    pub fn build(self) -> Extractor<T> {
         Extractor {
             agent: self.agent_builder.build(),
             _t: PhantomData,
@@ -381,10 +485,7 @@ mod tests {
         }
     }
 
-    fn extractor(
-        model: MockCompletionModel,
-        retries: u64,
-    ) -> Extractor<MockCompletionModel, Person> {
+    fn extractor(model: MockCompletionModel, retries: u64) -> Extractor<Person> {
         ExtractorBuilder::new(model).retries(retries).build()
     }
 
@@ -595,7 +696,7 @@ mod tests {
     async fn extractor_runs_through_full_response_lifecycle() {
         let model = MockCompletionModel::new([submit_turn("John")]);
         let counts = LifecycleCounts::default();
-        let response = ExtractorBuilder::<_, Person>::new(model.clone())
+        let response = ExtractorBuilder::<Person>::new(model.clone())
             .add_hook(counts.clone())
             .build()
             .extract("John")
@@ -614,7 +715,7 @@ mod tests {
         let capture = ExtractorResponseCapture::default();
         let expected_usage = usage(23);
         let response =
-            ExtractorBuilder::<_, Person>::new(MockCompletionModel::new([submit_turn("John")
+            ExtractorBuilder::<Person>::new(MockCompletionModel::new([submit_turn("John")
                 .with_usage(expected_usage)
                 .with_message_id("extractor-message")]))
             .add_hook(capture.clone())
@@ -646,7 +747,7 @@ mod tests {
         let model = MockCompletionModel::new([submit_turn("John")]);
         let probe = model.clone();
         let queries = Arc::new(Mutex::new(Vec::new()));
-        let response = ExtractorBuilder::<_, Person>::new(model)
+        let response = ExtractorBuilder::<Person>::new(model)
             .dynamic_context(
                 2,
                 ExtractorContextIndex {
@@ -677,7 +778,7 @@ mod tests {
     #[tokio::test]
     async fn extractor_completion_call_stop_prevents_provider_io() {
         let model = MockCompletionModel::new([submit_turn("John")]);
-        let error = ExtractorBuilder::<_, Person>::new(model.clone())
+        let error = ExtractorBuilder::<Person>::new(model.clone())
             .add_hook(StopBeforeCompletion)
             .build()
             .extract("John")
@@ -718,7 +819,7 @@ mod tests {
             submit_turn("ignored").with_usage(usage(10)),
             submit_turn("John").with_usage(usage(5)),
         ]);
-        let response = ExtractorBuilder::<_, Person>::new(model)
+        let response = ExtractorBuilder::<Person>::new(model)
             .retries(1)
             .add_hook(StopFirstBilledResponse {
                 phase,
@@ -767,7 +868,7 @@ mod tests {
         ]);
         let counts = LifecycleCounts::default();
 
-        let response = ExtractorBuilder::<_, Person>::new(model)
+        let response = ExtractorBuilder::<Person>::new(model)
             .retries(1)
             .add_hook(counts.clone())
             .build()
@@ -787,7 +888,7 @@ mod tests {
         let model =
             MockCompletionModel::new([MockTurn::tool_call("unknown", "unexpected", json!({}))]);
 
-        let error = ExtractorBuilder::<_, Person>::new(model)
+        let error = ExtractorBuilder::<Person>::new(model)
             .add_hook(StopOnInvalidToolCall)
             .build()
             .extract("John")
@@ -809,7 +910,7 @@ mod tests {
             json!({ "name": "John" }),
         )]);
 
-        let response = ExtractorBuilder::<_, Person>::new(model)
+        let response = ExtractorBuilder::<Person>::new(model)
             .add_hook(RepairUnexpectedAsSubmit)
             .build()
             .extract("John")
@@ -828,7 +929,7 @@ mod tests {
         .expect("two tool calls");
         let model = MockCompletionModel::new([turn]);
 
-        let response = ExtractorBuilder::<_, Person>::new(model)
+        let response = ExtractorBuilder::<Person>::new(model)
             .add_hook(SkipUnexpected)
             .build()
             .extract("John")

--- a/crates/rig-agent/src/integrations/cli_chatbot.rs
+++ b/crates/rig-agent/src/integrations/cli_chatbot.rs
@@ -1,12 +1,11 @@
 use rig_core::{
     markers::{Missing, Provided},
     message::Message,
-    wasm_compat::WasmCompatSend,
 };
 
 use crate::{
     agent::{Agent, MultiTurnStreamItem, Text},
-    completion::{Chat, CompletionError, CompletionModel, PromptError, Usage},
+    completion::{Chat, CompletionError, PromptError, Usage},
     streaming::{StreamedAssistantContent, StreamingPrompt},
 };
 use futures::StreamExt;
@@ -16,11 +15,8 @@ pub struct ChatImpl<T>(T)
 where
     T: Chat;
 
-pub struct AgentImpl<M>
-where
-    M: CompletionModel + 'static,
-{
-    agent: Agent<M>,
+pub struct AgentImpl {
+    agent: Agent,
     max_turns: usize,
     show_usage: bool,
     usage: Usage,
@@ -64,10 +60,7 @@ where
     }
 }
 
-impl<M> CliChat for AgentImpl<M>
-where
-    M: CompletionModel + WasmCompatSend + 'static,
-{
+impl CliChat for AgentImpl {
     async fn request(
         &mut self,
         prompt: &str,
@@ -141,10 +134,7 @@ impl ChatBotBuilder<Missing> {
         Self::default()
     }
 
-    pub fn agent<M: CompletionModel + 'static>(
-        self,
-        agent: Agent<M>,
-    ) -> ChatBotBuilder<Provided<AgentImpl<M>>> {
+    pub fn agent(self, agent: Agent) -> ChatBotBuilder<Provided<AgentImpl>> {
         ChatBotBuilder(Provided(AgentImpl {
             agent,
             max_turns: 1,
@@ -167,10 +157,7 @@ where
     }
 }
 
-impl<M> ChatBotBuilder<Provided<AgentImpl<M>>>
-where
-    M: CompletionModel + 'static,
-{
+impl ChatBotBuilder<Provided<AgentImpl>> {
     /// Set the total model-call budget for each prompt, including the initial
     /// call and every retry or continuation. Zero emits no model calls.
     pub fn max_turns(self, max_turns: usize) -> Self {
@@ -187,7 +174,7 @@ where
         }))
     }
 
-    pub fn build(self) -> ChatBot<AgentImpl<M>> {
+    pub fn build(self) -> ChatBot<AgentImpl> {
         ChatBot(self.0.0)
     }
 }

--- a/crates/rig-agent/src/integrations/discord_bot.rs
+++ b/crates/rig-agent/src/integrations/discord_bot.rs
@@ -1,7 +1,7 @@
 //! Integration for deploying your Rig agents (and more) as Discord bots.
 //! This feature is not WASM-compatible (and as such, is incompatible with the `worker` feature).
 use crate::agent::Agent;
-use crate::completion::{Chat, CompletionModel};
+use crate::completion::Chat;
 use rig_core::message::Message as RigMessage;
 use serenity::all::{
     Command, CommandInteraction, Context, CreateCommand, CreateThread, EventHandler,
@@ -22,13 +22,13 @@ pub enum DiscordBotError {
 }
 
 // Bot state containing the agent and conversation histories
-struct BotState<M: CompletionModel> {
-    agent: Agent<M>,
+struct BotState {
+    agent: Agent,
     conversations: Arc<RwLock<HashMap<u64, Vec<RigMessage>>>>,
 }
 
-impl<M: CompletionModel> BotState<M> {
-    fn new(agent: Agent<M>) -> Self {
+impl BotState {
+    fn new(agent: Agent) -> Self {
         Self {
             agent,
             conversations: Arc::new(RwLock::new(HashMap::new())),
@@ -37,15 +37,12 @@ impl<M: CompletionModel> BotState<M> {
 }
 
 // Event handler for the Discord bot
-struct Handler<M: CompletionModel> {
-    state: Arc<BotState<M>>,
+struct Handler {
+    state: Arc<BotState>,
 }
 
 #[async_trait]
-impl<M> EventHandler for Handler<M>
-where
-    M: CompletionModel + Send + Sync + 'static,
-{
+impl EventHandler for Handler {
     async fn ready(&self, ctx: Context, ready: Ready) {
         println!("{} is connected!", ready.user.name);
 
@@ -82,10 +79,7 @@ where
     }
 }
 
-impl<M> Handler<M>
-where
-    M: CompletionModel + Send + Sync + 'static,
-{
+impl Handler {
     async fn handle_command(&self, ctx: &Context, command: &CommandInteraction) {
         if command.data.name.as_str() == "new" {
             // Defer the response to prevent timeout
@@ -230,10 +224,7 @@ where
     }
 }
 
-impl<M> DiscordExt for Agent<M>
-where
-    M: CompletionModel + Send + Sync + 'static,
-{
+impl DiscordExt for Agent {
     async fn into_discord_bot(self, token: &str) -> Result<serenity::Client, DiscordBotError> {
         let intents = GatewayIntents::GUILDS
             | GatewayIntents::GUILD_MESSAGES

--- a/crates/rig-agent/src/lib.rs
+++ b/crates/rig-agent/src/lib.rs
@@ -76,8 +76,8 @@ pub mod test_utils;
 pub mod tool;
 
 pub use agent::{
-    Agent, AgentBuilder, AgentRun, AgentRunner, AgentStreamFinal, ModelHandle,
-    ModelSelectionContext,
+    Agent, AgentBuilder, AgentHook, AgentRun, AgentRunner, AgentStreamFinal, HookContext,
+    ModelHandle, ModelSelection, ModelSelectionAction,
 };
 pub use extractor::ExtractionResponse;
 

--- a/crates/rig-agent/src/lib.rs
+++ b/crates/rig-agent/src/lib.rs
@@ -75,7 +75,10 @@ pub mod streaming;
 pub mod test_utils;
 pub mod tool;
 
-pub use agent::{Agent, AgentBuilder, AgentRun, AgentRunner};
+pub use agent::{
+    Agent, AgentBuilder, AgentRun, AgentRunner, AgentStreamFinal, ModelHandle,
+    ModelSelectionContext,
+};
 pub use extractor::ExtractionResponse;
 
 #[cfg(feature = "derive")]

--- a/crates/rig-agent/src/prelude.rs
+++ b/crates/rig-agent/src/prelude.rs
@@ -11,7 +11,10 @@ pub use rig_core::client::audio_generation::AudioGenerationClient;
 #[cfg(feature = "image")]
 pub use rig_core::client::image_generation::ImageGenerationClient;
 
-pub use crate::agent::{Agent, MultiTurnStreamItem, StreamingResult};
+pub use crate::agent::{
+    Agent, AgentStreamFinal, ModelHandle, ModelSelectionContext, MultiTurnStreamItem,
+    StreamingResult,
+};
 pub use crate::client::{AgentClientExt, AgentModelExt};
 pub use crate::completion::{
     Chat, CompletionError, CompletionModel, Message, Prompt, PromptError, StructuredOutputError,

--- a/crates/rig-agent/src/prelude.rs
+++ b/crates/rig-agent/src/prelude.rs
@@ -12,8 +12,8 @@ pub use rig_core::client::audio_generation::AudioGenerationClient;
 pub use rig_core::client::image_generation::ImageGenerationClient;
 
 pub use crate::agent::{
-    Agent, AgentStreamFinal, ModelHandle, ModelSelectionContext, MultiTurnStreamItem,
-    StreamingResult,
+    Agent, AgentHook, AgentStreamFinal, HookContext, ModelHandle, ModelSelection,
+    ModelSelectionAction, MultiTurnStreamItem, StreamingResult,
 };
 pub use crate::client::{AgentClientExt, AgentModelExt};
 pub use crate::completion::{

--- a/crates/rig-agent/src/streaming.rs
+++ b/crates/rig-agent/src/streaming.rs
@@ -1,40 +1,24 @@
 //! High-level streaming prompting traits for the classic agent runtime.
 
-use crate::{
-    agent::StreamingPromptRequest,
-    completion::{CompletionModel, GetTokenUsage, Message},
-};
+use crate::{agent::StreamingPromptRequest, completion::Message};
 use rig_core::wasm_compat::{WasmCompatSend, WasmCompatSync};
 
 pub use rig_core::streaming::*;
 
 /// High-level one-shot streaming prompt interface.
-pub trait StreamingPrompt<M, R>
-where
-    M: CompletionModel + 'static,
-    M::StreamingResponse: WasmCompatSend,
-    R: Clone + Unpin + GetTokenUsage,
-{
+pub trait StreamingPrompt {
     /// Create a classic streaming request for `prompt`.
-    fn stream_prompt(
-        &self,
-        prompt: impl Into<Message> + WasmCompatSend,
-    ) -> StreamingPromptRequest<M>;
+    fn stream_prompt(&self, prompt: impl Into<Message> + WasmCompatSend) -> StreamingPromptRequest;
 }
 
 /// High-level streaming chat interface with caller-provided history.
-pub trait StreamingChat<M, R>: WasmCompatSend + WasmCompatSync
-where
-    M: CompletionModel + 'static,
-    M::StreamingResponse: WasmCompatSend,
-    R: Clone + Unpin + GetTokenUsage,
-{
+pub trait StreamingChat: WasmCompatSend + WasmCompatSync {
     /// Create a classic streaming request with canonical chat history.
     fn stream_chat<I, T>(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
         chat_history: I,
-    ) -> StreamingPromptRequest<M>
+    ) -> StreamingPromptRequest
     where
         I: IntoIterator<Item = T> + WasmCompatSend,
         T: Into<Message>;

--- a/crates/rig-agent/src/test_utils/model_conformance.rs
+++ b/crates/rig-agent/src/test_utils/model_conformance.rs
@@ -965,7 +965,7 @@ pub async fn parallel_tools<M, F>(
 ) -> Result<ScenarioReport, ScenarioError>
 where
     M: CompletionModel + 'static,
-    F: FnOnce(AgentBuilder<M, NoToolConfig>) -> AgentBuilder<M, NoToolConfig>,
+    F: FnOnce(AgentBuilder<NoToolConfig>) -> AgentBuilder<NoToolConfig>,
 {
     let add_calls = Arc::new(AtomicUsize::new(0));
     let subtract_calls = Arc::new(AtomicUsize::new(0));
@@ -1060,7 +1060,7 @@ pub async fn zero_argument_tool<M, F>(
 ) -> Result<ScenarioReport, ScenarioError>
 where
     M: CompletionModel + 'static,
-    F: FnOnce(AgentBuilder<M, NoToolConfig>) -> AgentBuilder<M, NoToolConfig>,
+    F: FnOnce(AgentBuilder<NoToolConfig>) -> AgentBuilder<NoToolConfig>,
 {
     const SCENARIO: &str = "zero_argument_tool";
     let calls = Arc::new(AtomicUsize::new(0));
@@ -1110,7 +1110,7 @@ pub async fn tool_output_serialization<M, F>(
 ) -> Result<ScenarioReport, ScenarioError>
 where
     M: CompletionModel + 'static,
-    F: FnOnce(AgentBuilder<M, NoToolConfig>) -> AgentBuilder<M, NoToolConfig>,
+    F: FnOnce(AgentBuilder<NoToolConfig>) -> AgentBuilder<NoToolConfig>,
 {
     const SCENARIO: &str = "tool_output_serialization";
     let started = Instant::now();
@@ -1172,7 +1172,7 @@ pub async fn complex_tool_arguments<M, F>(
 ) -> Result<ScenarioReport, ScenarioError>
 where
     M: CompletionModel + 'static,
-    F: FnOnce(AgentBuilder<M, NoToolConfig>) -> AgentBuilder<M, NoToolConfig>,
+    F: FnOnce(AgentBuilder<NoToolConfig>) -> AgentBuilder<NoToolConfig>,
 {
     const SCENARIO: &str = "complex_tool_arguments";
     let expected = ComplexArgs {
@@ -1308,7 +1308,7 @@ where
     const SCENARIO: &str = "structured_extraction";
     const INPUT: &str = "Hello, my name is Ada Lovelace and I work as a mathematician.";
     let started = Instant::now();
-    let response = crate::extractor::ExtractorBuilder::<M, ExtractedPerson>::new(model)
+    let response = crate::extractor::ExtractorBuilder::<ExtractedPerson>::new(model)
         .max_tokens(384)
         .retries(0)
         .build()
@@ -1376,7 +1376,7 @@ pub async fn invalid_tool_recovery<M, F>(
 ) -> Result<ScenarioReport, ScenarioError>
 where
     M: CompletionModel + 'static,
-    F: FnOnce(AgentBuilder<M, NoToolConfig>) -> AgentBuilder<M, NoToolConfig>,
+    F: FnOnce(AgentBuilder<NoToolConfig>) -> AgentBuilder<NoToolConfig>,
 {
     const SCENARIO: &str = "invalid_tool_recovery";
     const PROMPT: &str = "Call the add tool exactly once with x=2 and y=3. Do not call sum.";
@@ -1567,7 +1567,7 @@ pub async fn hook_rewrites_and_request_patch<M, F>(
 ) -> Result<ScenarioReport, ScenarioError>
 where
     M: CompletionModel + 'static,
-    F: FnOnce(AgentBuilder<M, NoToolConfig>) -> AgentBuilder<M, NoToolConfig>,
+    F: FnOnce(AgentBuilder<NoToolConfig>) -> AgentBuilder<NoToolConfig>,
 {
     const SCENARIO: &str = "hook_rewrites_and_request_patch";
     let started = Instant::now();
@@ -1641,7 +1641,7 @@ pub async fn cancellation_and_max_turns<M, F>(
 ) -> Result<ScenarioReport, ScenarioError>
 where
     M: CompletionModel + Clone + 'static,
-    F: Fn(AgentBuilder<M, NoToolConfig>) -> AgentBuilder<M, NoToolConfig>,
+    F: Fn(AgentBuilder<NoToolConfig>) -> AgentBuilder<NoToolConfig>,
 {
     const SCENARIO: &str = "cancellation_and_max_turns";
     const REASON: &str = "portable result veto";
@@ -1718,7 +1718,7 @@ pub async fn optional_argument<M, F>(
 ) -> Result<ScenarioReport, ScenarioError>
 where
     M: CompletionModel + 'static,
-    F: FnOnce(AgentBuilder<M, NoToolConfig>) -> AgentBuilder<M, NoToolConfig>,
+    F: FnOnce(AgentBuilder<NoToolConfig>) -> AgentBuilder<NoToolConfig>,
 {
     let calls = Arc::new(AtomicUsize::new(0));
     let started = Instant::now();
@@ -1753,7 +1753,7 @@ where
 pub async fn sequential_tools<M, F>(model: M, configure: F) -> Result<ScenarioReport, ScenarioError>
 where
     M: CompletionModel + 'static,
-    F: FnOnce(AgentBuilder<M, NoToolConfig>) -> AgentBuilder<M, NoToolConfig>,
+    F: FnOnce(AgentBuilder<NoToolConfig>) -> AgentBuilder<NoToolConfig>,
 {
     let add_calls = Arc::new(AtomicUsize::new(0));
     let multiply_calls = Arc::new(AtomicUsize::new(0));
@@ -1792,7 +1792,7 @@ where
 pub async fn streaming_tool<M, F>(model: M, configure: F) -> Result<ScenarioReport, ScenarioError>
 where
     M: CompletionModel + 'static,
-    F: FnOnce(AgentBuilder<M, NoToolConfig>) -> AgentBuilder<M, NoToolConfig>,
+    F: FnOnce(AgentBuilder<NoToolConfig>) -> AgentBuilder<NoToolConfig>,
 {
     let calls = Arc::new(AtomicUsize::new(0));
     let started = Instant::now();
@@ -1889,7 +1889,7 @@ pub async fn structured_after_tool<M, F>(
 ) -> Result<ScenarioReport, ScenarioError>
 where
     M: CompletionModel + 'static,
-    F: FnOnce(AgentBuilder<M, NoToolConfig>) -> AgentBuilder<M, NoToolConfig>,
+    F: FnOnce(AgentBuilder<NoToolConfig>) -> AgentBuilder<NoToolConfig>,
 {
     let calls = Arc::new(AtomicUsize::new(0));
     let started = Instant::now();
@@ -2034,7 +2034,7 @@ pub async fn streaming_structured_after_tool<M, F>(
 ) -> Result<ScenarioReport, ScenarioError>
 where
     M: CompletionModel + 'static,
-    F: FnOnce(AgentBuilder<M, NoToolConfig>) -> AgentBuilder<M, NoToolConfig>,
+    F: FnOnce(AgentBuilder<NoToolConfig>) -> AgentBuilder<NoToolConfig>,
 {
     let calls = Arc::new(AtomicUsize::new(0));
     let started = Instant::now();

--- a/crates/rig-agent/tests/runtime_model_swapping.rs
+++ b/crates/rig-agent/tests/runtime_model_swapping.rs
@@ -15,13 +15,14 @@ use futures::{Stream, StreamExt, stream};
 use rig_agent::{
     Agent, AgentBuilder, AgentStreamFinal, ModelHandle,
     agent::{
-        AgentHook, CompletionCallAction, HookContext, InvalidToolCallAction, ModelTurnAction,
-        ModelTurnFinished, NoToolConfig, PromptRequest, Standard, StreamingError, StreamingResult,
-        ToolCall as ToolCallEvent, ToolCallAction, ToolResultAction, ToolResultEvent,
+        AgentHook, CompletionCallAction, HookContext, InvalidToolCallAction, ModelSelection,
+        ModelSelectionAction, ModelTurnAction, ModelTurnFinished, NoToolConfig, PromptRequest,
+        Standard, StreamingError, StreamingResult, ToolCall as ToolCallEvent, ToolCallAction,
+        ToolResultAction, ToolResultEvent,
     },
     completion::{
         CompletionError, CompletionModel, CompletionRequest, CompletionResponse, GetTokenUsage,
-        Message, Prompt, TypedPrompt, Usage,
+        Message, Prompt, PromptError, TypedPrompt, Usage,
     },
     extractor::{Extractor, ExtractorBuilder},
     streaming::{
@@ -42,6 +43,45 @@ async fn wait_for_notification(notify: &Notify) {
     tokio::time::timeout(Duration::from_secs(5), notify.notified())
         .await
         .expect("model was polled before timeout");
+}
+
+struct SelectWith<F>(F);
+
+impl<F> AgentHook for SelectWith<F>
+where
+    F: for<'a> Fn(&HookContext, ModelSelection<'a>) -> ModelSelectionAction + Send + Sync,
+{
+    fn on_model_select(
+        &self,
+        context: &HookContext,
+        event: ModelSelection<'_>,
+    ) -> ModelSelectionAction {
+        (self.0)(context, event)
+    }
+}
+
+#[derive(Clone)]
+struct StopSelection {
+    completion_calls: Arc<AtomicUsize>,
+}
+
+impl AgentHook for StopSelection {
+    fn on_model_select(
+        &self,
+        _context: &HookContext,
+        _event: ModelSelection<'_>,
+    ) -> ModelSelectionAction {
+        ModelSelectionAction::stop("routing denied")
+    }
+
+    async fn on_completion_call(
+        &self,
+        _context: &HookContext,
+        _event: rig_agent::agent::CompletionCallEvent<'_>,
+    ) -> CompletionCallAction {
+        self.completion_calls.fetch_add(1, Ordering::SeqCst);
+        CompletionCallAction::continue_run()
+    }
 }
 
 fn usage(total_tokens: u64) -> Usage {
@@ -520,30 +560,128 @@ async fn replacement_and_override_scopes_have_value_semantics() {
         .expect("typed override");
     assert_eq!(typed.value, "typed beta");
 
+    let observed_candidates = Arc::new(Mutex::new(Vec::new()));
+    let observed_for_hook = observed_candidates.clone();
     assert_eq!(
         original
-            .prompt("selector after fixed")
-            .using_model(alpha_handle.clone())
-            .select_model(move |_| beta_handle.clone())
+            .prompt("hook after run default")
+            .using_model(alpha_handle)
+            .add_hook(SelectWith(
+                move |_context: &HookContext, event: ModelSelection<'_>| {
+                    observed_for_hook
+                        .lock()
+                        .expect("candidate observations")
+                        .push((
+                            event.default_model.label().map(str::to_owned),
+                            event.selected_model.label().map(str::to_owned),
+                        ));
+                    ModelSelectionAction::select(beta_handle.clone())
+                }
+            ))
             .await
-            .expect("selector takes precedence"),
+            .expect("hook overrides run default"),
         "beta"
     );
-
-    let beta_for_cleared_selector = ModelHandle::new(beta);
     assert_eq!(
-        original
-            .prompt("fixed after selector")
-            .select_model(move |_| beta_for_cleared_selector.clone())
-            .using_model(alpha_handle)
-            .await
-            .expect("fixed override clears selector"),
-        "alpha"
+        observed_candidates
+            .lock()
+            .expect("candidate observations")
+            .as_slice(),
+        &[(Some("alpha".to_owned()), Some("alpha".to_owned()))]
     );
 }
 
 #[tokio::test]
-async fn extraction_override_is_run_local_and_pins_all_retries() {
+async fn agent_and_request_model_selection_hooks_have_expected_scope() {
+    let default = ModelHandle::named("default", alpha_static("default"));
+    let routed = ModelHandle::named("routed", beta_static("agent routed"));
+    let request = ModelHandle::named("request", alpha_static("request routed"));
+    let routed_for_hook = routed.clone();
+    let agent = AgentBuilder::from_model_handle(default)
+        .add_hook(SelectWith(
+            move |_context: &HookContext, _event: ModelSelection<'_>| {
+                ModelSelectionAction::select(routed_for_hook.clone())
+            },
+        ))
+        .build();
+
+    assert_eq!(
+        agent.prompt("agent hook").await.expect("agent hook route"),
+        "agent routed"
+    );
+
+    assert_eq!(
+        agent
+            .prompt("request hook")
+            .add_hook(SelectWith(
+                move |_context: &HookContext, event: ModelSelection<'_>| {
+                    assert_eq!(event.selected_model.label(), Some("routed"));
+                    ModelSelectionAction::select(request.clone())
+                }
+            ))
+            .await
+            .expect("request hook route"),
+        "request routed"
+    );
+
+    assert_eq!(
+        agent
+            .prompt("agent hook remains")
+            .await
+            .expect("agent hook remains"),
+        "agent routed"
+    );
+}
+
+#[tokio::test]
+async fn model_selection_stop_cancels_before_provider_execution() {
+    let blocking_model = alpha_static("must not execute");
+    let blocking_script = blocking_model.0.clone();
+    let blocking_completion_calls = Arc::new(AtomicUsize::new(0));
+    let error = AgentBuilder::new(blocking_model)
+        .build()
+        .prompt("stop before execution")
+        .add_hook(StopSelection {
+            completion_calls: blocking_completion_calls.clone(),
+        })
+        .await
+        .expect_err("selection stop should cancel the run");
+
+    assert!(matches!(
+        error,
+        PromptError::PromptCancelled { reason, .. } if reason == "routing denied"
+    ));
+    assert!(blocking_script.requests().is_empty());
+    assert_eq!(blocking_completion_calls.load(Ordering::SeqCst), 0);
+
+    let streaming_model = alpha_static("must not stream");
+    let streaming_script = streaming_model.0.clone();
+    let streaming_completion_calls = Arc::new(AtomicUsize::new(0));
+    let mut stream = AgentBuilder::new(streaming_model)
+        .build()
+        .stream_prompt("stop before streaming")
+        .add_hook(StopSelection {
+            completion_calls: streaming_completion_calls.clone(),
+        })
+        .await;
+    let error = stream
+        .next()
+        .await
+        .expect("selection stop should emit an error")
+        .expect_err("selection stop should cancel the stream");
+
+    assert!(matches!(
+        error,
+        StreamingError::Prompt(error)
+            if matches!(*error, PromptError::PromptCancelled { ref reason, .. }
+                if reason == "routing denied")
+    ));
+    assert!(streaming_script.requests().is_empty());
+    assert_eq!(streaming_completion_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn extraction_override_is_run_local_and_sets_each_retry_default() {
     let default_turn = Turn::Tool {
         id: "default-submit".to_owned(),
         name: "submit".to_owned(),
@@ -602,6 +740,64 @@ async fn extraction_override_is_run_local_and_pins_all_retries() {
         .expect("default extraction remains unchanged");
     assert_eq!(default.value, "default");
     assert_eq!(default_script.requests().len(), 1);
+}
+
+#[tokio::test]
+async fn extraction_retries_reenter_model_selection_hooks() {
+    let default = alpha_static("default must not execute");
+    let default_script = default.0.clone();
+    let first = alpha_static("retry without submit");
+    let first_script = first.0.clone();
+    let submit_turn = Turn::Tool {
+        id: "routed-submit".to_owned(),
+        name: "submit".to_owned(),
+        arguments: serde_json::json!({"value": "hook selected"}),
+        usage: usage(2),
+        message_id: "routed-extraction".to_owned(),
+    };
+    let second = BetaModel(Script::new("second", [submit_turn.clone()], submit_turn));
+    let second_script = second.0.clone();
+    let first = ModelHandle::named("first", first);
+    let second = ModelHandle::named("second", second);
+    let selections = Arc::new(Mutex::new(Vec::new()));
+    let selections_for_hook = selections.clone();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_hook = attempts.clone();
+    let extractor = ExtractorBuilder::<ExtractedValue>::new(default)
+        .add_hook(SelectWith(
+            move |context: &HookContext, event: ModelSelection<'_>| {
+                selections_for_hook.lock().expect("selection log").push((
+                    context.turn(),
+                    event
+                        .previous_model
+                        .and_then(ModelHandle::label)
+                        .map(str::to_owned),
+                ));
+                let attempt = attempts_for_hook.fetch_add(1, Ordering::SeqCst);
+                ModelSelectionAction::select(if attempt == 0 {
+                    first.clone()
+                } else {
+                    second.clone()
+                })
+            },
+        ))
+        .retries(1)
+        .build();
+
+    let extracted = extractor
+        .extract("repair the structured output")
+        .await
+        .expect("hook-routed extraction retry");
+
+    assert_eq!(extracted.value, "hook selected");
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    assert_eq!(first_script.requests().len(), 1);
+    assert_eq!(second_script.requests().len(), 1);
+    assert!(default_script.requests().is_empty());
+    assert_eq!(
+        selections.lock().expect("selection log").as_slice(),
+        &[(1, None), (1, None)]
+    );
 }
 
 #[derive(Clone)]
@@ -704,6 +900,27 @@ fn history_has_tool_result(request: &CompletionRequest) -> bool {
 }
 
 #[tokio::test]
+async fn runner_default_is_used_for_every_attempt_without_a_selecting_hook() {
+    let first = Turn::tool("lookup", 2, "default-tool-message");
+    let second = Turn::text("default final", 3, "default-final-message");
+    let model = AlphaModel(Script::new("default", [first, second.clone()], second));
+    let script = model.0.clone();
+
+    let output = AgentBuilder::new(model)
+        .tool(LookupTool {
+            calls: Arc::new(AtomicUsize::new(0)),
+        })
+        .build()
+        .prompt("use the default twice")
+        .max_turns(2)
+        .await
+        .expect("default multi-turn run");
+
+    assert_eq!(output, "default final");
+    assert_eq!(script.requests().len(), 2);
+}
+
+#[tokio::test]
 async fn blocking_and_streaming_switch_after_tools_with_equivalent_semantics() {
     async fn run_blocking() -> (
         rig_agent::agent::PromptResponse,
@@ -728,17 +945,19 @@ async fn blocking_and_streaming_switch_after_tools_with_equivalent_semantics() {
             .build()
             .prompt("research then synthesize")
             .max_turns(3)
-            .select_model(move |context| {
-                selected_for_router
-                    .lock()
-                    .expect("selection lock")
-                    .push(context.turn);
-                if context.turn == 1 {
-                    alpha_handle.clone()
-                } else {
-                    beta_handle.clone()
-                }
-            })
+            .add_hook(SelectWith(
+                move |context: &HookContext, _event: ModelSelection<'_>| {
+                    selected_for_router
+                        .lock()
+                        .expect("selection lock")
+                        .push(context.turn());
+                    ModelSelectionAction::select(if context.turn() == 1 {
+                        alpha_handle.clone()
+                    } else {
+                        beta_handle.clone()
+                    })
+                },
+            ))
             .extended_details()
             .await
             .expect("blocking routed run");
@@ -781,17 +1000,19 @@ async fn blocking_and_streaming_switch_after_tools_with_equivalent_semantics() {
         let mut stream = agent
             .stream_prompt("research then synthesize")
             .max_turns(3)
-            .select_model(move |context| {
-                selected_for_router
-                    .lock()
-                    .expect("selection lock")
-                    .push(context.turn);
-                if context.turn == 1 {
-                    alpha_handle.clone()
-                } else {
-                    beta_handle.clone()
-                }
-            })
+            .add_hook(SelectWith(
+                move |context: &HookContext, _event: ModelSelection<'_>| {
+                    selected_for_router
+                        .lock()
+                        .expect("selection lock")
+                        .push(context.turn());
+                    ModelSelectionAction::select(if context.turn() == 1 {
+                        alpha_handle.clone()
+                    } else {
+                        beta_handle.clone()
+                    })
+                },
+            ))
             .await;
         let mut final_response = None;
         let mut events = Vec::new();
@@ -919,20 +1140,22 @@ async fn retries_reenter_selection_without_leaking_rejected_turn_state() {
         .build()
         .prompt("try twice")
         .max_turns(2)
-        .select_model(move |context| {
-            selections_for_router.lock().expect("selection lock").push((
-                context.turn,
-                context
-                    .previous_model
-                    .and_then(ModelHandle::label)
-                    .map(str::to_owned),
-            ));
-            if context.turn == 1 {
-                alpha_handle.clone()
-            } else {
-                beta_handle.clone()
-            }
-        })
+        .add_hook(SelectWith(
+            move |context: &HookContext, event: ModelSelection<'_>| {
+                selections_for_router.lock().expect("selection lock").push((
+                    context.turn(),
+                    event
+                        .previous_model
+                        .and_then(ModelHandle::label)
+                        .map(str::to_owned),
+                ));
+                ModelSelectionAction::select(if context.turn() == 1 {
+                    alpha_handle.clone()
+                } else {
+                    beta_handle.clone()
+                })
+            },
+        ))
         .extended_details()
         .await
         .expect("retry routed run");
@@ -990,24 +1213,29 @@ async fn invalid_tool_retry_reenters_selection_exactly_once() {
         .prompt("recover from an invalid tool")
         .max_turns(2)
         .max_invalid_tool_call_retries(1)
-        .select_model(move |context| {
-            selections_for_router
-                .lock()
-                .expect("selection lock")
-                .push(context.turn);
-            if context.turn == 1 {
-                alpha_handle.clone()
-            } else {
-                beta_handle.clone()
-            }
-        })
+        .add_hook(SelectWith(
+            move |context: &HookContext, event: ModelSelection<'_>| {
+                selections_for_router.lock().expect("selection lock").push((
+                    context.turn(),
+                    event
+                        .previous_model
+                        .and_then(ModelHandle::label)
+                        .map(str::to_owned),
+                ));
+                ModelSelectionAction::select(if context.turn() == 1 {
+                    alpha_handle.clone()
+                } else {
+                    beta_handle.clone()
+                })
+            },
+        ))
         .await
         .expect("invalid-tool retry run");
 
     assert_eq!(output, "recovered after invalid tool");
     assert_eq!(
         selections.lock().expect("selection lock").as_slice(),
-        &[1, 2]
+        &[(1, None), (2, Some("alpha".to_owned()))]
     );
 }
 
@@ -1161,13 +1389,15 @@ async fn selected_model_capability_is_used_for_each_prepared_attempt() {
         .build()
         .prompt("capability routing")
         .max_turns(2)
-        .select_model(move |context| {
-            if context.turn == 1 {
-                composing_handle.clone()
-            } else {
-                noncomposing_handle.clone()
-            }
-        })
+        .add_hook(SelectWith(
+            move |context: &HookContext, _event: ModelSelection<'_>| {
+                ModelSelectionAction::select(if context.turn() == 1 {
+                    composing_handle.clone()
+                } else {
+                    noncomposing_handle.clone()
+                })
+            },
+        ))
         .await
         .expect("capability run");
 
@@ -1270,13 +1500,15 @@ async fn routing_changes_cannot_rebind_an_in_flight_attempt_but_affect_the_next_
         agent
             .prompt("bind the attempt")
             .max_turns(2)
-            .select_model(move |_| {
-                if use_beta_for_router.load(Ordering::SeqCst) {
-                    beta_handle.clone()
-                } else {
-                    gated_handle.clone()
-                }
-            })
+            .add_hook(SelectWith(
+                move |_context: &HookContext, _event: ModelSelection<'_>| {
+                    ModelSelectionAction::select(if use_beta_for_router.load(Ordering::SeqCst) {
+                        beta_handle.clone()
+                    } else {
+                        gated_handle.clone()
+                    })
+                },
+            ))
             .await
     });
 
@@ -1444,12 +1676,16 @@ async fn concurrent_runs_and_handle_calls_are_independent() {
     let beta_handle = ModelHandle::named("beta", beta_static("beta concurrent"));
     let agent = AgentBuilder::from_model_handle(alpha_handle.clone()).build();
 
-    let alpha_run = agent
-        .prompt("alpha run")
-        .select_model(move |_| alpha_handle.clone());
-    let beta_run = agent
-        .prompt("beta run")
-        .select_model(move |_| beta_handle.clone());
+    let alpha_run = agent.prompt("alpha run").add_hook(SelectWith(
+        move |_context: &HookContext, _event: ModelSelection<'_>| {
+            ModelSelectionAction::select(alpha_handle.clone())
+        },
+    ));
+    let beta_run = agent.prompt("beta run").add_hook(SelectWith(
+        move |_context: &HookContext, _event: ModelSelection<'_>| {
+            ModelSelectionAction::select(beta_handle.clone())
+        },
+    ));
     let (alpha, beta) = tokio::join!(alpha_run, beta_run);
     assert_eq!(alpha.expect("alpha concurrent run"), "alpha concurrent");
     assert_eq!(beta.expect("beta concurrent run"), "beta concurrent");

--- a/crates/rig-agent/tests/runtime_model_swapping.rs
+++ b/crates/rig-agent/tests/runtime_model_swapping.rs
@@ -1,0 +1,1463 @@
+#![allow(clippy::expect_used, clippy::indexing_slicing)]
+
+use std::{
+    collections::VecDeque,
+    pin::Pin,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use futures::{Stream, StreamExt, stream};
+use rig_agent::{
+    Agent, AgentBuilder, AgentStreamFinal, ModelHandle,
+    agent::{
+        AgentHook, CompletionCallAction, HookContext, InvalidToolCallAction, ModelTurnAction,
+        ModelTurnFinished, NoToolConfig, PromptRequest, Standard, StreamingError, StreamingResult,
+        ToolCall as ToolCallEvent, ToolCallAction, ToolResultAction, ToolResultEvent,
+    },
+    completion::{
+        CompletionError, CompletionModel, CompletionRequest, CompletionResponse, GetTokenUsage,
+        Message, Prompt, TypedPrompt, Usage,
+    },
+    extractor::{Extractor, ExtractorBuilder},
+    streaming::{
+        RawStreamingChoice, RawStreamingToolCall, StreamedAssistantContent,
+        StreamingCompletionResponse, StreamingPrompt,
+    },
+    tool::{Tool, ToolContext, ToolExecutionError},
+};
+use rig_core::{
+    OneOrMany,
+    message::{AssistantContent, ReasoningContent, ToolCall, ToolFunction, UserContent},
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Notify;
+
+async fn wait_for_notification(notify: &Notify) {
+    tokio::time::timeout(Duration::from_secs(5), notify.notified())
+        .await
+        .expect("model was polled before timeout");
+}
+
+fn usage(total_tokens: u64) -> Usage {
+    Usage {
+        total_tokens,
+        ..Usage::new()
+    }
+}
+
+#[derive(Clone)]
+enum Turn {
+    Text {
+        text: String,
+        usage: Usage,
+        message_id: String,
+    },
+    Tool {
+        id: String,
+        name: String,
+        arguments: serde_json::Value,
+        usage: Usage,
+        message_id: String,
+    },
+    Rich {
+        text: String,
+        usage: Usage,
+        message_id: String,
+    },
+}
+
+impl Turn {
+    fn text(text: &str, total_tokens: u64, message_id: &str) -> Self {
+        Self::Text {
+            text: text.to_owned(),
+            usage: usage(total_tokens),
+            message_id: message_id.to_owned(),
+        }
+    }
+
+    fn tool(name: &str, total_tokens: u64, message_id: &str) -> Self {
+        Self::Tool {
+            id: format!("{name}-call"),
+            name: name.to_owned(),
+            arguments: serde_json::json!({"query": "rust"}),
+            usage: usage(total_tokens),
+            message_id: message_id.to_owned(),
+        }
+    }
+
+    fn rich(text: &str, total_tokens: u64, message_id: &str) -> Self {
+        Self::Rich {
+            text: text.to_owned(),
+            usage: usage(total_tokens),
+            message_id: message_id.to_owned(),
+        }
+    }
+
+    fn usage(&self) -> Usage {
+        match self {
+            Self::Text { usage, .. } | Self::Tool { usage, .. } | Self::Rich { usage, .. } => {
+                *usage
+            }
+        }
+    }
+
+    fn message_id(&self) -> String {
+        match self {
+            Self::Text { message_id, .. }
+            | Self::Tool { message_id, .. }
+            | Self::Rich { message_id, .. } => message_id.clone(),
+        }
+    }
+
+    fn choice(&self) -> OneOrMany<AssistantContent> {
+        match self {
+            Self::Text { text, .. } => OneOrMany::one(AssistantContent::text(text)),
+            Self::Tool {
+                id,
+                name,
+                arguments,
+                ..
+            } => OneOrMany::one(AssistantContent::ToolCall(ToolCall::new(
+                id.clone(),
+                ToolFunction::new(name.clone(), arguments.clone()),
+            ))),
+            Self::Rich { text, .. } => OneOrMany::many(vec![
+                AssistantContent::reasoning("considering the evidence"),
+                AssistantContent::text(text),
+            ])
+            .expect("rich turn contains two items"),
+        }
+    }
+}
+
+struct Script {
+    provider: &'static str,
+    secret: String,
+    turns: Mutex<VecDeque<Turn>>,
+    fallback: Turn,
+    requests: Mutex<Vec<CompletionRequest>>,
+    composes_native_output_with_tools: bool,
+}
+
+impl Script {
+    fn new(
+        provider: &'static str,
+        turns: impl IntoIterator<Item = Turn>,
+        fallback: Turn,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            provider,
+            secret: format!("{provider}-credential-must-not-leak"),
+            turns: Mutex::new(turns.into_iter().collect()),
+            fallback,
+            requests: Mutex::new(Vec::new()),
+            composes_native_output_with_tools: false,
+        })
+    }
+
+    fn composing(
+        provider: &'static str,
+        turns: impl IntoIterator<Item = Turn>,
+        fallback: Turn,
+    ) -> Arc<Self> {
+        let mut script = Self {
+            provider,
+            secret: format!("{provider}-credential-must-not-leak"),
+            turns: Mutex::new(turns.into_iter().collect()),
+            fallback,
+            requests: Mutex::new(Vec::new()),
+            composes_native_output_with_tools: true,
+        };
+        script.secret.shrink_to_fit();
+        Arc::new(script)
+    }
+
+    fn next_turn(&self) -> Turn {
+        self.turns
+            .lock()
+            .expect("script turn lock")
+            .pop_front()
+            .unwrap_or_else(|| self.fallback.clone())
+    }
+
+    fn record(&self, request: CompletionRequest) {
+        self.requests
+            .lock()
+            .expect("script request lock")
+            .push(request);
+    }
+
+    fn requests(&self) -> Vec<CompletionRequest> {
+        self.requests.lock().expect("script request lock").clone()
+    }
+}
+
+trait TestRaw:
+    Clone + Unpin + Send + Sync + Serialize + for<'de> Deserialize<'de> + GetTokenUsage + 'static
+{
+    fn new(provider: &str, usage: Usage) -> Self;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct AlphaRaw {
+    provider: String,
+    usage: Usage,
+}
+
+impl TestRaw for AlphaRaw {
+    fn new(provider: &str, usage: Usage) -> Self {
+        Self {
+            provider: provider.to_owned(),
+            usage,
+        }
+    }
+}
+
+impl GetTokenUsage for AlphaRaw {
+    fn token_usage(&self) -> Usage {
+        self.usage
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct BetaRaw {
+    provider: String,
+    usage: Usage,
+}
+
+impl TestRaw for BetaRaw {
+    fn new(provider: &str, usage: Usage) -> Self {
+        Self {
+            provider: provider.to_owned(),
+            usage,
+        }
+    }
+}
+
+impl GetTokenUsage for BetaRaw {
+    fn token_usage(&self) -> Usage {
+        self.usage
+    }
+}
+
+fn completion_from_script<R>(script: &Script, request: CompletionRequest) -> CompletionResponse<R>
+where
+    R: TestRaw,
+{
+    script.record(request);
+    let turn = script.next_turn();
+    CompletionResponse {
+        choice: turn.choice(),
+        usage: turn.usage(),
+        raw_response: R::new(script.provider, turn.usage()),
+        message_id: Some(turn.message_id()),
+    }
+}
+
+fn stream_from_script<R>(
+    script: &Script,
+    request: CompletionRequest,
+) -> StreamingCompletionResponse<R>
+where
+    R: TestRaw,
+{
+    script.record(request);
+    let turn = script.next_turn();
+    let mut events = vec![Ok(RawStreamingChoice::MessageId(turn.message_id()))];
+    match &turn {
+        Turn::Text { text, .. } => {
+            events.push(Ok(RawStreamingChoice::Message(text.clone())));
+        }
+        Turn::Tool {
+            id,
+            name,
+            arguments,
+            ..
+        } => {
+            let raw = RawStreamingToolCall::new(id.clone(), name.clone(), arguments.clone())
+                .with_internal_call_id(format!("{id}-internal"));
+            events.push(Ok(RawStreamingChoice::ToolCallDelta {
+                id: id.clone(),
+                internal_call_id: raw.internal_call_id.clone(),
+                content: rig_agent::streaming::ToolCallDeltaContent::Name(name.clone()),
+            }));
+            events.push(Ok(RawStreamingChoice::ToolCallDelta {
+                id: id.clone(),
+                internal_call_id: raw.internal_call_id.clone(),
+                content: rig_agent::streaming::ToolCallDeltaContent::Delta(arguments.to_string()),
+            }));
+            events.push(Ok(RawStreamingChoice::ToolCall(raw)));
+        }
+        Turn::Rich { text, .. } => {
+            events.push(Ok(RawStreamingChoice::Reasoning {
+                id: Some("reasoning-1".to_owned()),
+                content: ReasoningContent::Summary("summary".to_owned()),
+            }));
+            events.push(Ok(RawStreamingChoice::ReasoningDelta {
+                id: Some("reasoning-2".to_owned()),
+                reasoning: "reasoning delta".to_owned(),
+            }));
+            events.push(Ok(RawStreamingChoice::Unknown(serde_json::json!({
+                "type": "provider_native_event",
+                "provider": script.provider,
+            }))));
+            events.push(Ok(RawStreamingChoice::Message(text.clone())));
+        }
+    }
+    events.push(Ok(RawStreamingChoice::FinalResponse(R::new(
+        script.provider,
+        turn.usage(),
+    ))));
+
+    StreamingCompletionResponse::stream(Box::pin(stream::iter(events)))
+}
+
+#[derive(Clone)]
+struct AlphaModel(Arc<Script>);
+
+#[derive(Clone)]
+struct BetaModel(Arc<Script>);
+
+macro_rules! impl_test_model {
+    ($model:ty, $raw:ty) => {
+        impl CompletionModel for $model {
+            type Response = $raw;
+            type StreamingResponse = $raw;
+            type Client = ();
+
+            fn make(_client: &Self::Client, _model: impl Into<String>) -> Self {
+                Self(Script::new(
+                    "constructed",
+                    [],
+                    Turn::text("constructed", 0, "constructed-message"),
+                ))
+            }
+
+            async fn completion(
+                &self,
+                request: CompletionRequest,
+            ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+                Ok(completion_from_script(&self.0, request))
+            }
+
+            async fn stream(
+                &self,
+                request: CompletionRequest,
+            ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+                Ok(stream_from_script(&self.0, request))
+            }
+
+            fn composes_native_output_with_tools(&self) -> bool {
+                self.0.composes_native_output_with_tools
+            }
+        }
+    };
+}
+
+impl_test_model!(AlphaModel, AlphaRaw);
+impl_test_model!(BetaModel, BetaRaw);
+
+fn alpha_static(text: &str) -> AlphaModel {
+    AlphaModel(Script::new(
+        "alpha",
+        [],
+        Turn::text(text, 1, "alpha-message"),
+    ))
+}
+
+fn beta_static(text: &str) -> BetaModel {
+    BetaModel(Script::new("beta", [], Turn::text(text, 2, "beta-message")))
+}
+
+fn request(prompt: &str) -> CompletionRequest {
+    CompletionRequest {
+        model: None,
+        preamble: None,
+        chat_history: OneOrMany::one(Message::user(prompt)),
+        documents: Vec::new(),
+        tools: Vec::new(),
+        temperature: None,
+        max_tokens: None,
+        tool_choice: None,
+        additional_params: None,
+        output_schema: None,
+        record_telemetry_content: false,
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+struct ExtractedValue {
+    value: String,
+}
+
+fn assert_agent(_: Agent) {}
+fn assert_builder(_: AgentBuilder<NoToolConfig>) {}
+fn assert_prompt_request(_: PromptRequest<Standard>) {}
+fn assert_extractor(_: Extractor<ExtractedValue>) {}
+fn assert_agent_stream(_: StreamingResult) {}
+
+#[tokio::test]
+async fn downstream_models_keep_typed_low_level_apis_and_share_a_concrete_agent_type() {
+    let alpha = alpha_static("alpha");
+    let beta = beta_static("beta");
+
+    let alpha_agent = AgentBuilder::new(alpha.clone()).build();
+    let beta_agent = AgentBuilder::new(beta.clone()).build();
+    let agents: Vec<Agent> = vec![alpha_agent.clone(), beta_agent];
+    assert_eq!(agents.len(), 2);
+
+    assert_agent(alpha_agent.clone());
+    assert_builder(AgentBuilder::new(alpha.clone()));
+    assert_prompt_request(alpha_agent.prompt("typed request"));
+    assert_extractor(ExtractorBuilder::<ExtractedValue>::new(alpha.clone()).build());
+    assert_agent_stream(alpha_agent.stream_prompt("stream type").await);
+
+    let unary = alpha
+        .completion(request("low-level unary"))
+        .await
+        .expect("typed unary response");
+    let raw: AlphaRaw = unary.raw_response;
+    assert_eq!(raw.provider, "alpha");
+
+    let mut low_level_stream = beta
+        .stream(request("low-level stream"))
+        .await
+        .expect("typed provider stream");
+    let mut typed_final: Option<BetaRaw> = None;
+    while let Some(item) = low_level_stream.next().await {
+        if let StreamedAssistantContent::Final(final_) = item.expect("stream item") {
+            typed_final = Some(final_);
+        }
+    }
+    assert_eq!(
+        typed_final.expect("typed final").provider,
+        "beta",
+        "direct model streams retain their provider raw type"
+    );
+
+    let extraction_turn = Turn::Tool {
+        id: "submit-call".to_owned(),
+        name: "submit".to_owned(),
+        arguments: serde_json::json!({"value": "external model extraction"}),
+        usage: usage(3),
+        message_id: "extract-message".to_owned(),
+    };
+    let extracted = ExtractorBuilder::<ExtractedValue>::new(AlphaModel(Script::new(
+        "extractor",
+        [extraction_turn.clone()],
+        extraction_turn,
+    )))
+    .build()
+    .extract("extract a value")
+    .await
+    .expect("custom model extraction");
+    assert_eq!(extracted.value, "external model extraction");
+
+    let handle = ModelHandle::named("diagnostic-alpha", alpha);
+    let debug = format!("{handle:?}");
+    assert!(debug.contains("diagnostic-alpha"));
+    assert!(!debug.contains("credential-must-not-leak"));
+}
+
+#[tokio::test]
+async fn replacement_and_override_scopes_have_value_semantics() {
+    let alpha = alpha_static("alpha");
+    let beta = beta_static("beta");
+    let beta_handle = ModelHandle::named("beta", beta.clone());
+    let alpha_handle = ModelHandle::named("alpha", alpha.clone());
+
+    let mut agent = AgentBuilder::new(alpha.clone()).build();
+    let runner_before_replacement = agent.runner("runner snapshot");
+    agent.set_model(beta.clone());
+
+    assert_eq!(
+        runner_before_replacement
+            .run()
+            .await
+            .expect("old runner")
+            .output,
+        "alpha"
+    );
+    assert_eq!(
+        agent.prompt("new runner").await.expect("new default"),
+        "beta"
+    );
+
+    let original = AgentBuilder::new(alpha.clone()).build();
+    let changed_clone = original.clone().with_model_handle(beta_handle.clone());
+    assert_eq!(
+        original.prompt("original").await.expect("original"),
+        "alpha"
+    );
+    assert_eq!(
+        changed_clone.prompt("clone").await.expect("changed clone"),
+        "beta"
+    );
+
+    assert_eq!(
+        original
+            .prompt("one run")
+            .using_model(beta_handle.clone())
+            .await
+            .expect("fixed override"),
+        "beta"
+    );
+    assert_eq!(
+        original.prompt("default remains").await.expect("default"),
+        "alpha"
+    );
+
+    let typed: ExtractedValue = original
+        .prompt_typed("typed one-run override")
+        .using_model(ModelHandle::new(beta_static(r#"{"value":"typed beta"}"#)))
+        .await
+        .expect("typed override");
+    assert_eq!(typed.value, "typed beta");
+
+    assert_eq!(
+        original
+            .prompt("selector after fixed")
+            .using_model(alpha_handle.clone())
+            .select_model(move |_| beta_handle.clone())
+            .await
+            .expect("selector takes precedence"),
+        "beta"
+    );
+
+    let beta_for_cleared_selector = ModelHandle::new(beta);
+    assert_eq!(
+        original
+            .prompt("fixed after selector")
+            .select_model(move |_| beta_for_cleared_selector.clone())
+            .using_model(alpha_handle)
+            .await
+            .expect("fixed override clears selector"),
+        "alpha"
+    );
+}
+
+#[tokio::test]
+async fn extraction_override_is_run_local_and_pins_all_retries() {
+    let default_turn = Turn::Tool {
+        id: "default-submit".to_owned(),
+        name: "submit".to_owned(),
+        arguments: serde_json::json!({"value": "default"}),
+        usage: usage(1),
+        message_id: "default-extraction".to_owned(),
+    };
+    let specialist_turn = Turn::Tool {
+        id: "specialist-submit".to_owned(),
+        name: "submit".to_owned(),
+        arguments: serde_json::json!({"value": "specialist"}),
+        usage: usage(2),
+        message_id: "specialist-extraction".to_owned(),
+    };
+    let typed_turn = Turn::Tool {
+        id: "typed-submit".to_owned(),
+        name: "submit".to_owned(),
+        arguments: serde_json::json!({"value": "typed specialist"}),
+        usage: usage(3),
+        message_id: "typed-extraction".to_owned(),
+    };
+
+    let default_script = Script::new("default", [], default_turn);
+    let specialist_script = Script::new(
+        "specialist",
+        [
+            Turn::text("retry without submit", 1, "specialist-retry"),
+            specialist_turn.clone(),
+        ],
+        specialist_turn,
+    );
+    let extractor = ExtractorBuilder::<ExtractedValue>::new(AlphaModel(default_script.clone()))
+        .retries(1)
+        .build();
+
+    let specialist = extractor
+        .using_model(ModelHandle::new(BetaModel(specialist_script.clone())))
+        .extract("use the specialist")
+        .await
+        .expect("run-local extraction override");
+    assert_eq!(specialist.value, "specialist");
+    assert_eq!(specialist_script.requests().len(), 2);
+    assert!(default_script.requests().is_empty());
+
+    let typed = extractor
+        .using_model_value(BetaModel(Script::new("typed", [], typed_turn)))
+        .extract_with_usage("use a typed model value")
+        .await
+        .expect("typed extraction override");
+    assert_eq!(typed.data.value, "typed specialist");
+    assert_eq!(typed.usage, usage(3));
+
+    let default = extractor
+        .extract("use the default again")
+        .await
+        .expect("default extraction remains unchanged");
+    assert_eq!(default.value, "default");
+    assert_eq!(default_script.requests().len(), 1);
+}
+
+#[derive(Clone)]
+struct LookupTool {
+    calls: Arc<AtomicUsize>,
+}
+
+impl Tool for LookupTool {
+    const NAME: &'static str = "lookup";
+    type Error = ToolExecutionError;
+    type Args = serde_json::Value;
+    type Output = String;
+
+    fn description(&self) -> String {
+        "Look up deterministic evidence".to_owned()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object", "properties": {"query": {"type": "string"}}})
+    }
+
+    async fn call(
+        &self,
+        _context: &mut ToolContext,
+        _args: Self::Args,
+    ) -> Result<Self::Output, Self::Error> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok("durable evidence".to_owned())
+    }
+}
+
+#[derive(Clone, Default)]
+struct LifecycleLog(Arc<Mutex<Vec<String>>>);
+
+impl LifecycleLog {
+    fn entries(&self) -> Vec<String> {
+        self.0.lock().expect("lifecycle lock").clone()
+    }
+
+    fn push(&self, entry: impl Into<String>) {
+        self.0.lock().expect("lifecycle lock").push(entry.into());
+    }
+}
+
+impl AgentHook for LifecycleLog {
+    async fn on_completion_call(
+        &self,
+        context: &HookContext,
+        _event: rig_agent::agent::CompletionCallEvent<'_>,
+    ) -> CompletionCallAction {
+        self.push(format!("completion:{}", context.turn()));
+        CompletionCallAction::continue_run()
+    }
+
+    async fn on_model_turn_finished(
+        &self,
+        context: &HookContext,
+        _event: ModelTurnFinished<'_>,
+    ) -> ModelTurnAction {
+        self.push(format!("model:{}", context.turn()));
+        ModelTurnAction::continue_run()
+    }
+
+    async fn on_tool_call(
+        &self,
+        _context: &HookContext,
+        event: ToolCallEvent<'_>,
+    ) -> ToolCallAction {
+        self.push(format!("tool-call:{}", event.tool_name));
+        ToolCallAction::run()
+    }
+
+    async fn on_tool_result(
+        &self,
+        _context: &HookContext,
+        event: ToolResultEvent<'_>,
+    ) -> ToolResultAction {
+        self.push(format!("tool-result:{}", event.tool_name));
+        ToolResultAction::keep()
+    }
+}
+
+fn routing_models() -> (AlphaModel, BetaModel) {
+    let alpha_turn = Turn::tool("lookup", 3, "alpha-tool-message");
+    let beta_turn = Turn::text("synthesized answer", 5, "beta-answer-message");
+    (
+        AlphaModel(Script::new("alpha", [alpha_turn.clone()], alpha_turn)),
+        BetaModel(Script::new("beta", [beta_turn.clone()], beta_turn)),
+    )
+}
+
+fn history_has_tool_result(request: &CompletionRequest) -> bool {
+    request.chat_history.iter().any(|message| {
+        matches!(
+            message,
+            Message::User { content }
+                if content.iter().any(|item| matches!(item, UserContent::ToolResult(_)))
+        )
+    })
+}
+
+#[tokio::test]
+async fn blocking_and_streaming_switch_after_tools_with_equivalent_semantics() {
+    async fn run_blocking() -> (
+        rig_agent::agent::PromptResponse,
+        Vec<String>,
+        usize,
+        Vec<CompletionRequest>,
+        Vec<String>,
+    ) {
+        let (alpha, beta) = routing_models();
+        let beta_script = beta.0.clone();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let lifecycle = LifecycleLog::default();
+        let selected = Arc::new(Mutex::new(Vec::new()));
+        let selected_for_router = selected.clone();
+        let alpha_handle = ModelHandle::named("alpha", alpha);
+        let beta_handle = ModelHandle::named("beta", beta);
+        let response = AgentBuilder::from_model_handle(alpha_handle.clone())
+            .tool(LookupTool {
+                calls: calls.clone(),
+            })
+            .add_hook(lifecycle.clone())
+            .build()
+            .prompt("research then synthesize")
+            .max_turns(3)
+            .select_model(move |context| {
+                selected_for_router
+                    .lock()
+                    .expect("selection lock")
+                    .push(context.turn);
+                if context.turn == 1 {
+                    alpha_handle.clone()
+                } else {
+                    beta_handle.clone()
+                }
+            })
+            .extended_details()
+            .await
+            .expect("blocking routed run");
+        let selections = selected.lock().expect("selection lock").clone();
+        (
+            response,
+            lifecycle.entries(),
+            calls.load(Ordering::SeqCst),
+            beta_script.requests(),
+            selections
+                .into_iter()
+                .map(|turn| turn.to_string())
+                .collect(),
+        )
+    }
+
+    async fn run_streaming() -> (
+        rig_agent::agent::PromptResponse,
+        Vec<String>,
+        usize,
+        Vec<CompletionRequest>,
+        Vec<usize>,
+        Vec<&'static str>,
+        Vec<String>,
+    ) {
+        let (alpha, beta) = routing_models();
+        let beta_script = beta.0.clone();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let lifecycle = LifecycleLog::default();
+        let selected = Arc::new(Mutex::new(Vec::new()));
+        let selected_for_router = selected.clone();
+        let alpha_handle = ModelHandle::named("alpha", alpha);
+        let beta_handle = ModelHandle::named("beta", beta);
+        let agent = AgentBuilder::from_model_handle(alpha_handle.clone())
+            .tool(LookupTool {
+                calls: calls.clone(),
+            })
+            .add_hook(lifecycle.clone())
+            .build();
+        let mut stream = agent
+            .stream_prompt("research then synthesize")
+            .max_turns(3)
+            .select_model(move |context| {
+                selected_for_router
+                    .lock()
+                    .expect("selection lock")
+                    .push(context.turn);
+                if context.turn == 1 {
+                    alpha_handle.clone()
+                } else {
+                    beta_handle.clone()
+                }
+            })
+            .await;
+        let mut final_response = None;
+        let mut events = Vec::new();
+        let mut internal_call_ids = Vec::new();
+        while let Some(item) = stream.next().await {
+            match item.expect("stream item") {
+                rig_agent::agent::MultiTurnStreamItem::StreamAssistantItem(
+                    StreamedAssistantContent::ToolCallDelta {
+                        internal_call_id, ..
+                    },
+                ) => {
+                    events.push("tool-delta");
+                    internal_call_ids.push(internal_call_id);
+                }
+                rig_agent::agent::MultiTurnStreamItem::StreamAssistantItem(
+                    StreamedAssistantContent::ToolCall {
+                        internal_call_id, ..
+                    },
+                ) => {
+                    events.push("tool-call");
+                    internal_call_ids.push(internal_call_id);
+                }
+                rig_agent::agent::MultiTurnStreamItem::ToolExecutionCommitted {
+                    internal_call_id,
+                    ..
+                } => {
+                    events.push("tool-commit");
+                    internal_call_ids.push(internal_call_id);
+                }
+                rig_agent::agent::MultiTurnStreamItem::StreamUserItem(
+                    rig_agent::streaming::StreamedUserContent::ToolResult {
+                        internal_call_id, ..
+                    },
+                ) => {
+                    events.push("tool-result");
+                    internal_call_ids.push(internal_call_id);
+                }
+                rig_agent::agent::MultiTurnStreamItem::FinalResponse(response) => {
+                    final_response = Some(response)
+                }
+                _ => {}
+            }
+        }
+        (
+            final_response.expect("stream final response"),
+            lifecycle.entries(),
+            calls.load(Ordering::SeqCst),
+            beta_script.requests(),
+            selected.lock().expect("selection lock").clone(),
+            events,
+            internal_call_ids,
+        )
+    }
+
+    let (blocking, blocking_hooks, blocking_tool_calls, blocking_beta, blocking_selected) =
+        run_blocking().await;
+    let (
+        streaming,
+        streaming_hooks,
+        streaming_tool_calls,
+        streaming_beta,
+        streaming_selected,
+        stream_events,
+        stream_internal_call_ids,
+    ) = run_streaming().await;
+
+    assert_eq!(blocking.output, "synthesized answer");
+    assert_eq!(blocking.output, streaming.output);
+    assert_eq!(blocking.usage, usage(8));
+    assert_eq!(blocking.usage, streaming.usage);
+    assert_eq!(blocking.messages, streaming.messages);
+    assert_eq!(blocking_hooks, streaming_hooks);
+    assert_eq!(blocking_tool_calls, 1);
+    assert_eq!(streaming_tool_calls, 1);
+    assert_eq!(blocking_selected, vec!["1", "2"]);
+    assert_eq!(streaming_selected, vec![1, 2]);
+    assert!(blocking_beta.first().is_some_and(history_has_tool_result));
+    assert!(streaming_beta.first().is_some_and(history_has_tool_result));
+    assert_eq!(
+        stream_events,
+        vec![
+            "tool-delta",
+            "tool-delta",
+            "tool-call",
+            "tool-commit",
+            "tool-result"
+        ]
+    );
+    assert_eq!(
+        stream_internal_call_ids,
+        vec!["lookup-call-internal"; 5],
+        "deltas, the completed call, execution, and result retain one correlation id"
+    );
+}
+
+#[derive(Clone)]
+struct RetryFirst(Arc<AtomicUsize>);
+
+impl AgentHook for RetryFirst {
+    async fn on_model_turn_finished(
+        &self,
+        _context: &HookContext,
+        _event: ModelTurnFinished<'_>,
+    ) -> ModelTurnAction {
+        if self.0.fetch_add(1, Ordering::SeqCst) == 0 {
+            ModelTurnAction::repeat()
+        } else {
+            ModelTurnAction::continue_run()
+        }
+    }
+}
+
+#[tokio::test]
+async fn retries_reenter_selection_without_leaking_rejected_turn_state() {
+    let alpha = alpha_static("rejected draft");
+    let beta = beta_static("accepted answer");
+    let alpha_handle = ModelHandle::named("alpha", alpha);
+    let beta_script = beta.0.clone();
+    let beta_handle = ModelHandle::named("beta", beta);
+    let selections = Arc::new(Mutex::new(Vec::new()));
+    let selections_for_router = selections.clone();
+
+    let response = AgentBuilder::from_model_handle(alpha_handle.clone())
+        .add_hook(RetryFirst(Arc::new(AtomicUsize::new(0))))
+        .build()
+        .prompt("try twice")
+        .max_turns(2)
+        .select_model(move |context| {
+            selections_for_router.lock().expect("selection lock").push((
+                context.turn,
+                context
+                    .previous_model
+                    .and_then(ModelHandle::label)
+                    .map(str::to_owned),
+            ));
+            if context.turn == 1 {
+                alpha_handle.clone()
+            } else {
+                beta_handle.clone()
+            }
+        })
+        .extended_details()
+        .await
+        .expect("retry routed run");
+
+    assert_eq!(response.output, "accepted answer");
+    assert_eq!(
+        selections.lock().expect("selection lock").as_slice(),
+        &[(1, None), (2, Some("alpha".to_owned()))]
+    );
+    let beta_request = beta_script
+        .requests()
+        .into_iter()
+        .next()
+        .expect("beta request");
+    assert!(!beta_request.chat_history.iter().any(|message| {
+        matches!(
+            message,
+            Message::Assistant { content, .. }
+                if content.iter().any(|item| matches!(
+                    item,
+                    AssistantContent::Text(text) if text.text == "rejected draft"
+                ))
+        )
+    }));
+}
+
+#[derive(Clone)]
+struct RetryInvalidTool;
+
+impl AgentHook for RetryInvalidTool {
+    async fn on_invalid_tool_call(
+        &self,
+        _context: &HookContext,
+        _event: &rig_agent::agent::InvalidToolCallContext,
+    ) -> Option<InvalidToolCallAction> {
+        Some(InvalidToolCallAction::retry(
+            "answer directly instead of calling that tool",
+        ))
+    }
+}
+
+#[tokio::test]
+async fn invalid_tool_retry_reenters_selection_exactly_once() {
+    let invalid = Turn::tool("missing_tool", 2, "invalid-tool-message");
+    let alpha = AlphaModel(Script::new("alpha", [invalid.clone()], invalid));
+    let beta = beta_static("recovered after invalid tool");
+    let alpha_handle = ModelHandle::named("alpha", alpha);
+    let beta_handle = ModelHandle::named("beta", beta);
+    let selections = Arc::new(Mutex::new(Vec::new()));
+    let selections_for_router = selections.clone();
+
+    let output = AgentBuilder::from_model_handle(alpha_handle.clone())
+        .add_hook(RetryInvalidTool)
+        .build()
+        .prompt("recover from an invalid tool")
+        .max_turns(2)
+        .max_invalid_tool_call_retries(1)
+        .select_model(move |context| {
+            selections_for_router
+                .lock()
+                .expect("selection lock")
+                .push(context.turn);
+            if context.turn == 1 {
+                alpha_handle.clone()
+            } else {
+                beta_handle.clone()
+            }
+        })
+        .await
+        .expect("invalid-tool retry run");
+
+    assert_eq!(output, "recovered after invalid tool");
+    assert_eq!(
+        selections.lock().expect("selection lock").as_slice(),
+        &[1, 2]
+    );
+}
+
+#[tokio::test]
+async fn normalized_stream_preserves_events_message_id_usage_and_raw_json() {
+    let rich = Turn::rich("final text", 13, "rich-message-id");
+    let alpha = AlphaModel(Script::new("alpha", [rich.clone()], rich));
+    let agent = AgentBuilder::new(alpha).build();
+    let mut stream = agent.stream_prompt("rich stream").await;
+    let mut saw_reasoning = false;
+    let mut saw_reasoning_delta = false;
+    let mut saw_unknown = false;
+    let mut provider_final: Option<AgentStreamFinal> = None;
+    let mut final_response = None;
+
+    while let Some(item) = stream.next().await {
+        match item.expect("normalized stream item") {
+            rig_agent::agent::MultiTurnStreamItem::StreamAssistantItem(
+                StreamedAssistantContent::Reasoning(_),
+            ) => saw_reasoning = true,
+            rig_agent::agent::MultiTurnStreamItem::StreamAssistantItem(
+                StreamedAssistantContent::ReasoningDelta { .. },
+            ) => saw_reasoning_delta = true,
+            rig_agent::agent::MultiTurnStreamItem::StreamAssistantItem(
+                StreamedAssistantContent::Unknown(value),
+            ) => {
+                saw_unknown = value["type"] == "provider_native_event";
+            }
+            rig_agent::agent::MultiTurnStreamItem::StreamAssistantItem(
+                StreamedAssistantContent::Final(final_),
+            ) => provider_final = Some(final_),
+            rig_agent::agent::MultiTurnStreamItem::FinalResponse(response) => {
+                final_response = Some(response)
+            }
+            _ => {}
+        }
+    }
+
+    assert!(saw_reasoning);
+    assert!(saw_reasoning_delta);
+    assert!(saw_unknown);
+    let provider_final = provider_final.expect("normalized provider final");
+    assert_eq!(provider_final.usage, usage(13));
+    assert_eq!(provider_final.raw_response["provider"], "alpha");
+    assert_eq!(provider_final.raw_response["usage"]["total_tokens"], 13);
+    let final_response = final_response.expect("agent final response");
+    assert_eq!(final_response.output, "final text");
+    assert_eq!(final_response.usage, usage(13));
+    assert!(final_response.messages.is_some_and(|messages| {
+        messages.iter().any(|message| {
+            matches!(message, Message::Assistant { id: Some(id), .. } if id == "rich-message-id")
+        })
+    }));
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SerializationFails;
+
+impl Serialize for SerializationFails {
+    fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Err(serde::ser::Error::custom(
+            "intentional raw response failure",
+        ))
+    }
+}
+
+impl GetTokenUsage for SerializationFails {
+    fn token_usage(&self) -> Usage {
+        usage(1)
+    }
+}
+
+#[derive(Clone)]
+struct SerializationFailingModel;
+
+impl CompletionModel for SerializationFailingModel {
+    type Response = AlphaRaw;
+    type StreamingResponse = SerializationFails;
+    type Client = ();
+
+    fn make(_client: &Self::Client, _model: impl Into<String>) -> Self {
+        Self
+    }
+
+    async fn completion(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        Ok(CompletionResponse {
+            choice: OneOrMany::one(AssistantContent::text("unused")),
+            usage: usage(1),
+            raw_response: AlphaRaw::new("bad", usage(1)),
+            message_id: None,
+        })
+    }
+
+    async fn stream(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        Ok(StreamingCompletionResponse::stream(Box::pin(stream::iter(
+            [Ok(RawStreamingChoice::FinalResponse(SerializationFails))],
+        ))))
+    }
+}
+
+#[tokio::test]
+async fn provider_final_serialization_failure_is_a_structured_stream_error() {
+    let agent = AgentBuilder::new(SerializationFailingModel).build();
+    let mut stream = agent.stream_prompt("serialize").await;
+    let error = stream
+        .next()
+        .await
+        .expect("stream error item")
+        .expect_err("serialization must fail");
+    assert!(matches!(
+        error,
+        StreamingError::Completion(CompletionError::JsonError(_))
+    ));
+}
+
+#[tokio::test]
+async fn selected_model_capability_is_used_for_each_prepared_attempt() {
+    let composing_turn = Turn::text("retry me", 1, "compose-message");
+    let composing = BetaModel(Script::composing(
+        "composing",
+        [composing_turn.clone()],
+        composing_turn,
+    ));
+    let composing_script = composing.0.clone();
+    let noncomposing_turn = Turn::text("accepted", 1, "noncompose-message");
+    let noncomposing = AlphaModel(Script::new(
+        "noncomposing",
+        [noncomposing_turn.clone()],
+        noncomposing_turn,
+    ));
+    let noncomposing_script = noncomposing.0.clone();
+    let composing_handle = ModelHandle::new(composing);
+    let noncomposing_handle = ModelHandle::new(noncomposing);
+
+    let _response = AgentBuilder::from_model_handle(composing_handle.clone())
+        .output_schema::<ExtractedValue>()
+        .output_mode(rig_agent::agent::OutputMode::Auto)
+        .tool(LookupTool {
+            calls: Arc::new(AtomicUsize::new(0)),
+        })
+        .add_hook(RetryFirst(Arc::new(AtomicUsize::new(0))))
+        .build()
+        .prompt("capability routing")
+        .max_turns(2)
+        .select_model(move |context| {
+            if context.turn == 1 {
+                composing_handle.clone()
+            } else {
+                noncomposing_handle.clone()
+            }
+        })
+        .await
+        .expect("capability run");
+
+    let composing_request = composing_script
+        .requests()
+        .into_iter()
+        .next()
+        .expect("composing request");
+    assert!(composing_request.output_schema.is_some());
+    assert!(
+        !composing_request
+            .tools
+            .iter()
+            .any(|tool| tool.name.starts_with("final_result"))
+    );
+
+    let noncomposing_request = noncomposing_script
+        .requests()
+        .into_iter()
+        .next()
+        .expect("noncomposing request");
+    assert!(noncomposing_request.output_schema.is_none());
+    assert!(
+        noncomposing_request
+            .tools
+            .iter()
+            .any(|tool| tool.name.starts_with("final_result"))
+    );
+}
+
+#[derive(Clone)]
+struct GatedToolModel {
+    started: Arc<Notify>,
+    release: Arc<Notify>,
+}
+
+impl CompletionModel for GatedToolModel {
+    type Response = AlphaRaw;
+    type StreamingResponse = AlphaRaw;
+    type Client = ();
+
+    fn make(_client: &Self::Client, _model: impl Into<String>) -> Self {
+        Self {
+            started: Arc::new(Notify::new()),
+            release: Arc::new(Notify::new()),
+        }
+    }
+
+    async fn completion(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        self.started.notify_one();
+        self.release.notified().await;
+        let turn = Turn::tool("lookup", 3, "gated-tool-message");
+        Ok(CompletionResponse {
+            choice: turn.choice(),
+            usage: turn.usage(),
+            raw_response: AlphaRaw::new("gated", turn.usage()),
+            message_id: Some(turn.message_id()),
+        })
+    }
+
+    async fn stream(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        Ok(StreamingCompletionResponse::stream(Box::pin(stream::iter(
+            [
+                Ok(RawStreamingChoice::Message("unused".to_owned())),
+                Ok(RawStreamingChoice::FinalResponse(AlphaRaw::new(
+                    "gated",
+                    usage(1),
+                ))),
+            ],
+        ))))
+    }
+}
+
+#[tokio::test]
+async fn routing_changes_cannot_rebind_an_in_flight_attempt_but_affect_the_next_call() {
+    let gated = GatedToolModel {
+        started: Arc::new(Notify::new()),
+        release: Arc::new(Notify::new()),
+    };
+    let started = gated.started.clone();
+    let release = gated.release.clone();
+    let gated_handle = ModelHandle::named("gated", gated);
+    let beta_handle = ModelHandle::named("beta", beta_static("after tool"));
+    let use_beta = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let use_beta_for_router = use_beta.clone();
+    let tool_calls = Arc::new(AtomicUsize::new(0));
+
+    let agent = AgentBuilder::from_model_handle(gated_handle.clone())
+        .tool(LookupTool {
+            calls: tool_calls.clone(),
+        })
+        .build();
+    let task = tokio::spawn(async move {
+        agent
+            .prompt("bind the attempt")
+            .max_turns(2)
+            .select_model(move |_| {
+                if use_beta_for_router.load(Ordering::SeqCst) {
+                    beta_handle.clone()
+                } else {
+                    gated_handle.clone()
+                }
+            })
+            .await
+    });
+
+    wait_for_notification(&started).await;
+    use_beta.store(true, Ordering::SeqCst);
+    release.notify_one();
+
+    assert_eq!(
+        task.await
+            .expect("routing task join")
+            .expect("routing task result"),
+        "after tool"
+    );
+    assert_eq!(tool_calls.load(Ordering::SeqCst), 1);
+}
+
+struct DropGuard(Arc<AtomicUsize>);
+
+impl Drop for DropGuard {
+    fn drop(&mut self) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[derive(Clone)]
+struct PendingUnaryModel {
+    started: Arc<Notify>,
+    dropped: Arc<AtomicUsize>,
+}
+
+impl CompletionModel for PendingUnaryModel {
+    type Response = AlphaRaw;
+    type StreamingResponse = AlphaRaw;
+    type Client = ();
+
+    fn make(_client: &Self::Client, _model: impl Into<String>) -> Self {
+        Self {
+            started: Arc::new(Notify::new()),
+            dropped: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    async fn completion(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        let _guard = DropGuard(self.dropped.clone());
+        self.started.notify_one();
+        std::future::pending::<Result<CompletionResponse<AlphaRaw>, CompletionError>>().await
+    }
+
+    async fn stream(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        Ok(StreamingCompletionResponse::stream(Box::pin(
+            stream::empty(),
+        )))
+    }
+}
+
+struct PendingRawStream {
+    started: Arc<Notify>,
+    dropped: Arc<AtomicUsize>,
+    notified: bool,
+}
+
+impl Stream for PendingRawStream {
+    type Item = Result<RawStreamingChoice<AlphaRaw>, CompletionError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if !self.notified {
+            self.notified = true;
+            self.started.notify_one();
+        }
+        Poll::Pending
+    }
+}
+
+impl Drop for PendingRawStream {
+    fn drop(&mut self) {
+        self.dropped.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[derive(Clone)]
+struct PendingStreamingModel {
+    started: Arc<Notify>,
+    dropped: Arc<AtomicUsize>,
+}
+
+impl CompletionModel for PendingStreamingModel {
+    type Response = AlphaRaw;
+    type StreamingResponse = AlphaRaw;
+    type Client = ();
+
+    fn make(_client: &Self::Client, _model: impl Into<String>) -> Self {
+        Self {
+            started: Arc::new(Notify::new()),
+            dropped: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    async fn completion(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        Ok(CompletionResponse {
+            choice: OneOrMany::one(AssistantContent::text("unused")),
+            usage: Usage::new(),
+            raw_response: AlphaRaw::new("pending", Usage::new()),
+            message_id: None,
+        })
+    }
+
+    async fn stream(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        let raw: rig_agent::streaming::StreamingResult<AlphaRaw> = Box::pin(PendingRawStream {
+            started: self.started.clone(),
+            dropped: self.dropped.clone(),
+            notified: false,
+        });
+        Ok(StreamingCompletionResponse::stream(raw))
+    }
+}
+
+#[tokio::test]
+async fn dropping_pending_unary_and_streaming_attempts_cancels_by_drop() {
+    let unary_started = Arc::new(Notify::new());
+    let unary_dropped = Arc::new(AtomicUsize::new(0));
+    let unary_agent = AgentBuilder::new(PendingUnaryModel {
+        started: unary_started.clone(),
+        dropped: unary_dropped.clone(),
+    })
+    .build();
+    let unary_task = tokio::spawn(async move { unary_agent.prompt("pending unary").await });
+    wait_for_notification(&unary_started).await;
+    unary_task.abort();
+    let _join_error = unary_task.await.expect_err("unary task was aborted");
+    assert_eq!(unary_dropped.load(Ordering::SeqCst), 1);
+
+    let stream_started = Arc::new(Notify::new());
+    let stream_dropped = Arc::new(AtomicUsize::new(0));
+    let stream_agent = AgentBuilder::new(PendingStreamingModel {
+        started: stream_started.clone(),
+        dropped: stream_dropped.clone(),
+    })
+    .build();
+    let pending_stream = stream_agent.stream_prompt("pending stream").await;
+    let stream_task = tokio::spawn(async move {
+        let mut pending_stream = pending_stream;
+        pending_stream.next().await
+    });
+    wait_for_notification(&stream_started).await;
+    stream_task.abort();
+    let _join_error = stream_task.await.expect_err("stream task was aborted");
+    assert_eq!(stream_dropped.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn concurrent_runs_and_handle_calls_are_independent() {
+    let alpha_handle = ModelHandle::named("alpha", alpha_static("alpha concurrent"));
+    let beta_handle = ModelHandle::named("beta", beta_static("beta concurrent"));
+    let agent = AgentBuilder::from_model_handle(alpha_handle.clone()).build();
+
+    let alpha_run = agent
+        .prompt("alpha run")
+        .select_model(move |_| alpha_handle.clone());
+    let beta_run = agent
+        .prompt("beta run")
+        .select_model(move |_| beta_handle.clone());
+    let (alpha, beta) = tokio::join!(alpha_run, beta_run);
+    assert_eq!(alpha.expect("alpha concurrent run"), "alpha concurrent");
+    assert_eq!(beta.expect("beta concurrent run"), "beta concurrent");
+
+    let shared = ModelHandle::new(alpha_static("shared handle"));
+    let first = agent.prompt("first shared").using_model(shared.clone());
+    let second = agent.prompt("second shared").using_model(shared);
+    let (first, second) = tokio::join!(first, second);
+    assert_eq!(first.expect("first shared call"), "shared handle");
+    assert_eq!(second.expect("second shared call"), "shared handle");
+}

--- a/crates/rig-bedrock/examples/agent_with_bedrock.rs
+++ b/crates/rig-bedrock/examples/agent_with_bedrock.rs
@@ -33,8 +33,7 @@ fn client() -> Result<Client, anyhow::Error> {
     Ok(Client::from_env()?)
 }
 
-fn partial_agent() -> Result<AgentBuilder<rig_bedrock::completion::CompletionModel>, anyhow::Error>
-{
+fn partial_agent() -> Result<AgentBuilder, anyhow::Error> {
     Ok(client()?.agent(AMAZON_NOVA_LITE))
 }
 

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- Add model-independent `CompletionRequestBuilder::without_model` construction
+  for runtimes that bind a selected model only after request preparation.
+
 ## [0.41.0](https://github.com/0xPlaygrounds/rig/compare/rig-core-v0.40.0...rig-core-v0.41.0) - 2026-07-28
 
 ### Added

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -491,6 +491,14 @@ impl CompletionRequest {
         chat_history
     }
 
+    /// Returns the exact normalized input messages used by runtime telemetry.
+    ///
+    /// This includes documents at the same canonical insertion point used by
+    /// providers. It does not expose or transform provider-specific parameters.
+    pub fn messages_for_telemetry(&self) -> Vec<Message> {
+        self.chat_history_with_documents()
+    }
+
     /// Adds a provider-hosted tool by storing it in `additional_params.tools`.
     pub fn with_provider_tool(mut self, tool: ProviderToolDefinition) -> Self {
         self.additional_params =
@@ -591,7 +599,7 @@ fn merge_provider_tools_into_additional_params(
 ///
 /// Note: It is usually unnecessary to create a completion request builder directly.
 /// Instead, use the [CompletionModel::completion_request] method.
-pub struct CompletionRequestBuilder<M: CompletionModel> {
+pub struct CompletionRequestBuilder<M> {
     model: M,
     prompt: Message,
     request_model: Option<String>,
@@ -608,7 +616,7 @@ pub struct CompletionRequestBuilder<M: CompletionModel> {
     record_telemetry_content: bool,
 }
 
-impl<M: CompletionModel> CompletionRequestBuilder<M> {
+impl<M> CompletionRequestBuilder<M> {
     pub fn new(model: M, prompt: impl Into<Message>) -> Self {
         Self {
             model,
@@ -857,7 +865,10 @@ impl<M: CompletionModel> CompletionRequestBuilder<M> {
     }
 
     /// Sends the completion request to the completion model provider and returns the completion response.
-    pub async fn send(self) -> Result<CompletionResponse<M::Response>, CompletionError> {
+    pub async fn send(self) -> Result<CompletionResponse<M::Response>, CompletionError>
+    where
+        M: CompletionModel,
+    {
         let model = self.model.clone();
         model.completion(self.build()).await
     }
@@ -867,11 +878,23 @@ impl<M: CompletionModel> CompletionRequestBuilder<M> {
         self,
     ) -> Result<StreamingCompletionResponse<M::StreamingResponse>, CompletionError>
     where
+        M: CompletionModel,
         <M as CompletionModel>::StreamingResponse: 'a,
         Self: 'a,
     {
         let model = self.model.clone();
         model.stream(self.build()).await
+    }
+}
+
+impl CompletionRequestBuilder<()> {
+    /// Creates a model-independent request builder.
+    ///
+    /// This is used by runtimes that select a model only after entering a
+    /// concrete orchestration boundary. The built [`CompletionRequest`] can be
+    /// executed by any compatible [`CompletionModel`].
+    pub fn without_model(prompt: impl Into<Message>) -> Self {
+        Self::new((), prompt)
     }
 }
 

--- a/examples/agent_autonomous/src/main.rs
+++ b/examples/agent_autonomous/src/main.rs
@@ -18,9 +18,7 @@ struct Counter {
 const TARGET_NUMBER: u32 = 2000;
 const STEP_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
 
-fn build_counter_extractor(
-    client: &Client,
-) -> rig::extractor::Extractor<openai::responses_api::ResponsesCompletionModel, Counter> {
+fn build_counter_extractor(client: &Client) -> rig::extractor::Extractor<Counter> {
     client
         .extractor::<Counter>(openai::GPT_4)
         .preamble(

--- a/examples/agent_prompt_chaining/src/main.rs
+++ b/examples/agent_prompt_chaining/src/main.rs
@@ -14,15 +14,11 @@ const RNG_PREAMBLE: &str =
 const ADDER_PREAMBLE: &str =
     "Add 1000 to the number you receive, unless it is 0. Return only the final number.";
 
-fn build_rng_agent(
-    client: &Client,
-) -> rig::agent::Agent<openai::responses_api::ResponsesCompletionModel> {
+fn build_rng_agent(client: &Client) -> rig::agent::Agent {
     client.agent(openai::GPT_4).preamble(RNG_PREAMBLE).build()
 }
 
-fn build_adder_agent(
-    client: &Client,
-) -> rig::agent::Agent<openai::responses_api::ResponsesCompletionModel> {
+fn build_adder_agent(client: &Client) -> rig::agent::Agent {
     client.agent(openai::GPT_4).preamble(ADDER_PREAMBLE).build()
 }
 

--- a/examples/agent_routing/src/main.rs
+++ b/examples/agent_routing/src/main.rs
@@ -14,18 +14,14 @@ const ROUTER_PREAMBLE: &str = "
     Return only the category.
 ";
 
-fn build_router_agent(
-    client: &Client,
-) -> rig::agent::Agent<openai::responses_api::ResponsesCompletionModel> {
+fn build_router_agent(client: &Client) -> rig::agent::Agent {
     client
         .agent(openai::GPT_4)
         .preamble(ROUTER_PREAMBLE)
         .build()
 }
 
-fn build_response_agent(
-    client: &Client,
-) -> rig::agent::Agent<openai::responses_api::ResponsesCompletionModel> {
+fn build_response_agent(client: &Client) -> rig::agent::Agent {
     client.agent(openai::GPT_4).build()
 }
 

--- a/examples/agent_stream_chat/src/main.rs
+++ b/examples/agent_stream_chat/src/main.rs
@@ -10,7 +10,7 @@ use rig::providers::openai;
 const PREAMBLE: &str = "You are a comedian here to entertain the user using humour and jokes.";
 const PROMPT: &str = "Entertain me!";
 
-async fn collect_stream_final_response<R>(stream: &mut StreamingResult<R>) -> Result<String> {
+async fn collect_stream_final_response(stream: &mut StreamingResult) -> Result<String> {
     let mut final_response = None;
 
     while let Some(item) = stream.next().await {

--- a/examples/agent_with_memory_streaming/src/main.rs
+++ b/examples/agent_with_memory_streaming/src/main.rs
@@ -13,7 +13,7 @@ use rig::prelude::*;
 use rig::providers::openai;
 use rig::streaming::StreamingPrompt;
 
-async fn collect_final<R>(stream: &mut StreamingResult<R>) -> Result<String> {
+async fn collect_final(stream: &mut StreamingResult) -> Result<String> {
     let mut final_response = None;
     while let Some(item) = stream.next().await {
         if let MultiTurnStreamItem::FinalResponse(response) = item? {

--- a/examples/candle_wasm_chat/src/lib.rs
+++ b/examples/candle_wasm_chat/src/lib.rs
@@ -34,7 +34,7 @@ const MAX_HISTORY_MESSAGES: usize = 12;
 const MAX_HISTORY_JSON_BYTES: usize = 2048;
 
 struct ChatState {
-    agent: Agent<CandleModel>,
+    agent: Agent,
     history: Vec<Message>,
 }
 

--- a/examples/chain/src/main.rs
+++ b/examples/chain/src/main.rs
@@ -22,9 +22,7 @@ fn sample_definitions() -> [&'static str; 3] {
     ]
 }
 
-fn build_dictionary_agent(
-    client: &Client,
-) -> rig::agent::Agent<openai::responses_api::ResponsesCompletionModel> {
+fn build_dictionary_agent(client: &Client) -> rig::agent::Agent {
     client
         .agent(openai::GPT_4)
         .preamble(

--- a/examples/debate/src/main.rs
+++ b/examples/debate/src/main.rs
@@ -8,8 +8,8 @@ use rig::{
 };
 
 struct Debater {
-    gpt_4: Agent<openai::responses_api::ResponsesCompletionModel>,
-    coral: Agent<cohere::CompletionModel>,
+    gpt_4: Agent,
+    coral: Agent,
 }
 
 impl Debater {

--- a/examples/enum_dispatch/src/main.rs
+++ b/examples/enum_dispatch/src/main.rs
@@ -9,8 +9,8 @@ use rig::providers::openai::GPT_4O;
 use rig::providers::{anthropic, openai};
 
 enum Agents {
-    Anthropic(Agent<anthropic::completion::CompletionModel>),
-    OpenAI(Agent<openai::completion::CompletionModel>),
+    Anthropic(Agent),
+    OpenAI(Agent),
 }
 
 impl Agents {

--- a/examples/gemini_default_api_recovery/src/main.rs
+++ b/examples/gemini_default_api_recovery/src/main.rs
@@ -225,7 +225,7 @@ fn gemini_canary_additional_params() -> Result<serde_json::Value, serde_json::Er
 }
 
 async fn consume_workspace_like_stream(
-    mut stream: StreamingResult<gemini::streaming::StreamingCompletionResponse>,
+    mut stream: StreamingResult,
 ) -> Result<WorkspaceStreamObservation, String> {
     let mut observation = WorkspaceStreamObservation::default();
 

--- a/examples/multi_agent/src/main.rs
+++ b/examples/multi_agent/src/main.rs
@@ -4,7 +4,7 @@ use rig::prelude::*;
 use rig::providers::openai;
 use rig::{
     agent::{Agent, AgentBuilder},
-    completion::{Chat, CompletionModel, Message},
+    completion::{Chat, Message},
     providers::openai::Client as OpenAIClient,
     tool::Tool,
 };
@@ -13,7 +13,7 @@ use serde_json::json;
 
 // Define a wrapper around an agent so that it can be provided to another agent
 // as a tool
-struct TranslatorTool<M: CompletionModel>(Agent<M>);
+struct TranslatorTool(Agent);
 
 const TRANSLATOR_TOOL_NAME: &str = "translator";
 
@@ -23,7 +23,7 @@ struct TranslatorArgs {
     prompt: String,
 }
 
-impl<M: CompletionModel + 'static> Tool for TranslatorTool<M> {
+impl Tool for TranslatorTool {
     const NAME: &'static str = TRANSLATOR_TOOL_NAME;
 
     type Error = PromptError;

--- a/examples/reasoning_loop/src/main.rs
+++ b/examples/reasoning_loop/src/main.rs
@@ -1,7 +1,7 @@
 use rig::prelude::*;
 use rig::{
     agent::Agent,
-    completion::{CompletionError, CompletionModel, Prompt, PromptError},
+    completion::{CompletionError, Prompt, PromptError},
     extractor::Extractor,
     message::Message,
     providers::anthropic,
@@ -21,12 +21,12 @@ struct ChainOfThoughtSteps {
     steps: Vec<String>,
 }
 
-struct ReasoningAgent<M: CompletionModel> {
-    chain_of_thought_extractor: Extractor<M, ChainOfThoughtSteps>,
-    executor: Agent<M>,
+struct ReasoningAgent {
+    chain_of_thought_extractor: Extractor<ChainOfThoughtSteps>,
+    executor: Agent,
 }
 
-impl<M: CompletionModel + 'static> Prompt for ReasoningAgent<M> {
+impl Prompt for ReasoningAgent {
     #[allow(refining_impl_trait)]
     async fn prompt(&self, prompt: impl Into<Message> + Send) -> Result<String, PromptError> {
         let prompt: Message = prompt.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,8 @@ pub use rig_core::*;
 #[cfg(feature = "agent")]
 #[cfg_attr(docsrs, doc(cfg(feature = "agent")))]
 pub use rig_agent::{
-    Agent, AgentBuilder, AgentRun, AgentRunner, AgentStreamFinal, ExtractionResponse, ModelHandle,
-    ModelSelectionContext,
+    Agent, AgentBuilder, AgentHook, AgentRun, AgentRunner, AgentStreamFinal, ExtractionResponse,
+    HookContext, ModelHandle, ModelSelection, ModelSelectionAction,
 };
 
 /// Direct access to the portable provider and data contracts.
@@ -114,9 +114,10 @@ pub mod prelude {
     // pre-split `client.completion_model(m)` / `client.agent(m)` surface.
     #[cfg(feature = "agent")]
     pub use rig_agent::prelude::{
-        Agent, AgentClientExt, AgentModelExt, AgentStreamFinal, Chat, ModelHandle,
-        ModelSelectionContext, MultiTurnStreamItem, Prompt, PromptError, StreamingChat,
-        StreamingPrompt, StreamingResult, StructuredOutputError, ToolSet, TypedPrompt,
+        Agent, AgentClientExt, AgentHook, AgentModelExt, AgentStreamFinal, Chat, HookContext,
+        ModelHandle, ModelSelection, ModelSelectionAction, MultiTurnStreamItem, Prompt,
+        PromptError, StreamingChat, StreamingPrompt, StreamingResult, StructuredOutputError,
+        ToolSet, TypedPrompt,
     };
     pub use rig_core::prelude::*;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,10 @@ pub use rig_core::*;
 
 #[cfg(feature = "agent")]
 #[cfg_attr(docsrs, doc(cfg(feature = "agent")))]
-pub use rig_agent::{Agent, AgentBuilder, AgentRun, AgentRunner, ExtractionResponse};
+pub use rig_agent::{
+    Agent, AgentBuilder, AgentRun, AgentRunner, AgentStreamFinal, ExtractionResponse, ModelHandle,
+    ModelSelectionContext,
+};
 
 /// Direct access to the portable provider and data contracts.
 pub mod core {
@@ -111,9 +114,9 @@ pub mod prelude {
     // pre-split `client.completion_model(m)` / `client.agent(m)` surface.
     #[cfg(feature = "agent")]
     pub use rig_agent::prelude::{
-        Agent, AgentClientExt, AgentModelExt, Chat, MultiTurnStreamItem, Prompt, PromptError,
-        StreamingChat, StreamingPrompt, StreamingResult, StructuredOutputError, ToolSet,
-        TypedPrompt,
+        Agent, AgentClientExt, AgentModelExt, AgentStreamFinal, Chat, ModelHandle,
+        ModelSelectionContext, MultiTurnStreamItem, Prompt, PromptError, StreamingChat,
+        StreamingPrompt, StreamingResult, StructuredOutputError, ToolSet, TypedPrompt,
     };
     pub use rig_core::prelude::*;
 }

--- a/tests/common/reasoning.rs
+++ b/tests/common/reasoning.rs
@@ -423,8 +423,8 @@ fn record_reasoning(stats: &mut StreamStats, reasoning: &Reasoning, provider: &s
     );
 }
 
-pub(crate) async fn collect_stream_stats<R>(
-    stream: impl futures::Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>>,
+pub(crate) async fn collect_stream_stats(
+    stream: impl futures::Stream<Item = Result<MultiTurnStreamItem, StreamingError>>,
     provider: &str,
 ) -> StreamStats {
     let mut stats = StreamStats::new();

--- a/tests/common/support.rs
+++ b/tests/common/support.rs
@@ -3,7 +3,7 @@
 
 use futures::StreamExt;
 use rig::{
-    agent::{MultiTurnStreamItem, StreamingError, StreamingResult},
+    agent::{AgentStreamFinal, MultiTurnStreamItem, StreamingError, StreamingResult},
     completion::{AssistantContent, GetTokenUsage, ToolDefinition},
     embeddings::Embedding,
     streaming::{StreamedAssistantContent, StreamedUserContent, StreamingCompletionResponse},
@@ -477,8 +477,8 @@ pub(crate) fn assert_embeddings_nonempty_and_consistent(
     }
 }
 
-pub(crate) async fn collect_stream_final_response<R>(
-    stream: &mut StreamingResult<R>,
+pub(crate) async fn collect_stream_final_response(
+    stream: &mut StreamingResult,
 ) -> Result<String, StreamingError> {
     let mut final_response = None;
 
@@ -491,9 +491,9 @@ pub(crate) async fn collect_stream_final_response<R>(
     Ok(final_response.expect("stream should yield a final response"))
 }
 
-pub(crate) async fn collect_stream_final_response_and_provider_final<R>(
-    stream: &mut StreamingResult<R>,
-) -> Result<(String, R), StreamingError> {
+pub(crate) async fn collect_stream_final_response_and_provider_final(
+    stream: &mut StreamingResult,
+) -> Result<(String, AgentStreamFinal), StreamingError> {
     let mut final_response = None;
     let mut provider_final = None;
 
@@ -604,9 +604,7 @@ impl RawStreamObservation {
     }
 }
 
-pub(crate) async fn collect_stream_observation<R>(
-    stream: &mut StreamingResult<R>,
-) -> StreamObservation {
+pub(crate) async fn collect_stream_observation(stream: &mut StreamingResult) -> StreamObservation {
     let mut observation = StreamObservation::new();
 
     while let Some(item) = stream.next().await {

--- a/tests/core/reasoning_stream_stats.rs
+++ b/tests/core/reasoning_stream_stats.rs
@@ -25,7 +25,7 @@ async fn collect_stream_stats_tracks_only_final_turn_text() {
 
     let items = vec![
         Ok(MultiTurnStreamItem::StreamAssistantItem(
-            StreamedAssistantContent::<()>::text("Sure! Let me check the weather right away!"),
+            StreamedAssistantContent::text("Sure! Let me check the weather right away!"),
         )),
         Ok(MultiTurnStreamItem::StreamAssistantItem(
             StreamedAssistantContent::ToolCall {
@@ -37,7 +37,7 @@ async fn collect_stream_stats_tracks_only_final_turn_text() {
             StreamedUserContent::tool_result(tool_result, internal_call_id),
         )),
         Ok(MultiTurnStreamItem::StreamAssistantItem(
-            StreamedAssistantContent::<()>::text("It's 72F and sunny in Tokyo."),
+            StreamedAssistantContent::text("It's 72F and sunny in Tokyo."),
         )),
         Ok(MultiTurnStreamItem::final_response(
             OneOrMany::one(AssistantContent::text("It's 72F and sunny in Tokyo.")),

--- a/tests/providers/anthropic/cassette/streaming.rs
+++ b/tests/providers/anthropic/cassette/streaming.rs
@@ -1,6 +1,5 @@
 //! Anthropic streaming smoke test.
 
-use rig::completion::GetTokenUsage;
 use rig::prelude::*;
 use rig::providers::anthropic;
 use rig::streaming::StreamingPrompt;
@@ -20,13 +19,13 @@ async fn streaming_smoke() {
             .build();
 
         let mut stream = agent.stream_prompt(STREAMING_PROMPT).await;
-        let (response, provider_final): (_, anthropic::streaming::StreamingCompletionResponse) =
+        let (response, provider_final) =
             collect_stream_final_response_and_provider_final(&mut stream)
                 .await
                 .expect("streaming prompt should succeed");
 
         assert_nonempty_response(&response);
-        assert!(provider_final.token_usage().total_tokens > 0);
+        assert!(provider_final.usage.total_tokens > 0);
     })
     .await;
 }

--- a/tests/providers/anthropic/cassette/streaming_tools.rs
+++ b/tests/providers/anthropic/cassette/streaming_tools.rs
@@ -262,8 +262,8 @@ struct ConcurrentToolObservation {
     events: Vec<&'static str>,
 }
 
-async fn collect_concurrent_tool_observation<R>(
-    stream: &mut StreamingResult<R>,
+async fn collect_concurrent_tool_observation(
+    stream: &mut StreamingResult,
 ) -> ConcurrentToolObservation {
     let mut observation = ConcurrentToolObservation::default();
     let mut tool_names_by_id = HashMap::new();

--- a/tests/providers/gemini/cassette/streaming.rs
+++ b/tests/providers/gemini/cassette/streaming.rs
@@ -37,13 +37,13 @@ async fn streaming_smoke() {
             .build();
 
         let mut stream = agent.stream_prompt(STREAMING_PROMPT).await;
-        let (response, provider_final): (_, gemini::streaming::StreamingCompletionResponse) =
+        let (response, provider_final) =
             collect_stream_final_response_and_provider_final(&mut stream)
                 .await
                 .expect("streaming prompt should succeed");
 
         assert_nonempty_response(&response);
-        assert!(provider_final.token_usage().total_tokens > 0);
+        assert!(provider_final.usage.total_tokens > 0);
     })
     .await;
 }

--- a/tests/providers/openai/cassette/streaming.rs
+++ b/tests/providers/openai/cassette/streaming.rs
@@ -1,6 +1,5 @@
 //! OpenAI streaming coverage, including the migrated example path.
 
-use rig::completion::GetTokenUsage;
 use rig::prelude::*;
 use rig::providers::openai;
 use rig::streaming::StreamingPrompt;
@@ -20,15 +19,13 @@ async fn streaming_smoke() {
             .build();
 
         let mut stream = agent.stream_prompt(STREAMING_PROMPT).await;
-        let (response, provider_final): (
-            _,
-            openai::responses_api::streaming::StreamingCompletionResponse,
-        ) = collect_stream_final_response_and_provider_final(&mut stream)
-            .await
-            .expect("streaming prompt should succeed");
+        let (response, provider_final) =
+            collect_stream_final_response_and_provider_final(&mut stream)
+                .await
+                .expect("streaming prompt should succeed");
 
         assert_nonempty_response(&response);
-        assert!(provider_final.token_usage().total_tokens > 0);
+        assert!(provider_final.usage.total_tokens > 0);
     })
     .await;
 }


### PR DESCRIPTION
## Motivation

Rig's high-level agent types currently carry the concrete completion-model type through every runner, prompt, extractor, and stream. That prevents an application from changing models or providers while retaining the agent's tools, hooks, memory, instructions, context, and output configuration.

This PR makes model behavior a runtime value at the high-level agent boundary while preserving the existing open, typed provider contracts.

## Architecture

- Adds a public opaque, cloneable `ModelHandle` that erases any `CompletionModel` once into private unary, streaming, and capability callbacks.
- Makes `Agent`, `AgentRunner`, prompt/stream request handles, agent stream items, and extractor builders independent of the concrete model type. Useful output and typestate generics remain.
- Keeps `CompletionModel`, `CompletionClient`, provider transports, and direct low-level completion/stream APIs typed and externally implementable.
- Adds synchronous `AgentHook::on_model_select` routing with borrowed `ModelSelection` inputs and event-specific `ModelSelectionAction` results.
- Composes routing exclusively through the ordered `HookStack`: each hook sees the prior candidate, the last selection wins, and stop is terminal. Nested stacks preserve the same rules.
- Keeps one default `ModelHandle` on `AgentRunner`; agent replacement and one-run overrides change the initial candidate without suppressing routing hooks.
- Binds each provider-neutral prepared request to the exact final handle in `PreparedModelAttempt`, so capability inspection and execution cannot diverge.
- Normalizes only high-level provider-final stream events to `AgentStreamFinal { usage, raw_response }`; all other assistant events and correlation IDs pass through unchanged.

## Model-call lifecycle

The shared blocking/streaming driver resolves routing exactly once before each `AgentRunStep::CallModel`. This includes the initial call, post-tool calls, accepted-turn retries, invalid-tool recovery, and structured extraction repair attempts. Completion hooks and capability-sensitive request preparation run only after routing finishes.

Routing hooks run in registration order. `Continue` preserves the current candidate, `Select` replaces it for later hooks, and `Stop` cancels before completion hooks, request preparation, or provider execution. The final handle becomes `previous_model` for the next model-call boundary and is retained by the prepared attempt, so an in-flight unary future or stream cannot be rebound.

Hooks attached to an agent builder apply to later runners; request/runner hooks apply only to that run. Cloned runners own independent stack snapshots, while explicitly synchronized state captured by a hook follows that hook's clone semantics. Cancellation remains drop-based: no detached task consumes a future or provider stream after its caller is dropped.

`ModelHandle`, routing hooks, hook stacks, and actions are live runtime behavior and intentionally are not serializable. Applications should persist their own model identifier and resolve it to a handle at runtime. Provider-specific `additional_params` are not guaranteed to be portable across providers and retain existing validation behavior.

## User impact

Applications can keep one concrete `Agent`, store heterogeneous models in collections, replace defaults between runs, choose a specialist default for one prompt or extraction, or route from a fast research model to a stronger synthesis model after a tool result. The credential-free `runtime_model_routing` example demonstrates the two-model hook-driven tool round trip.

## Verification

Passed locally:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo test --workspace --all-features --doc`
- `cargo test -p rig-agent --all-features --lib agent::hook -- --nocapture` (37 passed)
- `cargo test -p rig-agent --test runtime_model_swapping -- --nocapture` (16 passed)
- `cargo run -p rig-agent --example runtime_model_routing`
- `RUSTDOCFLAGS="-D warnings" cargo doc --package rig-core --package rig-agent --package rig --no-deps --all-features`
- Standalone `wasm32-unknown-unknown` checks for `rig-core`, `rig-agent`, `rig`, `rig-candle`, and `candle_wasm_chat`
- The native-only `rmcp` WASM diagnostic check and Candle worker runtime tests
- Forbidden routing-API identifier search and `git diff --check`

A fresh independent review covered all 46 tracked files against merge base `6cfae6d829da21f9dc9e775e065fee157b264f7e` and found no P0/P1 or lower-severity issues. It separately validated hook composition, stop and retry behavior, attempt binding, cancellation/concurrency, exports, serialization boundaries, and browser-WASM bounds.

No cassette fixture changed. Cassette replay and safety/secret checks passed in the full workspace suite.

## Residual risk / unrelated limitation

The full workspace rustdoc command with warnings denied remains blocked by an existing `rig-neo4j` private intra-doc link at `crates/rig-neo4j/src/vector_index.rs:302`. The identical failure was reproduced on a detached `origin/main` worktree. Warning-denied documentation for the affected `rig-core`, `rig-agent`, and `rig` scope passes, so this PR intentionally leaves the unrelated warning unchanged.
