### PR TITLE
Normalize completion responses at the provider boundary

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,8 +1,9 @@
 # Migrating Rig
 
-This guide covers every breaking change from 0.30 through 0.41. Releases 0.36,
-0.37, 0.40 and 0.41 were the disruptive ones; 0.40 alone carried 31 breaking
-changes, and 0.37 renamed `rig-core`'s library target.
+This guide covers every breaking change from 0.30 through the unreleased changes
+after 0.41. Releases 0.36, 0.37, 0.40 and 0.41 were the disruptive ones; 0.40
+alone carried 31 breaking changes, and 0.37 renamed `rig-core`'s library
+target.
 
 ## Which sections apply to you
 
@@ -11,6 +12,7 @@ above it, in order. Each one is self-contained.
 
 | You are on | Start at |
 | --- | --- |
+| 0.41 | [0.41 → next](#041--next) |
 | 0.40 | [0.40 → 0.41](#040--041) |
 | 0.39 | [0.39 → 0.40](#039--040) |
 | 0.38 | [0.38 → 0.39](#038--039) |
@@ -271,6 +273,166 @@ They now key on `all(target_arch = "wasm32", target_os = "unknown")`. If you
 defined a `wasm` feature and expected it to drive these macros, you now get the
 target's answer instead. Gate on the target directly if you need the old
 association.
+
+---
+
+## 0.41 → next
+
+### Completion responses are concrete and normalized
+
+`CompletionResponse<T>` is now `CompletionResponse`. The provider-native
+`raw_response` field is gone; the normalized response carries the metadata that
+callers actually reached into `raw_response` for:
+
+```rust
+pub struct CompletionResponse {
+    pub choice: OneOrMany<AssistantContent>,
+    pub usage: Usage,
+    pub message_id: Option<String>,
+    pub finish_reason: Option<FinishReason>,
+    pub provider: String,
+    pub model: Option<String>,
+}
+```
+
+| Before | After |
+| --- | --- |
+| `response.raw_response.model` | `response.model` |
+| provider stop/finish reason off `raw_response` | `response.finish_reason` |
+| provider/message identity off `raw_response` | `response.provider`, `response.message_id` |
+| a genuinely provider-specific field | `model.raw_completion(request).await?` |
+
+`usage` is unchanged, including the rule that all-zero values mean the provider
+supplied no metrics. `model` is the identifier the *wire response* reported, not
+the one you requested — it is `None` when the provider omits it. `provider` is
+always populated, including on a response derived from a stream that ended
+before its terminal record.
+
+`CompletionResponse` is `#[non_exhaustive]`; build it with
+`CompletionResponse::new(choice, usage, provider)` plus the `with_*` helpers.
+Use `with_finish_reason` / `with_optional_finish_reason` rather than assigning
+the field: the setters apply `FinishReason::reconcile_with_output`, which
+upgrades a reported `Stop` to `ToolCalls` when the turn actually carried tool
+calls. Several OpenAI-compatible gateways report `stop` on a tool-calling turn,
+so code branching on `ToolCalls` would otherwise miss the call.
+
+### Provider-native responses moved to `raw_completion` / `raw_stream`
+
+Every built-in provider model exposes both:
+
+```rust
+let native = model.raw_completion(request).await?;   // the provider's own type
+let native_stream = model.raw_stream(request).await?; // RawStreamingResult<TheirTerminal>
+```
+
+These share one request builder, transport call, parser, telemetry path, and
+error-preservation path with the normalized methods — the normalized method
+calls the raw one and maps the result, so there is still exactly one network
+request.
+
+The trade: raw access now requires the concrete provider model rather than any
+`CompletionResponse`. Code that was generic over `CompletionModel` could never
+touch `raw_response` without a bound anyway, so in practice this affects code
+that had already committed to a provider.
+
+### Normalized finish reasons
+
+```rust
+pub enum FinishReason { Stop, Length, ToolCalls, ContentFilter, Other(String) }
+```
+
+Unrecognized provider values are preserved verbatim in `Other` — in the
+provider's own spelling, so Gemini's `RECITATION` stays `RECITATION`. A provider
+adding a new terminal reason surfaces it rather than reading as a natural stop.
+`None` means the provider genuinely reported no reason.
+
+### Ordinary streaming types no longer carry a response parameter
+
+`StreamingCompletionResponse<R>`, `StreamingResult<R>`,
+`StreamedAssistantContent<R>`, and the downstream agent streaming types are
+concrete. Their terminal record is `StreamFinal`, which carries normalized
+usage, finish reason, provider, provider-reported model, and message ID.
+
+`GetTokenUsage` is deleted — read `StreamFinal::usage` (or
+`StreamingCompletionResponse::usage()`) directly. A stream that ends without a
+terminal record still reports `Usage::new()`, the documented zero sentinel.
+
+`StreamingCompletionResponse::stream` takes the provider descriptor name first:
+
+```rust
+StreamingCompletionResponse::stream(PROVIDER_NAME, normalized_stream)
+```
+
+Provider implementations keep their native terminal type behind
+`RawStreamingResult<Native>` and map it once:
+
+```rust
+let raw = self.raw_stream(request).await?;
+let normalized = rig_core::streaming::normalize_stream(raw, |native| {
+    Ok(StreamFinal::new(PROVIDER_NAME, native.usage)
+        .with_optional_finish_reason(map_finish_reason(native.finish_reason)))
+});
+Ok(StreamingCompletionResponse::stream(PROVIDER_NAME, normalized))
+```
+
+`normalize_stream` applies the same `Stop` → `ToolCalls` reconciliation as the
+unary path, using the tool calls it actually saw on the stream.
+
+`StreamingPrompt<M, R>` and `StreamingChat<M, R>` lost their `R` parameter:
+`StreamingPrompt<M>`, `StreamingChat<M>`.
+
+### `CompletionModel` no longer owns response or construction types
+
+Remove `Response`, `StreamingResponse`, `Client`, and `make` from custom
+implementations. A custom model implements only the normalized operations, and
+optionally `capabilities`:
+
+```rust
+impl CompletionModel for MyModel {
+    async fn completion(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<CompletionResponse, CompletionError> { /* ... */ }
+
+    async fn stream(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse, CompletionError> { /* ... */ }
+}
+```
+
+Construction is a separate, optional opt-in. `CompletionClient::completion_model`
+is now required and calls your model's own constructor:
+
+```rust
+impl CompletionClient for MyClient {
+    type CompletionModel = MyModel;
+
+    fn completion_model(&self, model: impl Into<String>) -> MyModel {
+        MyModel::new(self.clone(), model.into())
+    }
+}
+```
+
+`client.completion_model(model)` and `client.agent(model)` are unchanged at call
+sites. A model type with no client at all is now expressible: implementing
+`CompletionModel` no longer drags in a client associated type.
+
+### Provider behavior is reported through capabilities
+
+`CompletionModel::composes_native_output_with_tools()` is replaced by
+`CompletionModel::capabilities()`:
+
+```rust
+fn capabilities(&self) -> ProviderCapabilities {
+    ProviderCapabilities::default().with_native_output_tool_composition(true)
+}
+```
+
+`ProviderCapabilities` is public and `#[non_exhaustive]`; start from `Default`
+or `ProviderCapabilities::new()` and enable what you support. Capabilities are
+plain data, so a runtime can snapshot them instead of holding a callback into
+the concrete model.
 
 ---
 

--- a/crates/rig-agent/CHANGELOG.md
+++ b/crates/rig-agent/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- *(completion)* [**breaking**] normalize completion responses at the provider boundary — `CompletionResponse` and `StreamingCompletionResponse` are concrete, carry normalized `finish_reason`/`provider`/`model`/`message_id`, and every provider model exposes typed `raw_completion`/`raw_stream` escape hatches
+- *(completion)* add public `ProviderCapabilities`, replacing `CompletionModel::composes_native_output_with_tools`
+
+### Removed
+
+- *(completion)* [**breaking**] remove `CompletionModel::{Response, StreamingResponse, Client, make}`; model construction moves to the required `CompletionClient::completion_model`
+- *(completion)* [**breaking**] remove the `GetTokenUsage` trait — read `StreamFinal::usage`
+- *(completion)* [**breaking**] remove `CompletionResponse::raw_response` — use a provider model's `raw_completion`/`raw_stream`
 ## [0.41.0](https://github.com/0xPlaygrounds/rig/compare/rig-agent-v0.0.0...rig-agent-v0.41.0) - 2026-07-28
 
 ### Added

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -5,8 +5,8 @@ use super::runner::AgentRunner;
 use crate::{
     agent::prompt_request::streaming::StreamingPromptRequest,
     completion::{
-        Chat, CompletionError, CompletionModel, CompletionRequestBuilder, Document, GetTokenUsage,
-        Message, Prompt, PromptError, ToolDefinition, TypedPrompt,
+        Chat, CompletionError, CompletionModel, CompletionRequestBuilder, Document, Message,
+        Prompt, PromptError, ToolDefinition, TypedPrompt,
     },
     json_utils,
     streaming::{StreamingChat, StreamingPrompt},
@@ -343,7 +343,7 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
             output_schema.is_some(),
             !executable_tool_names.is_empty(),
             tool_choice_permits_output_tool(tool_choice),
-            model.composes_native_output_with_tools(),
+            model.capabilities().composes_native_output_with_tools,
             output_mode,
         )
     };
@@ -691,10 +691,9 @@ where
     }
 }
 
-impl<M> StreamingPrompt<M, M::StreamingResponse> for Agent<M>
+impl<M> StreamingPrompt<M> for Agent<M>
 where
     M: CompletionModel + 'static,
-    M::StreamingResponse: GetTokenUsage,
 {
     fn stream_prompt(
         &self,
@@ -704,10 +703,9 @@ where
     }
 }
 
-impl<M> StreamingChat<M, M::StreamingResponse> for Agent<M>
+impl<M> StreamingChat<M> for Agent<M>
 where
     M: CompletionModel + 'static,
-    M::StreamingResponse: GetTokenUsage,
 {
     fn stream_chat<I, T>(
         &self,

--- a/crates/rig-agent/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-agent/src/agent/prompt_request/streaming.rs
@@ -20,7 +20,6 @@ use crate::{
         append_run_messages, build_chat_span, new_execute_tool_span, observe_action,
         resolve_completion_call, resolve_model_turn_action, run_single_tool,
     },
-    completion::GetTokenUsage,
     streaming::{StreamedAssistantContent, StreamedUserContent, ToolCallDeltaContent},
     tool::{ToolContext, server::ToolRegistrySnapshot},
 };
@@ -41,17 +40,16 @@ use rig_core::message::{Message, Text};
 // predicate, so keep the two in step: a bare `target_arch = "wasm32"` would
 // also drop `Send` on WASI, where `rig-core` still requires it.
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-pub type StreamingResult<R> =
-    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>> + Send>>;
+pub type StreamingResult =
+    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem, StreamingError>> + Send>>;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-pub type StreamingResult<R> =
-    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>>>>;
+pub type StreamingResult = Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem, StreamingError>>>>;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(tag = "type", rename_all = "camelCase")]
 #[non_exhaustive]
-pub enum MultiTurnStreamItem<R> {
+pub enum MultiTurnStreamItem {
     /// A streamed assistant content item — the content the **model emitted**:
     /// text/reasoning deltas, tool-call deltas, and, when the model turn is
     /// committed, the complete [`StreamedAssistantContent::ToolCall`] for each
@@ -67,7 +65,7 @@ pub enum MultiTurnStreamItem<R> {
     /// which finalizes the run directly — its structured result is surfaced in
     /// the [`FinalResponse`](Self::FinalResponse) rather than as a completed
     /// `ToolCall` item.
-    StreamAssistantItem(StreamedAssistantContent<R>),
+    StreamAssistantItem(StreamedAssistantContent),
     /// Confirmation that Rig **executed and committed** a tool call. This is not
     /// a real-time start notification: it is surfaced together with its
     /// `ToolResult` only after the whole batch settles successfully. Use tool
@@ -143,8 +141,8 @@ fn final_response_from_content(
     response
 }
 
-impl<R> MultiTurnStreamItem<R> {
-    pub(crate) fn stream_item(item: StreamedAssistantContent<R>) -> Self {
+impl MultiTurnStreamItem {
+    pub(crate) fn stream_item(item: StreamedAssistantContent) -> Self {
         Self::StreamAssistantItem(item)
     }
 
@@ -190,16 +188,13 @@ impl<R> MultiTurnStreamItem<R> {
 
 /// Drain a provider stream abandoned by invalid tool-call recovery so the
 /// reported usage for the recovered completion call is not lost.
-async fn drain_stream_usage<R>(
-    stream: &mut crate::streaming::StreamingCompletionResponse<R>,
-) -> Result<crate::completion::Usage, StreamingError>
-where
-    R: Clone + Unpin + GetTokenUsage,
-{
+async fn drain_stream_usage(
+    stream: &mut crate::streaming::StreamingCompletionResponse,
+) -> Result<crate::completion::Usage, StreamingError> {
     while let Some(content) = stream.next().await {
         match content {
             Ok(StreamedAssistantContent::Final(final_resp)) => {
-                return Ok(final_resp.token_usage());
+                return Ok(final_resp.usage);
             }
             Ok(_) => {}
             Err(err) => return Err(err.into()),
@@ -299,7 +294,6 @@ where
 impl<M> StreamingPromptRequest<M>
 where
     M: CompletionModel + 'static,
-    <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetTokenUsage,
 {
     /// Create a new `StreamingPromptRequest` from an agent, including its
     /// default hooks.
@@ -356,7 +350,7 @@ where
 
     forward_prompt_setters!(runner);
 
-    async fn send(self) -> StreamingResult<M::StreamingResponse> {
+    async fn send(self) -> StreamingResult {
         self.runner.stream().await
     }
 }
@@ -366,12 +360,12 @@ where
 /// per-step future leaking into the engine's own (`Send`) inference.
 // Same browser-wasm predicate as `StreamingResult` above, for the same reason.
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-pub(crate) type DriveStream<'a, R> =
-    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>> + Send + 'a>>;
+pub(crate) type DriveStream<'a> =
+    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem, StreamingError>> + Send + 'a>>;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-pub(crate) type DriveStream<'a, R> =
-    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>> + 'a>>;
+pub(crate) type DriveStream<'a> =
+    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem, StreamingError>> + 'a>>;
 
 /// One item emitted by the shared engine [`drive_agent`].
 ///
@@ -384,11 +378,11 @@ pub(crate) type DriveStream<'a, R> =
 // which the streaming path is specifically tuned to avoid. `Done` is yielded
 // once per run, so the wasted space on that rare variant is irrelevant.
 #[allow(clippy::large_enum_variant)]
-pub(crate) enum DriveItem<R> {
+pub(crate) enum DriveItem {
     /// An intermediate stream item (assistant delta, tool call/result, a
     /// per-call `CompletionCall`, or — last, for the streaming surface — the
     /// final response item).
-    Item(MultiTurnStreamItem<R>),
+    Item(MultiTurnStreamItem),
     /// The run finished; carries the canonical response the blocking fold
     /// returns. The streaming surface has already received the final item as the
     /// preceding `Item` and ignores this.
@@ -406,9 +400,6 @@ pub(crate) trait TurnSource<M>: WasmCompatSend
 where
     M: CompletionModel,
 {
-    /// The raw provider response carried on per-delta stream items.
-    type Raw: WasmCompatSend;
-
     /// Build this medium's per-turn `chat` span (name + parenting + any
     /// `follows_from` chaining differ between blocking and streaming).
     fn open_chat_span(
@@ -430,7 +421,7 @@ where
         chat_span: tracing::Span,
         agent_span: &'a tracing::Span,
         prompt: Message,
-    ) -> DriveStream<'a, Self::Raw>;
+    ) -> DriveStream<'a>;
 
     /// Execute a turn's tool calls, feeding the results into the machine and
     /// yielding any intermediate items.
@@ -441,7 +432,7 @@ where
         run: &'a mut AgentRun,
         calls: Vec<PendingToolCall>,
         tool_snapshot: Arc<ToolRegistrySnapshot>,
-    ) -> DriveStream<'a, Self::Raw>;
+    ) -> DriveStream<'a>;
 
     /// Record run-level telemetry onto the agent span at `Done`. Gated on
     /// `created_agent_span` so a caller-supplied outer span is never polluted.
@@ -454,7 +445,7 @@ where
 
     /// Build the final stream item surfaced at `Done`, or `None` when the
     /// surface discards it (the blocking fold) so the engine skips the work.
-    fn final_item(&self, response: &PromptResponse) -> Option<MultiTurnStreamItem<Self::Raw>>;
+    fn final_item(&self, response: &PromptResponse) -> Option<MultiTurnStreamItem>;
 }
 
 /// Convert a [`StreamingError`] back into a [`PromptError`] for the blocking
@@ -491,7 +482,7 @@ pub(crate) fn drive_agent<M, S>(
     created_agent_span: bool,
     memory_handle: Option<(Arc<dyn rig_core::memory::ConversationMemory>, String)>,
     is_streaming: bool,
-) -> impl Stream<Item = Result<DriveItem<S::Raw>, StreamingError>>
+) -> impl Stream<Item = Result<DriveItem, StreamingError>>
 where
     M: CompletionModel,
     S: TurnSource<M>,
@@ -695,7 +686,7 @@ where
 /// but the collect/commit and fail-fast behavior is identical, so `run()` and
 /// `stream()` return the same terminal reason. `chain_tool_span` lets the
 /// blocking surface chain spans into its linear `follows_from` sequence.
-pub(crate) fn drive_tool_calls<'a, M, R, F>(
+pub(crate) fn drive_tool_calls<'a, M, F>(
     runner: &'a AgentRunner<M>,
     hook_ctx: &'a HookContext,
     run: &'a mut AgentRun,
@@ -703,10 +694,9 @@ pub(crate) fn drive_tool_calls<'a, M, R, F>(
     tool_snapshot: Arc<ToolRegistrySnapshot>,
     chain_tool_span: F,
     forward_items: bool,
-) -> DriveStream<'a, R>
+) -> DriveStream<'a>
 where
     M: CompletionModel,
-    R: WasmCompatSend + 'a,
     F: Fn(tracing::Span) -> tracing::Span + WasmCompatSend + 'a,
 {
     // Per-call working state: a stable internal_call_id and the execute span,
@@ -925,7 +915,7 @@ where
         // turn) but is still committed. Every non-dropped slot is filled; a
         // dropped slot only occurs after a termination, handled above.
         let mut committed: Vec<UserContent> = Vec::with_capacity(call_count);
-        let mut surface_items: Vec<MultiTurnStreamItem<R>> =
+        let mut surface_items: Vec<MultiTurnStreamItem> =
             Vec::with_capacity(call_count.saturating_mul(2));
         for slot in collected {
             let CollectedToolResult { content, internal_call_id, surface } = match slot {
@@ -1026,10 +1016,7 @@ impl StreamingTurnSource {
 impl<M> TurnSource<M> for StreamingTurnSource
 where
     M: CompletionModel,
-    <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetTokenUsage,
 {
-    type Raw = M::StreamingResponse;
-
     fn open_chat_span(
         &self,
         runner: &AgentRunner<M>,
@@ -1047,7 +1034,7 @@ where
         chat_span: tracing::Span,
         agent_span: &'a tracing::Span,
         current_prompt: Message,
-    ) -> DriveStream<'a, M::StreamingResponse> {
+    ) -> DriveStream<'a> {
         Box::pin(async_stream::stream! {
             let mut stream = match prepared
                 .builder
@@ -1435,7 +1422,7 @@ where
         run: &'a mut AgentRun,
         calls: Vec<PendingToolCall>,
         tool_snapshot: Arc<ToolRegistrySnapshot>,
-    ) -> DriveStream<'a, M::StreamingResponse> {
+    ) -> DriveStream<'a> {
         // The streaming surface chains nothing onto its tool spans, and forwards
         // the ToolCall/ToolResult items to the consumer.
         drive_tool_calls(
@@ -1460,10 +1447,7 @@ where
         }
     }
 
-    fn final_item(
-        &self,
-        response: &PromptResponse,
-    ) -> Option<MultiTurnStreamItem<M::StreamingResponse>> {
+    fn final_item(&self, response: &PromptResponse) -> Option<MultiTurnStreamItem> {
         // Tool output mode (#1928): when the finishing turn made the output-tool
         // call, surface the run's structured output as the final content.
         let final_choice = finalize_streamed_choice(&self.last_final_choice, &response.output)
@@ -1493,7 +1477,6 @@ where
 impl<M> AgentRunner<M>
 where
     M: CompletionModel + 'static,
-    <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetTokenUsage,
 {
     /// Drive the agent loop, streaming assistant content, tool activity, and a
     /// final response. Hooks fire at every observable point, including streamed
@@ -1504,7 +1487,7 @@ where
     /// hook handling with the blocking [`run`](AgentRunner::run) via
     /// `drive_agent`, so the two behave identically apart from the streamed
     /// delta events.
-    pub async fn stream(self) -> StreamingResult<M::StreamingResponse> {
+    pub async fn stream(self) -> StreamingResult {
         let (agent_span, created_agent_span) = acquire_agent_span(
             self.agent_name_or_default(),
             self.preamble.as_deref(),
@@ -1573,9 +1556,8 @@ where
 impl<M> IntoFuture for StreamingPromptRequest<M>
 where
     M: CompletionModel + 'static,
-    <M as CompletionModel>::StreamingResponse: WasmCompatSend,
 {
-    type Output = StreamingResult<M::StreamingResponse>; // what `.await` returns
+    type Output = StreamingResult; // what `.await` returns
     type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
@@ -1591,8 +1573,8 @@ where
 /// metadata is returned on the [`PromptResponse`] via accessors such as
 /// [`PromptResponse::completion_calls`]. A model-turn retry prints a visible
 /// boundary because text already written to stdout cannot be retracted.
-pub async fn stream_to_stdout<R>(
-    stream: &mut StreamingResult<R>,
+pub async fn stream_to_stdout(
+    stream: &mut StreamingResult,
 ) -> Result<PromptResponse, std::io::Error> {
     let mut final_res = PromptResponse::empty();
     print!("Response: ");
@@ -1646,8 +1628,8 @@ mod migrated_tests {
     use crate::streaming::{StreamingPrompt, ToolCallDeltaContent};
     use crate::test_utils::{
         AppendFailingMemory, FailingMemory, MockAddTool, MockBarrierTool, MockCompletionModel,
-        MockContextProbeTool, MockResponse, MockStreamEvent, MockSubtractTool, MockToolError,
-        MockTurn, SessionId,
+        MockContextProbeTool, MockStreamEvent, MockSubtractTool, MockToolError, MockTurn,
+        SessionId,
     };
     use crate::tool::{Tool, ToolContext};
     use futures::{StreamExt, TryStreamExt};
@@ -2257,7 +2239,7 @@ mod migrated_tests {
 
         let hook_context = HookContext::new(true, None);
         hook_context.set_turn(1);
-        let mut stream = drive_tool_calls::<MockCompletionModel, MockResponse, _>(
+        let mut stream = drive_tool_calls::<MockCompletionModel, _>(
             &runner,
             &hook_context,
             &mut run,
@@ -3038,7 +3020,7 @@ mod migrated_tests {
 
     #[test]
     fn completion_calls_stream_item_serializes_and_deserializes_expected_shape() {
-        let item: MultiTurnStreamItem<MockResponse> =
+        let item: MultiTurnStreamItem =
             MultiTurnStreamItem::CompletionCall(CompletionCall::new(2, usage(3, 4)));
 
         let value = serde_json::to_value(&item).expect("serialize completion call event");
@@ -3060,7 +3042,7 @@ mod migrated_tests {
             })
         );
 
-        let item: MultiTurnStreamItem<MockResponse> =
+        let item: MultiTurnStreamItem =
             serde_json::from_value(value).expect("deserialize completion call event");
         match item {
             MultiTurnStreamItem::CompletionCall(call_usage) => {
@@ -3069,7 +3051,7 @@ mod migrated_tests {
             other => panic!("expected completion call event, got {other:?}"),
         }
 
-        let item: MultiTurnStreamItem<MockResponse> =
+        let item: MultiTurnStreamItem =
             MultiTurnStreamItem::CompletionCall(CompletionCall::new(3, Usage::new()));
         let value = serde_json::to_value(&item).expect("serialize missing usage event");
 
@@ -3094,7 +3076,7 @@ mod migrated_tests {
 
         // Stream items serialized before the Option encoding was dropped used
         // `"usage": null`; they must still deserialize.
-        let legacy: MultiTurnStreamItem<MockResponse> = serde_json::from_value(serde_json::json!({
+        let legacy: MultiTurnStreamItem = serde_json::from_value(serde_json::json!({
             "type": "completionCall",
             "call_index": 3,
             "usage": null
@@ -3110,16 +3092,15 @@ mod migrated_tests {
 
     #[test]
     fn final_response_serializes_completion_calls_with_missing_usage() {
-        let item: MultiTurnStreamItem<MockResponse> =
-            MultiTurnStreamItem::final_response_with_completion_calls(
-                OneOrMany::one(AssistantContent::text("done")),
-                usage(3, 4),
-                vec![
-                    CompletionCall::new(0, Usage::new()),
-                    CompletionCall::new(1, usage(3, 4)),
-                ],
-                None,
-            );
+        let item: MultiTurnStreamItem = MultiTurnStreamItem::final_response_with_completion_calls(
+            OneOrMany::one(AssistantContent::text("done")),
+            usage(3, 4),
+            vec![
+                CompletionCall::new(0, Usage::new()),
+                CompletionCall::new(1, usage(3, 4)),
+            ],
+            None,
+        );
 
         if let MultiTurnStreamItem::FinalResponse(response) = &item {
             assert_eq!(response.requests(), 2);

--- a/crates/rig-agent/src/agent/run/streamed.rs
+++ b/crates/rig-agent/src/agent/run/streamed.rs
@@ -44,7 +44,7 @@ use rig_core::{
 
 use crate::{
     agent::prompt_request::{TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER, tool_result_message},
-    completion::{CompletionError, GetTokenUsage, Message, Usage},
+    completion::{CompletionError, Message, Usage},
     json_utils,
     streaming::{StreamedAssistantContent, ToolCallDeltaContent},
 };
@@ -385,13 +385,10 @@ impl StreamedTurnAssembler {
     /// Returns an error when the provider stream is inconsistent (argument
     /// deltas finishing without a validated tool name) or when an invalid
     /// tool call is still awaiting resolution.
-    pub fn ingest<R>(
+    pub fn ingest(
         &mut self,
-        item: &StreamedAssistantContent<R>,
-    ) -> Result<Vec<StreamedTurnEvent>, CompletionError>
-    where
-        R: Clone + Unpin + GetTokenUsage,
-    {
+        item: &StreamedAssistantContent,
+    ) -> Result<Vec<StreamedTurnEvent>, CompletionError> {
         if self.pending_invalid.is_some() {
             return Err(CompletionError::ResponseError(
                 "streamed turn ingested while an invalid tool call awaits resolution".to_string(),
@@ -501,7 +498,7 @@ impl StreamedTurnAssembler {
                     return Err(err);
                 }
 
-                let usage = final_response.token_usage();
+                let usage = final_response.usage;
                 let emit_final = self.saw_text;
                 self.saw_text = false;
                 Ok(vec![StreamedTurnEvent::Completed { usage, emit_final }])
@@ -677,7 +674,7 @@ mod tests {
     use crate::agent::hook::InvalidToolCallAction;
     use crate::agent::run::{AgentRun, AgentRunStep};
     use crate::completion::PromptError;
-    use crate::test_utils::MockResponse;
+    use crate::test_utils::mock_final;
     use rig_core::message::{Text, ToolResultContent, UserContent};
     use serde_json::json;
 
@@ -689,7 +686,7 @@ mod tests {
         StreamedTurnAssembler::new(tool_names(&["add"]), tool_names(&["add"]))
     }
 
-    fn text_item(text: &str) -> StreamedAssistantContent<MockResponse> {
+    fn text_item(text: &str) -> StreamedAssistantContent {
         StreamedAssistantContent::Text(Text::new(text.to_string()))
     }
 
@@ -700,18 +697,18 @@ mod tests {
         )
     }
 
-    fn tool_call_item(id: &str, name: &str) -> StreamedAssistantContent<MockResponse> {
+    fn tool_call_item(id: &str, name: &str) -> StreamedAssistantContent {
         StreamedAssistantContent::ToolCall {
             tool_call: tool_call(id, name),
             internal_call_id: format!("internal_{id}"),
         }
     }
 
-    fn final_item() -> StreamedAssistantContent<MockResponse> {
-        StreamedAssistantContent::Final(MockResponse::with_usage(Usage::new()))
+    fn final_item() -> StreamedAssistantContent {
+        StreamedAssistantContent::Final(mock_final(Usage::new()))
     }
 
-    fn name_delta(id: &str, name: &str) -> StreamedAssistantContent<MockResponse> {
+    fn name_delta(id: &str, name: &str) -> StreamedAssistantContent {
         StreamedAssistantContent::ToolCallDelta {
             id: id.to_string(),
             internal_call_id: format!("internal_{id}"),
@@ -719,7 +716,7 @@ mod tests {
         }
     }
 
-    fn args_delta(id: &str, arguments: &str) -> StreamedAssistantContent<MockResponse> {
+    fn args_delta(id: &str, arguments: &str) -> StreamedAssistantContent {
         StreamedAssistantContent::ToolCallDelta {
             id: id.to_string(),
             internal_call_id: format!("internal_{id}"),
@@ -755,7 +752,7 @@ mod tests {
             .expect("ingest text should succeed");
 
         let events = asm
-            .ingest(&StreamedAssistantContent::<MockResponse>::Unknown(
+            .ingest(&StreamedAssistantContent::Unknown(
                 json!({ "type": "web_search_call", "id": "ws_1" }),
             ))
             .expect("ingest unknown should succeed");
@@ -816,7 +813,7 @@ mod tests {
     #[test]
     fn finish_orders_reasoning_text_then_tool_calls() {
         let mut asm = assembler();
-        asm.ingest(&StreamedAssistantContent::<MockResponse>::ReasoningDelta {
+        asm.ingest(&StreamedAssistantContent::ReasoningDelta {
             id: Some("rs_1".to_string()),
             reasoning: "think".to_string(),
         })
@@ -1161,12 +1158,12 @@ mod tests {
         run.next_step().expect("next_step");
 
         let mut asm = assembler();
-        asm.ingest(&StreamedAssistantContent::<MockResponse>::ToolCall {
+        asm.ingest(&StreamedAssistantContent::ToolCall {
             tool_call: tool_call("tc_1", "add"),
             internal_call_id: "internal_a".to_string(),
         })
         .expect("ingest should succeed");
-        asm.ingest(&StreamedAssistantContent::<MockResponse>::ToolCall {
+        asm.ingest(&StreamedAssistantContent::ToolCall {
             tool_call: tool_call("tc_1", "add"),
             internal_call_id: "internal_b".to_string(),
         })

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -900,8 +900,6 @@ impl<M> TurnSource<M> for UnaryTurnSource
 where
     M: CompletionModel,
 {
-    type Raw = M::Response;
-
     fn open_chat_span(
         &self,
         runner: &AgentRunner<M>,
@@ -920,7 +918,7 @@ where
         chat_span: tracing::Span,
         _agent_span: &'a tracing::Span,
         current_prompt: Message,
-    ) -> DriveStream<'a, M::Response> {
+    ) -> DriveStream<'a> {
         Box::pin(async_stream::stream! {
             let resp = match prepared.builder.send().instrument(chat_span.clone()).await {
                 Ok(resp) => resp,
@@ -1055,7 +1053,7 @@ where
         run: &'a mut AgentRun,
         calls: Vec<PendingToolCall>,
         tool_snapshot: Arc<ToolRegistrySnapshot>,
-    ) -> DriveStream<'a, M::Response> {
+    ) -> DriveStream<'a> {
         // The blocking surface chains tool spans into its linear `follows_from`
         // sequence (chat -> tool -> chat), and discards the yielded items, so it
         // skips building them.
@@ -1088,7 +1086,7 @@ where
         }
     }
 
-    fn final_item(&self, _response: &PromptResponse) -> Option<MultiTurnStreamItem<M::Response>> {
+    fn final_item(&self, _response: &PromptResponse) -> Option<MultiTurnStreamItem> {
         // The blocking surface folds the engine and discards the final item, so
         // building it (an extra full-response clone) is skipped entirely.
         None
@@ -3313,9 +3311,7 @@ mod migrated_tests {
         };
         use crate::streaming::StreamedAssistantContent;
         use crate::streaming::StreamingCompletionResponse;
-        use crate::test_utils::{
-            MockAddTool, MockCompletionModel, MockResponse, MockStreamEvent, MockTurn,
-        };
+        use crate::test_utils::{MockAddTool, MockCompletionModel, MockStreamEvent, MockTurn};
         use crate::tool::{ToolContext, ToolExecutionError};
         use rig_core::telemetry::{CompletionOperation, CompletionSpanBuilder};
 
@@ -3465,20 +3461,10 @@ mod migrated_tests {
         }
 
         impl CompletionModel for CompletionTelemetryModel {
-            type Response = MockResponse;
-            type StreamingResponse = MockResponse;
-            type Client = ();
-
-            fn make(_client: &Self::Client, _model: impl Into<String>) -> Self {
-                Self {
-                    inner: MockCompletionModel::default(),
-                }
-            }
-
             async fn completion(
                 &self,
                 request: CompletionRequest,
-            ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+            ) -> Result<CompletionResponse, CompletionError> {
                 let span = CompletionSpanBuilder::new(
                     "fixture-provider",
                     "fixture-model",
@@ -3491,8 +3477,7 @@ mod migrated_tests {
             async fn stream(
                 &self,
                 request: CompletionRequest,
-            ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError>
-            {
+            ) -> Result<StreamingCompletionResponse, CompletionError> {
                 let span = CompletionSpanBuilder::new(
                     "fixture-provider",
                     "fixture-model",
@@ -4387,8 +4372,8 @@ mod migrated_tests {
 
     /// Drive a stream to completion, panicking on any stream error, and return
     /// its final response.
-    async fn drive_to_final_response<R: Send + 'static>(
-        mut stream: crate::agent::prompt_request::streaming::StreamingResult<R>,
+    async fn drive_to_final_response(
+        mut stream: crate::agent::prompt_request::streaming::StreamingResult,
     ) -> crate::agent::prompt_request::PromptResponse {
         let mut final_response = None;
         while let Some(item) = stream.next().await {
@@ -6801,21 +6786,11 @@ mod migrated_tests {
     }
 
     impl CompletionModel for PausingCompletionModel {
-        type Response = crate::test_utils::MockResponse;
-        type StreamingResponse = crate::test_utils::MockResponse;
-        type Client = ();
-
-        fn make(_: &Self::Client, _: impl Into<String>) -> Self {
-            Self::new(MockCompletionModel::default()).0
-        }
-
         async fn completion(
             &self,
             request: crate::completion::CompletionRequest,
-        ) -> Result<
-            crate::completion::CompletionResponse<Self::Response>,
-            crate::completion::CompletionError,
-        > {
+        ) -> Result<crate::completion::CompletionResponse, crate::completion::CompletionError>
+        {
             self.inspect_and_pause(&request).await;
             self.inner.completion(request).await
         }
@@ -6823,10 +6798,8 @@ mod migrated_tests {
         async fn stream(
             &self,
             request: crate::completion::CompletionRequest,
-        ) -> Result<
-            crate::streaming::StreamingCompletionResponse<Self::StreamingResponse>,
-            crate::completion::CompletionError,
-        > {
+        ) -> Result<crate::streaming::StreamingCompletionResponse, crate::completion::CompletionError>
+        {
             self.inspect_and_pause(&request).await;
             self.inner.stream(request).await
         }

--- a/crates/rig-agent/src/streaming.rs
+++ b/crates/rig-agent/src/streaming.rs
@@ -2,18 +2,16 @@
 
 use crate::{
     agent::StreamingPromptRequest,
-    completion::{CompletionModel, GetTokenUsage, Message},
+    completion::{CompletionModel, Message},
 };
 use rig_core::wasm_compat::{WasmCompatSend, WasmCompatSync};
 
 pub use rig_core::streaming::*;
 
 /// High-level one-shot streaming prompt interface.
-pub trait StreamingPrompt<M, R>
+pub trait StreamingPrompt<M>
 where
     M: CompletionModel + 'static,
-    M::StreamingResponse: WasmCompatSend,
-    R: Clone + Unpin + GetTokenUsage,
 {
     /// Create a classic streaming request for `prompt`.
     fn stream_prompt(
@@ -23,11 +21,9 @@ where
 }
 
 /// High-level streaming chat interface with caller-provided history.
-pub trait StreamingChat<M, R>: WasmCompatSend + WasmCompatSync
+pub trait StreamingChat<M>: WasmCompatSend + WasmCompatSync
 where
     M: CompletionModel + 'static,
-    M::StreamingResponse: WasmCompatSend,
-    R: Clone + Unpin + GetTokenUsage,
 {
     /// Create a classic streaming request with canonical chat history.
     fn stream_chat<I, T>(

--- a/crates/rig-agent/src/test_utils/model_conformance.rs
+++ b/crates/rig-agent/src/test_utils/model_conformance.rs
@@ -1256,7 +1256,7 @@ where
                 streamed_text.push_str(&text.text);
             }
             crate::streaming::StreamedAssistantContent::Final(response) => {
-                streamed_usage = Some(crate::completion::GetTokenUsage::token_usage(&response));
+                streamed_usage = Some(response.usage);
             }
             crate::streaming::StreamedAssistantContent::ToolCall { .. }
             | crate::streaming::StreamedAssistantContent::ToolCallDelta { .. }
@@ -2095,7 +2095,7 @@ mod tests {
     use super::*;
     use crate::{
         completion::Usage,
-        test_utils::{MockCompletionModel, MockResponse, MockStreamEvent, MockTurn},
+        test_utils::{MockCompletionModel, MockStreamEvent, MockTurn, mock_final},
     };
     use rig_core::{
         OneOrMany,
@@ -2221,11 +2221,11 @@ mod tests {
                     "add",
                     serde_json::json!({"a": 17, "b": 25}),
                 ),
-                MockStreamEvent::FinalResponse(MockResponse::with_usage(usage(10, 2))),
+                MockStreamEvent::FinalResponse(mock_final(usage(10, 2))),
             ],
             vec![
                 MockStreamEvent::text("42"),
-                MockStreamEvent::FinalResponse(MockResponse::with_usage(usage(14, 1))),
+                MockStreamEvent::FinalResponse(mock_final(usage(14, 1))),
             ],
         ]);
         let report = streaming_tool(model, |builder| builder).await?;

--- a/crates/rig-bedrock/src/completion.rs
+++ b/crates/rig-bedrock/src/completion.rs
@@ -10,6 +10,7 @@ use crate::{
 
 use rig_core::completion::{self, CompletionError, CompletionRequest};
 use rig_core::streaming::StreamingCompletionResponse;
+use rig_core::telemetry::ProviderResponseExt;
 use rig_core::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
 use tracing::Instrument;
 
@@ -209,20 +210,16 @@ pub(crate) fn resolve_request_model(
         .unwrap_or_else(|| default_model.to_string())
 }
 
-impl completion::CompletionModel for CompletionModel {
-    type Response = AwsConverseOutput;
-    type StreamingResponse = crate::streaming::BedrockStreamingResponse;
-
-    type Client = Client;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
-
-    async fn completion(
+impl CompletionModel {
+    /// Execute a completion and return Bedrock's own Converse output.
+    ///
+    /// This is the escape hatch for fields rig does not normalize;
+    /// [`completion::CompletionModel::completion`] calls it and maps the
+    /// result, so there is exactly one request either way.
+    pub async fn raw_completion(
         &self,
         completion_request: completion::CompletionRequest,
-    ) -> Result<completion::CompletionResponse<AwsConverseOutput>, CompletionError> {
+    ) -> Result<AwsConverseOutput, CompletionError> {
         let request_model = resolve_request_model(&self.model, &completion_request);
 
         let span =
@@ -269,18 +266,27 @@ impl completion::CompletionModel for CompletionModel {
 
             let span = tracing::Span::current();
             span.record_response_metadata(&aws_output);
-            span.record_token_usage(&aws_output);
+            span.record_token_usage(&aws_output.get_usage().map(Into::into).unwrap_or_default());
 
-            aws_output.try_into()
+            Ok(aws_output)
         }
         .instrument(span)
         .await
+    }
+}
+
+impl completion::CompletionModel for CompletionModel {
+    async fn completion(
+        &self,
+        completion_request: completion::CompletionRequest,
+    ) -> Result<completion::CompletionResponse, CompletionError> {
+        self.raw_completion(completion_request).await?.try_into()
     }
 
     async fn stream(
         &self,
         request: CompletionRequest,
-    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+    ) -> Result<StreamingCompletionResponse, CompletionError> {
         CompletionModel::stream(self, request).await
     }
 }

--- a/crates/rig-bedrock/src/completion.rs
+++ b/crates/rig-bedrock/src/completion.rs
@@ -266,7 +266,7 @@ impl CompletionModel {
 
             let span = tracing::Span::current();
             span.record_response_metadata(&aws_output);
-            span.record_token_usage(&aws_output.get_usage().map(Into::into).unwrap_or_default());
+            span.record_token_usage(&aws_output.get_usage().unwrap_or_default());
 
             Ok(aws_output)
         }

--- a/crates/rig-bedrock/src/streaming.rs
+++ b/crates/rig-bedrock/src/streaming.rs
@@ -1,11 +1,12 @@
+use crate::types::assistant_content::{PROVIDER_NAME, map_stop_reason};
 use crate::types::completion_request::AwsCompletionRequest;
+use crate::types::converse_output::StopReason;
 use crate::{
     completion::{CompletionModel, resolve_request_model},
     types::errors::{AwsSdkConverseStreamError, converse_stream_output_completion_error},
 };
 use async_stream::stream;
 use aws_sdk_bedrockruntime::types as aws_bedrock;
-use rig_core::completion::GetTokenUsage;
 use rig_core::streaming::StreamingCompletionResponse;
 use rig_core::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
 use rig_core::{
@@ -19,6 +20,10 @@ use tracing_futures::Instrument;
 #[derive(Clone, Deserialize, Serialize)]
 pub struct BedrockStreamingResponse {
     pub usage: Option<BedrockUsage>,
+    /// Bedrock's own `stopReason` from the terminal `MessageStop` event, when
+    /// the stream reported one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<StopReason>,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -32,9 +37,10 @@ pub struct BedrockUsage {
     pub cache_write_input_tokens: Option<i32>,
 }
 
-impl GetTokenUsage for BedrockStreamingResponse {
-    fn token_usage(&self) -> rig_core::completion::Usage {
-        self.usage
+impl From<&BedrockStreamingResponse> for rig_core::completion::Usage {
+    fn from(response: &BedrockStreamingResponse) -> Self {
+        response
+            .usage
             .as_ref()
             .map(|u| rig_core::completion::Usage {
                 input_tokens: u.input_tokens as u64,
@@ -88,10 +94,12 @@ fn finalize_reasoning(
 }
 
 impl CompletionModel {
-    pub(crate) async fn stream(
+    /// Open a stream whose terminal record stays Bedrock's own response type.
+    pub async fn raw_stream(
         &self,
         completion_request: rig_core::completion::CompletionRequest,
-    ) -> Result<StreamingCompletionResponse<BedrockStreamingResponse>, CompletionError> {
+    ) -> Result<rig_core::streaming::RawStreamingResult<BedrockStreamingResponse>, CompletionError>
+    {
         let request_model = resolve_request_model(&self.model, &completion_request);
         let system_instructions = completion_request.preamble.clone();
         let record_telemetry_content = completion_request.record_telemetry_content;
@@ -137,6 +145,7 @@ impl CompletionModel {
             let span = tracing::Span::current();
             let mut current_tool_call: Option<ToolCallState> = None;
             let mut current_reasoning: Option<ReasoningState> = None;
+            let mut final_stop_reason: Option<StopReason> = None;
             let mut stream = response.stream;
             loop {
                 let output = match stream.recv().await {
@@ -228,6 +237,18 @@ impl CompletionModel {
                             }
                     },
                     aws_bedrock::ConverseStreamOutput::MessageStop(message_stop_event) => {
+                        // Remember Bedrock's own terminal reason so the final
+                        // record can report it; an unmapped SDK variant is kept
+                        // verbatim rather than dropped.
+                        final_stop_reason = Some(
+                            StopReason::try_from(message_stop_event.stop_reason.clone()).unwrap_or_else(
+                                |_| StopReason::Unknown(
+                                    crate::types::converse_output::UnknownVariantValue(
+                                        message_stop_event.stop_reason.as_str().to_owned(),
+                                    ),
+                                ),
+                            ),
+                        );
                         match message_stop_event.stop_reason {
                             aws_bedrock::StopReason::ToolUse => {
                                 if let Some(tool_call) = current_tool_call.take() {
@@ -262,8 +283,9 @@ impl CompletionModel {
                                     cache_read_input_tokens: usage.cache_read_input_tokens,
                                     cache_write_input_tokens: usage.cache_write_input_tokens,
                                 }),
+                                stop_reason: final_stop_reason.clone(),
                             };
-                            span.record_token_usage(&final_response);
+                            span.record_token_usage(&(&final_response).into());
                             yield Ok(RawStreamingChoice::FinalResponse(final_response));
                         }
                     },
@@ -272,7 +294,27 @@ impl CompletionModel {
             }
         }.instrument(span));
 
-        Ok(StreamingCompletionResponse::stream(stream))
+        Ok(stream)
+    }
+
+    /// Open a stream normalized to rig's terminal record. Delegates to
+    /// [`CompletionModel::raw_stream`] — one request either way.
+    pub(crate) async fn stream(
+        &self,
+        completion_request: rig_core::completion::CompletionRequest,
+    ) -> Result<StreamingCompletionResponse, CompletionError> {
+        let raw = self.raw_stream(completion_request).await?;
+        let normalized = rig_core::streaming::normalize_stream(raw, |response| {
+            let usage = (&response).into();
+            let finish_reason = response.stop_reason.as_ref().map(map_stop_reason);
+            Ok(rig_core::streaming::StreamFinal::new(PROVIDER_NAME, usage)
+                .with_optional_finish_reason(finish_reason))
+        });
+
+        Ok(StreamingCompletionResponse::stream(
+            PROVIDER_NAME,
+            normalized,
+        ))
     }
 }
 
@@ -305,10 +347,11 @@ mod tests {
                 cache_read_input_tokens: Some(40),
                 cache_write_input_tokens: Some(10),
             }),
+            stop_reason: None,
         };
 
         assert_eq!(
-            response.token_usage(),
+            rig_core::completion::Usage::from(&response),
             rig_core::completion::Usage {
                 input_tokens: 200,
                 output_tokens: 75,
@@ -323,16 +366,22 @@ mod tests {
 
     #[test]
     fn test_bedrock_streaming_response_without_usage() {
-        let response = BedrockStreamingResponse { usage: None };
+        let response = BedrockStreamingResponse {
+            usage: None,
+            stop_reason: None,
+        };
 
         // Zero-valued usage is rig's documented sentinel for "the provider
         // reported no usage metrics".
-        assert_eq!(response.token_usage(), rig_core::completion::Usage::new());
-        assert!(!response.token_usage().has_values());
+        assert_eq!(
+            rig_core::completion::Usage::from(&response),
+            rig_core::completion::Usage::new()
+        );
+        assert!(!rig_core::completion::Usage::from(&response).has_values());
     }
 
     #[test]
-    fn test_get_token_usage_trait() {
+    fn test_streaming_response_normalizes_usage() {
         let response = BedrockStreamingResponse {
             usage: Some(BedrockUsage {
                 input_tokens: 448,
@@ -341,11 +390,12 @@ mod tests {
                 cache_read_input_tokens: Some(80),
                 cache_write_input_tokens: Some(20),
             }),
+            stop_reason: None,
         };
 
-        // Test that GetTokenUsage trait is properly implemented
+        // The streaming response normalizes into rig's usage record.
         assert_eq!(
-            response.token_usage(),
+            rig_core::completion::Usage::from(&response),
             rig_core::completion::Usage {
                 input_tokens: 448,
                 output_tokens: 68,
@@ -399,6 +449,7 @@ mod tests {
                 cache_read_input_tokens: Some(30),
                 cache_write_input_tokens: Some(15),
             }),
+            stop_reason: None,
         };
 
         // Test serialization

--- a/crates/rig-bedrock/src/types/assistant_content.rs
+++ b/crates/rig-bedrock/src/types/assistant_content.rs
@@ -9,10 +9,10 @@ use serde::{Deserialize, Serialize};
 use crate::types::message::RigMessage;
 
 use super::{
-    converse_output::{ContentBlock, InternalConverseOutput, TokenUsage},
+    converse_output::{ContentBlock, InternalConverseOutput, StopReason, TokenUsage},
     json::AwsDocument,
 };
-use rig_core::completion::{self, GetTokenUsage};
+use rig_core::completion::{self};
 use rig_core::telemetry::ProviderResponseExt;
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -75,13 +75,28 @@ impl ProviderResponseExt for AwsConverseOutput {
     }
 }
 
-impl GetTokenUsage for AwsConverseOutput {
-    fn token_usage(&self) -> completion::Usage {
-        self.get_usage().unwrap_or_default()
+/// Stable descriptor name reported on normalized Bedrock responses.
+pub const PROVIDER_NAME: &str = "aws_bedrock";
+
+/// Map Bedrock's `stopReason` onto rig's normalized vocabulary.
+///
+/// `StopSequence` is a natural stop, not a truncation — the model emitted a
+/// configured stop string and finished. Guardrail intervention is a content
+/// filter by another name. Anything the SDK surfaced as unknown is carried
+/// verbatim.
+pub fn map_stop_reason(stop_reason: &StopReason) -> completion::FinishReason {
+    match stop_reason {
+        StopReason::EndTurn | StopReason::StopSequence => completion::FinishReason::Stop,
+        StopReason::MaxTokens => completion::FinishReason::Length,
+        StopReason::ToolUse => completion::FinishReason::ToolCalls,
+        StopReason::ContentFiltered | StopReason::GuardrailIntervened => {
+            completion::FinishReason::ContentFilter
+        }
+        StopReason::Unknown(value) => completion::FinishReason::Other(value.to_string()),
     }
 }
 
-impl TryFrom<AwsConverseOutput> for completion::CompletionResponse<AwsConverseOutput> {
+impl TryFrom<AwsConverseOutput> for completion::CompletionResponse {
     type Error = CompletionError;
 
     fn try_from(value: AwsConverseOutput) -> Result<Self, Self::Error> {
@@ -110,12 +125,12 @@ impl TryFrom<AwsConverseOutput> for completion::CompletionResponse<AwsConverseOu
 
         let usage = value.0.usage().map(normalize_usage).unwrap_or_default();
 
-        Ok(completion::CompletionResponse {
-            choice,
-            usage,
-            raw_response: value,
-            message_id: None,
-        })
+        let finish_reason = map_stop_reason(&value.0.stop_reason);
+
+        Ok(
+            completion::CompletionResponse::new(choice, usage, PROVIDER_NAME)
+                .with_finish_reason(finish_reason),
+        )
     }
 }
 
@@ -250,7 +265,6 @@ mod tests {
     use aws_sdk_bedrockruntime::types as aws_bedrock;
     use rig_core::{
         OneOrMany, completion,
-        completion::GetTokenUsage,
         message::{AssistantContent, ReasoningContent},
         telemetry::ProviderResponseExt,
     };
@@ -330,7 +344,7 @@ mod tests {
     fn get_token_usage_delegates_to_provider_response_ext() {
         let out = make_output("x", Some(make_usage(10, 20, 30)));
         assert_eq!(
-            out.token_usage(),
+            out.get_usage().unwrap_or_default(),
             completion::Usage {
                 input_tokens: 10,
                 output_tokens: 20,
@@ -345,8 +359,11 @@ mod tests {
         let out = make_output("x", None);
         // Zero-valued usage is rig's documented sentinel for "the provider
         // reported no usage metrics".
-        assert_eq!(out.token_usage(), completion::Usage::new());
-        assert!(!out.token_usage().has_values());
+        assert_eq!(
+            out.get_usage().unwrap_or_default(),
+            completion::Usage::new()
+        );
+        assert!(!out.get_usage().unwrap_or_default().has_values());
     }
 
     #[test]
@@ -367,7 +384,7 @@ mod tests {
             converse_output.try_into();
         assert!(converse_output.is_ok());
         let converse_output = converse_output.unwrap();
-        let completion: Result<completion::CompletionResponse<AwsConverseOutput>, _> =
+        let completion: Result<completion::CompletionResponse, _> =
             AwsConverseOutput(converse_output).try_into();
         assert!(completion.is_ok());
         let completion = completion.unwrap();
@@ -399,10 +416,9 @@ mod tests {
             ),
         ];
 
-        let completion: completion::CompletionResponse<AwsConverseOutput> =
-            make_output_with_content(content, None)
-                .try_into()
-                .expect("conversion should succeed");
+        let completion: completion::CompletionResponse = make_output_with_content(content, None)
+            .try_into()
+            .expect("conversion should succeed");
 
         let choice: Vec<_> = completion.choice.into_iter().collect();
         assert_eq!(choice.len(), 3);

--- a/crates/rig-candle/src/generation.rs
+++ b/crates/rig-candle/src/generation.rs
@@ -233,7 +233,7 @@ use candle_transformers::models::quantized_llama::ModelWeights as QuantizedLlama
 use candle_transformers::models::quantized_qwen3::ModelWeights as QuantizedQwen3;
 use candle_transformers::utils::apply_repeat_penalty;
 use rig_core::OneOrMany;
-use rig_core::completion::{AssistantContent, CompletionResponse, GetTokenUsage};
+use rig_core::completion::{AssistantContent, CompletionResponse};
 use rig_core::streaming::{RawStreamingChoice, RawStreamingToolCall};
 use tokenizers::tokenizer::DecodeStream;
 use tokenizers::{
@@ -558,7 +558,7 @@ pub(crate) fn infer(
     loaded: &LoadedModel,
     request: CompletionRequest,
     cancellation: &CancellationSignal,
-) -> Result<CompletionResponse<CandleCompletionResponse>, CandleError> {
+) -> Result<InferredCompletion, CandleError> {
     let parse_request = request.clone();
     let mut raw_response = generate(loaded, request, cancellation, |_| Ok(()))?;
     let parsed = crate::protocol::parse_assistant(
@@ -570,13 +570,35 @@ pub(crate) fn infer(
     let choice = OneOrMany::many(parsed.items).map_err(|_| {
         CandleError::Inference("output protocol produced no assistant content".to_string())
     })?;
-    let usage = raw_response.token_usage();
-    Ok(CompletionResponse {
+
+    Ok(InferredCompletion {
+        response: raw_response,
         choice,
-        usage,
-        raw_response,
-        message_id: None,
     })
+}
+
+/// One local generation, kept in both the shapes callers need.
+///
+/// The assistant protocol is parsed exactly once: `response.text` is the
+/// visible text with protocol markup stripped, and `choice` holds the items
+/// that parse produced. Re-parsing `response.text` would find no tool calls,
+/// since stripping already removed them — so both the raw and the normalized
+/// path read from this single result.
+pub(crate) struct InferredCompletion {
+    /// The local model's own response record.
+    pub(crate) response: CandleCompletionResponse,
+    /// Assistant content parsed out of the generated text.
+    pub(crate) choice: OneOrMany<AssistantContent>,
+}
+
+impl InferredCompletion {
+    /// Normalize into rig's completion response.
+    pub(crate) fn into_normalized(self) -> CompletionResponse {
+        let usage = (&self.response).into();
+        let finish_reason = self.response.finish_reason.into();
+        CompletionResponse::new(self.choice, usage, crate::types::PROVIDER_NAME)
+            .with_finish_reason(finish_reason)
+    }
 }
 
 pub(crate) fn stream_generate(

--- a/crates/rig-candle/src/model.rs
+++ b/crates/rig-candle/src/model.rs
@@ -217,9 +217,7 @@ impl CandleModel {
 
     /// Returns the validated conversation/output protocol.
     pub fn conversation_protocol(&self) -> Option<ConversationProtocol> {
-        match &self.state {
-            loaded => Some(loaded.profile.definition.protocol),
-        }
+        Some(self.state.profile.definition.protocol)
     }
 
     /// Backwards-compatible alias for [`Self::conversation_protocol`].
@@ -229,16 +227,12 @@ impl CandleModel {
 
     /// Returns the validated transformer architecture of the loaded checkpoint.
     pub fn architecture(&self) -> Option<ModelArchitecture> {
-        match &self.state {
-            loaded => Some(loaded.profile.definition.architecture),
-        }
+        Some(self.state.profile.definition.architecture)
     }
 
     /// Returns the detected checkpoint quantization, if the model is quantized.
     pub fn quantization(&self) -> Option<Quantization> {
-        match &self.state {
-            loaded => loaded.profile.definition.quantization,
-        }
+        self.state.profile.definition.quantization
     }
 }
 

--- a/crates/rig-candle/src/model.rs
+++ b/crates/rig-candle/src/model.rs
@@ -70,7 +70,7 @@ use rig_core::completion::{
 };
 #[cfg(test)]
 use rig_core::message::{Message, UserContent};
-use rig_core::streaming::{RawStreamingChoice, StreamingCompletionResponse, StreamingResult};
+use rig_core::streaming::{RawStreamingChoice, RawStreamingResult, StreamingCompletionResponse};
 #[cfg(test)]
 use tokenizers::Tokenizer;
 
@@ -102,16 +102,13 @@ const DEFAULT_MAX_CONCURRENT_REQUESTS: usize = 1;
 #[cfg(not(target_family = "wasm"))]
 const STREAM_CHANNEL_CAPACITY: usize = 8;
 
-#[derive(Clone)]
-enum ModelState {
-    Ready(Arc<LoadedModel>),
-    UnsupportedMake,
-}
-
 /// A cheaply cloneable, CPU-only Candle completion model.
+///
+/// A model always owns loaded weights: it is only constructible through the
+/// builders, which is what removing `CompletionModel::make` made expressible.
 #[derive(Clone)]
 pub struct CandleModel {
-    state: ModelState,
+    state: Arc<LoadedModel>,
 }
 
 /// Builder for loading a [`CandleModel`] and customizing generation defaults.
@@ -221,8 +218,7 @@ impl CandleModel {
     /// Returns the validated conversation/output protocol.
     pub fn conversation_protocol(&self) -> Option<ConversationProtocol> {
         match &self.state {
-            ModelState::Ready(loaded) => Some(loaded.profile.definition.protocol),
-            ModelState::UnsupportedMake => None,
+            loaded => Some(loaded.profile.definition.protocol),
         }
     }
 
@@ -234,16 +230,14 @@ impl CandleModel {
     /// Returns the validated transformer architecture of the loaded checkpoint.
     pub fn architecture(&self) -> Option<ModelArchitecture> {
         match &self.state {
-            ModelState::Ready(loaded) => Some(loaded.profile.definition.architecture),
-            ModelState::UnsupportedMake => None,
+            loaded => Some(loaded.profile.definition.architecture),
         }
     }
 
     /// Returns the detected checkpoint quantization, if the model is quantized.
     pub fn quantization(&self) -> Option<Quantization> {
         match &self.state {
-            ModelState::Ready(loaded) => loaded.profile.definition.quantization,
-            ModelState::UnsupportedMake => None,
+            loaded => loaded.profile.definition.quantization,
         }
     }
 }
@@ -332,7 +326,7 @@ impl<'a> CandleModelBuilder<'a> {
             )?,
         };
         Ok(CandleModel {
-            state: ModelState::Ready(Arc::new(loaded)),
+            state: Arc::new(loaded),
         })
     }
 }
@@ -418,24 +412,25 @@ fn stream_infer(
         .map_err(|_| CandleError::StreamingChannelClosed)
 }
 
-impl CompletionModel for CandleModel {
-    type Response = CandleCompletionResponse;
-    type StreamingResponse = CandleCompletionResponse;
-    type Client = ();
-
-    fn make(_: &Self::Client, _: impl Into<String>) -> Self {
-        Self {
-            state: ModelState::UnsupportedMake,
-        }
-    }
-
-    async fn completion(
+impl CandleModel {
+    /// Run one local completion and return this crate's own response record.
+    ///
+    /// This is the escape hatch for the local generation metrics rig does not
+    /// normalize (timings, tokens/second, the local finish reason).
+    /// [`CompletionModel::completion`] runs the same inference and normalizes
+    /// its result — the model is never run twice.
+    pub async fn raw_completion(
         &self,
         request: CompletionRequest,
-    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
-        let ModelState::Ready(loaded) = &self.state else {
-            return Err(CandleError::UnsupportedMake.into());
-        };
+    ) -> Result<CandleCompletionResponse, CompletionError> {
+        Ok(self.infer_completion(request).await?.response)
+    }
+
+    async fn infer_completion(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<crate::generation::InferredCompletion, CompletionError> {
+        let loaded = &self.state;
 
         #[cfg(not(target_family = "wasm"))]
         {
@@ -463,13 +458,13 @@ impl CompletionModel for CandleModel {
         }
     }
 
-    async fn stream(
+    /// Open a stream whose terminal record stays this crate's own response
+    /// type.
+    pub async fn raw_stream(
         &self,
         request: CompletionRequest,
-    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
-        let ModelState::Ready(loaded) = &self.state else {
-            return Err(CandleError::UnsupportedMake.into());
-        };
+    ) -> Result<RawStreamingResult<CandleCompletionResponse>, CompletionError> {
+        let loaded = &self.state;
 
         #[cfg(not(target_family = "wasm"))]
         {
@@ -495,13 +490,13 @@ impl CompletionModel for CandleModel {
                     let _ = sender.send(Err(error.into())).await;
                 }
             });
-            let stream: StreamingResult<CandleCompletionResponse> =
+            let stream: RawStreamingResult<CandleCompletionResponse> =
                 Box::pin(CandleReceiverStream {
                     receiver,
                     cancellation,
                 });
             cancel_on_drop.disarm();
-            Ok(StreamingCompletionResponse::stream(stream))
+            Ok(stream)
         }
 
         #[cfg(target_family = "wasm")]
@@ -512,10 +507,38 @@ impl CompletionModel for CandleModel {
                 Ok(())
             })?;
             events.push(Ok(RawStreamingChoice::FinalResponse(response)));
-            let stream: StreamingResult<CandleCompletionResponse> =
+            let stream: RawStreamingResult<CandleCompletionResponse> =
                 Box::pin(futures::stream::iter(events));
-            Ok(StreamingCompletionResponse::stream(stream))
+            Ok(stream)
         }
+    }
+}
+
+impl CompletionModel for CandleModel {
+    async fn completion(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<CompletionResponse, CompletionError> {
+        Ok(self.infer_completion(request).await?.into_normalized())
+    }
+
+    async fn stream(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse, CompletionError> {
+        let raw = self.raw_stream(request).await?;
+        let normalized = rig_core::streaming::normalize_stream(raw, |response| {
+            let usage = (&response).into();
+            Ok(
+                rig_core::streaming::StreamFinal::new(crate::types::PROVIDER_NAME, usage)
+                    .with_finish_reason(response.finish_reason.into()),
+            )
+        });
+
+        Ok(StreamingCompletionResponse::stream(
+            crate::types::PROVIDER_NAME,
+            normalized,
+        ))
     }
 }
 

--- a/crates/rig-candle/src/model/tests.rs
+++ b/crates/rig-candle/src/model/tests.rs
@@ -7,7 +7,6 @@ use rig_core::OneOrMany;
 use rig_core::completion::{CompletionModel, Document, ToolDefinition};
 use rig_core::message::{AudioMediaType, ImageDetail, ImageMediaType, ToolChoice};
 #[cfg(not(target_family = "wasm"))]
-use rig_core::streaming::StreamedAssistantContent;
 use safetensors::tensor::{Dtype, View, serialize};
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -642,9 +641,7 @@ fn context_limit_boundaries_clamp_and_detect_conversion_overflow() {
 #[test]
 fn loads_entirely_from_owned_bytes() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let model = LlamaModel::from_safetensors(model_data()?)?;
-    let loaded = &model.state else {
-        return Err("loaded model did not enter ready state".into());
-    };
+    let loaded = &model.state;
     assert!(loaded.runtime.is_consistent_cpu());
     assert_eq!(
         loaded.profile.definition.loader,
@@ -709,9 +706,7 @@ async fn async_loading_succeeds_and_preserves_builder_settings()
         .max_concurrent_requests(3)
         .build_async()
         .await?;
-    let loaded = &configured.state else {
-        return Err("async model did not enter ready state".into());
-    };
+    let loaded = &configured.state;
     assert_eq!(loaded.generation.max_tokens, 17);
     assert_eq!(loaded.generation.temperature, 0.25);
     assert_eq!(loaded.generation.top_k, Some(4));
@@ -736,8 +731,12 @@ async fn async_loading_preserves_typed_errors_and_converts_panics() {
 
     let panicked = join_model_load(tokio::task::spawn_blocking(|| {
         std::panic::resume_unwind(Box::new("intentional async-loading test panic"));
+        // Never evaluated — the closure panics above. It exists only to pin the
+        // return type that `join_model_load` expects.
         #[allow(unreachable_code)]
-        Ok::<CandleModel, CandleError>(unreachable!())
+        Err::<CandleModel, CandleError>(CandleError::Configuration(
+            "unreachable: the closure panics above".to_owned(),
+        ))
     }))
     .await;
     assert!(matches!(panicked, Err(CandleError::BlockingTaskJoin(_))));
@@ -1167,9 +1166,7 @@ async fn concurrent_completions_have_independent_caches_and_samplers()
 async fn closed_admission_controller_fails_public_operations()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let model = LlamaModel::builder(model_data()?).build()?;
-    let loaded = &model.state else {
-        return Err("loaded model was not ready".into());
-    };
+    let loaded = &model.state;
     loaded.concurrency.close();
     let completion_error = model
         .completion(request(vec![Message::user("hello")]))

--- a/crates/rig-candle/src/model/tests.rs
+++ b/crates/rig-candle/src/model/tests.rs
@@ -4,7 +4,7 @@ use candle_transformers::models::llama::LlamaConfig;
 #[cfg(not(target_family = "wasm"))]
 use futures::StreamExt;
 use rig_core::OneOrMany;
-use rig_core::completion::{CompletionModel, Document, GetTokenUsage, ToolDefinition};
+use rig_core::completion::{CompletionModel, Document, ToolDefinition};
 use rig_core::message::{AudioMediaType, ImageDetail, ImageMediaType, ToolChoice};
 #[cfg(not(target_family = "wasm"))]
 use rig_core::streaming::StreamedAssistantContent;
@@ -252,13 +252,13 @@ async fn collect_stream(
     model: &LlamaModel,
     request: CompletionRequest,
 ) -> Result<(String, CandleCompletionResponse), Box<dyn std::error::Error + Send + Sync>> {
-    let mut response = model.stream(request).await?;
+    let mut response = model.raw_stream(request).await?;
     let mut text = String::new();
     let mut final_response = None;
     while let Some(item) = response.next().await {
         match item? {
-            StreamedAssistantContent::Text(fragment) => text.push_str(&fragment.text),
-            StreamedAssistantContent::Final(raw) => final_response = Some(raw),
+            RawStreamingChoice::Message(fragment) => text.push_str(&fragment),
+            RawStreamingChoice::FinalResponse(raw) => final_response = Some(raw),
             _ => {}
         }
     }
@@ -283,7 +283,7 @@ fn controlled_model(
     loaded.test_control = Some(Arc::clone(&control));
     Ok((
         LlamaModel {
-            state: ModelState::Ready(Arc::new(loaded)),
+            state: Arc::new(loaded),
         },
         control,
         concurrency,
@@ -419,7 +419,7 @@ fn validates_tensor_shapes_dtypes_and_tied_embeddings()
         tokenizer: tiny_tokenizer()?,
         weights: checkpoint_custom(true, tensor(&[8, 4]), false)?,
     })?;
-    assert!(matches!(model.state, ModelState::Ready(_)));
+    assert!(matches!(model.state, _));
     Ok(())
 }
 
@@ -642,7 +642,7 @@ fn context_limit_boundaries_clamp_and_detect_conversion_overflow() {
 #[test]
 fn loads_entirely_from_owned_bytes() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let model = LlamaModel::from_safetensors(model_data()?)?;
-    let ModelState::Ready(loaded) = &model.state else {
+    let loaded = &model.state else {
         return Err("loaded model did not enter ready state".into());
     };
     assert!(loaded.runtime.is_consistent_cpu());
@@ -709,7 +709,7 @@ async fn async_loading_succeeds_and_preserves_builder_settings()
         .max_concurrent_requests(3)
         .build_async()
         .await?;
-    let ModelState::Ready(loaded) = &configured.state else {
+    let loaded = &configured.state else {
         return Err("async model did not enter ready state".into());
     };
     assert_eq!(loaded.generation.max_tokens, 17);
@@ -737,9 +737,7 @@ async fn async_loading_preserves_typed_errors_and_converts_panics() {
     let panicked = join_model_load(tokio::task::spawn_blocking(|| {
         std::panic::resume_unwind(Box::new("intentional async-loading test panic"));
         #[allow(unreachable_code)]
-        Ok(CandleModel {
-            state: ModelState::UnsupportedMake,
-        })
+        Ok::<CandleModel, CandleError>(unreachable!())
     }))
     .await;
     assert!(matches!(panicked, Err(CandleError::BlockingTaskJoin(_))));
@@ -841,26 +839,20 @@ async fn buffered_and_streaming_generation_are_equivalent()
         .max_tokens(3)
         .build()?;
     let completion_request = request(vec![Message::user("hello")]);
-    let buffered = model.completion(completion_request.clone()).await?;
+    let buffered = model.raw_completion(completion_request.clone()).await?;
     let (streamed_text, streamed) = collect_stream(&model, completion_request).await?;
 
-    assert_eq!(streamed_text, buffered.raw_response.text);
-    assert_eq!(streamed.text, buffered.raw_response.text);
-    assert_eq!(streamed.prompt_tokens, buffered.raw_response.prompt_tokens);
+    assert_eq!(streamed_text, buffered.text);
+    assert_eq!(streamed.text, buffered.text);
+    assert_eq!(streamed.prompt_tokens, buffered.prompt_tokens);
+    assert_eq!(streamed.generated_tokens, buffered.generated_tokens);
+    assert_eq!(streamed.finish_reason, buffered.finish_reason);
+    assert_eq!(streamed.requested_max_tokens, buffered.requested_max_tokens);
+    assert_eq!(streamed.effective_max_tokens, buffered.effective_max_tokens);
     assert_eq!(
-        streamed.generated_tokens,
-        buffered.raw_response.generated_tokens
+        rig_core::completion::Usage::from(&streamed),
+        rig_core::completion::Usage::from(&buffered)
     );
-    assert_eq!(streamed.finish_reason, buffered.raw_response.finish_reason);
-    assert_eq!(
-        streamed.requested_max_tokens,
-        buffered.raw_response.requested_max_tokens
-    );
-    assert_eq!(
-        streamed.effective_max_tokens,
-        buffered.raw_response.effective_max_tokens
-    );
-    assert_eq!(streamed.token_usage(), buffered.usage);
     assert!(streamed.time_to_first_token_ms.is_some());
     assert!(streamed.prefill_duration_ms <= streamed.generation_duration_ms);
     Ok(())
@@ -874,14 +866,14 @@ async fn streaming_reports_eos_and_excludes_the_stop_token()
     loaded.generation.temperature = 0.0;
     loaded.profile.stop_tokens.insert(0);
     let model = LlamaModel {
-        state: ModelState::Ready(Arc::new(loaded)),
+        state: Arc::new(loaded),
     };
     let (text, raw) = collect_stream(&model, request(vec![Message::user("hello")])).await?;
     assert!(text.is_empty());
     assert!(raw.text.is_empty());
     assert_eq!(raw.finish_reason, FinishReason::Eos);
     assert_eq!(raw.generated_tokens, 1);
-    assert_eq!(raw.token_usage().output_tokens, 1);
+    assert_eq!(rig_core::completion::Usage::from(&raw).output_tokens, 1);
     Ok(())
 }
 
@@ -897,7 +889,7 @@ async fn streaming_clamps_context_and_rejects_bad_request_options()
     let prompt_tokens = loaded.tokenizer.encode(prompt, false)?.len();
     loaded.profile.context_limit = prompt_tokens + 2;
     let model = LlamaModel {
-        state: ModelState::Ready(Arc::new(loaded)),
+        state: Arc::new(loaded),
     };
     let (_, raw) = collect_stream(&model, completion_request).await?;
     assert_eq!(raw.requested_max_tokens, 10);
@@ -910,7 +902,7 @@ async fn streaming_clamps_context_and_rejects_bad_request_options()
     ] {
         let mut bad_request = request(vec![Message::user("hello")]);
         bad_request.additional_params = Some(additional_params);
-        let mut stream = model.stream(bad_request).await?;
+        let mut stream = model.raw_stream(bad_request).await?;
         let item = stream
             .next()
             .await
@@ -1001,13 +993,14 @@ fn inference_clamps_context_and_uses_fresh_generation_state()
         &CancellationSignal::default(),
     )?;
     let second = infer(&loaded, completion_request, &CancellationSignal::default())?;
-    assert_eq!(first.raw_response.text, second.raw_response.text);
-    assert_eq!(first.raw_response.generated_tokens, 2);
-    assert_eq!(first.raw_response.requested_max_tokens, 10);
-    assert_eq!(first.raw_response.effective_max_tokens, 2);
-    assert_eq!(first.raw_response.finish_reason, FinishReason::MaxTokens);
-    assert_eq!(first.usage.output_tokens, 2);
-    assert!(!first.raw_response.text.contains("hello"));
+    let (first, second) = (first.response, second.response);
+    assert_eq!(first.text, second.text);
+    assert_eq!(first.generated_tokens, 2);
+    assert_eq!(first.requested_max_tokens, 10);
+    assert_eq!(first.effective_max_tokens, 2);
+    assert_eq!(first.finish_reason, FinishReason::MaxTokens);
+    assert_eq!(rig_core::completion::Usage::from(&first).output_tokens, 2);
+    assert!(!first.text.contains("hello"));
     Ok(())
 }
 
@@ -1018,11 +1011,14 @@ fn eos_is_counted_but_excluded_from_decoded_text()
     loaded.profile.stop_tokens.insert(0);
     let mut completion_request = request(vec![Message::user("hello")]);
     completion_request.temperature = Some(0.0);
-    let response = infer(&loaded, completion_request, &CancellationSignal::default())?;
-    assert_eq!(response.raw_response.finish_reason, FinishReason::Eos);
-    assert_eq!(response.raw_response.generated_tokens, 1);
-    assert_eq!(response.usage.output_tokens, 1);
-    assert!(response.raw_response.text.is_empty());
+    let response = infer(&loaded, completion_request, &CancellationSignal::default())?.response;
+    assert_eq!(response.finish_reason, FinishReason::Eos);
+    assert_eq!(response.generated_tokens, 1);
+    assert_eq!(
+        rig_core::completion::Usage::from(&response).output_tokens,
+        1
+    );
+    assert!(response.text.is_empty());
     Ok(())
 }
 
@@ -1138,14 +1134,14 @@ async fn concurrent_completions_have_independent_caches_and_samplers()
         .max_tokens(2)
         .max_concurrent_requests(2)
         .build()?;
-    let first = model.completion(request(vec![Message::user("hello")]));
-    let second = model.completion(request(vec![Message::user("hello")]));
+    let first = model.raw_completion(request(vec![Message::user("hello")]));
+    let second = model.raw_completion(request(vec![Message::user("hello")]));
     let (first, second) = tokio::join!(first, second);
     let first = first?;
     let second = second?;
-    assert_eq!(first.raw_response.text, second.raw_response.text);
-    assert_eq!(first.raw_response.generated_tokens, 2);
-    assert_eq!(second.raw_response.generated_tokens, 2);
+    assert_eq!(first.text, second.text);
+    assert_eq!(first.generated_tokens, 2);
+    assert_eq!(second.generated_tokens, 2);
 
     let first_stream = collect_stream(&model, request(vec![Message::user("hello")]));
     let second_stream = collect_stream(&model, request(vec![Message::user("hello")]));
@@ -1171,7 +1167,7 @@ async fn concurrent_completions_have_independent_caches_and_samplers()
 async fn closed_admission_controller_fails_public_operations()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let model = LlamaModel::builder(model_data()?).build()?;
-    let ModelState::Ready(loaded) = &model.state else {
+    let loaded = &model.state else {
         return Err("loaded model was not ready".into());
     };
     loaded.concurrency.close();
@@ -1211,7 +1207,7 @@ async fn dropping_buffered_completion_retains_permit_until_worker_exits()
     });
     control.wait_until_entered().await;
 
-    let second = model.completion(request(vec![Message::user("hello")]));
+    let second = model.raw_completion(request(vec![Message::user("hello")]));
     futures::pin_mut!(second);
     assert!(futures::poll!(&mut second).is_pending());
 
@@ -1221,7 +1217,7 @@ async fn dropping_buffered_completion_retains_permit_until_worker_exits()
     control.release()?;
 
     let second = second.await?;
-    assert_eq!(second.raw_response.generated_tokens, 2);
+    assert_eq!(second.generated_tokens, 2);
     Ok(())
 }
 
@@ -1230,10 +1226,12 @@ async fn dropping_buffered_completion_retains_permit_until_worker_exits()
 async fn dropping_stream_cancels_worker_before_queued_request_runs()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let (model, control, concurrency) = controlled_model(true, false, 2)?;
-    let stream = model.stream(request(vec![Message::user("hello")])).await?;
+    let stream = model
+        .raw_stream(request(vec![Message::user("hello")]))
+        .await?;
     control.wait_until_entered().await;
 
-    let queued = model.completion(request(vec![Message::user("hello")]));
+    let queued = model.raw_completion(request(vec![Message::user("hello")]));
     futures::pin_mut!(queued);
     assert!(futures::poll!(&mut queued).is_pending());
 
@@ -1242,7 +1240,7 @@ async fn dropping_stream_cancels_worker_before_queued_request_runs()
     control.release()?;
 
     let queued = queued.await?;
-    assert_eq!(queued.raw_response.generated_tokens, 2);
+    assert_eq!(queued.generated_tokens, 2);
     Ok(())
 }
 
@@ -1256,14 +1254,14 @@ async fn public_stream_cancel_stops_worker_without_dropping_response()
 
     stream.cancel();
     assert!(stream.next().await.is_none());
-    let queued = model.completion(request(vec![Message::user("hello")]));
+    let queued = model.raw_completion(request(vec![Message::user("hello")]));
     futures::pin_mut!(queued);
     assert!(futures::poll!(&mut queued).is_pending());
     assert!(Arc::clone(&concurrency).try_acquire_owned().is_err());
 
     control.release()?;
     let queued = queued.await?;
-    assert_eq!(queued.raw_response.generated_tokens, 2);
+    assert_eq!(queued.generated_tokens, 2);
     assert!(stream.next().await.is_none());
     Ok(())
 }
@@ -1274,7 +1272,9 @@ async fn streaming_channel_applies_bounded_backpressure()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let (model, control, concurrency) =
         controlled_model(false, false, (STREAM_CHANNEL_CAPACITY + 4) as u64)?;
-    let stream = model.stream(request(vec![Message::user("hello")])).await?;
+    let stream = model
+        .raw_stream(request(vec![Message::user("hello")]))
+        .await?;
     control
         .wait_for_delivery_attempts(STREAM_CHANNEL_CAPACITY + 1)
         .await;
@@ -1302,7 +1302,9 @@ async fn blocking_task_panic_maps_to_typed_completion_error()
     assert!(error.to_string().contains("Candle blocking task failed"));
 
     let (model, _, _) = controlled_model(false, true, 1)?;
-    let mut stream = model.stream(request(vec![Message::user("hello")])).await?;
+    let mut stream = model
+        .raw_stream(request(vec![Message::user("hello")]))
+        .await?;
     let error = stream
         .next()
         .await
@@ -1511,7 +1513,7 @@ fn converts_finish_reason_and_usage() -> Result<(), CandleError> {
         generation_duration_ms: 20,
         tokens_per_second: Some(100.0),
     };
-    let usage = response.token_usage();
+    let usage = rig_core::completion::Usage::from(&response);
     assert_eq!(usage.input_tokens, 5);
     assert_eq!(usage.output_tokens, 2);
     assert_eq!(usage.total_tokens, 7);
@@ -1523,32 +1525,5 @@ fn converts_finish_reason_and_usage() -> Result<(), CandleError> {
     assert_eq!(response.time_to_first_token_ms, Some(10));
     assert_eq!(response.generation_duration_ms, 20);
     assert_eq!(response.tokens_per_second, Some(100.0));
-    Ok(())
-}
-
-#[test]
-fn unsupported_make_fails_for_buffered_and_streaming()
--> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let runtime = tokio::runtime::Builder::new_current_thread().build()?;
-    runtime.block_on(async {
-        let model = <LlamaModel as CompletionModel>::make(&(), "llama");
-        let completion_error = model
-            .completion(request(vec![Message::user("hello")]))
-            .await
-            .err()
-            .ok_or("expected unsupported make")?;
-        assert!(
-            completion_error
-                .to_string()
-                .contains("CompletionModel::make")
-        );
-        let stream_error = model
-            .stream(request(vec![Message::user("hello")]))
-            .await
-            .err()
-            .ok_or("expected unsupported make")?;
-        assert!(stream_error.to_string().contains("CompletionModel::make"));
-        Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
-    })?;
     Ok(())
 }

--- a/crates/rig-candle/src/model/tests.rs
+++ b/crates/rig-candle/src/model/tests.rs
@@ -418,7 +418,9 @@ fn validates_tensor_shapes_dtypes_and_tied_embeddings()
         tokenizer: tiny_tokenizer()?,
         weights: checkpoint_custom(true, tensor(&[8, 4]), false)?,
     })?;
-    assert!(matches!(model.state, _));
+    // The model is only constructible loaded, so assert the loaded profile
+    // rather than a state discriminant that no longer exists.
+    assert!(model.state.runtime.is_consistent_cpu());
     Ok(())
 }
 

--- a/crates/rig-candle/src/types.rs
+++ b/crates/rig-candle/src/types.rs
@@ -1,6 +1,6 @@
 //! Public errors and response metadata.
 
-use rig_core::completion::{CompletionError, GetTokenUsage, Usage};
+use rig_core::completion::{CompletionError, Usage};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -250,13 +250,30 @@ pub struct CandleCompletionResponse {
     pub tokens_per_second: Option<f64>,
 }
 
-impl GetTokenUsage for CandleCompletionResponse {
-    fn token_usage(&self) -> Usage {
+/// Stable descriptor name reported on normalized responses from this crate.
+pub const PROVIDER_NAME: &str = "candle";
+
+impl From<&CandleCompletionResponse> for Usage {
+    fn from(response: &CandleCompletionResponse) -> Self {
         Usage {
-            input_tokens: self.prompt_tokens,
-            output_tokens: self.generated_tokens,
-            total_tokens: self.prompt_tokens.saturating_add(self.generated_tokens),
+            input_tokens: response.prompt_tokens,
+            output_tokens: response.generated_tokens,
+            total_tokens: response
+                .prompt_tokens
+                .saturating_add(response.generated_tokens),
             ..Usage::new()
+        }
+    }
+}
+
+impl From<FinishReason> for rig_core::completion::FinishReason {
+    fn from(reason: FinishReason) -> Self {
+        match reason {
+            // A sampled EOS token is the local equivalent of a natural stop;
+            // `reconcile_with_output` promotes it to `ToolCalls` when the
+            // protocol parsed tool calls out of the generated text.
+            FinishReason::Eos => rig_core::completion::FinishReason::Stop,
+            FinishReason::MaxTokens => rig_core::completion::FinishReason::Length,
         }
     }
 }

--- a/crates/rig-candle/tests/live_conformance.rs
+++ b/crates/rig-candle/tests/live_conformance.rs
@@ -65,7 +65,7 @@ async fn pinned_qwen3_model_contract() -> Result<(), Box<dyn std::error::Error +
 
     let simple = tokio::time::timeout(Duration::from_secs(300), async {
         loaded_model
-            .completion(
+            .raw_completion(
                 loaded_model
                     .completion_request("Answer with only the capital of France.")
                     .temperature(0.0)
@@ -75,20 +75,20 @@ async fn pinned_qwen3_model_contract() -> Result<(), Box<dyn std::error::Error +
             .await
     })
     .await??;
-    if !simple.raw_response.text.contains("Paris") {
+    if !simple.text.contains("Paris") {
         return Err(format!(
             "model-quality failure in simple completion: {:?}",
-            simple.raw_response.text
+            simple.text
         )
         .into());
     }
     println!(
         "PASS simple_buffered prompt_tokens={} generated_tokens={} tool_calls=0 duration={}ms throughput={:?} output={:?}",
-        simple.raw_response.prompt_tokens,
-        simple.raw_response.generated_tokens,
-        simple.raw_response.generation_duration_ms,
-        simple.raw_response.tokens_per_second,
-        simple.raw_response.text,
+        simple.prompt_tokens,
+        simple.generated_tokens,
+        simple.generation_duration_ms,
+        simple.tokens_per_second,
+        simple.text,
     );
 
     let text_parity = tokio::time::timeout(

--- a/crates/rig-candle/tests/real_model.rs
+++ b/crates/rig-candle/tests/real_model.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use futures::StreamExt;
 use rig_candle::{CandleModel, ModelData};
 use rig_core::completion::CompletionModel;
-use rig_core::streaming::StreamedAssistantContent;
+use rig_core::streaming::RawStreamingChoice;
 
 #[tokio::test(flavor = "current_thread")]
 #[ignore = "requires RIG_CANDLE_MODEL_DIR with local Llama 3 safetensors or SmolLM2 GGUF artifacts"]
@@ -37,36 +37,38 @@ async fn loads_and_generates_with_a_real_local_model()
         "Reply with one short greeting."
     };
     let request = model.completion_request(prompt).build();
-    let response = model.completion(request.clone()).await?;
-    if response.raw_response.text.is_empty() {
+    // The raw path is what carries Candle's own generated text and counters;
+    // the normalized path is exercised through the stream below.
+    let response = model.raw_completion(request.clone()).await?;
+    if response.text.is_empty() {
         return Err(std::io::Error::other("real model returned empty generated text").into());
     }
-    if response.usage.input_tokens == 0 || response.usage.output_tokens == 0 {
+    if response.prompt_tokens == 0 || response.generated_tokens == 0 {
         return Err(std::io::Error::other("real model returned zero token usage").into());
     }
-    if is_gguf && !response.raw_response.text.contains("Paris") {
+    if is_gguf && !response.text.contains("Paris") {
         return Err(std::io::Error::other(format!(
             "SmolLM2 coherence regression: {:?}",
-            response.raw_response.text
+            response.text
         ))
         .into());
     }
-    let mut stream = model.stream(request).await?;
+    let mut stream = model.raw_stream(request).await?;
     let mut streamed_text = String::new();
     let mut final_response = None;
     while let Some(item) = stream.next().await {
         match item? {
-            StreamedAssistantContent::Text(fragment) => streamed_text.push_str(&fragment.text),
-            StreamedAssistantContent::Final(raw) => final_response = Some(raw),
+            RawStreamingChoice::Message(fragment) => streamed_text.push_str(&fragment),
+            RawStreamingChoice::FinalResponse(raw) => final_response = Some(raw),
             _ => {}
         }
     }
     let final_response = final_response
         .ok_or_else(|| std::io::Error::other("real model stream omitted final metadata"))?;
-    if streamed_text != response.raw_response.text || final_response.text != streamed_text {
+    if streamed_text != response.text || final_response.text != streamed_text {
         return Err(std::io::Error::other("buffered and streamed output differed").into());
     }
-    if final_response.generated_tokens != response.raw_response.generated_tokens {
+    if final_response.generated_tokens != response.generated_tokens {
         return Err(std::io::Error::other("buffered and streamed usage differed").into());
     }
     Ok(())

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- *(completion)* [**breaking**] normalize completion responses at the provider boundary — `CompletionResponse` and `StreamingCompletionResponse` are concrete, carry normalized `finish_reason`/`provider`/`model`/`message_id`, and every provider model exposes typed `raw_completion`/`raw_stream` escape hatches
+- *(completion)* add public `ProviderCapabilities`, replacing `CompletionModel::composes_native_output_with_tools`
+
+### Removed
+
+- *(completion)* [**breaking**] remove `CompletionModel::{Response, StreamingResponse, Client, make}`; model construction moves to the required `CompletionClient::completion_model`
+- *(completion)* [**breaking**] remove the `GetTokenUsage` trait — read `StreamFinal::usage`
+- *(completion)* [**breaking**] remove `CompletionResponse::raw_response` — use a provider model's `raw_completion`/`raw_stream`
 ## [0.41.0](https://github.com/0xPlaygrounds/rig/compare/rig-core-v0.40.0...rig-core-v0.41.0) - 2026-07-28
 
 ### Added

--- a/crates/rig-core/src/client/completion.rs
+++ b/crates/rig-core/src/client/completion.rs
@@ -4,9 +4,13 @@ use crate::completion::CompletionModel;
 /// Clone is required for conversions between client types.
 pub trait CompletionClient {
     /// The type of CompletionModel used by the client.
-    type CompletionModel: CompletionModel<Client = Self>;
+    type CompletionModel: CompletionModel;
 
     /// Create a completion model with the given model.
+    ///
+    /// Construction lives here rather than on [`CompletionModel`] so a model
+    /// type can be implemented — and used — without any client type at all.
+    /// Implement this by calling the model's own inherent constructor.
     ///
     /// # Example with OpenAI
     /// ```no_run
@@ -21,7 +25,86 @@ pub trait CompletionClient {
     /// # Ok(())
     /// # }
     /// ```
-    fn completion_model(&self, model: impl Into<String>) -> Self::CompletionModel {
-        Self::CompletionModel::make(self, model)
+    fn completion_model(&self, model: impl Into<String>) -> Self::CompletionModel;
+}
+
+/// Crate-internal construction hook for the blanket [`CompletionClient`]
+/// implementation over [`crate::client::Client`].
+///
+/// That blanket implementation is generic over whichever model type a provider
+/// extension declares, so it needs some way to build that model. Coherence
+/// rules out one blanket implementation per provider family — they would all
+/// overlap on `Client<Ext, H>` — and the alternative of a public bound such as
+/// `From<(Client<Ext, H>, String)>` would push a synthetic conversion into
+/// every provider model's public API.
+///
+/// Keeping the hook crate-private means it constrains only rig's own generic
+/// client. Provider crates outside `rig-core` implement [`CompletionClient`]
+/// directly and never see this trait.
+pub(crate) trait ConstructCompletionModel<C>: Sized {
+    /// Build this model from its provider client and a model identifier.
+    fn construct(client: &C, model: String) -> Self;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::completion::{CompletionError, CompletionRequest, CompletionResponse};
+    use crate::streaming::StreamingCompletionResponse;
+
+    /// A model implemented entirely outside rig's provider machinery: no
+    /// response associated types, no client associated type, and no
+    /// construction hook.
+    #[derive(Clone)]
+    struct ExternalModel {
+        name: String,
+    }
+
+    impl CompletionModel for ExternalModel {
+        async fn completion(
+            &self,
+            _request: CompletionRequest,
+        ) -> Result<CompletionResponse, CompletionError> {
+            Err(CompletionError::ResponseError(format!(
+                "{} is a compile-coverage model",
+                self.name
+            )))
+        }
+
+        async fn stream(
+            &self,
+            _request: CompletionRequest,
+        ) -> Result<StreamingCompletionResponse, CompletionError> {
+            Err(CompletionError::ResponseError(format!(
+                "{} is a compile-coverage model",
+                self.name
+            )))
+        }
+    }
+
+    struct ExternalClient;
+
+    impl CompletionClient for ExternalClient {
+        type CompletionModel = ExternalModel;
+
+        fn completion_model(&self, model: impl Into<String>) -> Self::CompletionModel {
+            ExternalModel { name: model.into() }
+        }
+    }
+
+    #[test]
+    fn external_model_needs_no_client_or_response_associated_types() {
+        let model = ExternalClient.completion_model("external-model");
+        assert_eq!(model.name, "external-model");
+    }
+
+    #[test]
+    fn external_model_is_usable_without_a_client() {
+        // A bare model with no client at all still satisfies `CompletionModel`.
+        fn assert_completion_model<M: CompletionModel>(_: &M) {}
+
+        assert_completion_model(&ExternalModel {
+            name: "standalone".to_owned(),
+        });
     }
 }

--- a/crates/rig-core/src/client/mod.rs
+++ b/crates/rig-core/src/client/mod.rs
@@ -12,6 +12,7 @@ pub mod verify;
 
 use bytes::Bytes;
 pub use completion::CompletionClient;
+pub(crate) use completion::ConstructCompletionModel;
 pub use embeddings::EmbeddingsClient;
 use http::{HeaderMap, HeaderName, HeaderValue};
 pub use model_listing::{ModelLister, ModelListingClient};
@@ -757,12 +758,12 @@ where
 impl<M, Ext, H> CompletionClient for Client<Ext, H>
 where
     Ext: Capabilities<H, Completion = Capable<M>>,
-    M: CompletionModel<Client = Self>,
+    M: CompletionModel + ConstructCompletionModel<Self>,
 {
     type CompletionModel = M;
 
     fn completion_model(&self, model: impl Into<String>) -> Self::CompletionModel {
-        M::make(self, model)
+        M::construct(self, model.into())
     }
 }
 

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -43,7 +43,6 @@ use crate::{
     message::{Message, UserContent},
 };
 
-use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ops::{Add, AddAssign};
@@ -207,48 +206,156 @@ impl ProviderToolDefinition {
     }
 }
 
-/// General completion response struct that contains the high-level completion choice
-/// and the raw response. The completion choice contains one or more assistant content.
-#[derive(Debug)]
-pub struct CompletionResponse<T> {
+/// Why the model stopped generating, normalized across providers.
+///
+/// Providers report this under different names and vocabularies
+/// (`finish_reason`, `stop_reason`, `stopReason`, …). Each provider's response
+/// conversion maps its wire value onto these variants and preserves anything
+/// unmapped verbatim in [`FinishReason::Other`], so a provider adding a new
+/// terminal reason never silently reads as a natural stop. Closes #2090/#1886.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FinishReason {
+    /// Natural end of the response.
+    Stop,
+    /// The response hit the output-token limit.
+    Length,
+    /// The model stopped to call one or more tools.
+    ToolCalls,
+    /// The provider filtered the content.
+    ContentFilter,
+    /// A provider-specific reason outside the normalized vocabulary, carried
+    /// verbatim in the provider's own wire spelling.
+    Other(String),
+}
+
+impl FinishReason {
+    /// Reconcile a provider's reported reason with what the turn actually
+    /// produced.
+    ///
+    /// Several providers report a plain `stop` on a turn that carried tool
+    /// calls (OpenAI-compatible gateways are the usual offenders). A caller
+    /// branching on [`FinishReason::ToolCalls`] to decide whether to run tools
+    /// would then miss the call entirely, so a natural stop is upgraded
+    /// whenever the turn emitted at least one tool call.
+    ///
+    /// Only [`FinishReason::Stop`] is upgraded: `Length`, `ContentFilter`, and
+    /// `Other` describe terminations that remain true regardless of the
+    /// content, and overriding them would lose information.
+    ///
+    /// This is the single place the upgrade happens. Construct normalized
+    /// responses through [`CompletionResponse::with_finish_reason`] or
+    /// [`CompletionResponse::with_optional_finish_reason`] (and, for streams,
+    /// [`crate::streaming::normalize_stream`]) so it is always applied.
+    pub fn reconcile_with_output(self, has_tool_call: bool) -> Self {
+        if has_tool_call && matches!(self, Self::Stop) {
+            Self::ToolCalls
+        } else {
+            self
+        }
+    }
+}
+
+/// General completion response struct: the completion choice plus normalized
+/// response metadata. The completion choice contains one or more assistant
+/// content items.
+///
+/// This type is concrete — it carries no provider-typed payload. Callers who
+/// need a provider's own wire response call that model's inherent
+/// `raw_completion` method, which performs the same request and returns the
+/// provider's native type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CompletionResponse {
     /// The completion choice (represented by one or more assistant message content)
     /// returned by the completion model provider
     pub choice: OneOrMany<AssistantContent>,
     /// Tokens used during prompting and responding
     pub usage: Usage,
-    /// The raw response returned by the completion model provider
-    pub raw_response: T,
     /// Provider-assigned message ID (e.g. OpenAI Responses API `msg_` ID).
     /// Used to pair reasoning input items with their output items in multi-turn.
     pub message_id: Option<String>,
+    /// Why the model stopped generating, when the provider reported it.
+    ///
+    /// Prefer [`CompletionResponse::with_finish_reason`] over assigning this
+    /// field directly: the setter applies
+    /// [`FinishReason::reconcile_with_output`], which a direct assignment
+    /// skips.
+    pub finish_reason: Option<FinishReason>,
+    /// Stable descriptor name of the provider that produced this response, for
+    /// example `"openai"`. Always populated, including for responses derived
+    /// from a stream that ended before its terminal record.
+    pub provider: String,
+    /// Provider-reported model identifier for the response.
+    ///
+    /// This is the model named by the wire response, not the model that was
+    /// requested; it is `None` when the provider reports no identifier.
+    pub model: Option<String>,
 }
 
-/// A trait for grabbing the token usage of a completion response.
-///
-/// Primarily designed for streamed completion responses in streamed multi-turn, as otherwise it would be impossible to do.
-pub trait GetTokenUsage {
-    /// Returns token usage for this response. Zero-valued usage is
-    /// [`Usage`]'s documented sentinel for missing provider usage metrics;
-    /// response types that carry no usage return [`Usage::new`].
-    fn token_usage(&self) -> crate::completion::Usage;
-}
-
-impl GetTokenUsage for () {
-    fn token_usage(&self) -> crate::completion::Usage {
-        crate::completion::Usage::new()
-    }
-}
-
-impl<T> GetTokenUsage for Option<T>
-where
-    T: GetTokenUsage,
-{
-    fn token_usage(&self) -> crate::completion::Usage {
-        if let Some(usage) = self {
-            usage.token_usage()
-        } else {
-            crate::completion::Usage::new()
+impl CompletionResponse {
+    /// Create a response from its required parts; optional metadata starts
+    /// unset and is filled in with the `with_*` helpers.
+    pub fn new(
+        choice: OneOrMany<AssistantContent>,
+        usage: Usage,
+        provider: impl Into<String>,
+    ) -> Self {
+        Self {
+            choice,
+            usage,
+            message_id: None,
+            finish_reason: None,
+            provider: provider.into(),
+            model: None,
         }
+    }
+
+    /// Attach the provider-assigned message ID.
+    pub fn with_message_id(mut self, message_id: impl Into<String>) -> Self {
+        self.message_id = Some(message_id.into());
+        self
+    }
+
+    /// Attach the provider-assigned message ID when the provider reported one.
+    pub fn with_optional_message_id(mut self, message_id: Option<impl Into<String>>) -> Self {
+        self.message_id = message_id.map(Into::into);
+        self
+    }
+
+    /// Attach the normalized finish reason, reconciled against the choice via
+    /// [`FinishReason::reconcile_with_output`].
+    pub fn with_finish_reason(self, finish_reason: FinishReason) -> Self {
+        self.with_optional_finish_reason(Some(finish_reason))
+    }
+
+    /// Attach the normalized finish reason when the provider reported one.
+    ///
+    /// This is the `Option` form of [`CompletionResponse::with_finish_reason`]
+    /// and applies the same reconciliation. Provider conversions that hold an
+    /// `Option<FinishReason>` use this rather than assigning the field, so the
+    /// tool-call upgrade is never skipped.
+    pub fn with_optional_finish_reason(mut self, finish_reason: Option<FinishReason>) -> Self {
+        let has_tool_call = self
+            .choice
+            .iter()
+            .any(|content| matches!(content, AssistantContent::ToolCall(_)));
+        self.finish_reason =
+            finish_reason.map(|reason| reason.reconcile_with_output(has_tool_call));
+        self
+    }
+
+    /// Attach the provider-reported model identifier.
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    /// Attach the provider-reported model identifier when the response carried
+    /// one.
+    pub fn with_optional_model(mut self, model: Option<impl Into<String>>) -> Self {
+        self.model = model.map(Into::into);
+        self
     }
 }
 
@@ -332,58 +439,79 @@ impl AddAssign for Usage {
     }
 }
 
+/// Provider behavior that affects how runtimes prepare completion requests.
+///
+/// Capabilities are immutable facts about a model implementation rather than
+/// per-request state, so a runtime can snapshot this value when it erases a
+/// concrete model instead of retaining a callback into the provider.
+///
+/// The type is `#[non_exhaustive]`: build from [`ProviderCapabilities::new`] or
+/// [`Default`] and enable flags with the `with_*` methods, which keeps external
+/// implementations compiling when new capabilities are added.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub struct ProviderCapabilities {
+    /// Whether this provider's native structured output (`output_schema` ->
+    /// `format`/`response_format`) composes with tool calls in the same
+    /// multi-turn request without suppressing them.
+    ///
+    /// `false` is the safe assumption: the native constraint may make the model
+    /// emit schema JSON instead of calling its tools — see issue #1928.
+    /// Providers that enforce structured output *and* tool use together (e.g.
+    /// OpenAI, Anthropic) set this to `true`, which lets runtimes keep
+    /// guaranteed native structured output active when tools are present.
+    pub composes_native_output_with_tools: bool,
+}
+
+impl ProviderCapabilities {
+    /// Create the conservative capability set used by default.
+    pub const fn new() -> Self {
+        Self {
+            composes_native_output_with_tools: false,
+        }
+    }
+
+    /// Declare whether native structured output composes with tool calls.
+    pub const fn with_native_output_tool_composition(mut self, supported: bool) -> Self {
+        self.composes_native_output_with_tools = supported;
+        self
+    }
+}
+
 /// Trait defining a completion model that can be used to generate completion responses.
 /// This trait is meant to be implemented by the user to define a custom completion model,
 /// either from a third party provider (e.g.: OpenAI) or a local model.
+///
+/// Implementations return Rig's normalized [`CompletionResponse`] and
+/// [`StreamingCompletionResponse`]; a provider's own wire types stay on the
+/// provider's side of this boundary, reachable through its inherent
+/// `raw_completion`/`raw_stream` methods. Model construction belongs to
+/// [`crate::client::completion::CompletionClient`], not to this trait.
 pub trait CompletionModel: Clone + WasmCompatSend + WasmCompatSync {
-    /// The raw response type returned by the underlying completion model.
-    type Response: WasmCompatSend + WasmCompatSync + Serialize + DeserializeOwned;
-    /// The raw response type returned by the underlying completion model when streaming.
-    type StreamingResponse: Clone
-        + Unpin
-        + WasmCompatSend
-        + WasmCompatSync
-        + Serialize
-        + DeserializeOwned
-        + GetTokenUsage;
-
-    /// Provider client type used to construct this model.
-    type Client;
-
-    /// Construct a model handle from a provider client and model identifier.
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self;
-
     /// Generates a completion response for the given completion request.
     fn completion(
         &self,
         request: CompletionRequest,
-    ) -> impl std::future::Future<
-        Output = Result<CompletionResponse<Self::Response>, CompletionError>,
-    > + WasmCompatSend;
+    ) -> impl std::future::Future<Output = Result<CompletionResponse, CompletionError>> + WasmCompatSend;
 
+    /// Streams a completion response for the given completion request.
     fn stream(
         &self,
         request: CompletionRequest,
-    ) -> impl std::future::Future<
-        Output = Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError>,
-    > + WasmCompatSend;
+    ) -> impl std::future::Future<Output = Result<StreamingCompletionResponse, CompletionError>>
+    + WasmCompatSend;
 
     /// Generates a completion request builder for the given `prompt`.
     fn completion_request(&self, prompt: impl Into<Message>) -> CompletionRequestBuilder<Self> {
         CompletionRequestBuilder::new(self.clone(), prompt)
     }
 
-    /// Whether this provider's native structured output (`output_schema` ->
-    /// `format`/`response_format`) composes with tool calls in the same
-    /// multi-turn request without suppressing them.
+    /// Provider behavior a runtime should account for when preparing requests.
     ///
-    /// Defaults to `false` (the safe assumption: the native constraint may make
-    /// the model emit schema JSON instead of calling its tools — see issue
-    /// #1928). Providers that enforce structured output *and* tool use together
-    /// (e.g. OpenAI, Anthropic) override this to `true`, which lets runtimes keep
-    /// guaranteed native structured output active when tools are present.
-    fn composes_native_output_with_tools(&self) -> bool {
-        false
+    /// The default is conservative — see [`ProviderCapabilities`]. Override
+    /// this to declare the capabilities a provider actually supports.
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities::default()
     }
 }
 
@@ -857,19 +985,13 @@ impl<M: CompletionModel> CompletionRequestBuilder<M> {
     }
 
     /// Sends the completion request to the completion model provider and returns the completion response.
-    pub async fn send(self) -> Result<CompletionResponse<M::Response>, CompletionError> {
+    pub async fn send(self) -> Result<CompletionResponse, CompletionError> {
         let model = self.model.clone();
         model.completion(self.build()).await
     }
 
     /// Stream the completion request
-    pub async fn stream<'a>(
-        self,
-    ) -> Result<StreamingCompletionResponse<M::StreamingResponse>, CompletionError>
-    where
-        <M as CompletionModel>::StreamingResponse: 'a,
-        Self: 'a,
-    {
+    pub async fn stream(self) -> Result<StreamingCompletionResponse, CompletionError> {
         let model = self.model.clone();
         model.stream(self.build()).await
     }
@@ -877,6 +999,116 @@ impl<M: CompletionModel> CompletionRequestBuilder<M> {
 
 #[cfg(test)]
 mod tests {
+    use super::{CompletionResponse, FinishReason, ProviderCapabilities, Usage};
+    use crate::OneOrMany;
+    use crate::message::AssistantContent;
+
+    fn tool_call_choice() -> OneOrMany<AssistantContent> {
+        OneOrMany::one(AssistantContent::tool_call(
+            "call_1",
+            "lookup",
+            serde_json::json!({"query": "rig"}),
+        ))
+    }
+
+    #[test]
+    fn normalized_response_round_trips_through_serde() {
+        let response = CompletionResponse::new(
+            OneOrMany::one(AssistantContent::text("hello")),
+            Usage {
+                input_tokens: 3,
+                output_tokens: 2,
+                total_tokens: 5,
+                cached_input_tokens: 1,
+                cache_creation_input_tokens: 0,
+                tool_use_prompt_tokens: 0,
+                reasoning_tokens: 1,
+            },
+            "example",
+        )
+        .with_message_id("msg_123")
+        .with_finish_reason(FinishReason::Stop)
+        .with_model("provider-model-v2");
+
+        let encoded = serde_json::to_value(&response).expect("serialize response");
+        let decoded =
+            serde_json::from_value::<CompletionResponse>(encoded.clone()).expect("deserialize");
+
+        assert_eq!(
+            serde_json::to_value(decoded).expect("re-serialize"),
+            encoded
+        );
+    }
+
+    #[test]
+    fn unknown_finish_reason_survives_a_serde_round_trip_verbatim() {
+        let reason = FinishReason::Other("provider_specific_stop".to_owned());
+        let encoded = serde_json::to_string(&reason).expect("serialize");
+        let decoded = serde_json::from_str::<FinishReason>(&encoded).expect("deserialize");
+
+        assert_eq!(decoded, reason);
+    }
+
+    #[test]
+    fn stop_with_a_tool_call_reconciles_to_tool_calls() {
+        let response = CompletionResponse::new(tool_call_choice(), Usage::new(), "example")
+            .with_finish_reason(FinishReason::Stop);
+
+        assert_eq!(response.finish_reason, Some(FinishReason::ToolCalls));
+    }
+
+    /// The `Option` setter is what provider conversions actually reach for, so
+    /// it must reconcile identically — a provider holding an `Option` must not
+    /// have to choose between ergonomics and correctness.
+    #[test]
+    fn optional_setter_reconciles_exactly_like_the_plain_setter() {
+        let via_option = CompletionResponse::new(tool_call_choice(), Usage::new(), "example")
+            .with_optional_finish_reason(Some(FinishReason::Stop));
+        let via_plain = CompletionResponse::new(tool_call_choice(), Usage::new(), "example")
+            .with_finish_reason(FinishReason::Stop);
+
+        assert_eq!(via_option.finish_reason, Some(FinishReason::ToolCalls));
+        assert_eq!(via_option.finish_reason, via_plain.finish_reason);
+    }
+
+    #[test]
+    fn reconciliation_only_upgrades_a_natural_stop() {
+        // A truncated tool call is still a truncation; a filtered one is still
+        // filtered. Overriding either would lose why the turn actually ended.
+        for reason in [
+            FinishReason::Length,
+            FinishReason::ContentFilter,
+            FinishReason::Other("provider_specific".to_owned()),
+        ] {
+            let response = CompletionResponse::new(tool_call_choice(), Usage::new(), "example")
+                .with_finish_reason(reason.clone());
+
+            assert_eq!(response.finish_reason, Some(reason));
+        }
+    }
+
+    #[test]
+    fn reconciliation_leaves_a_stop_without_tool_calls_alone() {
+        let response = CompletionResponse::new(
+            OneOrMany::one(AssistantContent::text("done")),
+            Usage::new(),
+            "example",
+        )
+        .with_finish_reason(FinishReason::Stop);
+
+        assert_eq!(response.finish_reason, Some(FinishReason::Stop));
+    }
+
+    #[test]
+    fn provider_capabilities_are_externally_configurable_from_default() {
+        let capabilities =
+            ProviderCapabilities::default().with_native_output_tool_composition(true);
+
+        assert!(capabilities.composes_native_output_with_tools);
+        assert!(!ProviderCapabilities::new().composes_native_output_with_tools);
+        assert_eq!(ProviderCapabilities::new(), ProviderCapabilities::default());
+    }
+
     #[test]
     fn usage_has_values_reflects_the_zero_sentinel() {
         use super::Usage;

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -272,8 +272,14 @@ pub struct CompletionResponse {
     pub choice: OneOrMany<AssistantContent>,
     /// Tokens used during prompting and responding
     pub usage: Usage,
-    /// Provider-assigned message ID (e.g. OpenAI Responses API `msg_` ID).
-    /// Used to pair reasoning input items with their output items in multi-turn.
+    /// The identifier the provider assigned to this response, when it reported
+    /// one — an OpenAI Responses `msg_` ID, an Anthropic `msg_` ID, a Gemini
+    /// `responseId`, and so on. Providers differ in whether this names the
+    /// assistant message or the whole response; it is preserved as reported.
+    ///
+    /// The Responses API path uses it to pair reasoning input items with their
+    /// output items across turns. It is not echoed back to providers on replay:
+    /// request conversion drops [`Message::Assistant`]'s `id`.
     pub message_id: Option<String>,
     /// Why the model stopped generating, when the provider reported it.
     ///

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -359,6 +359,26 @@ impl CompletionResponse {
     }
 }
 
+/// Convert a provider's own completion payload into the normalized
+/// [`CompletionResponse`].
+///
+/// The provider descriptor name is an *input* rather than something the
+/// conversion knows, because several providers share one wire shape — the
+/// OpenAI chat-completions payload is used by more than a dozen of them. A
+/// conversion that hardcoded a name would mislabel every provider but one, and
+/// a placeholder overwritten by the caller would be correct only by convention.
+///
+/// This is a trait rather than `TryFrom<(&str, T)>` for a concrete reason:
+/// a tuple is not a local type, so `impl TryFrom<(&str, TheirResponse)> for
+/// CompletionResponse` is rejected by the orphan rule in any crate other than
+/// `rig-core`. Implementing this trait on a provider's own response type is
+/// allowed anywhere, which keeps provider extensions implementable outside this
+/// crate.
+pub trait NormalizeCompletionResponse {
+    /// Normalize this payload, attributing it to `provider`.
+    fn normalize(self, provider: &str) -> Result<CompletionResponse, CompletionError>;
+}
+
 /// Struct representing the token usage for a completion request.
 /// If tokens used are `0`, then the provider failed to supply token usage metrics.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -1,11 +1,10 @@
 //! Anthropic completion api implementation
 
 use crate::completion::CompletionRequest;
-use crate::providers::anthropic::streaming::StreamingCompletionResponse;
 use crate::{
     OneOrMany,
     client::Provider,
-    completion::{self, CompletionError, GetTokenUsage},
+    completion::{self, CompletionError},
     http_client::HttpClientExt,
     message::{self, DocumentMediaType, DocumentSourceKind, MessageError, MimeType, Reasoning},
     one_or_many::string_or_one_or_many,
@@ -64,6 +63,26 @@ pub struct CompletionResponse {
     pub stop_reason: Option<String>,
     pub stop_sequence: Option<String>,
     pub usage: Usage,
+}
+
+/// Map an Anthropic Messages `stop_reason` onto the normalized vocabulary,
+/// preserving anything unrecognized verbatim.
+///
+/// Shared by the unary and streaming paths so both agree, and so a stop reason
+/// Anthropic adds later surfaces in its own spelling rather than reading as a
+/// natural stop.
+pub(crate) fn map_finish_reason(stop_reason: &str) -> completion::FinishReason {
+    match stop_reason {
+        // `stop_sequence` is a natural termination too: the model completed its
+        // turn by emitting one of the caller's stop sequences.
+        "end_turn" | "stop_sequence" => completion::FinishReason::Stop,
+        "max_tokens" => completion::FinishReason::Length,
+        "tool_use" => completion::FinishReason::ToolCalls,
+        // Anthropic's classifier-driven refusal; the closest normalized reason
+        // is content filtering.
+        "refusal" => completion::FinishReason::ContentFilter,
+        other => completion::FinishReason::Other(other.to_owned()),
+    }
 }
 
 impl ProviderResponseExt for CompletionResponse {
@@ -130,20 +149,26 @@ impl std::fmt::Display for Usage {
     }
 }
 
-impl GetTokenUsage for Usage {
-    fn token_usage(&self) -> crate::completion::Usage {
+impl From<&Usage> for crate::completion::Usage {
+    fn from(value: &Usage) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
 
-        usage.input_tokens = self.input_tokens;
-        usage.output_tokens = self.output_tokens;
-        usage.cached_input_tokens = self.cache_read_input_tokens.unwrap_or_default();
-        usage.cache_creation_input_tokens = self.cache_creation_input_tokens.unwrap_or_default();
-        usage.total_tokens = self.input_tokens
-            + self.cache_read_input_tokens.unwrap_or_default()
-            + self.cache_creation_input_tokens.unwrap_or_default()
-            + self.output_tokens;
+        usage.input_tokens = value.input_tokens;
+        usage.output_tokens = value.output_tokens;
+        usage.cached_input_tokens = value.cache_read_input_tokens.unwrap_or_default();
+        usage.cache_creation_input_tokens = value.cache_creation_input_tokens.unwrap_or_default();
+        usage.total_tokens = value.input_tokens
+            + value.cache_read_input_tokens.unwrap_or_default()
+            + value.cache_creation_input_tokens.unwrap_or_default()
+            + value.output_tokens;
 
         usage
+    }
+}
+
+impl From<Usage> for crate::completion::Usage {
+    fn from(value: Usage) -> crate::completion::Usage {
+        (&value).into()
     }
 }
 
@@ -214,10 +239,17 @@ pub enum SystemContent {
     },
 }
 
-impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionResponse> {
+/// Normalize an Anthropic Messages response.
+///
+/// The provider descriptor name is an *input* rather than a constant: this same
+/// wire shape is served by every Anthropic-compatible provider (MiniMax, Z.ai,
+/// Moonshot, Xiaomi MiMo), so baking in `"anthropic"` here would mislabel all of
+/// them. Taking it as part of the conversion makes the correct name impossible
+/// to forget.
+impl TryFrom<(&str, CompletionResponse)> for completion::CompletionResponse {
     type Error = CompletionError;
 
-    fn try_from(response: CompletionResponse) -> Result<Self, Self::Error> {
+    fn try_from((provider, response): (&str, CompletionResponse)) -> Result<Self, Self::Error> {
         let content = response
             .content
             .iter()
@@ -240,25 +272,16 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 .map_err(|_| CompletionError::ResponseError(EMPTY_RESPONSE_ERROR.to_owned()))?
         };
 
-        let usage = completion::Usage {
-            input_tokens: response.usage.input_tokens,
-            output_tokens: response.usage.output_tokens,
-            total_tokens: response.usage.input_tokens
-                + response.usage.cache_read_input_tokens.unwrap_or(0)
-                + response.usage.cache_creation_input_tokens.unwrap_or(0)
-                + response.usage.output_tokens,
-            cached_input_tokens: response.usage.cache_read_input_tokens.unwrap_or(0),
-            cache_creation_input_tokens: response.usage.cache_creation_input_tokens.unwrap_or(0),
-            tool_use_prompt_tokens: 0,
-            reasoning_tokens: 0,
-        };
+        let finish_reason = response.stop_reason.as_deref().map(map_finish_reason);
 
-        Ok(completion::CompletionResponse {
+        Ok(completion::CompletionResponse::new(
             choice,
-            usage,
-            raw_response: response,
-            message_id: None,
-        })
+            crate::completion::Usage::from(&response.usage),
+            provider,
+        )
+        .with_optional_message_id(Some(response.id.as_str()).filter(|id| !id.is_empty()))
+        .with_model(response.model.as_str())
+        .with_optional_finish_reason(finish_reason))
     }
 }
 
@@ -2454,30 +2477,23 @@ pub(super) fn build_tool_definitions(
     Ok(tools)
 }
 
-impl<Ext, T> completion::CompletionModel for GenericCompletionModel<Ext, T>
+impl<Ext, T> GenericCompletionModel<Ext, T>
 where
     T: HttpClientExt + Clone + Default + WasmCompatSend + WasmCompatSync + 'static,
     Ext: AnthropicCompatibleProvider + Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
-    type Response = CompletionResponse;
-    type StreamingResponse = StreamingCompletionResponse;
-    type Client = crate::client::Client<Ext, T>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model.into())
-    }
-
-    // Anthropic's native structured outputs (constrained decoding) are designed
-    // to compose with strict tool use, so the schema constraint does not suppress
-    // tool calls. See issue #1928.
-    fn composes_native_output_with_tools(&self) -> bool {
-        true
-    }
-
-    async fn completion(
+    /// Execute a completion and return Anthropic's own wire response.
+    ///
+    /// This is the escape hatch for provider-specific fields rig does not
+    /// normalize. It shares the request builder, transport, telemetry, and
+    /// error handling with
+    /// [`CompletionModel::completion`](completion::CompletionModel::completion),
+    /// which calls it and then applies the provider-local mapping — one network
+    /// request either way.
+    pub async fn raw_completion(
         &self,
         mut completion_request: completion::CompletionRequest,
-    ) -> Result<completion::CompletionResponse<CompletionResponse>, CompletionError> {
+    ) -> Result<CompletionResponse, CompletionError> {
         let request_model = completion_request
             .model
             .clone()
@@ -2552,7 +2568,7 @@ where
                 ApiResponse::Message(completion) => {
                     let span = tracing::Span::current();
                     span.record_response_metadata(&completion);
-                    span.record_token_usage(&completion.usage);
+                    span.record_token_usage(&crate::completion::Usage::from(&completion.usage));
                     if enabled!(Level::TRACE) {
                         tracing::trace!(
                             target: "rig::completions",
@@ -2560,7 +2576,7 @@ where
                             serde_json::to_string_pretty(&completion)?
                         );
                     }
-                    completion.try_into()
+                    Ok(completion)
                 }
                 ApiResponse::Error(ApiErrorResponse { message }) => {
                     tracing::warn!(message = %message, "provider returned an error response");
@@ -2574,15 +2590,45 @@ where
         .instrument(span)
         .await
     }
+}
+
+impl<Ext, T> completion::CompletionModel for GenericCompletionModel<Ext, T>
+where
+    T: HttpClientExt + Clone + Default + WasmCompatSend + WasmCompatSync + 'static,
+    Ext: AnthropicCompatibleProvider + Clone + WasmCompatSend + WasmCompatSync + 'static,
+{
+    // Anthropic's native structured outputs (constrained decoding) are designed
+    // to compose with strict tool use, so the schema constraint does not suppress
+    // tool calls. See issue #1928.
+    fn capabilities(&self) -> completion::ProviderCapabilities {
+        completion::ProviderCapabilities::default().with_native_output_tool_composition(true)
+    }
+
+    async fn completion(
+        &self,
+        completion_request: completion::CompletionRequest,
+    ) -> Result<completion::CompletionResponse, CompletionError> {
+        let response = self.raw_completion(completion_request).await?;
+        (Ext::PROVIDER_NAME, response).try_into()
+    }
 
     async fn stream(
         &self,
         request: CompletionRequest,
-    ) -> Result<
-        crate::streaming::StreamingCompletionResponse<Self::StreamingResponse>,
-        CompletionError,
-    > {
+    ) -> Result<crate::streaming::StreamingCompletionResponse, CompletionError> {
         GenericCompletionModel::stream(self, request).await
+    }
+}
+
+impl<Ext, T> crate::client::ConstructCompletionModel<crate::client::Client<Ext, T>>
+    for GenericCompletionModel<Ext, T>
+where
+    crate::client::Client<Ext, T>: Clone,
+    T: HttpClientExt,
+    Ext: AnthropicCompatibleProvider + Clone + 'static,
+{
+    fn construct(client: &crate::client::Client<Ext, T>, model: String) -> Self {
+        Self::new(client.clone(), model)
     }
 }
 
@@ -4993,7 +5039,7 @@ mod tests {
             },
         };
 
-        let parsed: completion::CompletionResponse<CompletionResponse> = response
+        let parsed: completion::CompletionResponse = ("anthropic", response)
             .try_into()
             .expect("empty end_turn should not error");
 
@@ -5002,6 +5048,10 @@ mod tests {
             parsed.choice.first(),
             completion::AssistantContent::Text(text) if text.text.is_empty()
         ));
+        assert_eq!(parsed.provider, "anthropic");
+        assert_eq!(parsed.message_id.as_deref(), Some("msg_123"));
+        assert_eq!(parsed.model.as_deref(), Some(CLAUDE_SONNET_4_6));
+        assert_eq!(parsed.finish_reason, Some(completion::FinishReason::Stop));
     }
 
     #[test]
@@ -5021,13 +5071,84 @@ mod tests {
             },
         };
 
-        let err = completion::CompletionResponse::<CompletionResponse>::try_from(response)
+        let err = completion::CompletionResponse::try_from(("anthropic", response))
             .expect_err("empty non-end_turn should remain an error");
 
         assert!(matches!(
             err,
             CompletionError::ResponseError(message) if message == EMPTY_RESPONSE_ERROR
         ));
+    }
+
+    #[test]
+    fn stop_reason_maps_onto_the_normalized_vocabulary() {
+        assert_eq!(
+            map_finish_reason("end_turn"),
+            completion::FinishReason::Stop
+        );
+        assert_eq!(
+            map_finish_reason("stop_sequence"),
+            completion::FinishReason::Stop
+        );
+        assert_eq!(
+            map_finish_reason("max_tokens"),
+            completion::FinishReason::Length
+        );
+        assert_eq!(
+            map_finish_reason("tool_use"),
+            completion::FinishReason::ToolCalls
+        );
+        assert_eq!(
+            map_finish_reason("refusal"),
+            completion::FinishReason::ContentFilter
+        );
+    }
+
+    #[test]
+    fn unknown_stop_reason_is_preserved_verbatim() {
+        // Anthropic's own spelling survives, so a reason this crate does not yet
+        // model never reads as a natural stop.
+        assert_eq!(
+            map_finish_reason("pause_turn"),
+            completion::FinishReason::Other("pause_turn".to_owned())
+        );
+        assert_eq!(
+            map_finish_reason("model_context_window_exceeded"),
+            completion::FinishReason::Other("model_context_window_exceeded".to_owned())
+        );
+    }
+
+    #[test]
+    fn end_turn_with_a_tool_call_is_reconciled_to_tool_calls() {
+        // Anthropic reports `tool_use`, but the reconciliation the response
+        // builder applies must hold for any provider that reports a plain stop
+        // alongside a tool call.
+        let response = CompletionResponse {
+            content: vec![Content::ToolUse {
+                id: "toolu_1".to_string(),
+                name: "add".to_string(),
+                input: json!({"x": 1}),
+            }],
+            id: "msg_123".to_string(),
+            model: CLAUDE_SONNET_4_6.to_string(),
+            role: "assistant".to_string(),
+            stop_reason: Some("end_turn".to_string()),
+            stop_sequence: None,
+            usage: Usage {
+                input_tokens: 7,
+                cache_read_input_tokens: None,
+                cache_creation_input_tokens: None,
+                output_tokens: 2,
+            },
+        };
+
+        let parsed = completion::CompletionResponse::try_from(("anthropic", response))
+            .expect("tool-use response should normalize");
+
+        assert_eq!(
+            parsed.finish_reason,
+            Some(completion::FinishReason::ToolCalls)
+        );
     }
 
     #[test]
@@ -5283,11 +5404,13 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(value).unwrap();
-        let converted: completion::CompletionResponse<CompletionResponse> =
-            response.try_into().unwrap();
+        // The wire response is consumed by the conversion, so read the
+        // provider-native text off it first.
+        let raw_text_response = response.get_text_response();
+        let converted = completion::CompletionResponse::try_from(("anthropic", response)).unwrap();
         assert_eq!(converted.choice.len(), 3);
         assert_eq!(
-            converted.raw_response.get_text_response().as_deref(),
+            raw_text_response.as_deref(),
             Some("Claude Shannon was born on April 30, 1916.")
         );
 
@@ -5370,8 +5493,7 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(value).unwrap();
-        let converted: completion::CompletionResponse<CompletionResponse> =
-            response.try_into().unwrap();
+        let converted = completion::CompletionResponse::try_from(("anthropic", response)).unwrap();
         let message::AssistantContent::Text(web_search_result) = converted.choice.first() else {
             panic!("expected raw web_search_tool_result metadata");
         };
@@ -5476,8 +5598,7 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(value).unwrap();
-        let converted: completion::CompletionResponse<CompletionResponse> =
-            response.try_into().unwrap();
+        let converted = completion::CompletionResponse::try_from(("anthropic", response)).unwrap();
         let message::AssistantContent::Text(code_execution_result) = converted.choice.first()
         else {
             panic!("expected raw code_execution_tool_result metadata");
@@ -5981,6 +6102,14 @@ mod tests {
             Some(http::StatusCode::SERVICE_UNAVAILABLE)
         );
         assert_eq!(error.provider_response_body(), Some(body));
+
+        // The transport failure ends the stream: nothing may follow it that
+        // would read as a successfully completed turn.
+        assert!(stream.next().await.is_none());
+        assert!(
+            stream.response.is_none(),
+            "a stream cut short by a transport error must not synthesize a terminal record"
+        );
     }
 
     #[test]

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -1,6 +1,7 @@
 //! Anthropic completion api implementation
 
 use crate::completion::CompletionRequest;
+use crate::completion::NormalizeCompletionResponse;
 use crate::{
     OneOrMany,
     client::Provider,
@@ -246,10 +247,9 @@ pub enum SystemContent {
 /// Moonshot, Xiaomi MiMo), so baking in `"anthropic"` here would mislabel all of
 /// them. Taking it as part of the conversion makes the correct name impossible
 /// to forget.
-impl TryFrom<(&str, CompletionResponse)> for completion::CompletionResponse {
-    type Error = CompletionError;
-
-    fn try_from((provider, response): (&str, CompletionResponse)) -> Result<Self, Self::Error> {
+impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
+    fn normalize(self, provider: &str) -> Result<completion::CompletionResponse, CompletionError> {
+        let response = self;
         let content = response
             .content
             .iter()
@@ -2609,7 +2609,7 @@ where
         completion_request: completion::CompletionRequest,
     ) -> Result<completion::CompletionResponse, CompletionError> {
         let response = self.raw_completion(completion_request).await?;
-        (Ext::PROVIDER_NAME, response).try_into()
+        response.normalize(Ext::PROVIDER_NAME)
     }
 
     async fn stream(
@@ -5039,8 +5039,8 @@ mod tests {
             },
         };
 
-        let parsed: completion::CompletionResponse = ("anthropic", response)
-            .try_into()
+        let parsed: completion::CompletionResponse = response
+            .normalize("anthropic")
             .expect("empty end_turn should not error");
 
         assert_eq!(parsed.choice.len(), 1);
@@ -5071,7 +5071,8 @@ mod tests {
             },
         };
 
-        let err = completion::CompletionResponse::try_from(("anthropic", response))
+        let err = response
+            .normalize("anthropic")
             .expect_err("empty non-end_turn should remain an error");
 
         assert!(matches!(
@@ -5142,7 +5143,8 @@ mod tests {
             },
         };
 
-        let parsed = completion::CompletionResponse::try_from(("anthropic", response))
+        let parsed = response
+            .normalize("anthropic")
             .expect("tool-use response should normalize");
 
         assert_eq!(
@@ -5407,7 +5409,7 @@ mod tests {
         // The wire response is consumed by the conversion, so read the
         // provider-native text off it first.
         let raw_text_response = response.get_text_response();
-        let converted = completion::CompletionResponse::try_from(("anthropic", response)).unwrap();
+        let converted = response.normalize("anthropic").unwrap();
         assert_eq!(converted.choice.len(), 3);
         assert_eq!(
             raw_text_response.as_deref(),
@@ -5493,7 +5495,7 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(value).unwrap();
-        let converted = completion::CompletionResponse::try_from(("anthropic", response)).unwrap();
+        let converted = response.normalize("anthropic").unwrap();
         let message::AssistantContent::Text(web_search_result) = converted.choice.first() else {
             panic!("expected raw web_search_tool_result metadata");
         };
@@ -5598,7 +5600,7 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(value).unwrap();
-        let converted = completion::CompletionResponse::try_from(("anthropic", response)).unwrap();
+        let converted = response.normalize("anthropic").unwrap();
         let message::AssistantContent::Text(code_execution_result) = converted.choice.first()
         else {
             panic!("expected raw code_execution_tool_result metadata");

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -7,14 +7,15 @@ use tracing_futures::Instrument;
 
 use super::completion::{
     AnthropicCompatibleProvider, AnthropicCompletionRequest, AnthropicRequestParams, CacheTtl,
-    Content, GenericCompletionModel, Usage,
+    Content, GenericCompletionModel, Usage, map_finish_reason,
 };
-use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
+use crate::completion::{CompletionError, CompletionRequest};
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::http_client::{self, HttpClientExt};
 use crate::message::ReasoningContent;
 use crate::streaming::{
-    self, RawStreamingChoice, RawStreamingToolCall, StreamingResult, ToolCallDeltaContent,
+    self, RawStreamingChoice, RawStreamingResult, RawStreamingToolCall, StreamFinal,
+    ToolCallDeltaContent,
 };
 use crate::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
 use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
@@ -156,19 +157,25 @@ pub struct PartialUsage {
     pub cache_read_input_tokens: Option<u64>,
 }
 
-impl GetTokenUsage for PartialUsage {
-    fn token_usage(&self) -> crate::completion::Usage {
+impl From<&PartialUsage> for crate::completion::Usage {
+    fn from(value: &PartialUsage) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
 
-        usage.input_tokens = self.input_tokens.unwrap_or_default() as u64;
-        usage.output_tokens = self.output_tokens as u64;
-        usage.cached_input_tokens = self.cache_read_input_tokens.unwrap_or(0);
-        usage.cache_creation_input_tokens = self.cache_creation_input_tokens.unwrap_or(0);
+        usage.input_tokens = value.input_tokens.unwrap_or_default() as u64;
+        usage.output_tokens = value.output_tokens as u64;
+        usage.cached_input_tokens = value.cache_read_input_tokens.unwrap_or(0);
+        usage.cache_creation_input_tokens = value.cache_creation_input_tokens.unwrap_or(0);
         usage.total_tokens = usage.input_tokens
             + usage.cached_input_tokens
             + usage.cache_creation_input_tokens
             + usage.output_tokens;
         usage
+    }
+}
+
+impl From<PartialUsage> for crate::completion::Usage {
+    fn from(value: PartialUsage) -> crate::completion::Usage {
+        (&value).into()
     }
 }
 
@@ -193,24 +200,38 @@ struct ThinkingState {
     signature: String,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+/// Anthropic's own terminal stream record, as returned by
+/// [`GenericCompletionModel::raw_stream`].
+///
+/// [`crate::completion::CompletionModel::stream`] maps this once into the
+/// normalized [`StreamFinal`]; callers who want the provider-native shape read
+/// it here instead.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct StreamingCompletionResponse {
+    /// Token usage carried by the terminal `message_delta` event.
     pub usage: PartialUsage,
+    /// Anthropic's `stop_reason`, verbatim, when the stream reported one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<String>,
+    /// The `message_start` message ID, when the stream reported one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<String>,
+    /// The model named by `message_start`, when the stream reported one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
 }
 
-impl GetTokenUsage for StreamingCompletionResponse {
-    fn token_usage(&self) -> crate::completion::Usage {
-        let mut usage = crate::completion::Usage::new();
-        usage.input_tokens = self.usage.input_tokens.unwrap_or(0) as u64;
-        usage.output_tokens = self.usage.output_tokens as u64;
-        usage.cached_input_tokens = self.usage.cache_read_input_tokens.unwrap_or(0);
-        usage.cache_creation_input_tokens = self.usage.cache_creation_input_tokens.unwrap_or(0);
-        usage.total_tokens = usage.input_tokens
-            + usage.cached_input_tokens
-            + usage.cache_creation_input_tokens
-            + usage.output_tokens;
-
-        usage
+/// Normalize an Anthropic terminal stream record.
+///
+/// The provider descriptor name is an *input* rather than a constant: the
+/// Anthropic Messages stream format is shared by every Anthropic-compatible
+/// provider, so baking in `"anthropic"` here would mislabel all of them.
+impl From<(&str, StreamingCompletionResponse)> for StreamFinal {
+    fn from((provider, response): (&str, StreamingCompletionResponse)) -> Self {
+        StreamFinal::new(provider, crate::completion::Usage::from(&response.usage))
+            .with_optional_finish_reason(response.stop_reason.as_deref().map(map_finish_reason))
+            .with_optional_message_id(response.message_id)
+            .with_optional_model(response.model)
     }
 }
 
@@ -219,11 +240,18 @@ where
     T: HttpClientExt + Clone + Default + 'static,
     Ext: AnthropicCompatibleProvider + Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
-    pub(crate) async fn stream(
+    /// Open a stream whose terminal record stays Anthropic-native.
+    ///
+    /// This is the escape hatch for provider-specific terminal fields rig does
+    /// not normalize. It shares the request builder, transport, telemetry, and
+    /// error handling with
+    /// [`CompletionModel::stream`](crate::completion::CompletionModel::stream),
+    /// which calls it and then maps the terminal record once through
+    /// [`crate::streaming::normalize_stream`] — one network request either way.
+    pub async fn raw_stream(
         &self,
         completion_request: CompletionRequest,
-    ) -> Result<streaming::StreamingCompletionResponse<StreamingCompletionResponse>, CompletionError>
-    {
+    ) -> Result<RawStreamingResult<StreamingCompletionResponse>, CompletionError> {
         let request_model = completion_request
             .model
             .clone()
@@ -276,13 +304,17 @@ where
         let stream = GenericEventSource::new(self.client.clone(), req);
 
         // Use our SSE decoder to directly handle Server-Sent Events format
-        let stream: StreamingResult<StreamingCompletionResponse> = Box::pin(stream! {
+        let stream: RawStreamingResult<StreamingCompletionResponse> = Box::pin(stream! {
             let mut current_tool_call: Option<ToolCallState> = None;
             let mut server_tool_uses: HashMap<usize, ServerToolUseState> = HashMap::new();
             let mut current_thinking: Option<ThinkingState> = None;
             let mut sse_stream = Box::pin(stream);
             let mut input_tokens = 0;
             let mut final_usage = None;
+            let mut stop_reason = None;
+            let mut message_id = None;
+            let mut response_model = None;
+            let mut terminated_with_error = false;
 
             let mut text_content = String::new();
 
@@ -296,13 +328,15 @@ where
                                 match &event {
                                     StreamingEvent::MessageStart { message } => {
                                         input_tokens = message.usage.input_tokens;
+                                        message_id = Some(message.id.clone());
+                                        response_model = Some(message.model.clone());
 
                                         let span = tracing::Span::current();
                                         span.record("gen_ai.response.id", &message.id);
                                         span.record("gen_ai.response.model", &message.model);
                                     },
                                     StreamingEvent::MessageDelta { delta, usage } => {
-                                        if delta.stop_reason.is_some() {
+                                        if let Some(reason) = delta.stop_reason.as_ref() {
                                             // cache_creation_input_tokens and cache_read_input_tokens
                                             // are cumulative totals on message_delta.usage per the
                                             // Anthropic streaming API spec — use them directly.
@@ -314,8 +348,9 @@ where
                                             };
 
                                             let span = tracing::Span::current();
-                                            span.record_token_usage(&usage);
+                                            span.record_token_usage(&crate::completion::Usage::from(&usage));
                                             final_usage = Some(usage);
+                                            stop_reason = Some(reason.clone());
                                             break;
                                         }
                                     }
@@ -344,6 +379,7 @@ where
                         }
                     },
                     Err(e) => {
+                        terminated_with_error = true;
                         yield Err(CompletionError::from_stream_transport(e));
                         break;
                     }
@@ -353,12 +389,37 @@ where
             // Ensure event source is closed when stream ends
             sse_stream.close();
 
+            // A transport failure cut the stream short: whatever was accumulated
+            // is partial, so do not follow the error with a terminal record that
+            // would read as a successfully completed turn.
+            if terminated_with_error {
+                return;
+            }
+
             yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
-                usage: final_usage.unwrap_or_default()
+                usage: final_usage.unwrap_or_default(),
+                stop_reason,
+                message_id,
+                model: response_model,
             }))
         }.instrument(span));
 
-        Ok(streaming::StreamingCompletionResponse::stream(stream))
+        Ok(stream)
+    }
+
+    pub(crate) async fn stream(
+        &self,
+        completion_request: CompletionRequest,
+    ) -> Result<streaming::StreamingCompletionResponse, CompletionError> {
+        let stream = self.raw_stream(completion_request).await?;
+        let normalized = streaming::normalize_stream(stream, |response| {
+            Ok(StreamFinal::from((Ext::PROVIDER_NAME, response)))
+        });
+
+        Ok(streaming::StreamingCompletionResponse::stream(
+            Ext::PROVIDER_NAME,
+            normalized,
+        ))
     }
 }
 
@@ -560,14 +621,19 @@ mod tests {
     use async_stream::stream;
     use futures::StreamExt;
 
+    /// Normalize a hand-built Anthropic raw stream exactly as
+    /// [`GenericCompletionModel::stream`] does, so aggregation assertions run
+    /// against the same terminal-record mapping as the real path.
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     fn to_stream_result(
         stream: impl futures::Stream<
             Item = Result<RawStreamingChoice<StreamingCompletionResponse>, CompletionError>,
         > + Send
         + 'static,
-    ) -> crate::streaming::StreamingResult<StreamingCompletionResponse> {
-        Box::pin(stream)
+    ) -> crate::streaming::StreamingResult {
+        crate::streaming::normalize_stream(Box::pin(stream), |response| {
+            Ok(StreamFinal::from(("anthropic", response)))
+        })
     }
 
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -575,8 +641,10 @@ mod tests {
         stream: impl futures::Stream<
             Item = Result<RawStreamingChoice<StreamingCompletionResponse>, CompletionError>,
         > + 'static,
-    ) -> crate::streaming::StreamingResult<StreamingCompletionResponse> {
-        Box::pin(stream)
+    ) -> crate::streaming::StreamingResult {
+        crate::streaming::normalize_stream(Box::pin(stream), |response| {
+            Ok(StreamFinal::from(("anthropic", response)))
+        })
     }
 
     #[test]
@@ -1617,13 +1685,13 @@ mod tests {
             )
             .expect("citation delta should produce a raw choice");
 
-            yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
-                usage: PartialUsage::default(),
-            }));
+            yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse::default()));
         };
 
-        let mut stream =
-            crate::streaming::StreamingCompletionResponse::stream(to_stream_result(raw_stream));
+        let mut stream = crate::streaming::StreamingCompletionResponse::stream(
+            "anthropic",
+            to_stream_result(raw_stream),
+        );
         while stream.next().await.is_some() {}
 
         let choice_items: Vec<crate::message::AssistantContent> =
@@ -1762,13 +1830,13 @@ mod tests {
             )
             .expect("citation delta should produce a raw choice");
 
-            yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
-                usage: PartialUsage::default(),
-            }));
+            yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse::default()));
         };
 
-        let mut stream =
-            crate::streaming::StreamingCompletionResponse::stream(to_stream_result(raw_stream));
+        let mut stream = crate::streaming::StreamingCompletionResponse::stream(
+            "anthropic",
+            to_stream_result(raw_stream),
+        );
         while stream.next().await.is_some() {}
 
         let choice_items: Vec<crate::message::AssistantContent> =
@@ -1787,5 +1855,96 @@ mod tests {
         let json = r#"{"type": "something_new_from_anthropic", "field": "x"}"#;
         let delta: ContentDelta = serde_json::from_str(json).unwrap();
         assert!(matches!(delta, ContentDelta::Unknown));
+    }
+
+    #[tokio::test]
+    async fn terminal_record_normalizes_stop_reason_usage_and_metadata() {
+        let raw_stream = stream! {
+            yield Ok(RawStreamingChoice::Message("hi".to_string()));
+            yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
+                usage: PartialUsage {
+                    output_tokens: 5,
+                    input_tokens: Some(3),
+                    cache_creation_input_tokens: None,
+                    cache_read_input_tokens: Some(2),
+                },
+                stop_reason: Some("max_tokens".to_string()),
+                message_id: Some("msg_1".to_string()),
+                model: Some(CLAUDE_OPUS_4_8.to_string()),
+            }));
+        };
+
+        let mut stream = crate::streaming::StreamingCompletionResponse::stream(
+            "anthropic",
+            to_stream_result(raw_stream),
+        );
+        while stream.next().await.is_some() {}
+
+        let terminal = stream.response.expect("expected a terminal record");
+        assert_eq!(terminal.provider, "anthropic");
+        assert_eq!(terminal.message_id.as_deref(), Some("msg_1"));
+        assert_eq!(terminal.model.as_deref(), Some(CLAUDE_OPUS_4_8));
+        assert_eq!(
+            terminal.finish_reason,
+            Some(crate::completion::FinishReason::Length)
+        );
+        assert_eq!(terminal.usage.input_tokens, 3);
+        assert_eq!(terminal.usage.output_tokens, 5);
+        assert_eq!(terminal.usage.cached_input_tokens, 2);
+        assert_eq!(terminal.usage.total_tokens, 10);
+    }
+
+    #[tokio::test]
+    async fn terminal_record_upgrades_end_turn_to_tool_calls_after_a_streamed_tool_call() {
+        // Anthropic normally reports `tool_use`, but the reconciliation
+        // `normalize_stream` applies must hold whenever the turn actually
+        // emitted a tool call.
+        let raw_stream = stream! {
+            yield Ok(RawStreamingChoice::ToolCall(RawStreamingToolCall::new(
+                "toolu_1".to_string(),
+                "add".to_string(),
+                json!({"x": 1}),
+            )));
+            yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
+                stop_reason: Some("end_turn".to_string()),
+                ..Default::default()
+            }));
+        };
+
+        let mut stream = crate::streaming::StreamingCompletionResponse::stream(
+            "anthropic",
+            to_stream_result(raw_stream),
+        );
+        while stream.next().await.is_some() {}
+
+        let terminal = stream.response.expect("expected a terminal record");
+        assert_eq!(
+            terminal.finish_reason,
+            Some(crate::completion::FinishReason::ToolCalls)
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_stop_reason_survives_onto_the_terminal_record() {
+        let raw_stream = stream! {
+            yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
+                stop_reason: Some("pause_turn".to_string()),
+                ..Default::default()
+            }));
+        };
+
+        let mut stream = crate::streaming::StreamingCompletionResponse::stream(
+            "anthropic",
+            to_stream_result(raw_stream),
+        );
+        while stream.next().await.is_some() {}
+
+        let terminal = stream.response.expect("expected a terminal record");
+        assert_eq!(
+            terminal.finish_reason,
+            Some(crate::completion::FinishReason::Other(
+                "pause_turn".to_owned()
+            ))
+        );
     }
 }

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -29,7 +29,6 @@ use crate::client::{
     self, ApiKey, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
     ProviderClient,
 };
-use crate::completion::GetTokenUsage;
 use crate::http_client::multipart::Part;
 use crate::http_client::{self, HttpClientExt, MultipartForm, bearer_auth_header};
 use crate::transcription::TranscriptionError;
@@ -374,15 +373,22 @@ pub struct Usage {
     pub total_tokens: usize,
 }
 
-impl GetTokenUsage for Usage {
-    fn token_usage(&self) -> crate::completion::Usage {
-        let mut usage = crate::completion::Usage::new();
+impl From<&Usage> for crate::completion::Usage {
+    fn from(usage: &Usage) -> Self {
+        crate::providers::internal::completion_usage(
+            usage.prompt_tokens as u64,
+            // Azure's embeddings usage reports only prompt and total counts;
+            // the completion count is the remainder.
+            usage.total_tokens.saturating_sub(usage.prompt_tokens) as u64,
+            usage.total_tokens as u64,
+            0,
+        )
+    }
+}
 
-        usage.input_tokens = self.prompt_tokens as u64;
-        usage.total_tokens = self.total_tokens as u64;
-        usage.output_tokens = usage.total_tokens - usage.input_tokens;
-
-        usage
+impl From<Usage> for crate::completion::Usage {
+    fn from(usage: Usage) -> Self {
+        Self::from(&usage)
     }
 }
 

--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -22,7 +22,7 @@ use crate::client::{
     self, ApiKey, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
     ProviderClient, Transport,
 };
-use crate::completion::{self, CompletionError};
+use crate::completion::{self, CompletionError, NormalizeCompletionResponse};
 use crate::http_client::{self, HttpClientExt};
 use crate::providers::openai::responses_api::{
     self, CompletionRequest as ResponsesRequest, Include,
@@ -457,14 +457,44 @@ where
         &self,
         completion_request: completion::CompletionRequest,
     ) -> Result<responses_api::CompletionResponse, CompletionError> {
+        let record_telemetry_content = completion_request.record_telemetry_content;
         let request = self.create_request(completion_request)?;
-        self.raw_completion_from_sse(request).await
+        let span = self.completion_span(&request, record_telemetry_content);
+
+        tracing_futures::Instrument::instrument(
+            async move { Ok(self.send_completion(request).await?.0) },
+            span,
+        )
+        .await
     }
 
-    async fn raw_completion_from_sse(
+    /// Build the `chat` span for a non-streaming ChatGPT completion.
+    ///
+    /// The instructions recorded here are the ones actually sent: the request's
+    /// merged `instructions`, not the caller's preamble, which
+    /// `SystemInstructionsPlacement::AllInstructions` folds together with the
+    /// client's `default_instructions`.
+    fn completion_span(
+        &self,
+        request: &ResponsesRequest,
+        record_telemetry_content: bool,
+    ) -> tracing::Span {
+        CompletionSpanBuilder::new(PROVIDER_NAME, &request.model, CompletionOperation::Chat)
+            .system_instructions(request.instructions.as_deref(), record_telemetry_content)
+            .build()
+    }
+
+    /// Issue the request and return the reassembled wire response together with
+    /// the SSE body it came from.
+    ///
+    /// Both the raw and the normalized path go through here, so there is one
+    /// transport, one status check, and one parse — and the normalized path can
+    /// still reach the event stream for its empty-`output` fallback without
+    /// issuing a second request.
+    async fn send_completion(
         &self,
         request: ResponsesRequest,
-    ) -> Result<responses_api::CompletionResponse, CompletionError> {
+    ) -> Result<(responses_api::CompletionResponse, String), CompletionError> {
         let body = serde_json::to_vec(&request)?;
         let auth = self
             .client
@@ -491,43 +521,22 @@ where
         // event stream rather than parsed as one JSON document.
         let raw_response = responses_api::streaming::parse_sse_completion_body(&text, "ChatGPT")?;
 
-        Ok(raw_response)
+        let span = tracing::Span::current();
+        span.record("gen_ai.response.id", &raw_response.id);
+        span.record("gen_ai.response.model", &raw_response.model);
+
+        Ok((raw_response, text))
     }
 
     /// Normalize a ChatGPT completion, falling back to the SSE event stream
     /// when the reassembled response carries no output items.
     async fn normalized_completion(
         &self,
-        completion_request: completion::CompletionRequest,
+        request: ResponsesRequest,
     ) -> Result<completion::CompletionResponse, CompletionError> {
-        let request = self.create_request(completion_request)?;
-        let body = serde_json::to_vec(&request)?;
-        let auth = self
-            .client
-            .ext()
-            .auth
-            .auth_context()
-            .await
-            .map_err(|err| CompletionError::ProviderError(err.to_string()))?;
+        let (raw_response, text) = self.send_completion(request).await?;
 
-        let req = self
-            .add_auth_headers(self.client.post("/responses")?, &auth)
-            .body(body)
-            .map_err(|err| CompletionError::HttpError(err.into()))?;
-
-        let response = self.client.send(req).await?;
-        let status = response.status();
-        let text = http_client::text(response).await?;
-        if !status.is_success() {
-            return Err(CompletionError::from_http_response(status, text));
-        }
-
-        let raw_response = responses_api::streaming::parse_sse_completion_body(&text, "ChatGPT")?;
-        let span = tracing::Span::current();
-        span.record("gen_ai.response.id", &raw_response.id);
-        span.record("gen_ai.response.model", &raw_response.model);
-
-        match (PROVIDER_NAME, raw_response.clone()).try_into() {
+        match raw_response.clone().normalize(PROVIDER_NAME) {
             Ok(response) => Ok(response),
             // An empty `output` means the terminal event never carried the
             // assembled items; rebuild the response from the raw event stream.
@@ -573,19 +582,12 @@ where
         completion_request: completion::CompletionRequest,
     ) -> Result<completion::CompletionResponse, CompletionError> {
         let record_telemetry_content = completion_request.record_telemetry_content;
-        let model = completion_request
-            .model
-            .clone()
-            .unwrap_or_else(|| self.model.clone());
-        let preamble = completion_request.preamble.clone();
-
-        let span = CompletionSpanBuilder::new(PROVIDER_NAME, &model, CompletionOperation::Chat)
-            .system_instructions(preamble.as_deref(), record_telemetry_content)
-            .build();
+        let request = self.create_request(completion_request)?;
+        let span = self.completion_span(&request, record_telemetry_content);
 
         tracing_futures::Instrument::instrument(
             async move {
-                let response = self.normalized_completion(completion_request).await?;
+                let response = self.normalized_completion(request).await?;
                 let span = tracing::Span::current();
                 span.record("gen_ai.usage.output_tokens", response.usage.output_tokens);
                 span.record("gen_ai.usage.input_tokens", response.usage.input_tokens);

--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -439,11 +439,60 @@ where
         }
     }
 
-    async fn completion_from_sse(
+    /// Execute a ChatGPT completion and return the Responses API's own wire
+    /// response.
+    ///
+    /// This is the escape hatch for fields rig does not normalize;
+    /// [`completion::CompletionModel::completion`] calls it and maps the
+    /// result, so there is exactly one request either way.
+    pub async fn raw_completion(
+        &self,
+        completion_request: completion::CompletionRequest,
+    ) -> Result<responses_api::CompletionResponse, CompletionError> {
+        let request = self.create_request(completion_request)?;
+        self.raw_completion_from_sse(request).await
+    }
+
+    async fn raw_completion_from_sse(
         &self,
         request: ResponsesRequest,
-    ) -> Result<completion::CompletionResponse<responses_api::CompletionResponse>, CompletionError>
-    {
+    ) -> Result<responses_api::CompletionResponse, CompletionError> {
+        let body = serde_json::to_vec(&request)?;
+        let auth = self
+            .client
+            .ext()
+            .auth
+            .auth_context()
+            .await
+            .map_err(|err| CompletionError::ProviderError(err.to_string()))?;
+
+        let req = self
+            .add_auth_headers(self.client.post("/responses")?, &auth)
+            .body(body)
+            .map_err(|err| CompletionError::HttpError(err.into()))?;
+
+        let response = self.client.send(req).await?;
+        let status = response.status();
+        let text = http_client::text(response).await?;
+        if !status.is_success() {
+            return Err(CompletionError::from_http_response(status, text));
+        }
+
+        // The `/responses` endpoint answers with an SSE body even for a
+        // non-streaming request, so the wire response is reassembled from the
+        // event stream rather than parsed as one JSON document.
+        let raw_response = responses_api::streaming::parse_sse_completion_body(&text, "ChatGPT")?;
+
+        Ok(raw_response)
+    }
+
+    /// Normalize a ChatGPT completion, falling back to the SSE event stream
+    /// when the reassembled response carries no output items.
+    async fn normalized_completion(
+        &self,
+        completion_request: completion::CompletionRequest,
+    ) -> Result<completion::CompletionResponse, CompletionError> {
+        let request = self.create_request(completion_request)?;
         let body = serde_json::to_vec(&request)?;
         let auth = self
             .client
@@ -466,12 +515,21 @@ where
         }
 
         let raw_response = responses_api::streaming::parse_sse_completion_body(&text, "ChatGPT")?;
+        let span = tracing::Span::current();
+        span.record("gen_ai.response.id", &raw_response.id);
+        span.record("gen_ai.response.model", &raw_response.model);
 
-        match raw_response.clone().try_into() {
+        match (PROVIDER_NAME, raw_response.clone()).try_into() {
             Ok(response) => Ok(response),
+            // An empty `output` means the terminal event never carried the
+            // assembled items; rebuild the response from the raw event stream.
             Err(CompletionError::ResponseError(_)) if raw_response.output.is_empty() => {
-                responses_api::streaming::completion_response_from_sse_body(&text, raw_response)
-                    .await
+                responses_api::streaming::completion_response_from_sse_body(
+                    PROVIDER_NAME,
+                    &text,
+                    raw_response,
+                )
+                .await
             }
             Err(error) => Err(error),
         }
@@ -487,36 +545,40 @@ where
     }
 }
 
+impl<H> crate::client::ConstructCompletionModel<Client<H>> for ResponsesCompletionModel<H>
+where
+    Client<H>: HttpClientExt + Clone + Debug + 'static,
+    H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
+{
+    fn construct(client: &Client<H>, model: String) -> Self {
+        Self::new(client.clone(), model)
+    }
+}
+
 impl<H> completion::CompletionModel for ResponsesCompletionModel<H>
 where
     Client<H>: HttpClientExt + Clone + Debug + 'static,
     H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
 {
-    type Response = responses_api::CompletionResponse;
-    type StreamingResponse = responses_api::streaming::StreamingCompletionResponse;
-    type Client = Client<H>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
-
     async fn completion(
         &self,
         completion_request: completion::CompletionRequest,
-    ) -> Result<completion::CompletionResponse<Self::Response>, CompletionError> {
+    ) -> Result<completion::CompletionResponse, CompletionError> {
         let record_telemetry_content = completion_request.record_telemetry_content;
-        let request = self.create_request(completion_request)?;
+        let model = completion_request
+            .model
+            .clone()
+            .unwrap_or_else(|| self.model.clone());
+        let preamble = completion_request.preamble.clone();
 
-        let span = CompletionSpanBuilder::new("chatgpt", &request.model, CompletionOperation::Chat)
-            .system_instructions(request.instructions.as_deref(), record_telemetry_content)
+        let span = CompletionSpanBuilder::new(PROVIDER_NAME, &model, CompletionOperation::Chat)
+            .system_instructions(preamble.as_deref(), record_telemetry_content)
             .build();
 
         tracing_futures::Instrument::instrument(
             async move {
-                let response = self.completion_from_sse(request).await?;
+                let response = self.normalized_completion(completion_request).await?;
                 let span = tracing::Span::current();
-                span.record("gen_ai.response.id", &response.raw_response.id);
-                span.record("gen_ai.response.model", &response.raw_response.model);
                 span.record("gen_ai.usage.output_tokens", response.usage.output_tokens);
                 span.record("gen_ai.usage.input_tokens", response.usage.input_tokens);
                 span.record(
@@ -533,7 +595,7 @@ where
     async fn stream(
         &self,
         completion_request: completion::CompletionRequest,
-    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+    ) -> Result<StreamingCompletionResponse, CompletionError> {
         Self::stream(self, completion_request).await
     }
 }
@@ -543,11 +605,28 @@ where
     Client<H>: HttpClientExt + Clone + Debug + 'static,
     H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
 {
+    /// Open a stream normalized to rig's terminal record.
+    ///
+    /// Delegates to [`ResponsesCompletionModel::raw_stream`] — one request
+    /// either way.
     pub async fn stream(
         &self,
         completion_request: completion::CompletionRequest,
+    ) -> Result<StreamingCompletionResponse, CompletionError> {
+        let raw = self.raw_stream(completion_request).await?;
+
+        Ok(responses_api::streaming::normalize_responses_stream(
+            PROVIDER_NAME,
+            raw,
+        ))
+    }
+
+    /// Open a stream whose terminal record stays the Responses API's own type.
+    pub async fn raw_stream(
+        &self,
+        completion_request: completion::CompletionRequest,
     ) -> Result<
-        StreamingCompletionResponse<responses_api::streaming::StreamingCompletionResponse>,
+        crate::streaming::RawStreamingResult<responses_api::streaming::StreamingCompletionResponse>,
         CompletionError,
     > {
         let record_telemetry_content = completion_request.record_telemetry_content;
@@ -576,7 +655,7 @@ where
             .map_err(|err| CompletionError::HttpError(err.into()))?;
 
         let span = CompletionSpanBuilder::new(
-            "chatgpt",
+            PROVIDER_NAME,
             &request.model,
             CompletionOperation::ChatStreaming,
         )
@@ -587,12 +666,15 @@ where
         let event_source = crate::http_client::sse::GenericEventSource::new(client, req)
             .allow_missing_content_type();
 
-        Ok(responses_api::streaming::stream_from_event_source(
+        Ok(responses_api::streaming::raw_stream_from_event_source(
             event_source,
             span,
         ))
     }
 }
+
+/// Stable descriptor name reported on normalized ChatGPT responses.
+pub const PROVIDER_NAME: &str = "chatgpt";
 
 fn default_user_agent() -> String {
     format!(
@@ -810,10 +892,13 @@ data: [DONE]"#;
 
         let raw_response = responses_api::streaming::parse_sse_completion_body(body, "ChatGPT")
             .expect("expected response");
-        let response =
-            responses_api::streaming::completion_response_from_sse_body(body, raw_response)
-                .await
-                .expect("fallback response");
+        let response = responses_api::streaming::completion_response_from_sse_body(
+            PROVIDER_NAME,
+            body,
+            raw_response,
+        )
+        .await
+        .expect("fallback response");
 
         let text: String = response
             .choice

--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -442,9 +442,17 @@ where
     /// Execute a ChatGPT completion and return the Responses API's own wire
     /// response.
     ///
-    /// This is the escape hatch for fields rig does not normalize;
-    /// [`completion::CompletionModel::completion`] calls it and maps the
-    /// result, so there is exactly one request either way.
+    /// This is the escape hatch for fields rig does not normalize, and it
+    /// issues the same single request the normalized path does.
+    ///
+    /// One caveat is specific to this provider: `/responses` answers with an
+    /// SSE body even for a non-streaming request, so the value returned here is
+    /// reassembled from the terminal `response.completed` event. That event
+    /// sometimes carries an empty `output`, in which case the assistant content
+    /// exists only in the preceding events and
+    /// [`completion::CompletionModel::completion`] rebuilds it from them. When
+    /// you need the provider's events in full fidelity rather than just its
+    /// terminal record, use [`ResponsesCompletionModel::raw_stream`].
     pub async fn raw_completion(
         &self,
         completion_request: completion::CompletionRequest,

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -127,24 +127,15 @@ pub struct Usage {
 
 impl From<&Usage> for crate::completion::Usage {
     fn from(usage: &Usage) -> crate::completion::Usage {
-        // `tokens` is Cohere's actual token accounting; `billed_units` is the
-        // billing view of the same turn and only stands in when Cohere omits
-        // the token counts.
-        let counts = usage
-            .tokens
-            .as_ref()
-            .map(|tokens| (tokens.input_tokens, tokens.output_tokens))
-            .or_else(|| {
-                usage
-                    .billed_units
-                    .as_ref()
-                    .map(|billed| (billed.input_tokens, billed.output_tokens))
-            });
-
+        // Cohere reports both `billed_units` and `tokens`, and they differ.
+        // This reads `billed_units`, which is what rig reported before the
+        // response types were normalized — switching the source would silently
+        // change every caller's token numbers, which is not this change's job.
         let mut normalized = crate::completion::Usage::new();
-        if let Some((input_tokens, output_tokens)) = counts {
-            normalized.input_tokens = input_tokens.unwrap_or_default() as u64;
-            normalized.output_tokens = output_tokens.unwrap_or_default() as u64;
+
+        if let Some(billed_units) = usage.billed_units.as_ref() {
+            normalized.input_tokens = billed_units.input_tokens.unwrap_or_default() as u64;
+            normalized.output_tokens = billed_units.output_tokens.unwrap_or_default() as u64;
             normalized.total_tokens = normalized.input_tokens + normalized.output_tokens;
         }
 
@@ -226,7 +217,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse {
             // Cohere's `/v2/chat` payload reports no model identifier, so the
             // normalized `model` stays unset.
             completion::CompletionResponse::new(model_response, usage, PROVIDER_NAME)
-                .with_optional_message_id(Some(response.id.as_str()).filter(|id| !id.is_empty()))
+                // Cohere's `id` names the generation, not an assistant
+                // message, so it is not replayed as one.
                 .with_finish_reason(map_finish_reason(&response.finish_reason)),
         )
     }

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -1,6 +1,6 @@
 use crate::{
     OneOrMany,
-    completion::{self, CompletionError, GetTokenUsage},
+    completion::{self, CompletionError},
     http_client::{self, HttpClientExt},
     json_utils,
     message::{self, Reasoning, ToolChoice},
@@ -10,9 +10,12 @@ use std::collections::HashMap;
 
 use super::client::Client;
 use crate::completion::CompletionRequest;
-use crate::providers::cohere::streaming::StreamingCompletionResponse;
 use serde::{Deserialize, Serialize};
 use tracing::{Instrument, Level, enabled};
+
+/// Stable descriptor name recorded on normalized responses, streams, and
+/// telemetry spans for this provider.
+pub(crate) const PROVIDER_NAME: &str = "cohere";
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CompletionResponse {
@@ -93,6 +96,25 @@ pub enum FinishReason {
     Complete,
     Error,
     ToolCall,
+    /// A reason outside the set Cohere documents today, kept verbatim in
+    /// Cohere's own spelling rather than failing deserialization.
+    #[serde(untagged)]
+    Other(String),
+}
+
+/// Map Cohere's `finish_reason` onto rig's normalized vocabulary.
+///
+/// `ERROR` — and anything Cohere adds later — is carried through as
+/// [`completion::FinishReason::Other`] in Cohere's own wire spelling instead of
+/// being flattened into a natural stop.
+pub(crate) fn map_finish_reason(reason: &FinishReason) -> completion::FinishReason {
+    match reason {
+        FinishReason::Complete | FinishReason::StopSequence => completion::FinishReason::Stop,
+        FinishReason::MaxTokens => completion::FinishReason::Length,
+        FinishReason::ToolCall => completion::FinishReason::ToolCalls,
+        FinishReason::Error => completion::FinishReason::Other("ERROR".to_owned()),
+        FinishReason::Other(other) => completion::FinishReason::Other(other.clone()),
+    }
 }
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
@@ -103,17 +125,36 @@ pub struct Usage {
     pub tokens: Option<Tokens>,
 }
 
-impl GetTokenUsage for Usage {
-    fn token_usage(&self) -> crate::completion::Usage {
-        let mut usage = crate::completion::Usage::new();
+impl From<&Usage> for crate::completion::Usage {
+    fn from(usage: &Usage) -> crate::completion::Usage {
+        // `tokens` is Cohere's actual token accounting; `billed_units` is the
+        // billing view of the same turn and only stands in when Cohere omits
+        // the token counts.
+        let counts = usage
+            .tokens
+            .as_ref()
+            .map(|tokens| (tokens.input_tokens, tokens.output_tokens))
+            .or_else(|| {
+                usage
+                    .billed_units
+                    .as_ref()
+                    .map(|billed| (billed.input_tokens, billed.output_tokens))
+            });
 
-        if let Some(ref billed_units) = self.billed_units {
-            usage.input_tokens = billed_units.input_tokens.unwrap_or_default() as u64;
-            usage.output_tokens = billed_units.output_tokens.unwrap_or_default() as u64;
-            usage.total_tokens = usage.input_tokens + usage.output_tokens;
+        let mut normalized = crate::completion::Usage::new();
+        if let Some((input_tokens, output_tokens)) = counts {
+            normalized.input_tokens = input_tokens.unwrap_or_default() as u64;
+            normalized.output_tokens = output_tokens.unwrap_or_default() as u64;
+            normalized.total_tokens = normalized.input_tokens + normalized.output_tokens;
         }
 
-        usage
+        normalized
+    }
+}
+
+impl From<Usage> for crate::completion::Usage {
+    fn from(usage: Usage) -> crate::completion::Usage {
+        crate::completion::Usage::from(&usage)
     }
 }
 
@@ -137,7 +178,7 @@ pub struct Tokens {
     pub output_tokens: Option<f64>,
 }
 
-impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionResponse> {
+impl TryFrom<CompletionResponse> for completion::CompletionResponse {
     type Error = CompletionError;
 
     fn try_from(response: CompletionResponse) -> Result<Self, Self::Error> {
@@ -178,29 +219,16 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         let usage = response
             .usage
             .as_ref()
-            .and_then(|usage| usage.tokens.as_ref())
-            .map(|tokens| {
-                let input_tokens = tokens.input_tokens.unwrap_or(0.0);
-                let output_tokens = tokens.output_tokens.unwrap_or(0.0);
-
-                completion::Usage {
-                    input_tokens: input_tokens as u64,
-                    output_tokens: output_tokens as u64,
-                    total_tokens: (input_tokens + output_tokens) as u64,
-                    cached_input_tokens: 0,
-                    cache_creation_input_tokens: 0,
-                    tool_use_prompt_tokens: 0,
-                    reasoning_tokens: 0,
-                }
-            })
+            .map(completion::Usage::from)
             .unwrap_or_default();
 
-        Ok(completion::CompletionResponse {
-            choice: model_response,
-            usage,
-            raw_response: response,
-            message_id: None,
-        })
+        Ok(
+            // Cohere's `/v2/chat` payload reports no model identifier, so the
+            // normalized `model` stays unset.
+            completion::CompletionResponse::new(model_response, usage, PROVIDER_NAME)
+                .with_optional_message_id(Some(response.id.as_str()).filter(|id| !id.is_empty()))
+                .with_finish_reason(map_finish_reason(&response.finish_reason)),
+        )
     }
 }
 
@@ -622,28 +650,38 @@ where
     }
 }
 
-impl<T> completion::CompletionModel for CompletionModel<T>
+impl<T> crate::client::ConstructCompletionModel<Client<T>> for CompletionModel<T>
+where
+    T: HttpClientExt,
+    Client<T>: Clone,
+{
+    fn construct(client: &Client<T>, model: String) -> Self {
+        Self::new(client.clone(), model)
+    }
+}
+
+impl<T> CompletionModel<T>
 where
     T: HttpClientExt + Clone + 'static,
 {
-    type Response = CompletionResponse;
-    type StreamingResponse = StreamingCompletionResponse;
-    type Client = Client<T>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model.into())
-    }
-
-    async fn completion(
+    /// Execute a completion and return Cohere's own wire response.
+    ///
+    /// This is the escape hatch for Cohere-specific fields rig does not
+    /// normalize (citations, tool plans). It shares the request builder,
+    /// transport, telemetry, and error handling with
+    /// [`CompletionModel::completion`](completion::CompletionModel::completion),
+    /// which calls it and then applies the provider-local mapping — one network
+    /// request either way.
+    pub async fn raw_completion(
         &self,
         completion_request: completion::CompletionRequest,
-    ) -> Result<completion::CompletionResponse<CompletionResponse>, CompletionError> {
+    ) -> Result<CompletionResponse, CompletionError> {
         let system_instructions = completion_request.preamble.clone();
         let record_telemetry_content = completion_request.record_telemetry_content;
         let request = CohereCompletionRequest::try_from((self.model.as_ref(), completion_request))?;
 
         let llm_span =
-            CompletionSpanBuilder::new("cohere", &request.model, CompletionOperation::Chat)
+            CompletionSpanBuilder::new(PROVIDER_NAME, &request.model, CompletionOperation::Chat)
                 .system_instructions(system_instructions.as_deref(), record_telemetry_content)
                 .build();
 
@@ -675,7 +713,12 @@ where
             if status.is_success() {
                 let json_response: CompletionResponse = serde_json::from_slice(&body)?;
                 let span = tracing::Span::current();
-                span.record_token_usage(&json_response.usage);
+                let usage = json_response
+                    .usage
+                    .as_ref()
+                    .map(completion::Usage::from)
+                    .unwrap_or_default();
+                span.record_token_usage(&usage);
                 span.record_response_metadata(&json_response);
 
                 if enabled!(Level::TRACE) {
@@ -686,9 +729,7 @@ where
                     );
                 }
 
-                let completion: completion::CompletionResponse<CompletionResponse> =
-                    json_response.try_into()?;
-                Ok(completion)
+                Ok(json_response)
             } else {
                 Err(CompletionError::from_http_response(
                     status,
@@ -699,14 +740,23 @@ where
         .instrument(llm_span)
         .await
     }
+}
+
+impl<T> completion::CompletionModel for CompletionModel<T>
+where
+    T: HttpClientExt + Clone + 'static,
+{
+    async fn completion(
+        &self,
+        completion_request: completion::CompletionRequest,
+    ) -> Result<completion::CompletionResponse, CompletionError> {
+        self.raw_completion(completion_request).await?.try_into()
+    }
 
     async fn stream(
         &self,
         request: CompletionRequest,
-    ) -> Result<
-        crate::streaming::StreamingCompletionResponse<Self::StreamingResponse>,
-        CompletionError,
-    > {
+    ) -> Result<crate::streaming::StreamingCompletionResponse, CompletionError> {
         CompletionModel::stream(self, request).await
     }
 }
@@ -789,6 +839,75 @@ mod tests {
 
         assert_eq!(name, "subtract");
         assert_eq!(arguments, serde_json::json!({"x": 5, "y": 2}));
+    }
+
+    #[test]
+    fn finish_reason_maps_every_documented_wire_value() {
+        assert_eq!(
+            map_finish_reason(&FinishReason::Complete),
+            completion::FinishReason::Stop
+        );
+        assert_eq!(
+            map_finish_reason(&FinishReason::StopSequence),
+            completion::FinishReason::Stop
+        );
+        assert_eq!(
+            map_finish_reason(&FinishReason::MaxTokens),
+            completion::FinishReason::Length
+        );
+        assert_eq!(
+            map_finish_reason(&FinishReason::ToolCall),
+            completion::FinishReason::ToolCalls
+        );
+        assert_eq!(
+            map_finish_reason(&FinishReason::Error),
+            completion::FinishReason::Other("ERROR".to_owned())
+        );
+    }
+
+    #[test]
+    fn unknown_finish_reason_survives_verbatim() {
+        let reason: FinishReason = serde_json::from_str("\"ERROR_TOXIC\"")
+            .expect("unknown reasons must still deserialize");
+        assert_eq!(reason, FinishReason::Other("ERROR_TOXIC".to_owned()));
+        assert_eq!(
+            map_finish_reason(&reason),
+            completion::FinishReason::Other("ERROR_TOXIC".to_owned())
+        );
+    }
+
+    #[test]
+    fn tool_call_response_normalizes_to_tool_calls_finish_reason() {
+        let response: CompletionResponse = serde_json::from_str(
+            r#"{
+                "id": "abc123",
+                "message": {
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "id": "subtract_1",
+                        "type": "function",
+                        "function": {"name": "subtract", "arguments": "{\"x\":5,\"y\":2}"}
+                    }]
+                },
+                "finish_reason": "TOOL_CALL",
+                "usage": {"tokens": {"input_tokens": 10, "output_tokens": 4}}
+            }"#,
+        )
+        .expect("fixture should deserialize");
+
+        let normalized: completion::CompletionResponse =
+            response.try_into().expect("normalization should succeed");
+
+        assert_eq!(normalized.provider, PROVIDER_NAME);
+        assert_eq!(normalized.message_id.as_deref(), Some("abc123"));
+        assert_eq!(normalized.model, None);
+        assert_eq!(
+            normalized.finish_reason,
+            Some(completion::FinishReason::ToolCalls)
+        );
+        assert_eq!(normalized.usage.input_tokens, 10);
+        assert_eq!(normalized.usage.output_tokens, 4);
+        assert_eq!(normalized.usage.total_tokens, 14);
     }
 
     #[test]

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -128,14 +128,25 @@ pub struct Usage {
 impl From<&Usage> for crate::completion::Usage {
     fn from(usage: &Usage) -> crate::completion::Usage {
         // Cohere reports both `billed_units` and `tokens`, and they differ.
-        // This reads `billed_units`, which is what rig reported before the
-        // response types were normalized — switching the source would silently
-        // change every caller's token numbers, which is not this change's job.
-        let mut normalized = crate::completion::Usage::new();
+        // `billed_units` stays the primary source so existing callers' numbers
+        // are unchanged; `tokens` is only a fallback for the case rig used to
+        // report as zero — the documented "no metrics" sentinel — even though
+        // the provider had supplied counts.
+        let counts = usage
+            .billed_units
+            .as_ref()
+            .map(|billed| (billed.input_tokens, billed.output_tokens))
+            .or_else(|| {
+                usage
+                    .tokens
+                    .as_ref()
+                    .map(|tokens| (tokens.input_tokens, tokens.output_tokens))
+            });
 
-        if let Some(billed_units) = usage.billed_units.as_ref() {
-            normalized.input_tokens = billed_units.input_tokens.unwrap_or_default() as u64;
-            normalized.output_tokens = billed_units.output_tokens.unwrap_or_default() as u64;
+        let mut normalized = crate::completion::Usage::new();
+        if let Some((input_tokens, output_tokens)) = counts {
+            normalized.input_tokens = input_tokens.unwrap_or_default() as u64;
+            normalized.output_tokens = output_tokens.unwrap_or_default() as u64;
             normalized.total_tokens = normalized.input_tokens + normalized.output_tokens;
         }
 
@@ -217,8 +228,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse {
             // Cohere's `/v2/chat` payload reports no model identifier, so the
             // normalized `model` stays unset.
             completion::CompletionResponse::new(model_response, usage, PROVIDER_NAME)
-                // Cohere's `id` names the generation, not an assistant
-                // message, so it is not replayed as one.
+                .with_optional_message_id(Some(response.id.as_str()).filter(|id| !id.is_empty()))
                 .with_finish_reason(map_finish_reason(&response.finish_reason)),
         )
     }

--- a/crates/rig-core/src/providers/cohere/streaming.rs
+++ b/crates/rig-core/src/providers/cohere/streaming.rs
@@ -1,9 +1,13 @@
-use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
+use crate::completion::{CompletionError, CompletionRequest};
 use crate::http_client::HttpClientExt;
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::providers::cohere::CompletionModel;
-use crate::providers::cohere::completion::{CohereCompletionRequest, Usage};
-use crate::streaming::{RawStreamingChoice, RawStreamingToolCall, ToolCallDeltaContent};
+use crate::providers::cohere::completion::{
+    CohereCompletionRequest, FinishReason, PROVIDER_NAME, Usage, map_finish_reason,
+};
+use crate::streaming::{
+    RawStreamingChoice, RawStreamingResult, RawStreamingToolCall, StreamFinal, ToolCallDeltaContent,
+};
 use crate::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
 use crate::{json_utils, streaming};
 use async_stream::stream;
@@ -15,15 +19,26 @@ use tracing_futures::Instrument;
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", tag = "type")]
 enum StreamingEvent {
-    MessageStart,
+    MessageStart {
+        #[serde(default)]
+        id: Option<String>,
+    },
     ContentStart,
-    ContentDelta { delta: Option<Delta> },
+    ContentDelta {
+        delta: Option<Delta>,
+    },
     ContentEnd,
     ToolPlan,
-    ToolCallStart { delta: Option<Delta> },
-    ToolCallDelta { delta: Option<Delta> },
+    ToolCallStart {
+        delta: Option<Delta>,
+    },
+    ToolCallDelta {
+        delta: Option<Delta>,
+    },
     ToolCallEnd,
-    MessageEnd { delta: Option<MessageEndDelta> },
+    MessageEnd {
+        delta: Option<MessageEndDelta>,
+    },
 }
 
 #[derive(Debug, Deserialize)]
@@ -57,34 +72,40 @@ struct Delta {
 #[derive(Debug, Deserialize)]
 struct MessageEndDelta {
     usage: Option<Usage>,
+    #[serde(default)]
+    finish_reason: Option<FinishReason>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+/// Cohere's terminal stream record, kept provider-native for
+/// [`CompletionModel::raw_stream`].
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StreamingCompletionResponse {
     pub usage: Option<Usage>,
+    /// Cohere's own `finish_reason` from the `message-end` event, when reported.
+    #[serde(default)]
+    pub finish_reason: Option<FinishReason>,
+    /// The `message-start` event's message identifier, when reported.
+    #[serde(default)]
+    pub message_id: Option<String>,
 }
 
-impl GetTokenUsage for StreamingCompletionResponse {
-    fn token_usage(&self) -> crate::completion::Usage {
-        let tokens = self
+impl From<&StreamingCompletionResponse> for crate::completion::Usage {
+    fn from(response: &StreamingCompletionResponse) -> crate::completion::Usage {
+        response
             .usage
-            .clone()
-            .and_then(|response| response.tokens)
-            .map(|tokens| {
-                (
-                    tokens.input_tokens.map(|x| x as u64),
-                    tokens.output_tokens.map(|y| y as u64),
-                )
-            });
-        let Some((Some(input), Some(output))) = tokens else {
-            return crate::completion::Usage::new();
-        };
-        let mut usage = crate::completion::Usage::new();
-        usage.input_tokens = input;
-        usage.output_tokens = output;
-        usage.total_tokens = input + output;
+            .as_ref()
+            .map(crate::completion::Usage::from)
+            .unwrap_or_default()
+    }
+}
 
-        usage
+impl From<StreamingCompletionResponse> for StreamFinal {
+    fn from(response: StreamingCompletionResponse) -> StreamFinal {
+        // Cohere's streaming events carry no model identifier, so the
+        // normalized `model` stays unset.
+        StreamFinal::new(PROVIDER_NAME, crate::completion::Usage::from(&response))
+            .with_optional_finish_reason(response.finish_reason.as_ref().map(map_finish_reason))
+            .with_optional_message_id(response.message_id)
     }
 }
 
@@ -92,16 +113,22 @@ impl<T> CompletionModel<T>
 where
     T: HttpClientExt + Clone + 'static,
 {
-    pub(crate) async fn stream(
+    /// Open a stream whose terminal record stays Cohere-native.
+    ///
+    /// This is the escape hatch for Cohere's own terminal payload; it shares the
+    /// request builder, transport, telemetry, and error handling with
+    /// [`CompletionModel::stream`](crate::completion::CompletionModel::stream),
+    /// which calls it and normalizes the terminal record once through
+    /// [`streaming::normalize_stream`] — one network request either way.
+    pub async fn raw_stream(
         &self,
         request: CompletionRequest,
-    ) -> Result<streaming::StreamingCompletionResponse<StreamingCompletionResponse>, CompletionError>
-    {
+    ) -> Result<RawStreamingResult<StreamingCompletionResponse>, CompletionError> {
         let system_instructions = request.preamble.clone();
         let record_telemetry_content = request.record_telemetry_content;
         let mut request = CohereCompletionRequest::try_from((self.model.as_ref(), request))?;
         let span = CompletionSpanBuilder::new(
-            "cohere",
+            PROVIDER_NAME,
             &request.model,
             CompletionOperation::ChatStreaming,
         )
@@ -136,6 +163,9 @@ where
         let stream = stream! {
             let mut current_tool_call: Option<(String, String, String, String)> = None;
             let mut final_usage = None;
+            let mut final_finish_reason = None;
+            let mut message_id = None;
+            let mut terminated_with_error = false;
 
             while let Some(event_result) = event_source.next().await {
                 match event_result {
@@ -159,6 +189,10 @@ where
                         };
 
                         match event {
+                            StreamingEvent::MessageStart { id: Some(id) } => {
+                                message_id = Some(id);
+                            },
+
                             StreamingEvent::ContentDelta { delta: Some(delta) } => {
                                 let Some(message) = &delta.message else { continue; };
                                 let Some(content) = &message.content else { continue; };
@@ -169,8 +203,14 @@ where
 
                             StreamingEvent::MessageEnd { delta: Some(delta) } => {
                                 let span = tracing::Span::current();
-                                span.record_token_usage(&delta.usage);
-                                final_usage = Some(delta.usage.clone());
+                                let usage = delta
+                                    .usage
+                                    .as_ref()
+                                    .map(crate::completion::Usage::from)
+                                    .unwrap_or_default();
+                                span.record_token_usage(&usage);
+                                final_usage = Some(delta.usage);
+                                final_finish_reason = delta.finish_reason;
                                 break;
                             },
 
@@ -228,6 +268,7 @@ where
                     }
                     Err(err) => {
                         tracing::error!(?err, "SSE error");
+                        terminated_with_error = true;
                         yield Err(CompletionError::from_stream_transport(err));
                         break;
                     }
@@ -237,14 +278,35 @@ where
             // Ensure event source is closed when stream ends
             event_source.close();
 
+            // A stream that ended in an error never reached Cohere's
+            // `message-end` event, so there is no terminal record to report;
+            // synthesizing one would present a failed turn as a successful,
+            // zero-usage completion.
+            if terminated_with_error {
+                return;
+            }
+
             yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
-                usage: final_usage.unwrap_or_default()
+                usage: final_usage.unwrap_or_default(),
+                finish_reason: final_finish_reason,
+                message_id,
             }))
         }.instrument(span);
 
-        Ok(streaming::StreamingCompletionResponse::stream(Box::pin(
-            stream,
-        )))
+        Ok(Box::pin(stream))
+    }
+
+    pub(crate) async fn stream(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<streaming::StreamingCompletionResponse, CompletionError> {
+        let stream = self.raw_stream(request).await?;
+        let normalized = streaming::normalize_stream(stream, |response| Ok(response.into()));
+
+        Ok(streaming::StreamingCompletionResponse::stream(
+            PROVIDER_NAME,
+            normalized,
+        ))
     }
 }
 
@@ -252,6 +314,104 @@ where
 mod tests {
     use super::*;
     use serde_json::json;
+
+    fn cohere_client<H>(http_client: H) -> crate::providers::cohere::Client<H>
+    where
+        H: HttpClientExt,
+    {
+        crate::providers::cohere::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("client should build")
+    }
+
+    #[tokio::test]
+    async fn stream_terminal_record_is_normalized() {
+        use crate::client::CompletionClient;
+        use crate::completion::CompletionModel as _;
+        use crate::streaming::StreamedAssistantContent;
+        use crate::test_utils::MockStreamingClient;
+        use futures::StreamExt;
+
+        let sse_bytes = bytes::Bytes::from(
+            [
+                r#"{"type":"message-start","id":"msg_1"}"#,
+                r#"{"type":"content-delta","delta":{"message":{"content":{"text":"hi"}}}}"#,
+                r#"{"type":"message-end","delta":{"finish_reason":"MAX_TOKENS","usage":{"tokens":{"input_tokens":10,"output_tokens":4}}}}"#,
+            ]
+            .iter()
+            .map(|event| format!("data: {event}\n\n"))
+            .collect::<String>(),
+        );
+
+        let client = cohere_client(MockStreamingClient { sse_bytes });
+        let model = client.completion_model(crate::providers::cohere::COMMAND_R);
+        let request = model.completion_request("hello").build();
+
+        let mut stream = crate::completion::CompletionModel::stream(&model, request)
+            .await
+            .expect("stream should open");
+
+        let mut terminal = None;
+        while let Some(item) = stream.next().await {
+            if let StreamedAssistantContent::Final(final_response) =
+                item.expect("stream item should be Ok")
+            {
+                terminal = Some(final_response);
+            }
+        }
+
+        let terminal = terminal.expect("stream should yield a terminal record");
+        assert_eq!(terminal.provider, PROVIDER_NAME);
+        assert_eq!(terminal.message_id.as_deref(), Some("msg_1"));
+        assert_eq!(
+            terminal.finish_reason,
+            Some(crate::completion::FinishReason::Length)
+        );
+        assert_eq!(terminal.usage.input_tokens, 10);
+        assert_eq!(terminal.usage.output_tokens, 4);
+        assert_eq!(terminal.usage.total_tokens, 14);
+        // Cohere's stream never names the model.
+        assert_eq!(terminal.model, None);
+    }
+
+    #[tokio::test]
+    async fn errored_stream_does_not_synthesize_a_terminal_record() {
+        use crate::client::CompletionClient;
+        use crate::completion::CompletionModel as _;
+        use crate::streaming::StreamedAssistantContent;
+        use crate::test_utils::HttpErrorStreamingClient;
+        use futures::StreamExt;
+
+        let client = cohere_client(HttpErrorStreamingClient::new(
+            http::StatusCode::TOO_MANY_REQUESTS,
+            r#"{"message":"slow down"}"#,
+        ));
+        let model = client.completion_model(crate::providers::cohere::COMMAND_R);
+        let request = model.completion_request("hello").build();
+
+        let mut stream = crate::completion::CompletionModel::stream(&model, request)
+            .await
+            .expect("stream should open");
+
+        let mut saw_error = false;
+        let mut saw_terminal = false;
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(StreamedAssistantContent::Final(_)) => saw_terminal = true,
+                Ok(_) => {}
+                Err(_) => saw_error = true,
+            }
+        }
+
+        assert!(saw_error, "the transport failure must reach the consumer");
+        assert!(
+            !saw_terminal,
+            "a failed stream must not be reported as a successful, zero-usage completion"
+        );
+        assert!(stream.response.is_none());
+    }
 
     #[test]
     fn test_message_content_delta_deserialization() {

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -710,7 +710,7 @@ impl TryFrom<ChatCompletionResponse> for completion::CompletionResponse {
 
         Ok(
             completion::CompletionResponse::new(choice, usage, PROVIDER_NAME)
-                // Response-scoped `chatcmpl-…` id; see the OpenAI chat path.
+                .with_optional_message_id(Some(response.id.as_str()).filter(|id| !id.is_empty()))
                 .with_model(response.model.as_str())
                 .with_optional_finish_reason(finish_reason),
         )

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -26,6 +26,7 @@ use crate::client::{
     self, ApiKey, Capabilities, Capable, DebugExt, ModelLister, Nothing, Provider, ProviderBuilder,
     ProviderClient, Transport,
 };
+use crate::completion::NormalizeCompletionResponse;
 use crate::completion::{self, CompletionError};
 use crate::embeddings::{self, EmbeddingError};
 use crate::http_client::{self, HttpClientExt};
@@ -709,7 +710,7 @@ impl TryFrom<ChatCompletionResponse> for completion::CompletionResponse {
 
         Ok(
             completion::CompletionResponse::new(choice, usage, PROVIDER_NAME)
-                .with_optional_message_id(Some(response.id.as_str()).filter(|id| !id.is_empty()))
+                // Response-scoped `chatcmpl-…` id; see the OpenAI chat path.
                 .with_model(response.model.as_str())
                 .with_optional_finish_reason(finish_reason),
         )
@@ -1332,11 +1333,10 @@ where
                 .raw_completion_chat(completion_request)
                 .await?
                 .try_into(),
-            CompletionRoute::Responses => (
-                PROVIDER_NAME,
-                self.raw_completion_responses(completion_request).await?,
-            )
-                .try_into(),
+            CompletionRoute::Responses => self
+                .raw_completion_responses(completion_request)
+                .await?
+                .normalize(PROVIDER_NAME),
         }
     }
 

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -26,7 +26,7 @@ use crate::client::{
     self, ApiKey, Capabilities, Capable, DebugExt, ModelLister, Nothing, Provider, ProviderBuilder,
     ProviderClient, Transport,
 };
-use crate::completion::{self, CompletionError, GetTokenUsage};
+use crate::completion::{self, CompletionError};
 use crate::embeddings::{self, EmbeddingError};
 use crate::http_client::{self, HttpClientExt};
 use crate::model::{Model, ModelList, ModelListingError};
@@ -582,11 +582,22 @@ pub enum CopilotStreamingResponse {
     Responses(responses_api::streaming::StreamingCompletionResponse),
 }
 
-impl GetTokenUsage for CopilotStreamingResponse {
-    fn token_usage(&self) -> completion::Usage {
-        match self {
-            Self::Chat(response) => response.token_usage(),
-            Self::Responses(response) => response.token_usage(),
+impl From<&CopilotStreamingResponse> for completion::Usage {
+    fn from(response: &CopilotStreamingResponse) -> Self {
+        match response {
+            CopilotStreamingResponse::Chat(response) => (&response.usage).into(),
+            CopilotStreamingResponse::Responses(response) => (&response.usage).into(),
+        }
+    }
+}
+
+impl From<(&str, CopilotStreamingResponse)> for crate::streaming::StreamFinal {
+    fn from((provider, response): (&str, CopilotStreamingResponse)) -> Self {
+        // Both Copilot routes reuse an upstream terminal record, so each maps
+        // through that route's own conversion rather than re-deriving it here.
+        match response {
+            CopilotStreamingResponse::Chat(response) => (provider, response).into(),
+            CopilotStreamingResponse::Responses(response) => (provider, response).into(),
         }
     }
 }
@@ -614,13 +625,23 @@ pub struct ChatChoice {
     pub finish_reason: Option<String>,
 }
 
-impl TryFrom<ChatCompletionResponse> for completion::CompletionResponse<ChatCompletionResponse> {
+/// Stable descriptor name reported on normalized Copilot responses.
+pub const PROVIDER_NAME: &str = "copilot";
+
+impl TryFrom<ChatCompletionResponse> for completion::CompletionResponse {
     type Error = CompletionError;
 
     fn try_from(response: ChatCompletionResponse) -> Result<Self, Self::Error> {
         let choice = response.choices.first().ok_or_else(|| {
             CompletionError::ResponseError("Response contained no choices".to_owned())
         })?;
+
+        // Captured before `choice` is shadowed by the normalized content below.
+        let finish_reason = choice
+            .finish_reason
+            .as_deref()
+            .filter(|reason| !reason.is_empty())
+            .map(openai_chat_completions_compatible::map_openai_finish_reason);
 
         let content = match &choice.message {
             openai::completion::Message::Assistant {
@@ -686,12 +707,12 @@ impl TryFrom<ChatCompletionResponse> for completion::CompletionResponse<ChatComp
             })
             .unwrap_or_default();
 
-        Ok(completion::CompletionResponse {
-            choice,
-            usage,
-            raw_response: response,
-            message_id: None,
-        })
+        Ok(
+            completion::CompletionResponse::new(choice, usage, PROVIDER_NAME)
+                .with_optional_message_id(Some(response.id.as_str()).filter(|id| !id.is_empty()))
+                .with_model(response.model.as_str())
+                .with_optional_finish_reason(finish_reason),
+        )
     }
 }
 
@@ -817,10 +838,10 @@ where
         Ok(request)
     }
 
-    async fn completion_chat(
+    async fn raw_completion_chat(
         &self,
         completion_request: completion::CompletionRequest,
-    ) -> Result<completion::CompletionResponse<CopilotCompletionResponse>, CompletionError> {
+    ) -> Result<ChatCompletionResponse, CompletionError> {
         let initiator = request_initiator(&completion_request);
         let has_vision = request_has_vision(&completion_request);
         let system_instructions = completion_request.preamble.clone();
@@ -849,7 +870,6 @@ where
                 let body = http_client::text(response).await?;
                 match serde_json::from_str::<ChatApiResponse<ChatCompletionResponse>>(&body)? {
                     ChatApiResponse::Ok(response) => {
-                        let core = completion::CompletionResponse::try_from(response.clone())?;
                         let span = tracing::Span::current();
                         span.record("gen_ai.response.id", response.id.as_str());
                         span.record("gen_ai.response.model", response.model.as_str());
@@ -869,12 +889,7 @@ where
                             );
                         }
 
-                        Ok(completion::CompletionResponse {
-                            choice: core.choice,
-                            usage: core.usage,
-                            raw_response: CopilotCompletionResponse::Chat(Box::new(response)),
-                            message_id: core.message_id,
-                        })
+                        Ok(response)
                     }
                     ChatApiResponse::Err(err) => {
                         tracing::warn!(
@@ -893,10 +908,10 @@ where
         .await
     }
 
-    async fn completion_responses(
+    async fn raw_completion_responses(
         &self,
         completion_request: completion::CompletionRequest,
-    ) -> Result<completion::CompletionResponse<CopilotCompletionResponse>, CompletionError> {
+    ) -> Result<responses_api::CompletionResponse, CompletionError> {
         let initiator = request_initiator(&completion_request);
         let has_vision = request_has_vision(&completion_request);
         let system_instructions = completion_request.preamble.clone();
@@ -922,8 +937,6 @@ where
             if status.is_success() {
                 let body = http_client::text(response).await?;
                 let response = serde_json::from_str::<responses_api::CompletionResponse>(&body)?;
-                let core = completion::CompletionResponse::try_from(response.clone())?;
-
                 let span = tracing::Span::current();
                 span.record("gen_ai.response.id", response.id.as_str());
                 span.record("gen_ai.response.model", response.model.as_str());
@@ -940,12 +953,7 @@ where
                     );
                 }
 
-                Ok(completion::CompletionResponse {
-                    choice: core.choice,
-                    usage: core.usage,
-                    raw_response: CopilotCompletionResponse::Responses(Box::new(response)),
-                    message_id: core.message_id,
-                })
+                Ok(response)
             } else {
                 let body = http_client::text(response).await?;
                 Err(CompletionError::from_http_response(status, body))
@@ -955,10 +963,11 @@ where
         .await
     }
 
-    async fn stream_chat(
+    async fn raw_stream_chat(
         &self,
         completion_request: completion::CompletionRequest,
-    ) -> Result<StreamingCompletionResponse<CopilotStreamingResponse>, CompletionError> {
+    ) -> Result<crate::streaming::RawStreamingResult<CopilotStreamingResponse>, CompletionError>
+    {
         let initiator = request_initiator(&completion_request);
         let has_vision = request_has_vision(&completion_request);
         let system_instructions = completion_request.preamble.clone();
@@ -992,16 +1001,17 @@ where
         .build();
 
         tracing::Instrument::instrument(
-            send_copilot_chat_streaming_request(self.client.clone(), req),
+            send_copilot_chat_raw_streaming_request(self.client.clone(), req),
             span,
         )
         .await
     }
 
-    async fn stream_responses(
+    async fn raw_stream_responses(
         &self,
         completion_request: completion::CompletionRequest,
-    ) -> Result<StreamingCompletionResponse<CopilotStreamingResponse>, CompletionError> {
+    ) -> Result<crate::streaming::RawStreamingResult<CopilotStreamingResponse>, CompletionError>
+    {
         let initiator = request_initiator(&completion_request);
         let has_vision = request_has_vision(&completion_request);
         let system_instructions = completion_request.preamble.clone();
@@ -1032,6 +1042,9 @@ where
         let stream = tracing_futures::Instrument::instrument(
             stream! {
                 let mut final_usage = responses_api::ResponsesUsage::new();
+                let mut final_status = None;
+                let mut final_incomplete_details = None;
+                let mut final_model = None;
                 let mut reasoning_metadata = None;
                 let mut reasoning_context = None;
                 let mut tool_calls: Vec<streaming::RawStreamingChoice<CopilotStreamingResponse>> = Vec::new();
@@ -1142,6 +1155,14 @@ where
                                     responses_api::streaming::ResponseChunkKind::ResponseCompleted => {
                                         span.record("gen_ai.response.id", response.id.as_str());
                                         span.record("gen_ai.response.model", response.model.as_str());
+                                        // Terminal metadata for the normalized
+                                        // `StreamFinal`: the response `status`
+                                        // drives the finish reason, and the
+                                        // model name is the one the wire
+                                        // reported.
+                                        final_status = Some(response.status.clone());
+                                        final_incomplete_details = response.incomplete_details.clone();
+                                        final_model = Some(response.model.clone());
                                         if let Some(usage) = response.usage {
                                             final_usage = usage;
                                         }
@@ -1217,6 +1238,13 @@ where
                             usage: final_usage,
                             reasoning_metadata,
                             reasoning_context,
+                            status: final_status,
+                            incomplete_details: final_incomplete_details,
+                            // The assistant message ID is emitted as its own
+                            // `MessageId` event upstream, which takes
+                            // precedence over the terminal record anyway.
+                            message_id: None,
+                            model: final_model,
                         }
                     )
                 ));
@@ -1224,7 +1252,69 @@ where
             span,
         );
 
-        Ok(StreamingCompletionResponse::stream(Box::pin(stream)))
+        Ok(Box::pin(stream))
+    }
+
+    /// Execute a completion on whichever route this model is configured for and
+    /// return Copilot's own wire response.
+    ///
+    /// This is the escape hatch for fields rig does not normalize;
+    /// [`completion::CompletionModel::completion`] shares the same request,
+    /// transport, telemetry and error path.
+    pub async fn raw_completion(
+        &self,
+        completion_request: completion::CompletionRequest,
+    ) -> Result<CopilotCompletionResponse, CompletionError> {
+        match self.route() {
+            CompletionRoute::ChatCompletions => self
+                .raw_completion_chat(completion_request)
+                .await
+                .map(|response| CopilotCompletionResponse::Chat(Box::new(response))),
+            CompletionRoute::Responses => self
+                .raw_completion_responses(completion_request)
+                .await
+                .map(|response| CopilotCompletionResponse::Responses(Box::new(response))),
+        }
+    }
+
+    /// Open a stream on whichever route this model is configured for, keeping
+    /// the terminal record provider-native.
+    pub async fn raw_stream(
+        &self,
+        completion_request: completion::CompletionRequest,
+    ) -> Result<crate::streaming::RawStreamingResult<CopilotStreamingResponse>, CompletionError>
+    {
+        match self.route() {
+            CompletionRoute::ChatCompletions => self.raw_stream_chat(completion_request).await,
+            CompletionRoute::Responses => self.raw_stream_responses(completion_request).await,
+        }
+    }
+
+    /// Open a stream normalized to rig's terminal record. Delegates to
+    /// [`CompletionModel::raw_stream`] — one request either way.
+    async fn stream_normalized(
+        &self,
+        completion_request: completion::CompletionRequest,
+    ) -> Result<StreamingCompletionResponse, CompletionError> {
+        let raw = self.raw_stream(completion_request).await?;
+
+        Ok(StreamingCompletionResponse::stream(
+            PROVIDER_NAME,
+            crate::streaming::normalize_stream(
+                raw,
+                |response| Ok((PROVIDER_NAME, response).into()),
+            ),
+        ))
+    }
+}
+
+impl<H> crate::client::ConstructCompletionModel<Client<H>> for CompletionModel<H>
+where
+    Client<H>: HttpClientExt + Clone + Debug + 'static,
+    H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
+{
+    fn construct(client: &Client<H>, model: String) -> Self {
+        Self::new(client.clone(), model)
     }
 }
 
@@ -1233,32 +1323,28 @@ where
     Client<H>: HttpClientExt + Clone + Debug + 'static,
     H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
 {
-    type Response = CopilotCompletionResponse;
-    type StreamingResponse = CopilotStreamingResponse;
-    type Client = Client<H>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
-
     async fn completion(
         &self,
         completion_request: completion::CompletionRequest,
-    ) -> Result<completion::CompletionResponse<Self::Response>, CompletionError> {
+    ) -> Result<completion::CompletionResponse, CompletionError> {
         match self.route() {
-            CompletionRoute::ChatCompletions => self.completion_chat(completion_request).await,
-            CompletionRoute::Responses => self.completion_responses(completion_request).await,
+            CompletionRoute::ChatCompletions => self
+                .raw_completion_chat(completion_request)
+                .await?
+                .try_into(),
+            CompletionRoute::Responses => (
+                PROVIDER_NAME,
+                self.raw_completion_responses(completion_request).await?,
+            )
+                .try_into(),
         }
     }
 
     async fn stream(
         &self,
         completion_request: completion::CompletionRequest,
-    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
-        match self.route() {
-            CompletionRoute::ChatCompletions => self.stream_chat(completion_request).await,
-            CompletionRoute::Responses => self.stream_responses(completion_request).await,
-        }
+    ) -> Result<StreamingCompletionResponse, CompletionError> {
+        self.stream_normalized(completion_request).await
     }
 }
 
@@ -1598,10 +1684,23 @@ impl CompatibleStreamProfile for CopilotChatCompatibleProfile {
                 data.usage,
                 &data.choices,
                 |choice| CompatibleChoiceData {
-                    finish_reason: if choice.finish_reason == Some(ChatFinishReason::ToolCalls) {
-                        CompatibleFinishReason::ToolCalls
-                    } else {
-                        CompatibleFinishReason::Other
+                    finish_reason: match choice.finish_reason.as_ref() {
+                        Some(ChatFinishReason::ToolCalls) => {
+                            CompatibleFinishReason::Reported(completion::FinishReason::ToolCalls)
+                        }
+                        Some(ChatFinishReason::Stop) => {
+                            CompatibleFinishReason::Reported(completion::FinishReason::Stop)
+                        }
+                        Some(ChatFinishReason::Length) => {
+                            CompatibleFinishReason::Reported(completion::FinishReason::Length)
+                        }
+                        Some(ChatFinishReason::ContentFilter) => CompatibleFinishReason::Reported(
+                            completion::FinishReason::ContentFilter,
+                        ),
+                        Some(ChatFinishReason::Other(value)) => CompatibleFinishReason::Reported(
+                            openai_chat_completions_compatible::map_openai_finish_reason(value),
+                        ),
+                        None => CompatibleFinishReason::Absent,
                     },
                     text: choice.delta.content.clone(),
                     reasoning: choice.delta.reasoning_content.clone(),
@@ -1614,10 +1713,13 @@ impl CompatibleStreamProfile for CopilotChatCompatibleProfile {
         ))
     }
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse {
-        CopilotStreamingResponse::Chat(openai::completion::streaming::StreamingCompletionResponse {
-            usage,
-        })
+    fn build_final_response(
+        &self,
+        terminal: openai_chat_completions_compatible::CompatibleTerminal<Self::Usage>,
+    ) -> Self::FinalResponse {
+        CopilotStreamingResponse::Chat(
+            openai::completion::streaming::StreamingCompletionResponse::from_terminal(terminal),
+        )
     }
 
     fn uses_distinct_tool_call_eviction(&self) -> bool {
@@ -1625,14 +1727,14 @@ impl CompatibleStreamProfile for CopilotChatCompatibleProfile {
     }
 }
 
-async fn send_copilot_chat_streaming_request<T>(
+async fn send_copilot_chat_raw_streaming_request<T>(
     http_client: T,
     req: Request<Vec<u8>>,
-) -> Result<StreamingCompletionResponse<CopilotStreamingResponse>, CompletionError>
+) -> Result<crate::streaming::RawStreamingResult<CopilotStreamingResponse>, CompletionError>
 where
     T: HttpClientExt + Clone + 'static,
 {
-    openai_chat_completions_compatible::send_compatible_streaming_request(
+    openai_chat_completions_compatible::send_compatible_raw_streaming_request(
         http_client,
         req,
         CopilotChatCompatibleProfile,
@@ -2193,12 +2295,17 @@ mod tests {
             .expect("build client");
         let model = client.completion_model("gpt-5.3-codex");
         let request = model.completion_request("hello").build();
-        let mut stream = model.stream(request).await.expect("stream should start");
+        // Reasoning metadata is Copilot's own terminal payload, not part of
+        // the normalized `StreamFinal`, so this reads it through `raw_stream`.
+        let mut stream = model
+            .raw_stream(request)
+            .await
+            .expect("stream should start");
 
         while let Some(item) = stream.next().await {
-            if let StreamedAssistantContent::Final(super::CopilotStreamingResponse::Responses(
-                response,
-            )) = item.expect("completed stream should not error")
+            if let crate::streaming::RawStreamingChoice::FinalResponse(
+                super::CopilotStreamingResponse::Responses(response),
+            ) = item.expect("completed stream should not error")
             {
                 assert_eq!(response.reasoning_context.as_deref(), Some("all_turns"));
                 assert_eq!(response.reasoning_metadata.as_ref(), metadata.as_object());

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -18,9 +18,9 @@ use crate::client::{
     self, BearerAuth, Capabilities, Capable, DebugExt, ModelLister, Nothing, Provider,
     ProviderBuilder, ProviderClient,
 };
-use crate::completion::GetTokenUsage;
 use crate::http_client::{self, HttpClientExt};
 use crate::model::{Model, ModelList, ModelListingError};
+use crate::providers::internal::openai_chat_completions_compatible::map_openai_finish_reason;
 use crate::providers::openai;
 use crate::telemetry::ProviderResponseExt;
 use crate::{
@@ -159,9 +159,11 @@ pub type ClientBuilder<H = crate::markers::Missing> =
 pub type CompletionModel<H = reqwest::Client> =
     openai::completion::GenericCompletionModel<DeepSeekExt, H>;
 
-/// Final streaming response, shared with the OpenAI Chat Completions path but
-/// carrying DeepSeek's own usage payload (cache hit/miss counters).
-pub type StreamingCompletionResponse = openai::StreamingCompletionResponse<Usage>;
+/// DeepSeek's provider-native terminal streaming record: the value carried by
+/// the final item of the stream returned by `CompletionModel::raw_stream`.
+/// Shared with the OpenAI Chat Completions path but carrying DeepSeek's own
+/// usage payload (cache hit/miss counters).
+pub type StreamingCompletionResponse = openai::StreamingCompletionResponse;
 
 impl ProviderClient for Client {
     type Input = DeepSeekApiKey;
@@ -245,27 +247,32 @@ pub struct Usage {
     pub prompt_tokens_details: Option<PromptTokensDetails>,
 }
 
-impl GetTokenUsage for Usage {
-    fn token_usage(&self) -> crate::completion::Usage {
-        crate::completion::Usage {
-            input_tokens: self.prompt_tokens as u64,
-            output_tokens: self.completion_tokens as u64,
-            total_tokens: self.total_tokens as u64,
-            cached_input_tokens: self
+impl From<&Usage> for crate::completion::Usage {
+    fn from(usage: &Usage) -> Self {
+        let mut normalized = crate::providers::internal::completion_usage(
+            usage.prompt_tokens as u64,
+            usage.completion_tokens as u64,
+            usage.total_tokens as u64,
+            usage
                 .prompt_tokens_details
                 .as_ref()
                 .and_then(|details| details.cached_tokens)
                 .map(u64::from)
                 .unwrap_or(0),
-            cache_creation_input_tokens: 0,
-            tool_use_prompt_tokens: 0,
-            reasoning_tokens: self
-                .completion_tokens_details
-                .as_ref()
-                .and_then(|details| details.reasoning_tokens)
-                .map(u64::from)
-                .unwrap_or(0),
-        }
+        );
+        normalized.reasoning_tokens = usage
+            .completion_tokens_details
+            .as_ref()
+            .and_then(|details| details.reasoning_tokens)
+            .map(u64::from)
+            .unwrap_or(0);
+        normalized
+    }
+}
+
+impl From<Usage> for crate::completion::Usage {
+    fn from(usage: Usage) -> Self {
+        Self::from(&usage)
     }
 }
 
@@ -347,13 +354,24 @@ pub enum ToolType {
     Function,
 }
 
-impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionResponse> {
+/// Normalize a DeepSeek chat completion response.
+///
+/// The provider descriptor name is an *input* rather than a constant so the
+/// shared OpenAI-compatible completion path labels the response with the
+/// descriptor that actually produced it, exactly as it does for the OpenAI
+/// wire type.
+impl TryFrom<(&str, CompletionResponse)> for completion::CompletionResponse {
     type Error = CompletionError;
 
-    fn try_from(response: CompletionResponse) -> Result<Self, Self::Error> {
+    fn try_from((provider, response): (&str, CompletionResponse)) -> Result<Self, Self::Error> {
         let choice = response.choices.first().ok_or_else(|| {
             CompletionError::ResponseError("Response contained no choices".to_owned())
         })?;
+
+        let finish_reason = Some(choice.finish_reason.as_str())
+            .filter(|reason| !reason.is_empty())
+            .map(map_openai_finish_reason);
+
         let content = match &choice.message {
             Message::Assistant {
                 content,
@@ -397,14 +415,12 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             )
         })?;
 
-        let usage = response.usage.token_usage();
+        let usage = crate::completion::Usage::from(&response.usage);
 
-        Ok(completion::CompletionResponse {
-            choice,
-            usage,
-            raw_response: response,
-            message_id: None,
-        })
+        Ok(completion::CompletionResponse::new(choice, usage, provider)
+            .with_optional_message_id(response.id.as_deref().filter(|id| !id.is_empty()))
+            .with_optional_model(response.model.as_deref().filter(|model| !model.is_empty()))
+            .with_optional_finish_reason(finish_reason))
     }
 }
 
@@ -507,12 +523,21 @@ pub const DEEPSEEK_V4_PRO: &str = "deepseek-v4-pro";
 mod tests {
     use super::*;
     use crate::client::ModelListingClient;
-    use crate::completion::{CompletionRequestBuilder, ToolDefinition as RigToolDefinition};
+    use crate::completion::{
+        CompletionRequestBuilder, FinishReason, ToolDefinition as RigToolDefinition,
+    };
     use crate::message::ToolChoice as RigToolChoice;
     use crate::providers::openai::completion::{
         CompletionRequest as OpenAICompletionRequest, OpenAICompatibleProvider, OpenAIRequestParams,
     };
     use crate::test_utils::{MockCompletionModel, RecordingHttpClient};
+
+    /// Normalize a DeepSeek wire response the way the shared completion path
+    /// does, threading DeepSeek's own descriptor name through the conversion.
+    fn normalized(response: CompletionResponse) -> crate::completion::CompletionResponse {
+        crate::completion::CompletionResponse::try_from((DeepSeekExt::PROVIDER_NAME, response))
+            .expect("DeepSeek response should convert")
+    }
 
     fn finalized_body(request: crate::completion::CompletionRequest) -> serde_json::Value {
         let request = OpenAICompletionRequest::try_from(OpenAIRequestParams {
@@ -729,16 +754,95 @@ mod tests {
         }))
         .expect("fixture should deserialize");
 
-        let converted = crate::completion::CompletionResponse::try_from(raw.clone())
-            .expect("DeepSeek response should convert");
+        let converted = normalized(raw.clone());
 
         assert_eq!(raw.id.as_deref(), Some("chatcmpl_123"));
         assert_eq!(raw.model.as_deref(), Some("deepseek-v4-flash"));
         assert_eq!(raw.system_fingerprint.as_deref(), Some("fp_123"));
+        assert_eq!(converted.provider, "deepseek");
+        assert_eq!(converted.message_id.as_deref(), Some("chatcmpl_123"));
+        assert_eq!(converted.model.as_deref(), Some("deepseek-v4-flash"));
+        assert_eq!(converted.finish_reason, Some(FinishReason::Stop));
         assert_eq!(converted.usage.input_tokens, 10);
         assert_eq!(converted.usage.cached_input_tokens, 3);
         assert_eq!(converted.usage.output_tokens, 8);
         assert_eq!(converted.usage.reasoning_tokens, 5);
+    }
+
+    fn response_with_finish_reason(finish_reason: &str) -> CompletionResponse {
+        serde_json::from_value(serde_json::json!({
+            "id": "chatcmpl_finish",
+            "model": "deepseek-v4-flash",
+            "choices": [{
+                "finish_reason": finish_reason,
+                "index": 0,
+                "logprobs": null,
+                "message": {"role": "assistant", "content": "done"}
+            }],
+            "usage": {
+                "completion_tokens": 1,
+                "prompt_tokens": 1,
+                "prompt_cache_hit_tokens": 0,
+                "prompt_cache_miss_tokens": 1,
+                "total_tokens": 2
+            }
+        }))
+        .expect("fixture should deserialize")
+    }
+
+    #[test]
+    fn deepseek_finish_reasons_normalize_and_preserve_unknowns() {
+        for (wire, expected) in [
+            ("stop", FinishReason::Stop),
+            ("length", FinishReason::Length),
+            ("max_tokens", FinishReason::Length),
+            ("tool_calls", FinishReason::ToolCalls),
+            ("function_call", FinishReason::ToolCalls),
+            ("content_filter", FinishReason::ContentFilter),
+            // Anything DeepSeek invents survives verbatim rather than reading
+            // as a natural stop.
+            (
+                "insufficient_system_resource",
+                FinishReason::Other("insufficient_system_resource".to_owned()),
+            ),
+        ] {
+            let converted = normalized(response_with_finish_reason(wire));
+
+            assert_eq!(converted.finish_reason, Some(expected), "wire: {wire}");
+        }
+    }
+
+    #[test]
+    fn deepseek_stop_finish_reason_upgrades_when_the_turn_called_a_tool() {
+        let raw: CompletionResponse = serde_json::from_value(serde_json::json!({
+            "id": "chatcmpl_tool",
+            "model": "deepseek-v4-flash",
+            "choices": [{
+                "finish_reason": "stop",
+                "index": 0,
+                "logprobs": null,
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "index": 0,
+                        "type": "function",
+                        "function": {"name": "subtract", "arguments": "{\"x\":2,\"y\":5}"}
+                    }]
+                }
+            }],
+            "usage": {
+                "completion_tokens": 1,
+                "prompt_tokens": 1,
+                "prompt_cache_hit_tokens": 0,
+                "prompt_cache_miss_tokens": 1,
+                "total_tokens": 2
+            }
+        }))
+        .expect("fixture should deserialize");
+
+        assert_eq!(normalized(raw).finish_reason, Some(FinishReason::ToolCalls));
     }
 
     #[test]

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -163,7 +163,7 @@ pub type CompletionModel<H = reqwest::Client> =
 /// the final item of the stream returned by `CompletionModel::raw_stream`.
 /// Shared with the OpenAI Chat Completions path but carrying DeepSeek's own
 /// usage payload (cache hit/miss counters).
-pub type StreamingCompletionResponse = openai::StreamingCompletionResponse;
+pub type StreamingCompletionResponse = openai::StreamingCompletionResponse<Usage>;
 
 impl ProviderClient for Client {
     type Input = DeepSeekApiKey;
@@ -360,10 +360,9 @@ pub enum ToolType {
 /// shared OpenAI-compatible completion path labels the response with the
 /// descriptor that actually produced it, exactly as it does for the OpenAI
 /// wire type.
-impl TryFrom<(&str, CompletionResponse)> for completion::CompletionResponse {
-    type Error = CompletionError;
-
-    fn try_from((provider, response): (&str, CompletionResponse)) -> Result<Self, Self::Error> {
+impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
+    fn normalize(self, provider: &str) -> Result<completion::CompletionResponse, CompletionError> {
+        let response = self;
         let choice = response.choices.first().ok_or_else(|| {
             CompletionError::ResponseError("Response contained no choices".to_owned())
         })?;
@@ -523,6 +522,7 @@ pub const DEEPSEEK_V4_PRO: &str = "deepseek-v4-pro";
 mod tests {
     use super::*;
     use crate::client::ModelListingClient;
+    use crate::completion::NormalizeCompletionResponse;
     use crate::completion::{
         CompletionRequestBuilder, FinishReason, ToolDefinition as RigToolDefinition,
     };
@@ -535,7 +535,8 @@ mod tests {
     /// Normalize a DeepSeek wire response the way the shared completion path
     /// does, threading DeepSeek's own descriptor name through the conversion.
     fn normalized(response: CompletionResponse) -> crate::completion::CompletionResponse {
-        crate::completion::CompletionResponse::try_from((DeepSeekExt::PROVIDER_NAME, response))
+        response
+            .normalize(DeepSeekExt::PROVIDER_NAME)
             .expect("DeepSeek response should convert")
     }
 

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -33,15 +33,14 @@ use crate::message::{self, MimeType, Reasoning};
 use crate::providers::gemini::completion::gemini_api_types::{
     AdditionalParameters, FunctionCallingMode, ToolConfig,
 };
-use crate::providers::gemini::streaming::StreamingCompletionResponse;
 use crate::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
 use crate::{
     OneOrMany,
-    completion::{self, CompletionError, CompletionRequest, GetTokenUsage},
+    completion::{self, CompletionError, CompletionRequest},
 };
 use gemini_api_types::{
     Content, FinishReason, FunctionDeclaration, GenerateContentRequest, GenerateContentResponse,
-    GenerationConfig, Part, PartKind, Role, Tool,
+    GenerationConfig, Part, PartKind, Role, Tool, map_finish_reason,
 };
 use serde_json::{Map, Value};
 use std::convert::TryFrom;
@@ -53,6 +52,12 @@ use super::Client;
 // =================================================================
 // Rig Implementation Types
 // =================================================================
+
+/// Stable descriptor name for the Gemini GenerateContent API.
+///
+/// Recorded on every normalized response and stream this module produces, and
+/// on the telemetry spans, so the two never drift apart.
+pub(crate) const PROVIDER_NAME: &str = "gcp.gemini";
 
 #[derive(Clone, Debug)]
 pub struct CompletionModel<T = reqwest::Client> {
@@ -76,25 +81,25 @@ impl<T> CompletionModel<T> {
     }
 }
 
-impl<T> completion::CompletionModel for CompletionModel<T>
+impl<T> CompletionModel<T>
 where
     T: HttpClientExt + Clone + 'static,
 {
-    type Response = GenerateContentResponse;
-    type StreamingResponse = StreamingCompletionResponse;
-    type Client = super::Client<T>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
-
-    async fn completion(
+    /// Execute a completion and return Gemini's own `generateContent` payload.
+    ///
+    /// This is the escape hatch for provider-specific fields rig does not
+    /// normalize. It shares the request builder, transport, telemetry, and
+    /// error handling with
+    /// [`CompletionModel::completion`](completion::CompletionModel::completion),
+    /// which calls it and then applies the provider-local mapping — one network
+    /// request either way.
+    pub async fn raw_completion(
         &self,
         completion_request: CompletionRequest,
-    ) -> Result<completion::CompletionResponse<GenerateContentResponse>, CompletionError> {
+    ) -> Result<GenerateContentResponse, CompletionError> {
         let request_model = resolve_request_model(&self.model, &completion_request);
         let span = CompletionSpanBuilder::new(
-            "gcp.gemini",
+            PROVIDER_NAME,
             &request_model,
             CompletionOperation::GenerateContent,
         )
@@ -147,7 +152,12 @@ where
 
                 let span = tracing::Span::current();
                 span.record_response_metadata(&response);
-                span.record_token_usage(&response.usage_metadata);
+                let usage = response
+                    .usage_metadata
+                    .as_ref()
+                    .map(crate::completion::Usage::from)
+                    .unwrap_or_default();
+                span.record_token_usage(&usage);
 
                 if enabled!(Level::TRACE) {
                     tracing::trace!(
@@ -157,7 +167,7 @@ where
                     );
                 }
 
-                response.try_into()
+                Ok(response)
             } else {
                 let status = response.status();
                 let body = response
@@ -174,15 +184,33 @@ where
         .instrument(span)
         .await
     }
+}
+
+impl<T> completion::CompletionModel for CompletionModel<T>
+where
+    T: HttpClientExt + Clone + 'static,
+{
+    async fn completion(
+        &self,
+        completion_request: CompletionRequest,
+    ) -> Result<completion::CompletionResponse, CompletionError> {
+        self.raw_completion(completion_request).await?.try_into()
+    }
 
     async fn stream(
         &self,
         request: CompletionRequest,
-    ) -> Result<
-        crate::streaming::StreamingCompletionResponse<Self::StreamingResponse>,
-        CompletionError,
-    > {
+    ) -> Result<crate::streaming::StreamingCompletionResponse, CompletionError> {
         CompletionModel::stream(self, request).await
+    }
+}
+
+impl<T> crate::client::ConstructCompletionModel<Client<T>> for CompletionModel<T>
+where
+    Client<T>: Clone,
+{
+    fn construct(client: &Client<T>, model: String) -> Self {
+        Self::new(client.clone(), model)
     }
 }
 
@@ -406,7 +434,8 @@ pub(crate) fn function_call_finish_reason_error(
     }
 }
 
-impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<GenerateContentResponse> {
+/// Normalize a Gemini `generateContent` response.
+impl TryFrom<GenerateContentResponse> for completion::CompletionResponse {
     type Error = CompletionError;
 
     fn try_from(response: GenerateContentResponse) -> Result<Self, Self::Error> {
@@ -420,6 +449,8 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
         {
             return Err(err);
         }
+
+        let finish_reason = candidate.finish_reason.as_ref().map(map_finish_reason);
 
         let content = candidate
             .content
@@ -513,15 +544,17 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
         let usage = response
             .usage_metadata
             .as_ref()
-            .map(GetTokenUsage::token_usage)
+            .map(crate::completion::Usage::from)
             .unwrap_or_default();
 
-        Ok(completion::CompletionResponse {
-            choice,
-            usage,
-            raw_response: response,
-            message_id: None,
-        })
+        Ok(
+            completion::CompletionResponse::new(choice, usage, PROVIDER_NAME)
+                .with_optional_message_id(
+                    Some(response.response_id.as_str()).filter(|id| !id.is_empty()),
+                )
+                .with_optional_model(response.model_version.as_deref())
+                .with_optional_finish_reason(finish_reason),
+        )
     }
 }
 
@@ -535,7 +568,6 @@ pub mod gemini_api_types {
     use serde::{Deserialize, Serialize};
     use serde_json::{Value, json};
 
-    use crate::completion::GetTokenUsage;
     use crate::message::{DocumentSourceKind, ImageMediaType, MessageError, MimeType};
     use crate::{
         completion::CompletionError,
@@ -1424,19 +1456,25 @@ pub mod gemini_api_types {
         }
     }
 
-    impl GetTokenUsage for UsageMetadata {
-        fn token_usage(&self) -> crate::completion::Usage {
+    impl From<&UsageMetadata> for crate::completion::Usage {
+        fn from(value: &UsageMetadata) -> crate::completion::Usage {
             let mut usage = crate::completion::Usage::new();
 
-            usage.input_tokens = self.prompt_token_count as u64;
-            usage.output_tokens = self.candidates_token_count.unwrap_or_default() as u64;
-            usage.cached_input_tokens = self.cached_content_token_count.unwrap_or_default() as u64;
-            usage.reasoning_tokens = self.thoughts_token_count.unwrap_or_default() as u64;
+            usage.input_tokens = value.prompt_token_count as u64;
+            usage.output_tokens = value.candidates_token_count.unwrap_or_default() as u64;
+            usage.cached_input_tokens = value.cached_content_token_count.unwrap_or_default() as u64;
+            usage.reasoning_tokens = value.thoughts_token_count.unwrap_or_default() as u64;
             usage.tool_use_prompt_tokens =
-                self.tool_use_prompt_token_count.unwrap_or_default() as u64;
-            usage.total_tokens = self.total_token_count as u64;
+                value.tool_use_prompt_token_count.unwrap_or_default() as u64;
+            usage.total_tokens = value.total_token_count as u64;
 
             usage
+        }
+    }
+
+    impl From<UsageMetadata> for crate::completion::Usage {
+        fn from(value: UsageMetadata) -> crate::completion::Usage {
+            (&value).into()
         }
     }
 
@@ -1499,6 +1537,51 @@ pub mod gemini_api_types {
         TooManyToolCalls,
         /// The provider could not parse the generated response into a valid protocol shape.
         MalformedResponse,
+    }
+
+    impl FinishReason {
+        /// The exact spelling Gemini uses for this reason on the wire.
+        ///
+        /// Spelled out rather than derived from `Debug` (which would yield
+        /// `MaxTokens`, not `MAX_TOKENS`) so the string that reaches
+        /// [`crate::completion::FinishReason::Other`] is the provider's own.
+        pub fn as_wire_str(&self) -> &'static str {
+            match self {
+                Self::FinishReasonUnspecified => "FINISH_REASON_UNSPECIFIED",
+                Self::Stop => "STOP",
+                Self::MaxTokens => "MAX_TOKENS",
+                Self::Safety => "SAFETY",
+                Self::Recitation => "RECITATION",
+                Self::Language => "LANGUAGE",
+                Self::Other => "OTHER",
+                Self::Blocklist => "BLOCKLIST",
+                Self::ProhibitedContent => "PROHIBITED_CONTENT",
+                Self::Spii => "SPII",
+                Self::MalformedFunctionCall => "MALFORMED_FUNCTION_CALL",
+                Self::UnexpectedToolCall => "UNEXPECTED_TOOL_CALL",
+                Self::MissingThoughtSignature => "MISSING_THOUGHT_SIGNATURE",
+                Self::TooManyToolCalls => "TOO_MANY_TOOL_CALLS",
+                Self::MalformedResponse => "MALFORMED_RESPONSE",
+            }
+        }
+    }
+
+    /// Map a Gemini `finishReason` onto rig's normalized vocabulary.
+    ///
+    /// Only the four reasons that have a normalized counterpart are folded in;
+    /// everything else — including Gemini's own `OTHER` and the tool-protocol
+    /// failures — is carried verbatim so a reason rig does not model never reads
+    /// as a natural stop. Shared by the unary and streaming paths so both agree.
+    pub(crate) fn map_finish_reason(reason: &FinishReason) -> crate::completion::FinishReason {
+        match reason {
+            FinishReason::Stop => crate::completion::FinishReason::Stop,
+            FinishReason::MaxTokens => crate::completion::FinishReason::Length,
+            FinishReason::Safety
+            | FinishReason::Blocklist
+            | FinishReason::ProhibitedContent
+            | FinishReason::Spii => crate::completion::FinishReason::ContentFilter,
+            other => crate::completion::FinishReason::Other(other.as_wire_str().to_owned()),
+        }
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2563,7 +2646,7 @@ mod tests {
             model_version: None,
         };
 
-        let converted: crate::completion::CompletionResponse<GenerateContentResponse> =
+        let converted: crate::completion::CompletionResponse =
             response.try_into().expect("convert response");
         let first = converted.choice.first();
         assert!(matches!(
@@ -2634,10 +2717,8 @@ mod tests {
                 model_version: None,
             };
 
-            let err = crate::completion::CompletionResponse::<GenerateContentResponse>::try_from(
-                response,
-            )
-            .expect_err("tool protocol finish reason should fail");
+            let err = crate::completion::CompletionResponse::try_from(response)
+                .expect_err("tool protocol finish reason should fail");
 
             assert!(matches!(
                 err,
@@ -2688,7 +2769,7 @@ mod tests {
             model_version: Some("gemini-2.0-flash-001".to_string()),
         };
 
-        let converted: crate::completion::CompletionResponse<GenerateContentResponse> =
+        let converted: crate::completion::CompletionResponse =
             response.try_into().expect("convert response");
 
         assert_eq!(converted.usage.input_tokens, 40);
@@ -2697,6 +2778,141 @@ mod tests {
         assert_eq!(converted.usage.reasoning_tokens, 10);
         assert_eq!(converted.usage.tool_use_prompt_tokens, 12);
         assert_eq!(converted.usage.total_tokens, 100);
+    }
+
+    #[test]
+    fn test_finish_reason_maps_every_wire_variant() {
+        use crate::completion::FinishReason as Normalized;
+
+        for (wire, expected) in [
+            (FinishReason::Stop, Normalized::Stop),
+            (FinishReason::MaxTokens, Normalized::Length),
+            (FinishReason::Safety, Normalized::ContentFilter),
+            (FinishReason::Blocklist, Normalized::ContentFilter),
+            (FinishReason::ProhibitedContent, Normalized::ContentFilter),
+            (FinishReason::Spii, Normalized::ContentFilter),
+            // Everything Gemini reports that rig does not model survives in the
+            // provider's own SCREAMING_SNAKE_CASE spelling.
+            (
+                FinishReason::FinishReasonUnspecified,
+                Normalized::Other("FINISH_REASON_UNSPECIFIED".to_string()),
+            ),
+            (
+                FinishReason::Recitation,
+                Normalized::Other("RECITATION".to_string()),
+            ),
+            (
+                FinishReason::Language,
+                Normalized::Other("LANGUAGE".to_string()),
+            ),
+            (FinishReason::Other, Normalized::Other("OTHER".to_string())),
+            (
+                FinishReason::MalformedFunctionCall,
+                Normalized::Other("MALFORMED_FUNCTION_CALL".to_string()),
+            ),
+            (
+                FinishReason::UnexpectedToolCall,
+                Normalized::Other("UNEXPECTED_TOOL_CALL".to_string()),
+            ),
+            (
+                FinishReason::MissingThoughtSignature,
+                Normalized::Other("MISSING_THOUGHT_SIGNATURE".to_string()),
+            ),
+            (
+                FinishReason::TooManyToolCalls,
+                Normalized::Other("TOO_MANY_TOOL_CALLS".to_string()),
+            ),
+            (
+                FinishReason::MalformedResponse,
+                Normalized::Other("MALFORMED_RESPONSE".to_string()),
+            ),
+        ] {
+            assert_eq!(map_finish_reason(&wire), expected, "wire reason {wire:?}");
+        }
+    }
+
+    #[test]
+    fn test_finish_reason_wire_spelling_matches_serde() {
+        // `as_wire_str` is hand-written; keep it honest against the serde
+        // representation the same enum deserializes from.
+        for reason in [
+            FinishReason::FinishReasonUnspecified,
+            FinishReason::Stop,
+            FinishReason::MaxTokens,
+            FinishReason::Safety,
+            FinishReason::Recitation,
+            FinishReason::Language,
+            FinishReason::Other,
+            FinishReason::Blocklist,
+            FinishReason::ProhibitedContent,
+            FinishReason::Spii,
+            FinishReason::MalformedFunctionCall,
+            FinishReason::UnexpectedToolCall,
+            FinishReason::MissingThoughtSignature,
+            FinishReason::TooManyToolCalls,
+            FinishReason::MalformedResponse,
+        ] {
+            let serialized = serde_json::to_value(&reason).expect("reason should serialize");
+            assert_eq!(serialized, json!(reason.as_wire_str()));
+        }
+    }
+
+    #[test]
+    fn test_completion_response_carries_normalized_metadata() {
+        let response: GenerateContentResponse = serde_json::from_value(json!({
+            "responseId": "resp-meta",
+            "modelVersion": "gemini-2.0-flash-001",
+            "candidates": [{
+                "content": {
+                    "parts": [{"text": "hi"}],
+                    "role": "model"
+                },
+                "finishReason": "MAX_TOKENS"
+            }]
+        }))
+        .expect("response should deserialize");
+
+        let converted: crate::completion::CompletionResponse =
+            response.try_into().expect("convert response");
+
+        assert_eq!(converted.provider, PROVIDER_NAME);
+        assert_eq!(converted.model.as_deref(), Some("gemini-2.0-flash-001"));
+        assert_eq!(converted.message_id.as_deref(), Some("resp-meta"));
+        assert_eq!(
+            converted.finish_reason,
+            Some(crate::completion::FinishReason::Length)
+        );
+    }
+
+    #[test]
+    fn test_completion_response_upgrades_stop_to_tool_calls() {
+        // Gemini reports STOP on turns that only emitted a function call; the
+        // normalized response must still say `ToolCalls`.
+        let response: GenerateContentResponse = serde_json::from_value(json!({
+            "responseId": "resp-tool",
+            "candidates": [{
+                "content": {
+                    "parts": [{
+                        "functionCall": {
+                            "name": "get_weather",
+                            "args": {"city": "Paris"}
+                        }
+                    }],
+                    "role": "model"
+                },
+                "finishReason": "STOP"
+            }]
+        }))
+        .expect("response should deserialize");
+
+        let converted: crate::completion::CompletionResponse =
+            response.try_into().expect("convert response");
+
+        assert_eq!(
+            converted.finish_reason,
+            Some(crate::completion::FinishReason::ToolCalls)
+        );
+        assert_eq!(converted.model, None);
     }
 
     #[test]
@@ -2778,7 +2994,7 @@ mod tests {
         }))
         .expect("response should deserialize");
 
-        let converted: crate::completion::CompletionResponse<GenerateContentResponse> =
+        let converted: crate::completion::CompletionResponse =
             response.try_into().expect("response should convert");
         let message::AssistantContent::ToolCall(tool_call) = converted.choice.first() else {
             panic!("expected a tool call");

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -548,10 +548,10 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse {
             .unwrap_or_default();
 
         Ok(
-            // No `message_id`: Gemini's `responseId` names the response, not an
-            // assistant message, and it is the streaming path's absence of one
-            // that would otherwise make the two paths disagree.
             completion::CompletionResponse::new(choice, usage, PROVIDER_NAME)
+                .with_optional_message_id(
+                    Some(response.response_id.as_str()).filter(|id| !id.is_empty()),
+                )
                 .with_optional_model(response.model_version.as_deref())
                 .with_optional_finish_reason(finish_reason),
         )

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -548,10 +548,10 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse {
             .unwrap_or_default();
 
         Ok(
+            // No `message_id`: Gemini's `responseId` names the response, not an
+            // assistant message, and it is the streaming path's absence of one
+            // that would otherwise make the two paths disagree.
             completion::CompletionResponse::new(choice, usage, PROVIDER_NAME)
-                .with_optional_message_id(
-                    Some(response.response_id.as_str()).filter(|id| !id.is_empty()),
-                )
                 .with_optional_model(response.model_version.as_deref())
                 .with_optional_finish_reason(finish_reason),
         )

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -4,7 +4,7 @@
 use base64::{Engine, prelude::BASE64_STANDARD};
 
 use crate::OneOrMany;
-use crate::completion::{self, CompletionError, CompletionRequest, GetTokenUsage};
+use crate::completion::{self, CompletionError, CompletionRequest};
 use crate::http_client::HttpClientExt;
 use crate::message::{self, MimeType, Reasoning};
 use crate::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
@@ -22,6 +22,13 @@ pub use interactions_api_types::*;
 // =================================================================
 // Rig Implementation Types
 // =================================================================
+
+/// Stable descriptor name for the Gemini Interactions API.
+///
+/// The Interactions API is a second surface over the same provider, so it
+/// reports the same descriptor as GenerateContent — matching the telemetry
+/// spans, which have always shared it.
+pub(crate) const PROVIDER_NAME: &str = "gcp.gemini";
 
 /// Completion model wrapper for the Gemini Interactions API.
 #[derive(Clone, Debug)]
@@ -106,24 +113,24 @@ where
     }
 }
 
-impl<T> completion::CompletionModel for InteractionsCompletionModel<T>
+impl<T> InteractionsCompletionModel<T>
 where
     T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
 {
-    type Response = Interaction;
-    type StreamingResponse = streaming::StreamingCompletionResponse;
-    type Client = InteractionsClient<T>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
-
-    async fn completion(
+    /// Execute a completion and return the Interactions API's own payload.
+    ///
+    /// This is the escape hatch for interaction fields rig does not normalize —
+    /// step history, lifecycle status, hosted-tool exchanges. It shares the
+    /// request builder, transport, telemetry, and error handling with
+    /// [`CompletionModel::completion`](completion::CompletionModel::completion),
+    /// which calls it and then applies the provider-local mapping — one network
+    /// request either way.
+    pub async fn raw_completion(
         &self,
         completion_request: CompletionRequest,
-    ) -> Result<completion::CompletionResponse<Interaction>, CompletionError> {
+    ) -> Result<Interaction, CompletionError> {
         let span = CompletionSpanBuilder::new(
-            "gcp.gemini",
+            PROVIDER_NAME,
             &self.model,
             CompletionOperation::Interactions,
         )
@@ -173,7 +180,8 @@ where
 
                 let span = tracing::Span::current();
                 span.record_response_metadata(&response);
-                span.record_token_usage(&response);
+                let usage = crate::completion::Usage::from(&response);
+                span.record_token_usage(&usage);
 
                 if enabled!(Level::TRACE) {
                     tracing::trace!(
@@ -183,7 +191,7 @@ where
                     );
                 }
 
-                response.try_into()
+                Ok(response)
             } else {
                 let status = response.status();
                 let body = response
@@ -200,15 +208,34 @@ where
         .instrument(span)
         .await
     }
+}
+
+impl<T> completion::CompletionModel for InteractionsCompletionModel<T>
+where
+    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
+{
+    async fn completion(
+        &self,
+        completion_request: CompletionRequest,
+    ) -> Result<completion::CompletionResponse, CompletionError> {
+        self.raw_completion(completion_request).await?.try_into()
+    }
 
     async fn stream(
         &self,
         request: CompletionRequest,
-    ) -> Result<
-        crate::streaming::StreamingCompletionResponse<Self::StreamingResponse>,
-        CompletionError,
-    > {
+    ) -> Result<crate::streaming::StreamingCompletionResponse, CompletionError> {
         InteractionsCompletionModel::stream(self, request).await
+    }
+}
+
+impl<T> crate::client::ConstructCompletionModel<InteractionsClient<T>>
+    for InteractionsCompletionModel<T>
+where
+    InteractionsClient<T>: Clone,
+{
+    fn construct(client: &InteractionsClient<T>, model: String) -> Self {
+        Self::new(client.clone(), model)
     }
 }
 
@@ -461,7 +488,8 @@ fn build_interaction_stream_path(interaction_id: &str, last_event_id: Option<&st
     )
 }
 
-impl TryFrom<Interaction> for completion::CompletionResponse<Interaction> {
+/// Normalize a Gemini Interactions API payload.
+impl TryFrom<Interaction> for completion::CompletionResponse {
     type Error = CompletionError;
 
     fn try_from(response: Interaction) -> Result<Self, Self::Error> {
@@ -495,15 +523,17 @@ impl TryFrom<Interaction> for completion::CompletionResponse<Interaction> {
         let usage = response
             .usage
             .as_ref()
-            .map(|usage| usage.token_usage())
+            .map(crate::completion::Usage::from)
             .unwrap_or_default();
 
-        Ok(completion::CompletionResponse {
-            choice,
-            usage,
-            raw_response: response,
-            message_id: None,
-        })
+        let finish_reason = response.status.as_ref().map(map_interaction_status);
+
+        Ok(
+            completion::CompletionResponse::new(choice, usage, PROVIDER_NAME)
+                .with_optional_message_id(Some(response.id.as_str()).filter(|id| !id.is_empty()))
+                .with_optional_model(response.model.as_deref())
+                .with_optional_finish_reason(finish_reason),
+        )
     }
 }
 
@@ -632,7 +662,7 @@ fn split_data_uri(
 /// Raw request/response types and convenience helpers for the Gemini Interactions API.
 pub mod interactions_api_types {
     use super::split_data_uri;
-    use crate::completion::{CompletionError, GetTokenUsage, Usage};
+    use crate::completion::{CompletionError, Usage};
     use crate::message::{self, MimeType};
     use crate::telemetry::ProviderResponseExt;
     use base64::{Engine, prelude::BASE64_STANDARD};
@@ -740,12 +770,15 @@ pub mod interactions_api_types {
         pub input: Option<InteractionInput>,
     }
 
-    impl GetTokenUsage for Interaction {
-        fn token_usage(&self) -> Usage {
-            self.usage
-                .as_ref()
-                .map(|usage| usage.token_usage())
-                .unwrap_or_default()
+    impl From<&Interaction> for Usage {
+        fn from(value: &Interaction) -> Usage {
+            value.usage.as_ref().map(Usage::from).unwrap_or_default()
+        }
+    }
+
+    impl From<Interaction> for Usage {
+        fn from(value: Interaction) -> Usage {
+            (&value).into()
         }
     }
 
@@ -1278,6 +1311,42 @@ pub mod interactions_api_types {
                     | InteractionStatus::Cancelled
             )
         }
+
+        /// The exact spelling the Interactions API uses for this status on the
+        /// wire.
+        ///
+        /// Spelled out rather than derived from `Debug` (which would yield
+        /// `BudgetExceeded`, not `budget_exceeded`) so the string that reaches
+        /// [`crate::completion::FinishReason::Other`] is the provider's own.
+        pub fn as_wire_str(&self) -> &'static str {
+            match self {
+                Self::InProgress => "in_progress",
+                Self::RequiresAction => "requires_action",
+                Self::Incomplete => "incomplete",
+                Self::BudgetExceeded => "budget_exceeded",
+                Self::Completed => "completed",
+                Self::Failed => "failed",
+                Self::Cancelled => "cancelled",
+            }
+        }
+    }
+
+    /// Map an interaction's lifecycle status onto rig's normalized finish
+    /// reasons.
+    ///
+    /// The Interactions API has no `finishReason` field — the interaction's
+    /// terminal state is the closest equivalent. Only the three statuses with a
+    /// normalized counterpart are folded in; the rest (including the
+    /// non-terminal `in_progress`) are carried verbatim rather than guessed at.
+    pub(crate) fn map_interaction_status(
+        status: &InteractionStatus,
+    ) -> crate::completion::FinishReason {
+        match status {
+            InteractionStatus::Completed => crate::completion::FinishReason::Stop,
+            InteractionStatus::RequiresAction => crate::completion::FinishReason::ToolCalls,
+            InteractionStatus::BudgetExceeded => crate::completion::FinishReason::Length,
+            other => crate::completion::FinishReason::Other(other.as_wire_str().to_owned()),
+        }
     }
 
     /// Token usage metadata for an interaction.
@@ -1292,15 +1361,21 @@ pub mod interactions_api_types {
         pub total_tokens: Option<u64>,
     }
 
-    impl GetTokenUsage for InteractionUsage {
-        fn token_usage(&self) -> Usage {
+    impl From<&InteractionUsage> for Usage {
+        fn from(value: &InteractionUsage) -> Usage {
             let mut usage = Usage::new();
-            usage.input_tokens = self.total_input_tokens.unwrap_or_default();
-            usage.output_tokens = self.total_output_tokens.unwrap_or_default();
-            usage.total_tokens = self
+            usage.input_tokens = value.total_input_tokens.unwrap_or_default();
+            usage.output_tokens = value.total_output_tokens.unwrap_or_default();
+            usage.total_tokens = value
                 .total_tokens
                 .unwrap_or(usage.input_tokens + usage.output_tokens);
             usage
+        }
+    }
+
+    impl From<InteractionUsage> for Usage {
+        fn from(value: InteractionUsage) -> Usage {
+            (&value).into()
         }
     }
 
@@ -2839,7 +2914,7 @@ mod tests {
             ..Default::default()
         };
 
-        let response: completion::CompletionResponse<Interaction> =
+        let response: completion::CompletionResponse =
             interaction.try_into().expect("conversion should succeed");
 
         let choice = response.choice.first();
@@ -3234,6 +3309,111 @@ mod tests {
         interaction.status = Some(InteractionStatus::BudgetExceeded);
         assert!(interaction.is_terminal());
         assert!(!interaction.is_completed());
+    }
+
+    #[test]
+    fn test_interaction_status_maps_every_wire_variant() {
+        use crate::completion::FinishReason as Normalized;
+
+        for (status, expected) in [
+            (InteractionStatus::Completed, Normalized::Stop),
+            (InteractionStatus::RequiresAction, Normalized::ToolCalls),
+            (InteractionStatus::BudgetExceeded, Normalized::Length),
+            // Statuses rig does not model survive in the provider's own
+            // spelling rather than being guessed at.
+            (
+                InteractionStatus::InProgress,
+                Normalized::Other("in_progress".to_string()),
+            ),
+            (
+                InteractionStatus::Incomplete,
+                Normalized::Other("incomplete".to_string()),
+            ),
+            (
+                InteractionStatus::Failed,
+                Normalized::Other("failed".to_string()),
+            ),
+            (
+                InteractionStatus::Cancelled,
+                Normalized::Other("cancelled".to_string()),
+            ),
+        ] {
+            assert_eq!(
+                map_interaction_status(&status),
+                expected,
+                "status {status:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_interaction_status_wire_spelling_matches_serde() {
+        // `as_wire_str` is hand-written; keep it honest against the serde
+        // representation the same enum deserializes from.
+        for status in [
+            InteractionStatus::InProgress,
+            InteractionStatus::RequiresAction,
+            InteractionStatus::Incomplete,
+            InteractionStatus::BudgetExceeded,
+            InteractionStatus::Completed,
+            InteractionStatus::Failed,
+            InteractionStatus::Cancelled,
+        ] {
+            let serialized = serde_json::to_value(&status).expect("status should serialize");
+            assert_eq!(serialized, json!(status.as_wire_str()));
+        }
+    }
+
+    #[test]
+    fn test_completion_response_carries_normalized_metadata() {
+        let interaction = Interaction {
+            id: "interaction-meta".to_string(),
+            model: Some("gemini-2.5-pro".to_string()),
+            status: Some(InteractionStatus::BudgetExceeded),
+            steps: vec![Step::ModelOutput {
+                content: vec![Content::Text(TextContent {
+                    text: "partial answer".to_string(),
+                    annotations: None,
+                })],
+            }],
+            ..Default::default()
+        };
+
+        let response: completion::CompletionResponse =
+            interaction.try_into().expect("conversion should succeed");
+
+        assert_eq!(response.provider, PROVIDER_NAME);
+        assert_eq!(response.model.as_deref(), Some("gemini-2.5-pro"));
+        assert_eq!(response.message_id.as_deref(), Some("interaction-meta"));
+        assert_eq!(
+            response.finish_reason,
+            Some(crate::completion::FinishReason::Length)
+        );
+    }
+
+    #[test]
+    fn test_completion_response_upgrades_completed_to_tool_calls() {
+        // A `completed` interaction whose outputs are function calls is a tool
+        // turn; the normalized response must say so.
+        let interaction = Interaction {
+            id: "interaction-tool".to_string(),
+            status: Some(InteractionStatus::Completed),
+            steps: vec![Step::FunctionCall(FunctionCallContent {
+                name: Some("get_weather".to_string()),
+                arguments: Some(json!({"location": "Paris"})),
+                id: Some("call-123".to_string()),
+            })],
+            ..Default::default()
+        };
+
+        let response: completion::CompletionResponse =
+            interaction.try_into().expect("conversion should succeed");
+
+        assert_eq!(
+            response.finish_reason,
+            Some(crate::completion::FinishReason::ToolCalls)
+        );
+        assert_eq!(response.model, None);
     }
 
     #[test]

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -530,7 +530,8 @@ impl TryFrom<Interaction> for completion::CompletionResponse {
 
         Ok(
             completion::CompletionResponse::new(choice, usage, PROVIDER_NAME)
-                .with_optional_message_id(Some(response.id.as_str()).filter(|id| !id.is_empty()))
+                // The interaction id is response-scoped, not an assistant
+                // message id.
                 .with_optional_model(response.model.as_deref())
                 .with_optional_finish_reason(finish_reason),
         )

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -530,8 +530,7 @@ impl TryFrom<Interaction> for completion::CompletionResponse {
 
         Ok(
             completion::CompletionResponse::new(choice, usage, PROVIDER_NAME)
-                // The interaction id is response-scoped, not an assistant
-                // message id.
+                .with_optional_message_id(Some(response.id.as_str()).filter(|id| !id.is_empty()))
                 .with_optional_model(response.model.as_deref())
                 .with_optional_finish_reason(finish_reason),
         )

--- a/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
@@ -5,14 +5,13 @@ use std::pin::Pin;
 use tracing::{Level, enabled};
 use tracing_futures::Instrument;
 
-use super::InteractionsCompletionModel;
-use super::create_request_body;
 use super::interactions_api_types::{
     Content, ContentDelta, FunctionCallContent, FunctionCallDelta, Interaction,
     InteractionSseEvent, InteractionUsage, Step, TextDelta, ThoughtSummaryContent,
-    ThoughtSummaryDelta,
+    ThoughtSummaryDelta, map_interaction_status,
 };
-use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
+use super::{InteractionsCompletionModel, PROVIDER_NAME, create_request_body};
+use crate::completion::{CompletionError, CompletionRequest};
 use crate::http_client::HttpClientExt;
 use crate::http_client::Request;
 use crate::http_client::sse::{Event, GenericEventSource};
@@ -40,26 +39,60 @@ pub type InteractionEventStream =
 pub type InteractionEventStream =
     Pin<Box<dyn Stream<Item = Result<InteractionSseEvent, CompletionError>>>>;
 
-impl GetTokenUsage for StreamingCompletionResponse {
-    fn token_usage(&self) -> crate::completion::Usage {
-        self.usage
+impl From<&StreamingCompletionResponse> for crate::completion::Usage {
+    fn from(value: &StreamingCompletionResponse) -> crate::completion::Usage {
+        value
+            .usage
             .as_ref()
-            .map(|usage| usage.token_usage())
+            .map(crate::completion::Usage::from)
             .unwrap_or_default()
     }
+}
+
+impl From<StreamingCompletionResponse> for crate::completion::Usage {
+    fn from(value: StreamingCompletionResponse) -> crate::completion::Usage {
+        (&value).into()
+    }
+}
+
+/// Normalize the Interactions API's terminal streaming record.
+///
+/// The finish reason comes from the completed interaction's lifecycle status —
+/// the API has no `finishReason` field — and is absent when the stream ended
+/// without one.
+fn map_stream_final(
+    response: StreamingCompletionResponse,
+) -> Result<streaming::StreamFinal, CompletionError> {
+    let usage = (&response).into();
+    let interaction = response.interaction.as_ref();
+    let finish_reason = interaction
+        .and_then(|interaction| interaction.status.as_ref())
+        .map(map_interaction_status);
+    let message_id = interaction
+        .map(|interaction| interaction.id.as_str())
+        .filter(|id| !id.is_empty());
+
+    Ok(streaming::StreamFinal::new(PROVIDER_NAME, usage)
+        .with_optional_finish_reason(finish_reason)
+        .with_optional_message_id(message_id)
+        .with_optional_model(response.model_version.as_deref()))
 }
 
 impl<T> InteractionsCompletionModel<T>
 where
     T: HttpClientExt + Clone + Default + std::fmt::Debug + 'static,
 {
-    pub(crate) async fn stream(
+    /// Open an Interactions stream whose terminal record stays provider-native.
+    ///
+    /// The normalized [`CompletionModel::stream`](crate::completion::CompletionModel::stream)
+    /// delegates here and maps only the terminal record, so both paths open
+    /// exactly one stream over the same request, telemetry, and error handling.
+    pub async fn raw_stream(
         &self,
         completion_request: CompletionRequest,
-    ) -> Result<streaming::StreamingCompletionResponse<StreamingCompletionResponse>, CompletionError>
-    {
+    ) -> Result<streaming::RawStreamingResult<StreamingCompletionResponse>, CompletionError> {
         let span = CompletionSpanBuilder::new(
-            "gcp.gemini",
+            PROVIDER_NAME,
             &self.model,
             CompletionOperation::InteractionsStreaming,
         )
@@ -92,6 +125,7 @@ where
         let stream = stream! {
             let mut final_interaction: Option<Interaction> = None;
             let mut final_usage: Option<InteractionUsage> = None;
+            let mut stream_failed = false;
 
             while let Some(event_result) = event_source.next().await {
                 match event_result {
@@ -134,7 +168,7 @@ where
                                 }
 
                                 if let Some(usage) = interaction.usage.clone() {
-                                    span.record_token_usage(&usage);
+                                    span.record_token_usage(&crate::completion::Usage::from(&usage));
                                     final_usage = Some(usage);
                                 }
                                 final_interaction = Some(interaction);
@@ -145,6 +179,7 @@ where
                                 // the SSE path's `completion_error_from_body`. The error
                                 // arrives over an established stream, so there is no HTTP
                                 // status to attach (status: None).
+                                stream_failed = true;
                                 yield Err(crate::provider_response::completion_error_from_body(
                                     message.data,
                                 ));
@@ -158,6 +193,7 @@ where
                     }
                     Err(error) => {
                         tracing::error!(?error, "SSE error");
+                        stream_failed = true;
                         yield Err(CompletionError::from_stream_transport(error));
                         break;
                     }
@@ -166,18 +202,33 @@ where
 
             event_source.close();
 
-            let model_version = final_interaction.as_ref().and_then(|i| i.model.clone());
-            yield Ok(streaming::RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
-                usage: final_usage.or_else(|| final_interaction.as_ref().and_then(|i| i.usage.clone())),
-                interaction: final_interaction,
-                model_version,
-            }));
+            // A stream that errored out never gets a synthesized terminal
+            // record: yielding one would report a successful completion for a
+            // turn the provider aborted.
+            if !stream_failed {
+                let model_version = final_interaction.as_ref().and_then(|i| i.model.clone());
+                yield Ok(streaming::RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
+                    usage: final_usage.or_else(|| final_interaction.as_ref().and_then(|i| i.usage.clone())),
+                    interaction: final_interaction,
+                    model_version,
+                }));
+            }
         }
         .instrument(span);
 
-        Ok(streaming::StreamingCompletionResponse::stream(Box::pin(
-            stream,
-        )))
+        Ok(Box::pin(stream))
+    }
+
+    pub(crate) async fn stream(
+        &self,
+        completion_request: CompletionRequest,
+    ) -> Result<streaming::StreamingCompletionResponse, CompletionError> {
+        let inner = self.raw_stream(completion_request).await?;
+
+        Ok(streaming::StreamingCompletionResponse::stream(
+            PROVIDER_NAME,
+            streaming::normalize_stream(inner, map_stream_final),
+        ))
     }
 }
 

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -6,13 +6,14 @@ use tracing_futures::Instrument;
 
 use super::completion::gemini_api_types::{
     ContentCandidate, FinishReason, ModalityTokenCount, Part, PartKind, TrafficType,
+    map_finish_reason,
 };
 use super::completion::{
-    CompletionModel, create_request_body, function_call_finish_reason_error, resolve_request_model,
-    streaming_endpoint,
+    CompletionModel, PROVIDER_NAME, create_request_body, function_call_finish_reason_error,
+    resolve_request_model, streaming_endpoint,
 };
 use crate::completion::message::ReasoningContent;
-use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
+use crate::completion::{CompletionError, CompletionRequest};
 use crate::http_client::HttpClientExt;
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::streaming;
@@ -45,18 +46,24 @@ pub struct PartialUsage {
     pub traffic_type: Option<TrafficType>,
 }
 
-impl GetTokenUsage for PartialUsage {
-    fn token_usage(&self) -> crate::completion::Usage {
+impl From<&PartialUsage> for crate::completion::Usage {
+    fn from(value: &PartialUsage) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
 
-        usage.input_tokens = self.prompt_token_count as u64;
-        usage.output_tokens = self.candidates_token_count.unwrap_or_default() as u64;
-        usage.cached_input_tokens = self.cached_content_token_count.unwrap_or_default() as u64;
-        usage.reasoning_tokens = self.thoughts_token_count.unwrap_or_default() as u64;
-        usage.tool_use_prompt_tokens = self.tool_use_prompt_token_count.unwrap_or_default() as u64;
-        usage.total_tokens = self.total_token_count as u64;
+        usage.input_tokens = value.prompt_token_count as u64;
+        usage.output_tokens = value.candidates_token_count.unwrap_or_default() as u64;
+        usage.cached_input_tokens = value.cached_content_token_count.unwrap_or_default() as u64;
+        usage.reasoning_tokens = value.thoughts_token_count.unwrap_or_default() as u64;
+        usage.tool_use_prompt_tokens = value.tool_use_prompt_token_count.unwrap_or_default() as u64;
+        usage.total_tokens = value.total_token_count as u64;
 
         usage
+    }
+}
+
+impl From<PartialUsage> for crate::completion::Usage {
+    fn from(value: PartialUsage) -> crate::completion::Usage {
+        (&value).into()
     }
 }
 
@@ -82,10 +89,33 @@ pub struct StreamingCompletionResponse {
     pub model_version: Option<String>,
 }
 
-impl GetTokenUsage for StreamingCompletionResponse {
-    fn token_usage(&self) -> crate::completion::Usage {
-        self.usage_metadata.token_usage()
+impl From<&StreamingCompletionResponse> for crate::completion::Usage {
+    fn from(value: &StreamingCompletionResponse) -> crate::completion::Usage {
+        (&value.usage_metadata).into()
     }
+}
+
+impl From<StreamingCompletionResponse> for crate::completion::Usage {
+    fn from(value: StreamingCompletionResponse) -> crate::completion::Usage {
+        (&value).into()
+    }
+}
+
+/// Normalize Gemini's terminal streaming record.
+///
+/// Infallible in practice, but stated as a `Result` because
+/// [`crate::streaming::normalize_stream`] maps terminal records through a
+/// fallible closure.
+fn map_stream_final(
+    response: StreamingCompletionResponse,
+) -> Result<streaming::StreamFinal, CompletionError> {
+    let finish_reason = response.finish_reason.as_ref().map(map_finish_reason);
+
+    Ok(
+        streaming::StreamFinal::new(PROVIDER_NAME, (&response.usage_metadata).into())
+            .with_optional_finish_reason(finish_reason)
+            .with_optional_model(response.model_version),
+    )
 }
 
 fn tool_protocol_finish_reason_error(choice: &ContentCandidate) -> Option<CompletionError> {
@@ -97,14 +127,19 @@ impl<T> CompletionModel<T>
 where
     T: HttpClientExt + Clone + 'static,
 {
-    pub(crate) async fn stream(
+    /// Open a `streamGenerateContent` stream whose terminal record stays
+    /// provider-native.
+    ///
+    /// The normalized [`CompletionModel::stream`](crate::completion::CompletionModel::stream)
+    /// delegates here and maps only the terminal record, so both paths open
+    /// exactly one stream over the same request, telemetry, and error handling.
+    pub async fn raw_stream(
         &self,
         completion_request: CompletionRequest,
-    ) -> Result<streaming::StreamingCompletionResponse<StreamingCompletionResponse>, CompletionError>
-    {
+    ) -> Result<streaming::RawStreamingResult<StreamingCompletionResponse>, CompletionError> {
         let request_model = resolve_request_model(&self.model, &completion_request);
         let span = CompletionSpanBuilder::new(
-            "gcp.gemini",
+            PROVIDER_NAME,
             &request_model,
             CompletionOperation::ChatStreaming,
         )
@@ -171,7 +206,7 @@ where
                             final_model_version = Some(model_version.clone());
                         }
                         if let Some(usage) = data.usage_metadata.as_ref() {
-                            span.record_token_usage(usage);
+                            span.record_token_usage(&crate::completion::Usage::from(usage));
                             final_usage = Some(usage.clone());
                         }
 
@@ -292,6 +327,9 @@ where
             // Ensure event source is closed when stream ends
             event_source.close();
 
+            // A stream that errored out never gets a synthesized terminal
+            // record: yielding one would report a successful completion for a
+            // turn the provider aborted.
             if !stream_failed {
                 yield Ok(streaming::RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
                     usage_metadata: final_usage.unwrap_or_default(),
@@ -302,9 +340,19 @@ where
             }
         }.instrument(span);
 
-        Ok(streaming::StreamingCompletionResponse::stream(Box::pin(
-            stream,
-        )))
+        Ok(Box::pin(stream))
+    }
+
+    pub(crate) async fn stream(
+        &self,
+        completion_request: CompletionRequest,
+    ) -> Result<streaming::StreamingCompletionResponse, CompletionError> {
+        let inner = self.raw_stream(completion_request).await?;
+
+        Ok(streaming::StreamingCompletionResponse::stream(
+            PROVIDER_NAME,
+            streaming::normalize_stream(inner, map_stream_final),
+        ))
     }
 }
 
@@ -434,7 +482,7 @@ mod tests {
         let usage = response
             .usage_metadata
             .as_ref()
-            .map(GetTokenUsage::token_usage)
+            .map(crate::completion::Usage::from)
             .unwrap();
         assert_eq!(usage.input_tokens, 10);
         assert_eq!(usage.output_tokens, 5);
@@ -684,7 +732,7 @@ mod tests {
             traffic_type: None,
         };
 
-        let token_usage = usage.token_usage();
+        let token_usage = crate::completion::Usage::from(&usage);
         assert_eq!(token_usage.input_tokens, 40);
         assert_eq!(token_usage.cached_input_tokens, 20);
         assert_eq!(token_usage.output_tokens, 30);
@@ -709,7 +757,7 @@ mod tests {
             traffic_type: None,
         };
 
-        let token_usage = usage.token_usage();
+        let token_usage = crate::completion::Usage::from(&usage);
         assert_eq!(token_usage.input_tokens, 20);
         assert_eq!(token_usage.cached_input_tokens, 0);
         assert_eq!(token_usage.output_tokens, 30);
@@ -777,7 +825,7 @@ mod tests {
             model_version: Some("gemini-2.0-flash-001".to_string()),
         };
 
-        let token_usage = response.token_usage();
+        let token_usage = crate::completion::Usage::from(&response);
         assert_eq!(token_usage.input_tokens, 75);
         assert_eq!(token_usage.output_tokens, 75);
         assert_eq!(token_usage.reasoning_tokens, 0);
@@ -832,7 +880,7 @@ mod tests {
             Some(TrafficType::ProvisionedThroughput)
         ));
 
-        let token_usage = usage.token_usage();
+        let token_usage = crate::completion::Usage::from(&usage);
         assert_eq!(token_usage.input_tokens, 100);
         assert_eq!(token_usage.cached_input_tokens, 25);
         assert_eq!(token_usage.output_tokens, 50);

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -122,7 +122,9 @@ pub type ClientBuilder<H = crate::markers::Missing> =
 pub type CompletionModel<H = reqwest::Client> =
     openai::completion::GenericCompletionModel<GroqExt, H>;
 
-/// Final streaming response, shared with the OpenAI Chat Completions path.
+/// Groq's provider-native terminal streaming record: the value carried by the
+/// final item of the stream returned by `CompletionModel::raw_stream`. Shared
+/// with the OpenAI Chat Completions path, usage payload included.
 pub type StreamingCompletionResponse = openai::StreamingCompletionResponse;
 
 impl ProviderClient for Client {

--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
@@ -13,7 +13,7 @@ use futures::StreamExt;
 use http::Request;
 use tracing_futures::Instrument;
 
-use crate::completion::{CompletionError, GetTokenUsage};
+use crate::completion::{CompletionError, FinishReason, Usage};
 use crate::http_client::HttpClientExt;
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::json_utils;
@@ -41,10 +41,65 @@ fn provider_response_from_compatible_sse_data(data: &str) -> Option<CompletionEr
     Some(crate::provider_response::completion_error_from_body(data))
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Map an OpenAI Chat Completions-style `finish_reason` string onto the
+/// normalized vocabulary, preserving anything unrecognized verbatim.
+///
+/// Shared by the unary and streaming paths so both agree, and so a gateway
+/// inventing a new reason surfaces it rather than reading as a natural stop.
+pub(crate) fn map_openai_finish_reason(reason: &str) -> FinishReason {
+    match reason {
+        "stop" => FinishReason::Stop,
+        "length" | "max_tokens" => FinishReason::Length,
+        "tool_calls" | "function_call" => FinishReason::ToolCalls,
+        "content_filter" => FinishReason::ContentFilter,
+        other => FinishReason::Other(other.to_owned()),
+    }
+}
+
+/// A chunk's terminal reason, as reported by an OpenAI-compatible provider.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CompatibleFinishReason {
-    ToolCalls,
-    Other,
+    /// The chunk reported a terminal reason, normalized.
+    Reported(FinishReason),
+    /// The chunk carried no `finish_reason` field.
+    Absent,
+}
+
+impl CompatibleFinishReason {
+    /// Normalize a wire `finish_reason` field.
+    pub(crate) fn from_wire(reason: Option<&str>) -> Self {
+        match reason.filter(|reason| !reason.is_empty()) {
+            Some(reason) => Self::Reported(map_openai_finish_reason(reason)),
+            None => Self::Absent,
+        }
+    }
+
+    /// Whether the provider explicitly ended the turn to call tools.
+    pub(crate) fn is_tool_calls(&self) -> bool {
+        matches!(self, Self::Reported(FinishReason::ToolCalls))
+    }
+
+    /// The normalized reason, when the provider reported one.
+    pub(crate) fn reported(&self) -> Option<FinishReason> {
+        match self {
+            Self::Reported(reason) => Some(reason.clone()),
+            Self::Absent => None,
+        }
+    }
+}
+
+/// The terminal state a compatible stream reached, handed to a profile so it
+/// can build its own provider-native terminal record.
+#[derive(Debug, Clone)]
+pub(crate) struct CompatibleTerminal<U> {
+    /// Provider-native usage payload from the terminal event.
+    pub(crate) usage: U,
+    /// Normalized finish reason, when the stream reported one.
+    pub(crate) finish_reason: Option<FinishReason>,
+    /// Provider-assigned response identifier, when emitted.
+    pub(crate) response_id: Option<String>,
+    /// Provider-reported model identifier, when emitted.
+    pub(crate) model: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -156,13 +211,19 @@ where
 }
 
 pub(crate) trait CompatibleStreamProfile: WasmCompatSend {
-    type Usage: Clone + Default + GetTokenUsage + WasmCompatSend + 'static;
+    type Usage: Clone + Default + Into<Usage> + WasmCompatSend + 'static;
     type Detail: WasmCompatSend + 'static;
-    type FinalResponse: Clone + Unpin + GetTokenUsage + WasmCompatSend + 'static;
+    type FinalResponse: Clone + WasmCompatSend + 'static;
 
     fn normalize_chunk(&self, data: &str) -> NormalizedCompatibleChunk<Self::Usage, Self::Detail>;
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse;
+    /// Build the provider's own terminal record from the stream's terminal
+    /// state. The record stays provider-native for `raw_stream`; the normalized
+    /// path maps it once through [`crate::streaming::normalize_stream`].
+    fn build_final_response(
+        &self,
+        terminal: CompatibleTerminal<Self::Usage>,
+    ) -> Self::FinalResponse;
 
     fn uses_distinct_tool_call_eviction(&self) -> bool {
         false
@@ -215,11 +276,11 @@ pub(crate) fn should_evict_distinct_named_tool_call(
     false
 }
 
-pub(crate) async fn send_compatible_streaming_request<T, P>(
+pub(crate) async fn send_compatible_raw_streaming_request<T, P>(
     http_client: T,
     req: Request<Vec<u8>>,
     profile: P,
-) -> Result<streaming::StreamingCompletionResponse<P::FinalResponse>, CompletionError>
+) -> Result<streaming::RawStreamingResult<P::FinalResponse>, CompletionError>
 where
     T: HttpClientExt + Clone + 'static,
     P: CompatibleStreamProfile + 'static,
@@ -231,6 +292,9 @@ where
     let stream = stream! {
         let mut tool_calls: HashMap<usize, RawStreamingToolCall> = HashMap::new();
         let mut final_usage = None;
+        let mut final_finish_reason = None;
+        let mut response_id = None;
+        let mut response_model = None;
         let mut terminated_with_error = false;
 
         while let Some(event_result) = event_source.next().await {
@@ -266,6 +330,14 @@ where
                         chunk.response_model.as_deref(),
                     );
 
+                    if let Some(id) = chunk.response_id.as_ref() {
+                        response_id = Some(id.clone());
+                    }
+
+                    if let Some(model) = chunk.response_model.as_ref() {
+                        response_model = Some(model.clone());
+                    }
+
                     if let Some(usage) = chunk.usage {
                         final_usage = Some(usage);
                     }
@@ -273,6 +345,10 @@ where
                     let Some(choice) = chunk.choice else {
                         continue;
                     };
+
+                    if let Some(reason) = choice.finish_reason.reported() {
+                        final_finish_reason = Some(reason);
+                    }
 
                     for incoming in choice.tool_calls {
                         if let Some(existing) = tool_calls.get(&incoming.index)
@@ -351,7 +427,7 @@ where
                         yield Ok(RawStreamingChoice::Message(content));
                     }
 
-                    if choice.finish_reason == CompatibleFinishReason::ToolCalls {
+                    if choice.finish_reason.is_tool_calls() {
                         for tool_call in take_finalized_tool_calls(
                             &mut tool_calls,
                             DroppedToolCallContext::ToolCallsFinishReason,
@@ -385,27 +461,26 @@ where
         }
 
         let final_usage = final_usage.unwrap_or_default();
-        record_usage(&span, &final_usage);
+        record_usage(&span, &final_usage.clone().into());
         yield Ok(RawStreamingChoice::FinalResponse(
-            profile.build_final_response(final_usage),
+            profile.build_final_response(CompatibleTerminal {
+                usage: final_usage,
+                finish_reason: final_finish_reason,
+                response_id,
+                model: response_model,
+            }),
         ));
     }
     .instrument(instrument_span);
 
-    Ok(streaming::StreamingCompletionResponse::stream(Box::pin(
-        stream,
-    )))
+    Ok(Box::pin(stream))
 }
 
-fn record_usage<T>(span: &tracing::Span, usage: &T)
-where
-    T: GetTokenUsage,
-{
+fn record_usage(span: &tracing::Span, usage: &Usage) {
     if span.is_disabled() {
         return;
     }
 
-    let usage = usage.token_usage();
     if !usage.has_values() {
         // Zero-valued usage is the documented sentinel for missing provider
         // usage metrics; leave the span fields unset.
@@ -576,7 +651,6 @@ fn take_finalized_tool_calls(
 
 #[cfg(test)]
 pub(crate) mod test_support {
-    use crate::completion::GetTokenUsage;
     use crate::streaming::{self, StreamedAssistantContent};
     use bytes::Bytes;
     use futures::StreamExt;
@@ -607,14 +681,12 @@ pub(crate) mod test_support {
         )
     }
 
-    pub(crate) async fn assert_zero_arg_tool_call_is_emitted<R>(
-        mut stream: streaming::StreamingCompletionResponse<R>,
+    pub(crate) async fn assert_zero_arg_tool_call_is_emitted(
+        mut stream: streaming::StreamingCompletionResponse,
         expected_id: &str,
         expected_name: &str,
         expect_final_response: bool,
-    ) where
-        R: Clone + Unpin + GetTokenUsage,
-    {
+    ) {
         let mut saw_final = false;
         let mut collected_tool_calls = Vec::new();
 
@@ -647,8 +719,8 @@ pub(crate) mod test_support {
 mod tests {
     use super::test_support::sse_bytes_from_data_lines;
     use super::{
-        finalize_completed_streaming_tool_call, finalize_pending_tool_call,
-        send_compatible_streaming_request,
+        CompatibleStreamProfile, finalize_completed_streaming_tool_call,
+        finalize_pending_tool_call, send_compatible_raw_streaming_request,
     };
     use crate::completion::CompletionError;
     use crate::http_client;
@@ -660,6 +732,24 @@ mod tests {
         FinishReasonCleanupProfile,
     };
     use futures::StreamExt;
+
+    /// Wrap a profile-driven raw stream into the normalized carrier, so these
+    /// tests exercise the same path providers use.
+    async fn send_compatible_streaming_request<T, P>(
+        http_client: T,
+        req: http::Request<Vec<u8>>,
+        profile: P,
+    ) -> Result<crate::streaming::StreamingCompletionResponse, CompletionError>
+    where
+        T: crate::http_client::HttpClientExt + Clone + 'static,
+        P: CompatibleStreamProfile<FinalResponse = crate::streaming::StreamFinal> + 'static,
+    {
+        let raw = send_compatible_raw_streaming_request(http_client, req, profile).await?;
+        Ok(crate::streaming::StreamingCompletionResponse::stream(
+            "test-compatible",
+            crate::streaming::normalize_stream(raw, Ok),
+        ))
+    }
 
     #[test]
     fn sse_error_detector_handles_null_empty_and_object_or_string_errors() {

--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
@@ -1158,7 +1158,7 @@ mod tests {
             .body(Vec::new())
             .expect("request should build");
 
-        let mut stream = send_compatible_streaming_request(client, req)
+        let mut stream = send_compatible_streaming_request(client, req, "openai")
             .await
             .expect("stream should start");
 
@@ -1208,7 +1208,7 @@ mod tests {
             .body(Vec::new())
             .expect("request should build");
 
-        let mut stream = send_compatible_streaming_request(client, req)
+        let mut stream = send_compatible_streaming_request(client, req, "openai")
             .await
             .expect("stream should start");
 
@@ -1277,7 +1277,7 @@ mod tests {
             .body(Vec::new())
             .expect("request should build");
 
-        let mut stream = send_compatible_streaming_request(client, req)
+        let mut stream = send_compatible_streaming_request(client, req, "openai")
             .await
             .expect("stream should start");
 

--- a/crates/rig-core/src/providers/mira.rs
+++ b/crates/rig-core/src/providers/mira.rs
@@ -338,10 +338,9 @@ impl From<Usage> for completion::Usage {
 /// The provider descriptor name is an *input* rather than a constant so the
 /// shared OpenAI-compatible completion path labels the response with the
 /// descriptor that actually produced it.
-impl TryFrom<(&str, CompletionResponse)> for completion::CompletionResponse {
-    type Error = CompletionError;
-
-    fn try_from((provider, response): (&str, CompletionResponse)) -> Result<Self, Self::Error> {
+impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
+    fn normalize(self, provider: &str) -> Result<completion::CompletionResponse, CompletionError> {
+        let response = self;
         let (content, usage, message_id, model, finish_reason) = match &response {
             CompletionResponse::Structured {
                 id,
@@ -457,12 +456,14 @@ impl std::fmt::Display for Usage {
 mod tests {
     use super::*;
     use crate::completion::FinishReason;
+    use crate::completion::NormalizeCompletionResponse;
     use crate::providers::openai::completion::OpenAICompatibleProvider;
 
     /// Normalize a Mira wire response the way the shared completion path does,
     /// threading Mira's own descriptor name through the conversion.
     fn normalized(response: CompletionResponse) -> completion::CompletionResponse {
-        completion::CompletionResponse::try_from((MiraExt::PROVIDER_NAME, response))
+        response
+            .normalize(MiraExt::PROVIDER_NAME)
             .expect("Mira response should convert")
     }
 

--- a/crates/rig-core/src/providers/mira.rs
+++ b/crates/rig-core/src/providers/mira.rs
@@ -12,6 +12,7 @@ use crate::client::{
     ProviderClient,
 };
 use crate::http_client::{self, HttpClientExt};
+use crate::providers::internal::openai_chat_completions_compatible::map_openai_finish_reason;
 use crate::{
     OneOrMany,
     completion::{self, CompletionError},
@@ -313,39 +314,59 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
     }
 }
 
-impl crate::completion::GetTokenUsage for Usage {
-    fn token_usage(&self) -> crate::completion::Usage {
-        let mut usage = crate::completion::Usage::new();
-        usage.input_tokens = self.prompt_tokens as u64;
-        usage.output_tokens = self.total_tokens.saturating_sub(self.prompt_tokens) as u64;
-        usage.total_tokens = self.total_tokens as u64;
-        usage
+impl From<&Usage> for completion::Usage {
+    fn from(usage: &Usage) -> Self {
+        crate::providers::internal::completion_usage(
+            usage.prompt_tokens as u64,
+            // Mira reports only prompt and total counts; the completion count
+            // is the remainder.
+            usage.total_tokens.saturating_sub(usage.prompt_tokens) as u64,
+            usage.total_tokens as u64,
+            0,
+        )
     }
 }
 
-impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionResponse> {
+impl From<Usage> for completion::Usage {
+    fn from(usage: Usage) -> Self {
+        Self::from(&usage)
+    }
+}
+
+/// Normalize a Mira chat completion response.
+///
+/// The provider descriptor name is an *input* rather than a constant so the
+/// shared OpenAI-compatible completion path labels the response with the
+/// descriptor that actually produced it.
+impl TryFrom<(&str, CompletionResponse)> for completion::CompletionResponse {
     type Error = CompletionError;
 
-    fn try_from(response: CompletionResponse) -> Result<Self, Self::Error> {
-        let (content, usage) = match &response {
-            CompletionResponse::Structured { choices, usage, .. } => {
+    fn try_from((provider, response): (&str, CompletionResponse)) -> Result<Self, Self::Error> {
+        let (content, usage, message_id, model, finish_reason) = match &response {
+            CompletionResponse::Structured {
+                id,
+                model,
+                choices,
+                usage,
+                ..
+            } => {
                 let choice = choices.first().ok_or_else(|| {
                     CompletionError::ResponseError("Response contained no choices".to_owned())
                 })?;
 
                 let usage = usage
                     .as_ref()
-                    .map(|usage| completion::Usage {
-                        input_tokens: usage.prompt_tokens as u64,
-                        output_tokens: usage.total_tokens.saturating_sub(usage.prompt_tokens)
-                            as u64,
-                        total_tokens: usage.total_tokens as u64,
-                        cached_input_tokens: 0,
-                        cache_creation_input_tokens: 0,
-                        tool_use_prompt_tokens: 0,
-                        reasoning_tokens: 0,
-                    })
+                    .map(completion::Usage::from)
                     .unwrap_or_default();
+
+                let finish_reason = choice
+                    .finish_reason
+                    .as_deref()
+                    .filter(|reason| !reason.is_empty())
+                    .map(map_openai_finish_reason);
+
+                let message_id = Some(id.clone()).filter(|id| !id.is_empty());
+                let model = Some(model.clone()).filter(|model| !model.is_empty());
 
                 // Convert RawMessage to message::Message
                 let message = message::Message::try_from(choice.message.clone())?;
@@ -390,11 +411,16 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                     }
                 };
 
-                (content, usage)
+                (content, usage, message_id, model, finish_reason)
             }
+            // The bare-string variant carries no metadata at all — not even a
+            // terminal reason, so the normalized reason stays `None`.
             CompletionResponse::Simple(text) => (
                 vec![completion::AssistantContent::text(text)],
                 completion::Usage::new(),
+                None,
+                None,
+                None,
             ),
         };
 
@@ -404,12 +430,10 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             )
         })?;
 
-        Ok(completion::CompletionResponse {
-            choice,
-            usage,
-            raw_response: response,
-            message_id: None,
-        })
+        Ok(completion::CompletionResponse::new(choice, usage, provider)
+            .with_optional_message_id(message_id)
+            .with_optional_model(model)
+            .with_optional_finish_reason(finish_reason))
     }
 }
 
@@ -432,6 +456,15 @@ impl std::fmt::Display for Usage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::completion::FinishReason;
+    use crate::providers::openai::completion::OpenAICompatibleProvider;
+
+    /// Normalize a Mira wire response the way the shared completion path does,
+    /// threading Mira's own descriptor name through the conversion.
+    fn normalized(response: CompletionResponse) -> completion::CompletionResponse {
+        completion::CompletionResponse::try_from((MiraExt::PROVIDER_NAME, response))
+            .expect("Mira response should convert")
+    }
 
     #[test]
     fn test_completion_response_conversion() {
@@ -454,14 +487,71 @@ mod tests {
             }),
         };
 
-        let completion_response: completion::CompletionResponse<CompletionResponse> =
-            mira_response.try_into().unwrap();
+        let completion_response = normalized(mira_response);
 
         assert_eq!(
             completion_response.choice.first(),
             completion::AssistantContent::text("Test response")
         );
+        assert_eq!(completion_response.provider, "mira");
+        assert_eq!(completion_response.message_id.as_deref(), Some("resp_123"));
+        assert_eq!(completion_response.model.as_deref(), Some("deepseek-r1"));
+        assert_eq!(completion_response.finish_reason, Some(FinishReason::Stop));
+        assert_eq!(completion_response.usage.input_tokens, 10);
+        assert_eq!(completion_response.usage.output_tokens, 10);
+        assert_eq!(completion_response.usage.total_tokens, 20);
     }
+
+    fn structured_response_with_finish_reason(finish_reason: &str) -> CompletionResponse {
+        CompletionResponse::Structured {
+            id: "resp_123".to_string(),
+            object: "chat.completion".to_string(),
+            created: 1234567890,
+            model: "deepseek-r1".to_string(),
+            choices: vec![ChatChoice {
+                message: RawMessage {
+                    role: "assistant".to_string(),
+                    content: "Test response".to_string(),
+                },
+                finish_reason: Some(finish_reason.to_string()),
+                index: Some(0),
+            }],
+            usage: None,
+        }
+    }
+
+    #[test]
+    fn mira_finish_reasons_normalize_and_preserve_unknowns() {
+        for (wire, expected) in [
+            ("stop", FinishReason::Stop),
+            ("length", FinishReason::Length),
+            ("max_tokens", FinishReason::Length),
+            ("tool_calls", FinishReason::ToolCalls),
+            ("function_call", FinishReason::ToolCalls),
+            ("content_filter", FinishReason::ContentFilter),
+            // A gateway-specific reason survives verbatim rather than reading
+            // as a natural stop.
+            (
+                "ERROR_UPSTREAM",
+                FinishReason::Other("ERROR_UPSTREAM".to_owned()),
+            ),
+        ] {
+            let converted = normalized(structured_response_with_finish_reason(wire));
+
+            assert_eq!(converted.finish_reason, Some(expected), "wire: {wire}");
+        }
+    }
+
+    #[test]
+    fn mira_simple_response_reports_no_metadata() {
+        let converted = normalized(CompletionResponse::Simple("Test response".to_string()));
+
+        assert_eq!(converted.provider, "mira");
+        assert_eq!(converted.message_id, None);
+        assert_eq!(converted.model, None);
+        assert_eq!(converted.finish_reason, None);
+    }
+
     #[test]
     fn test_client_initialization() {
         let _client =

--- a/crates/rig-core/src/providers/mistral/client.rs
+++ b/crates/rig-core/src/providers/mistral/client.rs
@@ -207,6 +207,23 @@ impl Usage {
     }
 }
 
+impl From<&Usage> for crate::completion::Usage {
+    fn from(usage: &Usage) -> Self {
+        crate::providers::internal::completion_usage(
+            usage.prompt_tokens as u64,
+            usage.completion_tokens as u64,
+            usage.total_tokens as u64,
+            usage.cached_tokens(),
+        )
+    }
+}
+
+impl From<Usage> for crate::completion::Usage {
+    fn from(usage: Usage) -> Self {
+        Self::from(&usage)
+    }
+}
+
 impl std::fmt::Display for Usage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Deserializer, Serialize};
 
 use super::client::{MistralExt, Usage};
-use crate::completion::GetTokenUsage;
+use crate::providers::internal::openai_chat_completions_compatible::map_openai_finish_reason;
 use crate::providers::openai;
 use crate::{
     OneOrMany,
@@ -35,9 +35,11 @@ pub const CODESTRAL_MAMBA: &str = "open-codestral-mamba";
 pub type CompletionModel<H = reqwest::Client> =
     openai::completion::GenericCompletionModel<MistralExt, H>;
 
-/// Final streaming response, shared with the OpenAI Chat Completions path but
-/// carrying Mistral's own usage payload (cached-token fallbacks).
-pub type MistralStreamingCompletionResponse = openai::StreamingCompletionResponse<Usage>;
+/// Mistral's provider-native terminal streaming record: the value carried by
+/// the final item of the stream returned by `CompletionModel::raw_stream`.
+/// Shared with the OpenAI Chat Completions path but carrying Mistral's own
+/// usage payload (cached-token fallbacks).
+pub type MistralStreamingCompletionResponse = openai::StreamingCompletionResponse;
 
 // =================================================================
 // Rig Implementation Types
@@ -175,33 +177,23 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
     }
 }
 
-impl GetTokenUsage for Usage {
-    fn token_usage(&self) -> crate::completion::Usage {
-        let mut usage = crate::completion::Usage::new();
-        usage.input_tokens = self.prompt_tokens as u64;
-        usage.output_tokens = self.completion_tokens as u64;
-        usage.total_tokens = self.total_tokens as u64;
-        usage.cached_input_tokens = self.cached_tokens();
-        usage
-    }
-}
-
-impl GetTokenUsage for CompletionResponse {
-    fn token_usage(&self) -> crate::completion::Usage {
-        self.usage
-            .as_ref()
-            .map(GetTokenUsage::token_usage)
-            .unwrap_or_default()
-    }
-}
-
-impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionResponse> {
+/// Normalize a Mistral chat completion response.
+///
+/// The provider descriptor name is an *input* rather than a constant so the
+/// shared OpenAI-compatible completion path labels the response with the
+/// descriptor that actually produced it.
+impl TryFrom<(&str, CompletionResponse)> for completion::CompletionResponse {
     type Error = CompletionError;
 
-    fn try_from(response: CompletionResponse) -> Result<Self, Self::Error> {
+    fn try_from((provider, response): (&str, CompletionResponse)) -> Result<Self, Self::Error> {
         let choice = response.choices.first().ok_or_else(|| {
             CompletionError::ResponseError("Response contained no choices".to_owned())
         })?;
+
+        let finish_reason = Some(choice.finish_reason.as_str())
+            .filter(|reason| !reason.is_empty())
+            .map(map_openai_finish_reason);
+
         let content = match &choice.message {
             Message::Assistant {
                 content,
@@ -242,25 +234,13 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         let usage = response
             .usage
             .as_ref()
-            .map(|usage| completion::Usage {
-                input_tokens: usage.prompt_tokens as u64,
-                output_tokens: usage.completion_tokens as u64,
-                total_tokens: usage.total_tokens as u64,
-                cached_input_tokens: usage.cached_tokens(),
-                cache_creation_input_tokens: 0,
-                tool_use_prompt_tokens: 0,
-                reasoning_tokens: 0,
-            })
+            .map(completion::Usage::from)
             .unwrap_or_default();
 
-        let message_id = response.id.clone();
-
-        Ok(completion::CompletionResponse {
-            choice,
-            usage,
-            raw_response: response,
-            message_id: Some(message_id),
-        })
+        Ok(completion::CompletionResponse::new(choice, usage, provider)
+            .with_message_id(response.id.as_str())
+            .with_model(response.model.as_str())
+            .with_optional_finish_reason(finish_reason))
     }
 }
 

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -39,7 +39,8 @@ pub type CompletionModel<H = reqwest::Client> =
 /// the final item of the stream returned by `CompletionModel::raw_stream`.
 /// Shared with the OpenAI Chat Completions path but carrying Mistral's own
 /// usage payload (cached-token fallbacks).
-pub type MistralStreamingCompletionResponse = openai::StreamingCompletionResponse;
+pub type MistralStreamingCompletionResponse =
+    openai::StreamingCompletionResponse<super::client::Usage>;
 
 // =================================================================
 // Rig Implementation Types
@@ -182,10 +183,9 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
 /// The provider descriptor name is an *input* rather than a constant so the
 /// shared OpenAI-compatible completion path labels the response with the
 /// descriptor that actually produced it.
-impl TryFrom<(&str, CompletionResponse)> for completion::CompletionResponse {
-    type Error = CompletionError;
-
-    fn try_from((provider, response): (&str, CompletionResponse)) -> Result<Self, Self::Error> {
+impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
+    fn normalize(self, provider: &str) -> Result<completion::CompletionResponse, CompletionError> {
+        let response = self;
         let choice = response.choices.first().ok_or_else(|| {
             CompletionError::ResponseError("Response contained no choices".to_owned())
         })?;

--- a/crates/rig-core/src/providers/mod.rs
+++ b/crates/rig-core/src/providers/mod.rs
@@ -52,7 +52,22 @@
 //!   [`CompletionRequest`](crate::completion::CompletionRequest), without
 //!   inventing unsupported provider API fields;
 //! - response conversion into Rig response types, including usage and tool or
-//!   multimodal content where applicable;
+//!   multimodal content where applicable, built through the
+//!   [`CompletionResponse`](crate::completion::CompletionResponse) `new`/`with_*`
+//!   builders rather than a struct literal — the `with_*_finish_reason` setters
+//!   are what apply
+//!   [`FinishReason::reconcile_with_output`](crate::completion::FinishReason::reconcile_with_output);
+//! - a finish-reason mapping covering every value the provider can report,
+//!   with anything unrecognized preserved verbatim in
+//!   [`FinishReason::Other`](crate::completion::FinishReason::Other) rather
+//!   than guessed at;
+//! - a shared conversion (one used by several OpenAI-compatible providers)
+//!   that takes the provider descriptor name as an input instead of hardcoding
+//!   one, so a reused wire type cannot mislabel its provider;
+//! - `raw_completion` and `raw_stream` inherent methods returning the
+//!   provider's own wire types, with the normalized
+//!   [`CompletionModel`](crate::completion::CompletionModel) methods delegating
+//!   to them so there is exactly one request path either way;
 //! - streaming support when the provider supports streaming;
 //! - provider-response error preservation plus `ProviderResponseExt` and
 //!   telemetry fields consistent with nearby providers where applicable;

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -42,11 +42,11 @@ use crate::client::{
     self, ApiKey, Capabilities, Capable, DebugExt, ModelLister, Nothing, Provider, ProviderBuilder,
     ProviderClient,
 };
-use crate::completion::{GetTokenUsage, Usage};
+use crate::completion::Usage;
 use crate::http_client::{self, HttpClientExt};
 use crate::message::DocumentSourceKind;
 use crate::model::{Model, ModelList, ModelListingError};
-use crate::streaming::RawStreamingChoice;
+use crate::streaming::{RawStreamingChoice, RawStreamingResult, StreamFinal};
 use crate::telemetry::{CompletionOperation, CompletionSpanBuilder};
 use crate::{
     OneOrMany,
@@ -67,6 +67,10 @@ use tracing_futures::Instrument;
 // ---------- Main Client ----------
 
 const OLLAMA_API_BASE_URL: &str = "http://localhost:11434";
+
+/// Stable descriptor name recorded on normalized responses, streams, and
+/// telemetry spans for this provider.
+const PROVIDER_NAME: &str = "ollama";
 
 /// Optional API key for Ollama. By default Ollama requires no authentication,
 /// but proxied or secured deployments may require a Bearer token.
@@ -321,95 +325,92 @@ pub struct CompletionResponse {
     #[serde(default)]
     pub eval_duration: Option<u64>,
 }
-impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionResponse> {
+/// Map Ollama's `done_reason` onto rig's normalized vocabulary.
+///
+/// Ollama documents `stop` and `length`, but also emits operational reasons
+/// such as `load`/`unload`; those are carried verbatim in Ollama's own spelling
+/// rather than being flattened into a natural stop.
+pub(crate) fn map_done_reason(reason: &str) -> completion::FinishReason {
+    match reason {
+        "stop" => completion::FinishReason::Stop,
+        "length" => completion::FinishReason::Length,
+        other => completion::FinishReason::Other(other.to_owned()),
+    }
+}
+
+impl From<&CompletionResponse> for Usage {
+    fn from(response: &CompletionResponse) -> Usage {
+        let input_tokens = response.prompt_eval_count.unwrap_or(0);
+        let output_tokens = response.eval_count.unwrap_or(0);
+
+        let mut usage = Usage::new();
+        usage.input_tokens = input_tokens;
+        usage.output_tokens = output_tokens;
+        usage.total_tokens = input_tokens + output_tokens;
+        usage
+    }
+}
+
+impl TryFrom<CompletionResponse> for completion::CompletionResponse {
     type Error = CompletionError;
     fn try_from(resp: CompletionResponse) -> Result<Self, Self::Error> {
-        match resp.message {
-            // Process only if an assistant message is present.
-            Message::Assistant {
-                content,
-                thinking,
-                tool_calls,
-                ..
-            } => {
-                let mut assistant_contents = Vec::new();
-                let permits_omitted_think_start = resp.model.to_ascii_lowercase().contains("qwen3");
-                let (legacy_thinking, visible_content) =
-                    if matches!(thinking.as_deref(), None | Some("")) {
-                        split_legacy_thinking(&content, permits_omitted_think_start)
-                    } else {
-                        (None, content.as_str())
-                    };
-                // Preserve the model's reasoning so it round-trips into agent
-                // history and is echoed back to Ollama on the next turn (issue
-                // #1926). Without this, non-streaming `thinking` is kept only in
-                // `raw_response` and lost from `choice`, unlike the streaming path
-                // (see `RawStreamingChoice::ReasoningDelta` below).
-                if let Some(thinking) = thinking.as_deref().filter(|t| !t.is_empty()) {
-                    assistant_contents.push(completion::AssistantContent::reasoning(thinking));
-                }
-                if let Some(legacy_thinking) = legacy_thinking {
-                    assistant_contents
-                        .push(completion::AssistantContent::reasoning(legacy_thinking));
-                }
-                // Add the assistant's text content if any.
-                if !visible_content.is_empty() {
-                    assistant_contents.push(completion::AssistantContent::text(visible_content));
-                }
-                // Process tool_calls following Ollama's chat response definition.
-                // Each ToolCall has an id, a type, and a function field.
-                for tc in tool_calls.iter() {
-                    assistant_contents.push(completion::AssistantContent::tool_call(
-                        tc.function.name.clone(),
-                        tc.function.name.clone(),
-                        tc.function.arguments.clone(),
-                    ));
-                }
-                let choice = OneOrMany::many(assistant_contents).map_err(|_| {
-                    CompletionError::ResponseError("No content provided".to_owned())
-                })?;
-                let prompt_tokens = resp.prompt_eval_count.unwrap_or(0);
-                let completion_tokens = resp.eval_count.unwrap_or(0);
+        let usage = Usage::from(&resp);
+        let finish_reason = resp.done_reason.as_deref().map(map_done_reason);
+        let model = resp.model.clone();
+        let permits_omitted_think_start = resp.model.to_ascii_lowercase().contains("qwen3");
 
-                let raw_response = CompletionResponse {
-                    model: resp.model,
-                    created_at: resp.created_at,
-                    done: resp.done,
-                    done_reason: resp.done_reason,
-                    total_duration: resp.total_duration,
-                    load_duration: resp.load_duration,
-                    prompt_eval_count: resp.prompt_eval_count,
-                    prompt_eval_duration: resp.prompt_eval_duration,
-                    eval_count: resp.eval_count,
-                    eval_duration: resp.eval_duration,
-                    message: Message::Assistant {
-                        content,
-                        thinking,
-                        images: None,
-                        name: None,
-                        tool_calls,
-                    },
-                };
-
-                Ok(completion::CompletionResponse {
-                    choice,
-                    usage: Usage {
-                        input_tokens: prompt_tokens,
-                        output_tokens: completion_tokens,
-                        total_tokens: prompt_tokens + completion_tokens,
-                        cached_input_tokens: 0,
-                        cache_creation_input_tokens: 0,
-                        tool_use_prompt_tokens: 0,
-                        reasoning_tokens: 0,
-                    },
-                    raw_response,
-                    message_id: None,
-                })
-            }
-            _ => Err(CompletionError::ResponseError(
+        // Process only if an assistant message is present.
+        let Message::Assistant {
+            content,
+            thinking,
+            tool_calls,
+            ..
+        } = resp.message
+        else {
+            return Err(CompletionError::ResponseError(
                 "Chat response does not include an assistant message".into(),
-            )),
+            ));
+        };
+
+        let mut assistant_contents = Vec::new();
+        let (legacy_thinking, visible_content) = if matches!(thinking.as_deref(), None | Some("")) {
+            split_legacy_thinking(&content, permits_omitted_think_start)
+        } else {
+            (None, content.as_str())
+        };
+        // Preserve the model's reasoning so it round-trips into agent history
+        // and is echoed back to Ollama on the next turn (issue #1926). `choice`
+        // is the only place it can live — the normalized response carries no
+        // provider payload — so dropping it here would lose the reasoning
+        // entirely, unlike the streaming path (see
+        // `RawStreamingChoice::ReasoningDelta` below).
+        if let Some(thinking) = thinking.as_deref().filter(|t| !t.is_empty()) {
+            assistant_contents.push(completion::AssistantContent::reasoning(thinking));
         }
+        if let Some(legacy_thinking) = legacy_thinking {
+            assistant_contents.push(completion::AssistantContent::reasoning(legacy_thinking));
+        }
+        // Add the assistant's text content if any.
+        if !visible_content.is_empty() {
+            assistant_contents.push(completion::AssistantContent::text(visible_content));
+        }
+        // Process tool_calls following Ollama's chat response definition.
+        // Each ToolCall has an id, a type, and a function field.
+        for tc in tool_calls.iter() {
+            assistant_contents.push(completion::AssistantContent::tool_call(
+                tc.function.name.clone(),
+                tc.function.name.clone(),
+                tc.function.arguments.clone(),
+            ));
+        }
+        let choice = OneOrMany::many(assistant_contents)
+            .map_err(|_| CompletionError::ResponseError("No content provided".to_owned()))?;
+
+        Ok(
+            completion::CompletionResponse::new(choice, usage, PROVIDER_NAME)
+                .with_model(model)
+                .with_optional_finish_reason(finish_reason),
+        )
     }
 }
 
@@ -574,11 +575,20 @@ pub struct CompletionModel<T = reqwest::Client> {
 }
 
 impl<T> CompletionModel<T> {
-    pub fn new(client: Client<T>, model: &str) -> Self {
+    pub fn new(client: Client<T>, model: impl Into<String>) -> Self {
         Self {
             client,
-            model: model.to_owned(),
+            model: model.into(),
         }
+    }
+}
+
+impl<T> crate::client::ConstructCompletionModel<Client<T>> for CompletionModel<T>
+where
+    Client<T>: Clone,
+{
+    fn construct(client: &Client<T>, model: String) -> Self {
+        Self::new(client.clone(), model)
     }
 }
 
@@ -600,8 +610,12 @@ enum Level {
 
 // ---------- CompletionModel Implementation ----------
 
+/// Ollama's terminal stream record, kept provider-native for
+/// [`CompletionModel::raw_stream`].
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct StreamingCompletionResponse {
+    /// Provider-reported model identifier from the terminating NDJSON line.
+    pub model: String,
     pub done_reason: Option<String>,
     pub total_duration: Option<u64>,
     pub load_duration: Option<u64>,
@@ -611,16 +625,26 @@ pub struct StreamingCompletionResponse {
     pub eval_duration: Option<u64>,
 }
 
-impl GetTokenUsage for StreamingCompletionResponse {
-    fn token_usage(&self) -> crate::completion::Usage {
-        let mut usage = crate::completion::Usage::new();
-        let input_tokens = self.prompt_eval_count.unwrap_or_default();
-        let output_tokens = self.eval_count.unwrap_or_default();
+impl From<&StreamingCompletionResponse> for Usage {
+    fn from(response: &StreamingCompletionResponse) -> Usage {
+        let input_tokens = response.prompt_eval_count.unwrap_or_default();
+        let output_tokens = response.eval_count.unwrap_or_default();
+
+        let mut usage = Usage::new();
         usage.input_tokens = input_tokens;
         usage.output_tokens = output_tokens;
         usage.total_tokens = input_tokens + output_tokens;
-
         usage
+    }
+}
+
+impl From<StreamingCompletionResponse> for StreamFinal {
+    fn from(response: StreamingCompletionResponse) -> StreamFinal {
+        // Ollama's `/api/chat` stream assigns no message identifier, so the
+        // normalized `message_id` stays unset.
+        StreamFinal::new(PROVIDER_NAME, Usage::from(&response))
+            .with_optional_finish_reason(response.done_reason.as_deref().map(map_done_reason))
+            .with_model(response.model)
     }
 }
 
@@ -656,29 +680,29 @@ impl NdjsonBuffer {
     }
 }
 
-impl<T> completion::CompletionModel for CompletionModel<T>
+impl<T> CompletionModel<T>
 where
     T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
 {
-    type Response = CompletionResponse;
-    type StreamingResponse = StreamingCompletionResponse;
-
-    type Client = Client<T>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model.into().as_str())
-    }
-
-    async fn completion(
+    /// Execute a completion and return Ollama's own wire response.
+    ///
+    /// This is the escape hatch for Ollama-specific fields rig does not
+    /// normalize (the timing counters, `created_at`). It shares the request
+    /// builder, transport, telemetry, and error handling with
+    /// [`CompletionModel::completion`](completion::CompletionModel::completion),
+    /// which calls it and then applies the provider-local mapping — one network
+    /// request either way.
+    pub async fn raw_completion(
         &self,
         completion_request: CompletionRequest,
-    ) -> Result<completion::CompletionResponse<Self::Response>, CompletionError> {
+    ) -> Result<CompletionResponse, CompletionError> {
         let system_instructions = completion_request.preamble.clone();
         let record_telemetry_content = completion_request.record_telemetry_content;
         let request = OllamaCompletionRequest::try_from((self.model.as_ref(), completion_request))?;
-        let span = CompletionSpanBuilder::new("ollama", &request.model, CompletionOperation::Chat)
-            .system_instructions(system_instructions.as_deref(), record_telemetry_content)
-            .build();
+        let span =
+            CompletionSpanBuilder::new(PROVIDER_NAME, &request.model, CompletionOperation::Chat)
+                .system_instructions(system_instructions.as_deref(), record_telemetry_content)
+                .build();
 
         if tracing::enabled!(tracing::Level::TRACE) {
             tracing::trace!(target: "rig::completions",
@@ -726,25 +750,28 @@ where
                 );
             }
 
-            let response: completion::CompletionResponse<CompletionResponse> =
-                response.try_into()?;
-
             Ok(response)
         };
 
         tracing::Instrument::instrument(async_block, span).await
     }
 
-    async fn stream(
+    /// Open a stream whose terminal record stays Ollama-native.
+    ///
+    /// This is the escape hatch for Ollama's own terminal payload; it shares the
+    /// request builder, transport, telemetry, and error handling with
+    /// [`CompletionModel::stream`](completion::CompletionModel::stream), which
+    /// calls it and normalizes the terminal record once through
+    /// [`streaming::normalize_stream`] — one network request either way.
+    pub async fn raw_stream(
         &self,
         request: CompletionRequest,
-    ) -> Result<streaming::StreamingCompletionResponse<Self::StreamingResponse>, CompletionError>
-    {
+    ) -> Result<RawStreamingResult<StreamingCompletionResponse>, CompletionError> {
         let system_instructions = request.preamble.clone();
         let record_telemetry_content = request.record_telemetry_content;
         let mut request = OllamaCompletionRequest::try_from((self.model.as_ref(), request))?;
         let span = CompletionSpanBuilder::new(
-            "ollama",
+            PROVIDER_NAME,
             &request.model,
             CompletionOperation::ChatStreaming,
         )
@@ -832,6 +859,7 @@ where
                         span.record("gen_ai.usage.output_tokens", response.eval_count);
                         yield RawStreamingChoice::FinalResponse(
                             StreamingCompletionResponse {
+                                model: response.model,
                                 total_duration: response.total_duration,
                                 load_duration: response.load_duration,
                                 prompt_eval_count: response.prompt_eval_count,
@@ -847,9 +875,32 @@ where
             }
         }.instrument(span);
 
-        Ok(streaming::StreamingCompletionResponse::stream(Box::pin(
-            stream,
-        )))
+        Ok(Box::pin(stream))
+    }
+}
+
+impl<T> completion::CompletionModel for CompletionModel<T>
+where
+    T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+{
+    async fn completion(
+        &self,
+        completion_request: CompletionRequest,
+    ) -> Result<completion::CompletionResponse, CompletionError> {
+        self.raw_completion(completion_request).await?.try_into()
+    }
+
+    async fn stream(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<streaming::StreamingCompletionResponse, CompletionError> {
+        let stream = self.raw_stream(request).await?;
+        let normalized = streaming::normalize_stream(stream, |response| Ok(response.into()));
+
+        Ok(streaming::StreamingCompletionResponse::stream(
+            PROVIDER_NAME,
+            normalized,
+        ))
     }
 }
 
@@ -1385,12 +1436,107 @@ mod tests {
 
         let chat_resp: CompletionResponse =
             serde_json::from_str(&sample_text).expect("Invalid JSON structure");
-        let conv: completion::CompletionResponse<CompletionResponse> =
-            chat_resp.try_into().unwrap();
+        let conv: completion::CompletionResponse = chat_resp.try_into().unwrap();
         assert!(
             !conv.choice.is_empty(),
             "Expected non-empty choice in chat response"
         );
+    }
+
+    #[test]
+    fn done_reason_maps_documented_values_and_preserves_the_rest() {
+        assert_eq!(map_done_reason("stop"), completion::FinishReason::Stop);
+        assert_eq!(map_done_reason("length"), completion::FinishReason::Length);
+        // Ollama's operational reasons have no normalized equivalent, so they
+        // are carried through verbatim rather than read as a natural stop.
+        assert_eq!(
+            map_done_reason("load"),
+            completion::FinishReason::Other("load".to_owned())
+        );
+        assert_eq!(
+            map_done_reason("unload"),
+            completion::FinishReason::Other("unload".to_owned())
+        );
+    }
+
+    #[test]
+    fn response_metadata_is_normalized() {
+        let response: CompletionResponse = serde_json::from_value(json!({
+            "model": "llama3.2",
+            "created_at": "2023-08-04T19:22:45.499127Z",
+            "message": {"role": "assistant", "content": "Hi!", "tool_calls": []},
+            "done": true,
+            "done_reason": "length",
+            "prompt_eval_count": 12u64,
+            "eval_count": 3u64
+        }))
+        .expect("fixture should deserialize");
+
+        let normalized: completion::CompletionResponse =
+            response.try_into().expect("normalization should succeed");
+
+        assert_eq!(normalized.provider, PROVIDER_NAME);
+        assert_eq!(normalized.model.as_deref(), Some("llama3.2"));
+        assert_eq!(
+            normalized.finish_reason,
+            Some(completion::FinishReason::Length)
+        );
+        // Ollama assigns no message identifier.
+        assert_eq!(normalized.message_id, None);
+        assert_eq!(normalized.usage.input_tokens, 12);
+        assert_eq!(normalized.usage.output_tokens, 3);
+        assert_eq!(normalized.usage.total_tokens, 15);
+    }
+
+    // A `done_reason` of `stop` on a turn that actually called a tool must be
+    // upgraded by the response builder's reconciliation.
+    #[test]
+    fn tool_call_turn_upgrades_a_plain_stop_to_tool_calls() {
+        let response: CompletionResponse = serde_json::from_value(json!({
+            "model": "qwen3:4b",
+            "created_at": "2023-08-04T19:22:45.499127Z",
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"type": "function", "function": {"name": "get_weather", "arguments": {"location": "Berlin"}}}
+                ]
+            },
+            "done": true,
+            "done_reason": "stop"
+        }))
+        .expect("fixture should deserialize");
+
+        let normalized: completion::CompletionResponse =
+            response.try_into().expect("normalization should succeed");
+
+        assert_eq!(
+            normalized.finish_reason,
+            Some(completion::FinishReason::ToolCalls)
+        );
+    }
+
+    #[test]
+    fn streaming_terminal_record_is_normalized() {
+        let terminal = StreamingCompletionResponse {
+            model: "llama3.2".to_string(),
+            done_reason: Some("dragons".to_string()),
+            total_duration: None,
+            load_duration: None,
+            prompt_eval_count: Some(7),
+            prompt_eval_duration: None,
+            eval_count: Some(5),
+            eval_duration: None,
+        };
+
+        let final_record = StreamFinal::from(terminal);
+        assert_eq!(final_record.provider, PROVIDER_NAME);
+        assert_eq!(final_record.model.as_deref(), Some("llama3.2"));
+        assert_eq!(
+            final_record.finish_reason,
+            Some(completion::FinishReason::Other("dragons".to_owned()))
+        );
+        assert_eq!(final_record.usage.total_tokens, 12);
     }
 
     // Test conversion from provider Message to completion Message.
@@ -1677,7 +1823,7 @@ mod tests {
 
         let raw: CompletionResponse =
             serde_json::from_value(sample_response).expect("deserialize ollama response");
-        let completed: completion::CompletionResponse<CompletionResponse> =
+        let completed: completion::CompletionResponse =
             raw.try_into().expect("convert to completion response");
 
         let reasoning = completed.choice.iter().find_map(|c| match c {

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -1217,10 +1217,7 @@ impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
             .unwrap_or_default();
 
         Ok(completion::CompletionResponse::new(choice, usage, provider)
-            // Deliberately no `message_id`: chat completions report a
-            // response-scoped `chatcmpl-…` id, not an assistant message id, and
-            // the agent replays `message_id` into assistant history. The
-            // response id is still recorded on telemetry.
+            .with_optional_message_id(Some(response.id.as_str()).filter(|id| !id.is_empty()))
             .with_model(response.model.as_str())
             .with_optional_finish_reason(finish_reason))
     }

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -2,10 +2,8 @@
 // OpenAI Completion API
 // ================================================================
 
-use super::{client::ApiResponse, streaming::StreamingCompletionResponse};
-use crate::completion::{
-    CompletionError, CompletionRequest as CoreCompletionRequest, GetTokenUsage,
-};
+use super::client::ApiResponse;
+use crate::completion::{CompletionError, CompletionRequest as CoreCompletionRequest};
 use crate::http_client::{self, HttpClientExt};
 use crate::message::{AudioMediaType, DocumentSourceKind, ImageDetail, MimeType};
 use crate::one_or_many::string_or_one_or_many;
@@ -1140,13 +1138,23 @@ pub struct CompletionResponse {
     pub usage: Option<Usage>,
 }
 
-impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionResponse> {
+/// Normalize an OpenAI-compatible chat completion response.
+///
+/// The provider descriptor name is an *input* rather than a constant: this same
+/// wire shape is shared by every OpenAI-compatible provider, so baking in
+/// `"openai"` here would mislabel Groq, Together, DeepSeek and the rest. Taking
+/// it as part of the conversion makes the correct name impossible to forget.
+impl TryFrom<(&str, CompletionResponse)> for completion::CompletionResponse {
     type Error = CompletionError;
 
-    fn try_from(response: CompletionResponse) -> Result<Self, Self::Error> {
+    fn try_from((provider, response): (&str, CompletionResponse)) -> Result<Self, Self::Error> {
         let choice = response.choices.first().ok_or_else(|| {
             CompletionError::ResponseError("Response contained no choices".to_owned())
         })?;
+
+        let finish_reason = Some(choice.finish_reason.as_str())
+            .filter(|reason| !reason.is_empty())
+            .map(crate::providers::internal::openai_chat_completions_compatible::map_openai_finish_reason);
 
         let content = match &choice.message {
             Message::Assistant {
@@ -1205,15 +1213,13 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         let usage = response
             .usage
             .as_ref()
-            .map(GetTokenUsage::token_usage)
+            .map(crate::completion::Usage::from)
             .unwrap_or_default();
 
-        Ok(completion::CompletionResponse {
-            choice,
-            usage,
-            raw_response: response,
-            message_id: None,
-        })
+        Ok(completion::CompletionResponse::new(choice, usage, provider)
+            .with_optional_message_id(Some(response.id.as_str()).filter(|id| !id.is_empty()))
+            .with_model(response.model.as_str())
+            .with_optional_finish_reason(finish_reason))
     }
 }
 
@@ -1360,8 +1366,21 @@ impl fmt::Display for Usage {
     }
 }
 
-impl GetTokenUsage for Usage {
-    fn token_usage(&self) -> crate::completion::Usage {
+impl From<&Usage> for crate::completion::Usage {
+    fn from(value: &Usage) -> crate::completion::Usage {
+        value.to_normalized()
+    }
+}
+
+impl From<Usage> for crate::completion::Usage {
+    fn from(value: Usage) -> crate::completion::Usage {
+        value.to_normalized()
+    }
+}
+
+impl Usage {
+    /// Normalize this provider usage payload into rig's [`crate::completion::Usage`].
+    pub fn to_normalized(&self) -> crate::completion::Usage {
         let mut usage = crate::providers::internal::completion_usage(
             self.prompt_tokens as u64,
             self.completion_tokens
@@ -1439,7 +1458,7 @@ pub trait OpenAICompatibleProvider: crate::client::Provider {
     /// fallbacks, DeepSeek's cache hit/miss counters) substitute their own.
     type StreamingUsage: Clone
         + Default
-        + GetTokenUsage
+        + Into<crate::completion::Usage>
         + Serialize
         + serde::de::DeserializeOwned
         + Unpin
@@ -1448,10 +1467,13 @@ pub trait OpenAICompatibleProvider: crate::client::Provider {
         + 'static;
 
     /// The chat-completions payload this provider returns.
+    ///
+    /// The normalization bound is stated over `(&str, Self::Response)` so the
+    /// provider descriptor name is threaded through the conversion instead of
+    /// being hardcoded by whichever wire type happens to implement it.
     type Response: serde::de::DeserializeOwned
         + Serialize
-        + crate::telemetry::ProviderResponseExt<Usage: GetTokenUsage>
-        + TryInto<completion::CompletionResponse<Self::Response>, Error = CompletionError>
+        + crate::telemetry::ProviderResponseExt<Usage: Into<crate::completion::Usage>>
         + WasmCompatSend
         + WasmCompatSync;
 
@@ -1901,7 +1923,7 @@ impl TryFrom<(String, CoreCompletionRequest)> for CompletionRequest {
     }
 }
 
-impl<Ext, H> completion::CompletionModel for GenericCompletionModel<Ext, H>
+impl<Ext, H> GenericCompletionModel<Ext, H>
 where
     crate::client::Client<Ext, H>:
         HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
@@ -1914,34 +1936,18 @@ where
         + 'static,
     H: Clone + Default + std::fmt::Debug + WasmCompatSend + WasmCompatSync + 'static,
 {
-    type Response = Ext::Response;
-    type StreamingResponse = StreamingCompletionResponse<Ext::StreamingUsage>;
-
-    type Client = crate::client::Client<Ext, H>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
-
-    // OpenAI Chat Completions *defers* `response_format` while tools are present
-    // and no tool result exists yet (see `should_apply_response_format`), then
-    // applies it once a tool result is in the history. So the native constraint
-    // does not suppress tool calls — they compose — which is what this flag
-    // governs. (Caveat: a turn-1 answer with no tool call is therefore not
-    // schema-constrained; `Native` is "guaranteed" only once tools have run.)
-    // See issue #1928.
-    fn composes_native_output_with_tools(&self) -> bool {
-        // Providers that drop `output_schema` (SUPPORTS_RESPONSE_FORMAT =
-        // false) cannot compose native structured output with tools; the
-        // agent then falls back to tool-mode enforcement as their
-        // pre-migration hand-rolled models did.
-        Ext::SUPPORTS_RESPONSE_FORMAT
-    }
-
-    async fn completion(
+    /// Execute a chat completion and return the provider's own wire response.
+    ///
+    /// This is the escape hatch for provider-specific fields rig does not
+    /// normalize. It shares the request builder, transport, telemetry, and
+    /// error handling with
+    /// [`CompletionModel::completion`](completion::CompletionModel::completion),
+    /// which calls it and then applies the provider-local mapping — one
+    /// network request either way.
+    pub async fn raw_completion(
         &self,
         completion_request: CoreCompletionRequest,
-    ) -> Result<completion::CompletionResponse<Ext::Response>, CompletionError> {
+    ) -> Result<Ext::Response, CompletionError> {
         let system_instructions = completion_request.preamble.clone();
         let record_telemetry_content = completion_request.record_telemetry_content;
         let options = CompletionModelOptions {
@@ -1997,7 +2003,11 @@ where
                     ApiResponse::Ok(response) => {
                         let span = tracing::Span::current();
                         span.record_response_metadata(&response);
-                        span.record_token_usage(&response.get_usage());
+                        let usage = response
+                            .get_usage()
+                            .map(Into::into)
+                            .unwrap_or_default();
+                        span.record_token_usage(&usage);
                         if enabled!(Level::TRACE) {
                             tracing::trace!(
                                 target: "rig::completions",
@@ -2006,7 +2016,7 @@ where
                             );
                         }
 
-                        response.try_into()
+                        Ok(response)
                     }
                     ApiResponse::Err(err) => {
                         tracing::warn!(message = %err.message, "provider returned an error response");
@@ -2021,15 +2031,65 @@ where
         .instrument(span)
         .await
     }
+}
+
+impl<Ext, H> completion::CompletionModel for GenericCompletionModel<Ext, H>
+where
+    crate::client::Client<Ext, H>:
+        HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
+    Ext: crate::client::Provider
+        + OpenAICompatibleProvider
+        + crate::client::DebugExt
+        + Clone
+        + WasmCompatSend
+        + WasmCompatSync
+        + 'static,
+    H: Clone + Default + std::fmt::Debug + WasmCompatSend + WasmCompatSync + 'static,
+    // Threading the descriptor name through the conversion is what keeps a
+    // shared wire type from mislabeling every provider that reuses it.
+    for<'a> (&'a str, Ext::Response):
+        TryInto<completion::CompletionResponse, Error = CompletionError>,
+{
+    // OpenAI Chat Completions *defers* `response_format` while tools are present
+    // and no tool result exists yet (see `should_apply_response_format`), then
+    // applies it once a tool result is in the history. So the native constraint
+    // does not suppress tool calls — they compose — which is what this flag
+    // governs. (Caveat: a turn-1 answer with no tool call is therefore not
+    // schema-constrained; `Native` is "guaranteed" only once tools have run.)
+    // See issue #1928.
+    fn capabilities(&self) -> completion::ProviderCapabilities {
+        // Providers that drop `output_schema` (SUPPORTS_RESPONSE_FORMAT =
+        // false) cannot compose native structured output with tools; the
+        // agent then falls back to tool-mode enforcement as their
+        // pre-migration hand-rolled models did.
+        completion::ProviderCapabilities::default()
+            .with_native_output_tool_composition(Ext::SUPPORTS_RESPONSE_FORMAT)
+    }
+
+    async fn completion(
+        &self,
+        completion_request: CoreCompletionRequest,
+    ) -> Result<completion::CompletionResponse, CompletionError> {
+        let response = self.raw_completion(completion_request).await?;
+        (Ext::PROVIDER_NAME, response).try_into()
+    }
 
     async fn stream(
         &self,
         request: CoreCompletionRequest,
-    ) -> Result<
-        crate::streaming::StreamingCompletionResponse<Self::StreamingResponse>,
-        CompletionError,
-    > {
+    ) -> Result<crate::streaming::StreamingCompletionResponse, CompletionError> {
         GenericCompletionModel::stream(self, request).await
+    }
+}
+
+impl<Ext, H> crate::client::ConstructCompletionModel<crate::client::Client<Ext, H>>
+    for GenericCompletionModel<Ext, H>
+where
+    crate::client::Client<Ext, H>: std::fmt::Debug + Clone + 'static,
+    Ext: crate::client::Provider + Clone + 'static,
+{
+    fn construct(client: &crate::client::Client<Ext, H>, model: String) -> Self {
+        Self::new(client.clone(), model)
     }
 }
 
@@ -2998,8 +3058,10 @@ mod tests {
             panic!("expected successful completion response");
         };
 
-        let response: completion::CompletionResponse<CompletionResponse> =
-            response.try_into().unwrap();
+        let response: completion::CompletionResponse =
+            (<crate::providers::openai::OpenAICompletionsExt as OpenAICompatibleProvider>::PROVIDER_NAME, response)
+                .try_into()
+                .unwrap();
 
         assert_eq!(response.choice.len(), 1);
 

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -3,6 +3,7 @@
 // ================================================================
 
 use super::client::ApiResponse;
+use crate::completion::NormalizeCompletionResponse;
 use crate::completion::{CompletionError, CompletionRequest as CoreCompletionRequest};
 use crate::http_client::{self, HttpClientExt};
 use crate::message::{AudioMediaType, DocumentSourceKind, ImageDetail, MimeType};
@@ -1144,10 +1145,9 @@ pub struct CompletionResponse {
 /// wire shape is shared by every OpenAI-compatible provider, so baking in
 /// `"openai"` here would mislabel Groq, Together, DeepSeek and the rest. Taking
 /// it as part of the conversion makes the correct name impossible to forget.
-impl TryFrom<(&str, CompletionResponse)> for completion::CompletionResponse {
-    type Error = CompletionError;
-
-    fn try_from((provider, response): (&str, CompletionResponse)) -> Result<Self, Self::Error> {
+impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
+    fn normalize(self, provider: &str) -> Result<completion::CompletionResponse, CompletionError> {
+        let response = self;
         let choice = response.choices.first().ok_or_else(|| {
             CompletionError::ResponseError("Response contained no choices".to_owned())
         })?;
@@ -1217,7 +1217,10 @@ impl TryFrom<(&str, CompletionResponse)> for completion::CompletionResponse {
             .unwrap_or_default();
 
         Ok(completion::CompletionResponse::new(choice, usage, provider)
-            .with_optional_message_id(Some(response.id.as_str()).filter(|id| !id.is_empty()))
+            // Deliberately no `message_id`: chat completions report a
+            // response-scoped `chatcmpl-…` id, not an assistant message id, and
+            // the agent replays `message_id` into assistant history. The
+            // response id is still recorded on telemetry.
             .with_model(response.model.as_str())
             .with_optional_finish_reason(finish_reason))
     }
@@ -1474,6 +1477,7 @@ pub trait OpenAICompatibleProvider: crate::client::Provider {
     type Response: serde::de::DeserializeOwned
         + Serialize
         + crate::telemetry::ProviderResponseExt<Usage: Into<crate::completion::Usage>>
+        + crate::completion::NormalizeCompletionResponse
         + WasmCompatSend
         + WasmCompatSync;
 
@@ -2045,10 +2049,6 @@ where
         + WasmCompatSync
         + 'static,
     H: Clone + Default + std::fmt::Debug + WasmCompatSend + WasmCompatSync + 'static,
-    // Threading the descriptor name through the conversion is what keeps a
-    // shared wire type from mislabeling every provider that reuses it.
-    for<'a> (&'a str, Ext::Response):
-        TryInto<completion::CompletionResponse, Error = CompletionError>,
 {
     // OpenAI Chat Completions *defers* `response_format` while tools are present
     // and no tool result exists yet (see `should_apply_response_format`), then
@@ -2071,7 +2071,7 @@ where
         completion_request: CoreCompletionRequest,
     ) -> Result<completion::CompletionResponse, CompletionError> {
         let response = self.raw_completion(completion_request).await?;
-        (Ext::PROVIDER_NAME, response).try_into()
+        response.normalize(Ext::PROVIDER_NAME)
     }
 
     async fn stream(
@@ -3059,8 +3059,8 @@ mod tests {
         };
 
         let response: completion::CompletionResponse =
-            (<crate::providers::openai::OpenAICompletionsExt as OpenAICompatibleProvider>::PROVIDER_NAME, response)
-                .try_into()
+            response
+                .normalize(<crate::providers::openai::OpenAICompletionsExt as OpenAICompatibleProvider>::PROVIDER_NAME)
                 .unwrap();
 
         assert_eq!(response.choice.len(), 1);

--- a/crates/rig-core/src/providers/openai/completion/streaming.rs
+++ b/crates/rig-core/src/providers/openai/completion/streaming.rs
@@ -210,12 +210,9 @@ where
     U: Into<crate::completion::Usage>,
 {
     fn from((provider, response): (&str, StreamingCompletionResponse<U>)) -> Self {
-        // No `message_id`: the chat-completions `id` is response-scoped
-        // (`chatcmpl-…`), not the assistant message id that `message_id` names
-        // and that the agent replays into history. It stays on the raw terminal
-        // record for callers who want it.
         StreamFinal::new(provider, response.usage.into())
             .with_optional_finish_reason(response.finish_reason)
+            .with_optional_message_id(response.response_id)
             .with_optional_model(response.model)
     }
 }

--- a/crates/rig-core/src/providers/openai/completion/streaming.rs
+++ b/crates/rig-core/src/providers/openai/completion/streaming.rs
@@ -4,17 +4,24 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::{Level, enabled};
 
-use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
+use crate::completion::{CompletionError, CompletionRequest};
 use crate::http_client::HttpClientExt;
 use crate::json_utils::{self, merge};
 use crate::providers::internal::openai_chat_completions_compatible::{
     self, CompatibleChoiceData, CompatibleChunk, CompatibleFinishReason, CompatibleStreamProfile,
-    CompatibleToolCallChunk,
+    CompatibleTerminal, CompatibleToolCallChunk,
 };
 use crate::providers::openai::completion::{
     CompletionModelOptions, GenericCompletionModel, OpenAICompatibleProvider, Usage,
 };
-use crate::streaming;
+use crate::streaming::{self, RawStreamingResult, StreamFinal};
+
+/// Descriptor name for OpenAI itself.
+///
+/// Only the free-function transport helpers below use it; the model path
+/// threads `Ext::PROVIDER_NAME` so a compatible provider is never mislabeled.
+const OPENAI_PROVIDER_NAME: &str =
+    <crate::providers::openai::OpenAICompletionsExt as OpenAICompatibleProvider>::PROVIDER_NAME;
 
 // ================================================================
 // OpenAI Completion Streaming API
@@ -97,6 +104,35 @@ pub enum FinishReason {
     Other(String), // This will handle the deprecated function_call
 }
 
+impl FinishReason {
+    /// This reason in the provider's own wire spelling.
+    ///
+    /// Round-tripping through the wire form keeps `map_openai_finish_reason`
+    /// the single place the OpenAI-compatible vocabulary is interpreted, so the
+    /// streaming and unary paths cannot drift — including on the deprecated
+    /// `function_call` spelling, which this enum captures in
+    /// [`FinishReason::Other`].
+    fn as_wire(&self) -> &str {
+        match self {
+            Self::ToolCalls => "tool_calls",
+            Self::Stop => "stop",
+            Self::ContentFilter => "content_filter",
+            Self::Length => "length",
+            Self::Other(other) => other,
+        }
+    }
+}
+
+/// Normalize a streamed OpenAI-compatible `finish_reason` field.
+///
+/// A missing value — or an empty one, as some gateways send — is reported as
+/// [`CompatibleFinishReason::Absent`]; anything outside the normalized
+/// vocabulary is preserved verbatim in
+/// [`crate::completion::FinishReason::Other`].
+pub(crate) fn map_finish_reason(reason: Option<&FinishReason>) -> CompatibleFinishReason {
+    CompatibleFinishReason::from_wire(reason.map(FinishReason::as_wire))
+}
+
 #[derive(Deserialize, Debug)]
 struct StreamingChoice {
     delta: StreamingDelta,
@@ -114,18 +150,72 @@ struct StreamingCompletionChunk<U = Usage> {
 /// Final streaming response. `U` is the provider's streaming usage payload
 /// ([`Usage`] for OpenAI itself; providers with richer usage accounting, e.g.
 /// Mistral and DeepSeek, substitute their own via
-/// [`OpenAICompatibleProvider::StreamingUsage`].
-#[derive(Clone, Serialize, Deserialize)]
+/// [`OpenAICompatibleProvider::StreamingUsage`]).
+///
+/// This is the provider-native terminal record yielded by
+/// [`GenericCompletionModel::raw_stream`]. The normalized path maps it into a
+/// [`StreamFinal`] exactly once, through
+/// [`normalize_stream`](crate::streaming::normalize_stream).
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StreamingCompletionResponse<U = Usage> {
+    /// Usage reported on the stream's terminal event.
     pub usage: U,
+    /// Why the model stopped generating, when the stream reported it.
+    ///
+    /// Normalized out of the OpenAI-compatible `finish_reason` vocabulary, with
+    /// unrecognized values preserved verbatim. The `Stop` -> `ToolCalls`
+    /// upgrade is deliberately *not* applied here: it belongs to
+    /// [`normalize_stream`](crate::streaming::normalize_stream), the only place
+    /// that sees which tool calls the stream actually emitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<crate::completion::FinishReason>,
+    /// Provider-assigned response identifier, when the stream emitted one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_id: Option<String>,
+    /// Provider-reported model identifier, when the stream emitted one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
 }
 
-impl<U> GetTokenUsage for StreamingCompletionResponse<U>
+impl<U> StreamingCompletionResponse<U> {
+    /// Create a terminal record carrying `usage`; the optional metadata starts
+    /// unset.
+    pub fn new(usage: U) -> Self {
+        Self {
+            usage,
+            finish_reason: None,
+            response_id: None,
+            model: None,
+        }
+    }
+
+    /// Build the terminal record from the shared streaming layer's terminal
+    /// state.
+    pub(crate) fn from_terminal(terminal: CompatibleTerminal<U>) -> Self {
+        Self {
+            usage: terminal.usage,
+            finish_reason: terminal.finish_reason,
+            response_id: terminal.response_id,
+            model: terminal.model,
+        }
+    }
+}
+
+/// Normalize an OpenAI-compatible streaming terminal record.
+///
+/// As on the unary path, the provider descriptor name is an *input* rather than
+/// a constant: this terminal record is shared by every OpenAI-compatible
+/// provider, so baking in `"openai"` here would mislabel Groq, Together,
+/// DeepSeek and the rest.
+impl<U> From<(&str, StreamingCompletionResponse<U>)> for StreamFinal
 where
-    U: GetTokenUsage,
+    U: Into<crate::completion::Usage>,
 {
-    fn token_usage(&self) -> crate::completion::Usage {
-        self.usage.token_usage()
+    fn from((provider, response): (&str, StreamingCompletionResponse<U>)) -> Self {
+        StreamFinal::new(provider, response.usage.into())
+            .with_optional_finish_reason(response.finish_reason)
+            .with_optional_message_id(response.response_id)
+            .with_optional_model(response.model)
     }
 }
 
@@ -138,13 +228,20 @@ where
         + crate::wasm_compat::WasmCompatSend
         + 'static,
 {
-    pub(crate) async fn stream(
+    /// Open a chat-completions stream whose terminal record stays
+    /// provider-native.
+    ///
+    /// This is the escape hatch for provider-specific terminal fields rig does
+    /// not normalize. It shares the request builder, transport, telemetry, and
+    /// error handling with
+    /// [`CompletionModel::stream`](crate::completion::CompletionModel::stream),
+    /// which calls it and normalizes the terminal record — one network request
+    /// either way.
+    pub async fn raw_stream(
         &self,
         completion_request: CompletionRequest,
-    ) -> Result<
-        streaming::StreamingCompletionResponse<StreamingCompletionResponse<Ext::StreamingUsage>>,
-        CompletionError,
-    > {
+    ) -> Result<RawStreamingResult<StreamingCompletionResponse<Ext::StreamingUsage>>, CompletionError>
+    {
         let preamble = completion_request.preamble.clone();
         let record_telemetry_content = completion_request.record_telemetry_content;
         let options = CompletionModelOptions {
@@ -216,7 +313,7 @@ where
         let client = self.client.clone();
 
         tracing::Instrument::instrument(
-            openai_chat_completions_compatible::send_compatible_streaming_request(
+            openai_chat_completions_compatible::send_compatible_raw_streaming_request(
                 client,
                 req,
                 OpenAICompatibleProfile::<Ext, Ext::StreamingUsage> {
@@ -229,6 +326,24 @@ where
             span,
         )
         .await
+    }
+
+    /// Open a chat-completions stream with a normalized terminal record.
+    ///
+    /// Delegates to [`raw_stream`](Self::raw_stream) and maps only its terminal
+    /// record; every incremental event passes through untouched.
+    pub(crate) async fn stream(
+        &self,
+        completion_request: CompletionRequest,
+    ) -> Result<streaming::StreamingCompletionResponse, CompletionError> {
+        let stream = self.raw_stream(completion_request).await?;
+
+        Ok(streaming::StreamingCompletionResponse::stream(
+            Ext::PROVIDER_NAME,
+            streaming::normalize_stream(stream, |response| {
+                Ok((Ext::PROVIDER_NAME, response).into())
+            }),
+        ))
     }
 }
 
@@ -244,15 +359,14 @@ where
     Ext: OpenAICompatibleProvider + Clone + crate::wasm_compat::WasmCompatSend,
     U: Clone
         + Default
-        + GetTokenUsage
+        + Into<crate::completion::Usage>
         + serde::de::DeserializeOwned
         + crate::wasm_compat::WasmCompatSend
-        + Unpin
         + 'static,
 {
     type Usage = U;
     type Detail = serde_json::Value;
-    type FinalResponse = StreamingCompletionResponse<U>;
+    type FinalResponse = StreamingCompletionResponse<Self::Usage>;
 
     fn normalize_chunk(
         &self,
@@ -273,15 +387,10 @@ where
                 data.usage,
                 &data.choices,
                 |choice| CompatibleChoiceData {
-                    // `function_call` is the deprecated pre-tools finish reason
-                    // some compatible providers still emit for tool calls.
-                    finish_reason: match &choice.finish_reason {
-                        Some(FinishReason::ToolCalls) => CompatibleFinishReason::ToolCalls,
-                        Some(FinishReason::Other(other)) if other == "function_call" => {
-                            CompatibleFinishReason::ToolCalls
-                        }
-                        _ => CompatibleFinishReason::Other,
-                    },
+                    // The shared mapping also folds `function_call` — the
+                    // deprecated pre-tools finish reason some compatible
+                    // providers still emit — onto `ToolCalls`.
+                    finish_reason: map_finish_reason(choice.finish_reason.as_ref()),
                     text: choice.delta.content.clone(),
                     reasoning: choice
                         .delta
@@ -297,8 +406,11 @@ where
         ))
     }
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse {
-        StreamingCompletionResponse { usage }
+    fn build_final_response(
+        &self,
+        terminal: CompatibleTerminal<Self::Usage>,
+    ) -> Self::FinalResponse {
+        StreamingCompletionResponse::from_terminal(terminal)
     }
 
     fn decorate_tool_call(
@@ -319,14 +431,16 @@ where
     }
 }
 
-pub async fn send_compatible_streaming_request<T>(
+/// Send an OpenAI chat-completions streaming request, keeping the terminal
+/// record provider-native.
+pub(crate) async fn send_compatible_raw_streaming_request<T>(
     http_client: T,
     req: Request<Vec<u8>>,
-) -> Result<streaming::StreamingCompletionResponse<StreamingCompletionResponse>, CompletionError>
+) -> Result<RawStreamingResult<StreamingCompletionResponse<Usage>>, CompletionError>
 where
     T: HttpClientExt + Clone + 'static,
 {
-    openai_chat_completions_compatible::send_compatible_streaming_request(
+    openai_chat_completions_compatible::send_compatible_raw_streaming_request(
         http_client,
         req,
         OpenAICompatibleProfile::<crate::providers::openai::OpenAICompletionsExt, Usage>::default(),
@@ -334,12 +448,92 @@ where
     .await
 }
 
+/// Send an OpenAI chat-completions streaming request and normalize its terminal
+/// record.
+pub async fn send_compatible_streaming_request<T>(
+    http_client: T,
+    req: Request<Vec<u8>>,
+) -> Result<streaming::StreamingCompletionResponse, CompletionError>
+where
+    T: HttpClientExt + Clone + 'static,
+{
+    let stream = send_compatible_raw_streaming_request(http_client, req).await?;
+
+    Ok(streaming::StreamingCompletionResponse::stream(
+        OPENAI_PROVIDER_NAME,
+        streaming::normalize_stream(stream, |response| {
+            Ok((OPENAI_PROVIDER_NAME, response).into())
+        }),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::completion::FinishReason as NormalizedFinishReason;
     use crate::providers::internal::openai_chat_completions_compatible::test_support::{
         assert_zero_arg_tool_call_is_emitted, sse_bytes_from_data_lines,
     };
+
+    fn streaming_request() -> http::Request<Vec<u8>> {
+        http::Request::builder()
+            .method("POST")
+            .uri("http://localhost/v1/chat/completions")
+            .body(Vec::new())
+            .unwrap()
+    }
+
+    #[test]
+    fn test_finish_reason_mapping_covers_every_wire_value() {
+        for (wire, expected) in [
+            (FinishReason::Stop, NormalizedFinishReason::Stop),
+            (FinishReason::Length, NormalizedFinishReason::Length),
+            (FinishReason::ToolCalls, NormalizedFinishReason::ToolCalls),
+            (
+                FinishReason::ContentFilter,
+                NormalizedFinishReason::ContentFilter,
+            ),
+            // The deprecated pre-tools spelling still means a tool call.
+            (
+                FinishReason::Other("function_call".to_string()),
+                NormalizedFinishReason::ToolCalls,
+            ),
+            // Some gateways report the token limit under OpenAI's older name.
+            (
+                FinishReason::Other("max_tokens".to_string()),
+                NormalizedFinishReason::Length,
+            ),
+        ] {
+            assert_eq!(
+                map_finish_reason(Some(&wire)),
+                CompatibleFinishReason::Reported(expected),
+                "unexpected mapping for {wire:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_unknown_finish_reason_is_preserved_verbatim() {
+        let wire = FinishReason::Other("GUARDRAIL_INTERVENED".to_string());
+
+        assert_eq!(
+            map_finish_reason(Some(&wire)),
+            CompatibleFinishReason::Reported(NormalizedFinishReason::Other(
+                "GUARDRAIL_INTERVENED".to_string()
+            )),
+            "an unrecognized reason must survive in the provider's own spelling"
+        );
+    }
+
+    #[test]
+    fn test_missing_or_empty_finish_reason_is_absent() {
+        assert_eq!(map_finish_reason(None), CompatibleFinishReason::Absent);
+        assert_eq!(
+            map_finish_reason(Some(&FinishReason::Other(String::new()))),
+            CompatibleFinishReason::Absent,
+            "an empty finish_reason must not read as a provider-reported reason"
+        );
+    }
 
     #[test]
     fn test_streaming_function_deserialization() {
@@ -593,13 +787,7 @@ mod tests {
             ]),
         };
 
-        let req = http::Request::builder()
-            .method("POST")
-            .uri("http://localhost/v1/chat/completions")
-            .body(Vec::new())
-            .unwrap();
-
-        let mut stream = send_compatible_streaming_request(client, req)
+        let mut stream = send_compatible_streaming_request(client, streaming_request())
             .await
             .unwrap();
 
@@ -612,8 +800,110 @@ mod tests {
         }
 
         let usage = final_usage.expect("expected a final response with usage");
-        assert_eq!(usage.prompt_tokens, 10);
+        assert_eq!(usage.input_tokens, 10);
         assert_eq!(usage.total_tokens, 15);
+    }
+
+    #[tokio::test]
+    async fn test_streaming_final_record_carries_provider_metadata() {
+        use crate::test_utils::MockStreamingClient;
+        use futures::StreamExt;
+
+        let client = MockStreamingClient {
+            sse_bytes: sse_bytes_from_data_lines([
+                "{\"id\":\"chatcmpl-42\",\"model\":\"gpt-5.2-2026-01-01\",\"choices\":[{\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}],\"usage\":null}",
+                "{\"id\":\"chatcmpl-42\",\"model\":\"gpt-5.2-2026-01-01\",\"choices\":[{\"delta\":{},\"finish_reason\":\"length\"}],\"usage\":null}",
+                "[DONE]",
+            ]),
+        };
+
+        let mut stream = send_compatible_streaming_request(client, streaming_request())
+            .await
+            .unwrap();
+
+        let mut final_response = None;
+        while let Some(chunk) = stream.next().await {
+            if let streaming::StreamedAssistantContent::Final(res) = chunk.unwrap() {
+                final_response = Some(res);
+                break;
+            }
+        }
+
+        let res = final_response.expect("expected a final response");
+        assert_eq!(res.provider, "openai");
+        assert_eq!(res.message_id.as_deref(), Some("chatcmpl-42"));
+        assert_eq!(res.model.as_deref(), Some("gpt-5.2-2026-01-01"));
+        assert_eq!(res.finish_reason, Some(NormalizedFinishReason::Length));
+    }
+
+    #[tokio::test]
+    async fn test_streaming_unknown_finish_reason_reaches_the_final_record() {
+        use crate::test_utils::MockStreamingClient;
+        use futures::StreamExt;
+
+        let client = MockStreamingClient {
+            sse_bytes: sse_bytes_from_data_lines([
+                "{\"choices\":[{\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}],\"usage\":null}",
+                "{\"choices\":[{\"delta\":{},\"finish_reason\":\"GUARDRAIL_INTERVENED\"}],\"usage\":null}",
+                "[DONE]",
+            ]),
+        };
+
+        let mut stream = send_compatible_streaming_request(client, streaming_request())
+            .await
+            .unwrap();
+
+        let mut final_response = None;
+        while let Some(chunk) = stream.next().await {
+            if let streaming::StreamedAssistantContent::Final(res) = chunk.unwrap() {
+                final_response = Some(res);
+                break;
+            }
+        }
+
+        let res = final_response.expect("expected a final response");
+        assert_eq!(
+            res.finish_reason,
+            Some(NormalizedFinishReason::Other(
+                "GUARDRAIL_INTERVENED".to_string()
+            ))
+        );
+    }
+
+    /// A `stop` reported on a turn that streamed a tool call must surface as
+    /// `ToolCalls`. The provider mapper deliberately does not do this — the
+    /// upgrade belongs to `normalize_stream`, which sees the emitted tool
+    /// calls — so this pins the wiring rather than the mapping.
+    #[tokio::test]
+    async fn test_stop_finish_reason_upgrades_to_tool_calls() {
+        use crate::test_utils::MockStreamingClient;
+        use futures::StreamExt;
+
+        let client = MockStreamingClient {
+            sse_bytes: sse_bytes_from_data_lines([
+                "{\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"ping\",\"arguments\":\"{}\"}}]},\"finish_reason\":null}],\"usage\":null}",
+                "{\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":null}",
+                "[DONE]",
+            ]),
+        };
+
+        let mut stream = send_compatible_streaming_request(client, streaming_request())
+            .await
+            .unwrap();
+
+        let mut saw_tool_call = false;
+        let mut final_response = None;
+        while let Some(chunk) = stream.next().await {
+            match chunk.unwrap() {
+                streaming::StreamedAssistantContent::ToolCall { .. } => saw_tool_call = true,
+                streaming::StreamedAssistantContent::Final(res) => final_response = Some(res),
+                _ => {}
+            }
+        }
+
+        assert!(saw_tool_call, "expected the tool call to be emitted");
+        let res = final_response.expect("expected a final response");
+        assert_eq!(res.finish_reason, Some(NormalizedFinishReason::ToolCalls));
     }
 
     #[tokio::test]
@@ -632,19 +922,13 @@ mod tests {
             ]),
         };
 
-        let req = http::Request::builder()
-            .method("POST")
-            .uri("http://localhost/v1/chat/completions")
-            .body(Vec::new())
-            .unwrap();
-
-        let mut stream = send_compatible_streaming_request(client, req)
+        let mut stream = send_compatible_streaming_request(client, streaming_request())
             .await
             .unwrap();
 
         let mut reasoning_chunks = Vec::new();
         let mut text_chunks = Vec::new();
-        let mut final_usage = None;
+        let mut final_response = None;
 
         while let Some(chunk) = stream.next().await {
             match chunk.unwrap() {
@@ -653,7 +937,7 @@ mod tests {
                 }
                 streaming::StreamedAssistantContent::Text(text) => text_chunks.push(text.text),
                 streaming::StreamedAssistantContent::Final(response) => {
-                    final_usage = Some(response.usage)
+                    final_response = Some(response)
                 }
                 _ => {}
             }
@@ -665,15 +949,16 @@ mod tests {
         );
         assert_eq!(text_chunks, vec!["hel".to_string(), "lo".to_string()]);
 
-        let usage = final_usage.expect("expected final usage");
-        assert_eq!(usage.prompt_tokens, 4);
-        assert_eq!(usage.total_tokens, 10);
-        let token_usage = usage.token_usage();
-        assert_eq!(token_usage.output_tokens, 6);
+        let response = final_response.expect("expected final usage");
+        assert_eq!(response.usage.input_tokens, 4);
+        assert_eq!(response.usage.output_tokens, 6);
+        assert_eq!(response.usage.total_tokens, 10);
+        assert_eq!(response.finish_reason, Some(NormalizedFinishReason::Stop));
     }
 
     #[tokio::test]
     async fn test_streaming_cached_input_tokens_populated() {
+        use crate::streaming::RawStreamingChoice;
         use crate::test_utils::MockStreamingClient;
         use futures::StreamExt;
 
@@ -686,19 +971,16 @@ mod tests {
             ]),
         };
 
-        let req = http::Request::builder()
-            .method("POST")
-            .uri("http://localhost/v1/chat/completions")
-            .body(Vec::new())
-            .unwrap();
-
-        let mut stream = send_compatible_streaming_request(client, req)
+        // The raw stream keeps the provider's own usage payload, so this
+        // asserts both halves: what the provider reported and what it
+        // normalizes into.
+        let mut stream = send_compatible_raw_streaming_request(client, streaming_request())
             .await
             .unwrap();
 
         let mut final_response = None;
         while let Some(chunk) = stream.next().await {
-            if let streaming::StreamedAssistantContent::Final(res) = chunk.unwrap() {
+            if let RawStreamingChoice::FinalResponse(res) = chunk.unwrap() {
                 final_response = Some(res);
                 break;
             }
@@ -716,8 +998,8 @@ mod tests {
             80
         );
 
-        // Verify core Usage also has cached_input_tokens via GetTokenUsage
-        let core_usage = res.token_usage();
+        // Verify core Usage also has cached_input_tokens
+        let core_usage = crate::completion::Usage::from(res.usage);
         assert_eq!(core_usage.cached_input_tokens, 80);
         assert_eq!(core_usage.input_tokens, 100);
         assert_eq!(core_usage.total_tokens, 110);
@@ -748,13 +1030,7 @@ mod tests {
             ]),
         };
 
-        let req = http::Request::builder()
-            .method("POST")
-            .uri("http://localhost/v1/chat/completions")
-            .body(Vec::new())
-            .unwrap();
-
-        let mut stream = send_compatible_streaming_request(client, req)
+        let mut stream = send_compatible_streaming_request(client, streaming_request())
             .await
             .unwrap();
 
@@ -805,13 +1081,7 @@ mod tests {
             ]),
         };
 
-        let req = http::Request::builder()
-            .method("POST")
-            .uri("http://localhost/v1/chat/completions")
-            .body(Vec::new())
-            .unwrap();
-
-        let mut stream = send_compatible_streaming_request(client, req)
+        let mut stream = send_compatible_streaming_request(client, streaming_request())
             .await
             .unwrap();
 
@@ -861,13 +1131,7 @@ mod tests {
             ]),
         };
 
-        let req = http::Request::builder()
-            .method("POST")
-            .uri("http://localhost/v1/chat/completions")
-            .body(Vec::new())
-            .unwrap();
-
-        let mut stream = send_compatible_streaming_request(client, req)
+        let mut stream = send_compatible_streaming_request(client, streaming_request())
             .await
             .unwrap();
 
@@ -912,13 +1176,7 @@ mod tests {
             ]),
         };
 
-        let req = http::Request::builder()
-            .method("POST")
-            .uri("http://localhost/v1/chat/completions")
-            .body(Vec::new())
-            .unwrap();
-
-        let stream = send_compatible_streaming_request(client, req)
+        let stream = send_compatible_streaming_request(client, streaming_request())
             .await
             .unwrap();
 
@@ -935,13 +1193,7 @@ mod tests {
             ]),
         };
 
-        let req = http::Request::builder()
-            .method("POST")
-            .uri("http://localhost/v1/chat/completions")
-            .body(Vec::new())
-            .unwrap();
-
-        let stream = send_compatible_streaming_request(client, req)
+        let stream = send_compatible_streaming_request(client, streaming_request())
             .await
             .unwrap();
 

--- a/crates/rig-core/src/providers/openai/completion/streaming.rs
+++ b/crates/rig-core/src/providers/openai/completion/streaming.rs
@@ -20,8 +20,6 @@ use crate::streaming::{self, RawStreamingResult, StreamFinal};
 ///
 /// Only the free-function transport helpers below use it; the model path
 /// threads `Ext::PROVIDER_NAME` so a compatible provider is never mislabeled.
-const OPENAI_PROVIDER_NAME: &str =
-    <crate::providers::openai::OpenAICompletionsExt as OpenAICompatibleProvider>::PROVIDER_NAME;
 
 // ================================================================
 // OpenAI Completion Streaming API
@@ -212,9 +210,12 @@ where
     U: Into<crate::completion::Usage>,
 {
     fn from((provider, response): (&str, StreamingCompletionResponse<U>)) -> Self {
+        // No `message_id`: the chat-completions `id` is response-scoped
+        // (`chatcmpl-…`), not the assistant message id that `message_id` names
+        // and that the agent replays into history. It stays on the raw terminal
+        // record for callers who want it.
         StreamFinal::new(provider, response.usage.into())
             .with_optional_finish_reason(response.finish_reason)
-            .with_optional_message_id(response.response_id)
             .with_optional_model(response.model)
     }
 }
@@ -450,9 +451,15 @@ where
 
 /// Send an OpenAI chat-completions streaming request and normalize its terminal
 /// record.
+///
+/// `provider` is the descriptor name to attribute the stream to. It is a
+/// parameter rather than a constant because this helper is public and the
+/// chat-completions wire shape is shared: hardcoding `"openai"` would label
+/// every out-of-tree compatible provider's stream as OpenAI's.
 pub async fn send_compatible_streaming_request<T>(
     http_client: T,
     req: Request<Vec<u8>>,
+    provider: &'static str,
 ) -> Result<streaming::StreamingCompletionResponse, CompletionError>
 where
     T: HttpClientExt + Clone + 'static,
@@ -460,10 +467,8 @@ where
     let stream = send_compatible_raw_streaming_request(http_client, req).await?;
 
     Ok(streaming::StreamingCompletionResponse::stream(
-        OPENAI_PROVIDER_NAME,
-        streaming::normalize_stream(stream, |response| {
-            Ok((OPENAI_PROVIDER_NAME, response).into())
-        }),
+        provider,
+        streaming::normalize_stream(stream, move |response| Ok((provider, response).into())),
     ))
 }
 
@@ -787,7 +792,7 @@ mod tests {
             ]),
         };
 
-        let mut stream = send_compatible_streaming_request(client, streaming_request())
+        let mut stream = send_compatible_streaming_request(client, streaming_request(), "openai")
             .await
             .unwrap();
 
@@ -817,7 +822,7 @@ mod tests {
             ]),
         };
 
-        let mut stream = send_compatible_streaming_request(client, streaming_request())
+        let mut stream = send_compatible_streaming_request(client, streaming_request(), "openai")
             .await
             .unwrap();
 
@@ -849,7 +854,7 @@ mod tests {
             ]),
         };
 
-        let mut stream = send_compatible_streaming_request(client, streaming_request())
+        let mut stream = send_compatible_streaming_request(client, streaming_request(), "openai")
             .await
             .unwrap();
 
@@ -887,7 +892,7 @@ mod tests {
             ]),
         };
 
-        let mut stream = send_compatible_streaming_request(client, streaming_request())
+        let mut stream = send_compatible_streaming_request(client, streaming_request(), "openai")
             .await
             .unwrap();
 
@@ -922,7 +927,7 @@ mod tests {
             ]),
         };
 
-        let mut stream = send_compatible_streaming_request(client, streaming_request())
+        let mut stream = send_compatible_streaming_request(client, streaming_request(), "openai")
             .await
             .unwrap();
 
@@ -1030,7 +1035,7 @@ mod tests {
             ]),
         };
 
-        let mut stream = send_compatible_streaming_request(client, streaming_request())
+        let mut stream = send_compatible_streaming_request(client, streaming_request(), "openai")
             .await
             .unwrap();
 
@@ -1081,7 +1086,7 @@ mod tests {
             ]),
         };
 
-        let mut stream = send_compatible_streaming_request(client, streaming_request())
+        let mut stream = send_compatible_streaming_request(client, streaming_request(), "openai")
             .await
             .unwrap();
 
@@ -1131,7 +1136,7 @@ mod tests {
             ]),
         };
 
-        let mut stream = send_compatible_streaming_request(client, streaming_request())
+        let mut stream = send_compatible_streaming_request(client, streaming_request(), "openai")
             .await
             .unwrap();
 
@@ -1176,7 +1181,7 @@ mod tests {
             ]),
         };
 
-        let stream = send_compatible_streaming_request(client, streaming_request())
+        let stream = send_compatible_streaming_request(client, streaming_request(), "openai")
             .await
             .unwrap();
 
@@ -1193,7 +1198,7 @@ mod tests {
             ]),
         };
 
-        let stream = send_compatible_streaming_request(client, streaming_request())
+        let stream = send_compatible_streaming_request(client, streaming_request(), "openai")
             .await
             .unwrap();
 

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -15,6 +15,7 @@
 //! ```
 use super::InputAudio;
 use crate::completion::CompletionError;
+use crate::completion::NormalizeCompletionResponse;
 use crate::http_client;
 use crate::http_client::HttpClientExt;
 use crate::json_utils;
@@ -2400,7 +2401,7 @@ where
         completion_request: crate::completion::CompletionRequest,
     ) -> Result<completion::CompletionResponse, CompletionError> {
         let response = self.raw_completion(completion_request).await?;
-        (Ext::PROVIDER_NAME, response).try_into()
+        response.normalize(Ext::PROVIDER_NAME)
     }
 
     async fn stream(
@@ -2429,10 +2430,9 @@ where
 /// and Copilot return this exact wire shape, so hardcoding `"openai"` here would
 /// mislabel them. Taking it as part of the conversion makes the correct name
 /// impossible to forget.
-impl TryFrom<(&str, CompletionResponse)> for completion::CompletionResponse {
-    type Error = CompletionError;
-
-    fn try_from((provider, response): (&str, CompletionResponse)) -> Result<Self, Self::Error> {
+impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
+    fn normalize(self, provider: &str) -> Result<completion::CompletionResponse, CompletionError> {
+        let response = self;
         // The assistant message ID (`msg_...`) from the first message output
         // item. This is NOT `response.id` (`resp_...`), which identifies the
         // whole response; only the message ID pairs reasoning items with their
@@ -3939,8 +3939,8 @@ mod tests {
             json!("thinking through the answer")
         );
 
-        let completion: completion::CompletionResponse = ("openai", response)
-            .try_into()
+        let completion: completion::CompletionResponse = response
+            .normalize("openai")
             .expect("response should convert");
         let items = completion.choice.iter().collect::<Vec<_>>();
         assert!(matches!(
@@ -3996,8 +3996,8 @@ mod tests {
         }))
         .expect("reasoning-only response should deserialize");
 
-        let completion: completion::CompletionResponse = ("openai", response)
-            .try_into()
+        let completion: completion::CompletionResponse = response
+            .normalize("openai")
             .expect("reasoning-only response should convert");
         let items = completion.choice.iter().collect::<Vec<_>>();
 
@@ -4021,7 +4021,8 @@ mod tests {
         }))
         .expect("empty response shape should deserialize");
 
-        let err = completion::CompletionResponse::try_from(("openai", response))
+        let err = response
+            .normalize("openai")
             .expect_err("empty response without reasoning should be rejected");
 
         assert!(
@@ -4125,8 +4126,8 @@ mod tests {
         }))
         .expect("response should deserialize");
 
-        let completion: completion::CompletionResponse = ("openai", response)
-            .try_into()
+        let completion: completion::CompletionResponse = response
+            .normalize("openai")
             .expect("response should convert");
 
         // The two IDs are distinct in this API: `resp_...` names the response,
@@ -4159,8 +4160,8 @@ mod tests {
         }))
         .expect("response should deserialize");
 
-        let completion: completion::CompletionResponse = ("chatgpt", response)
-            .try_into()
+        let completion: completion::CompletionResponse = response
+            .normalize("chatgpt")
             .expect("response should convert");
 
         assert_eq!(completion.provider, "chatgpt");
@@ -4186,8 +4187,8 @@ mod tests {
         }))
         .expect("response should deserialize");
 
-        let completion: completion::CompletionResponse = ("openai", response)
-            .try_into()
+        let completion: completion::CompletionResponse = response
+            .normalize("openai")
             .expect("response should convert");
 
         // `completed` is reconciled up to `ToolCalls` because the turn carried
@@ -4218,8 +4219,8 @@ mod tests {
         }))
         .expect("response should deserialize");
 
-        let completion: completion::CompletionResponse = ("openai", response)
-            .try_into()
+        let completion: completion::CompletionResponse = response
+            .normalize("openai")
             .expect("response should convert");
 
         assert_eq!(
@@ -4279,8 +4280,8 @@ mod tests {
             })
         );
 
-        let completion: completion::CompletionResponse = ("openai", response)
-            .try_into()
+        let completion: completion::CompletionResponse = response
+            .normalize("openai")
             .expect("response should convert");
         let items = completion.choice.iter().collect::<Vec<_>>();
         assert_eq!(items.len(), 1);
@@ -4486,8 +4487,8 @@ mod tests {
         }))
         .expect("response should deserialize");
 
-        let completion: completion::CompletionResponse = ("openai", response)
-            .try_into()
+        let completion: completion::CompletionResponse = response
+            .normalize("openai")
             .expect("response should convert");
         let reasoning_count = completion
             .choice

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -14,8 +14,7 @@
 //! # }
 //! ```
 use super::InputAudio;
-use super::responses_api::streaming::StreamingCompletionResponse;
-use crate::completion::{CompletionError, GetTokenUsage};
+use crate::completion::CompletionError;
 use crate::http_client;
 use crate::http_client::HttpClientExt;
 use crate::json_utils;
@@ -960,25 +959,31 @@ impl ResponsesUsage {
     }
 }
 
-impl GetTokenUsage for ResponsesUsage {
-    fn token_usage(&self) -> crate::completion::Usage {
+impl From<&ResponsesUsage> for crate::completion::Usage {
+    fn from(usage: &ResponsesUsage) -> Self {
         crate::completion::Usage {
-            input_tokens: self.input_tokens,
-            output_tokens: self.output_tokens,
-            total_tokens: self.total_tokens,
-            cached_input_tokens: self
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
+            total_tokens: usage.total_tokens,
+            cached_input_tokens: usage
                 .input_tokens_details
                 .as_ref()
                 .map(|details| details.cached_tokens)
                 .unwrap_or(0),
             cache_creation_input_tokens: 0,
             tool_use_prompt_tokens: 0,
-            reasoning_tokens: self
+            reasoning_tokens: usage
                 .output_tokens_details
                 .as_ref()
                 .map(|details| details.reasoning_tokens)
                 .unwrap_or(0),
         }
+    }
+}
+
+impl From<ResponsesUsage> for crate::completion::Usage {
+    fn from(usage: ResponsesUsage) -> Self {
+        Self::from(&usage)
     }
 }
 
@@ -1092,6 +1097,68 @@ pub enum ResponseStatus {
     Incomplete,
 }
 
+/// The wire spelling of a [`ResponseStatus`].
+///
+/// Statuses outside the normalized finish-reason vocabulary are carried through
+/// as [`completion::FinishReason::Other`], so they must keep OpenAI's own
+/// spelling rather than a Rust `Debug` name.
+fn response_status_wire_name(status: &ResponseStatus) -> &'static str {
+    match status {
+        ResponseStatus::InProgress => "in_progress",
+        ResponseStatus::Completed => "completed",
+        ResponseStatus::Failed => "failed",
+        ResponseStatus::Cancelled => "cancelled",
+        ResponseStatus::Queued => "queued",
+        ResponseStatus::Incomplete => "incomplete",
+    }
+}
+
+/// Map the Responses API's terminal state onto the normalized finish reason.
+///
+/// This API reports how a turn ended with two fields rather than one: `status`
+/// says whether the turn ran to completion, and `incomplete_details.reason`
+/// says why it did not. Both the unary and streaming paths funnel through here
+/// so they cannot disagree.
+///
+/// `completed` maps to [`completion::FinishReason::Stop`]; the upgrade to
+/// [`completion::FinishReason::ToolCalls`] for a turn that emitted function
+/// calls is applied once, centrally, by
+/// [`completion::CompletionResponse::with_optional_finish_reason`] (and, for
+/// streams, by [`crate::streaming::normalize_stream`]).
+///
+/// Anything unrecognized — a new `incomplete_details.reason`, or a terminal
+/// status such as `failed`/`cancelled` that has no normalized counterpart — is
+/// preserved verbatim in OpenAI's spelling instead of being smoothed into a
+/// natural stop. In-flight statuses report no reason at all.
+pub(crate) fn map_finish_reason(
+    status: &ResponseStatus,
+    incomplete_details: Option<&IncompleteDetailsReason>,
+) -> Option<completion::FinishReason> {
+    match status {
+        ResponseStatus::Completed => Some(completion::FinishReason::Stop),
+        ResponseStatus::Incomplete => Some(
+            match incomplete_details
+                .map(|details| details.reason.as_str())
+                .filter(|reason| !reason.is_empty())
+            {
+                Some("max_output_tokens") => completion::FinishReason::Length,
+                Some("content_filter") => completion::FinishReason::ContentFilter,
+                Some(other) => completion::FinishReason::Other(other.to_owned()),
+                // Incomplete without a stated reason: the status itself is all
+                // the provider told us.
+                None => {
+                    completion::FinishReason::Other(response_status_wire_name(status).to_owned())
+                }
+            },
+        ),
+        ResponseStatus::Failed | ResponseStatus::Cancelled => Some(
+            completion::FinishReason::Other(response_status_wire_name(status).to_owned()),
+        ),
+        // The turn has not terminated, so there is genuinely no reason yet.
+        ResponseStatus::InProgress | ResponseStatus::Queued => None,
+    }
+}
+
 /// Controls where Rig system instructions are placed in an OpenAI Responses request.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -1120,6 +1187,14 @@ pub enum SystemInstructionsPlacement {
 /// [`GenericResponsesCompletionModel`], so a client-level configuration can
 /// control request shaping for every model created from that client.
 pub trait ResponsesProviderExt {
+    /// Stable descriptor name recorded on `gen_ai.provider.name` telemetry
+    /// spans and on every normalized response produced through this extension.
+    ///
+    /// Defaults to `"openai"` because the Responses wire format is OpenAI's;
+    /// providers that merely *speak* it (ChatGPT, Copilot) override this so a
+    /// shared wire type never mislabels them.
+    const PROVIDER_NAME: &'static str = "openai";
+
     /// Where Rig system instructions are placed in requests built from this
     /// provider. See [`SystemInstructionsPlacement`].
     ///
@@ -1361,6 +1436,12 @@ where
 
     pub fn with_model(client: crate::client::Client<Ext, H>, model: &str) -> Self {
         Self::new(client, model)
+    }
+
+    /// The stable descriptor name of the provider behind this model, as
+    /// recorded on telemetry spans and normalized responses.
+    pub fn provider_name(&self) -> &'static str {
+        Ext::PROVIDER_NAME
     }
 
     /// Enable strict mode for function tool schemas.
@@ -2202,7 +2283,7 @@ pub enum OutputRole {
     Assistant,
 }
 
-impl<Ext, H> completion::CompletionModel for GenericResponsesCompletionModel<Ext, H>
+impl<Ext, H> GenericResponsesCompletionModel<Ext, H>
 where
     crate::client::Client<Ext, H>:
         HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
@@ -2215,32 +2296,28 @@ where
         + 'static,
     H: Clone + Default + std::fmt::Debug + WasmCompatSend + WasmCompatSync + 'static,
 {
-    type Response = CompletionResponse;
-    type StreamingResponse = StreamingCompletionResponse;
-
-    type Client = crate::client::Client<Ext, H>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
-
-    // The OpenAI Responses API constrains only the final assistant message via
-    // `text.format`; tools are still called across turns, so native structured
-    // output composes with tool calls. See issue #1928.
-    fn composes_native_output_with_tools(&self) -> bool {
-        true
-    }
-
-    async fn completion(
+    /// Execute a completion and return the provider's own wire response.
+    ///
+    /// This is the escape hatch for Responses-API fields rig does not normalize
+    /// (hosted-tool output items, `previous_response_id`, service tier, ...). It
+    /// shares the request builder, transport, telemetry, and error handling with
+    /// [`CompletionModel::completion`](completion::CompletionModel::completion),
+    /// which calls it and then applies the provider-local mapping — one network
+    /// request either way.
+    pub async fn raw_completion(
         &self,
         completion_request: crate::completion::CompletionRequest,
-    ) -> Result<completion::CompletionResponse<Self::Response>, CompletionError> {
+    ) -> Result<CompletionResponse, CompletionError> {
         let system_instructions = completion_request.preamble.clone();
         let record_telemetry_content = completion_request.record_telemetry_content;
         let request = self.create_completion_request(completion_request)?;
-        let span = CompletionSpanBuilder::new("openai", &request.model, CompletionOperation::Chat)
-            .system_instructions(system_instructions.as_deref(), record_telemetry_content)
-            .build();
+        let span = CompletionSpanBuilder::new(
+            Ext::PROVIDER_NAME,
+            &request.model,
+            CompletionOperation::Chat,
+        )
+        .system_instructions(system_instructions.as_deref(), record_telemetry_content)
+        .build();
         let body = serde_json::to_vec(&request)?;
 
         if enabled!(Level::TRACE) {
@@ -2262,8 +2339,11 @@ where
 
             if response.status().is_success() {
                 let t = http_client::text(response).await?;
-                let response = serde_json::from_str::<Self::Response>(&t)?;
+                let response = serde_json::from_str::<CompletionResponse>(&t)?;
                 let span = tracing::Span::current();
+                // `gen_ai.response.id` is the response ID (`resp_...`), which is
+                // deliberately *not* the assistant message ID (`msg_...`) that
+                // the normalized response carries.
                 span.record("gen_ai.response.id", &response.id);
                 span.record("gen_ai.response.model", &response.model);
                 if let Some(ref usage) = response.usage {
@@ -2283,7 +2363,7 @@ where
                         response = serde_json::to_string_pretty(&response)?
                     );
                 }
-                response.try_into()
+                Ok(response)
             } else {
                 let status = response.status();
                 let text = http_client::text(response).await?;
@@ -2293,23 +2373,70 @@ where
         .instrument(span)
         .await
     }
+}
+
+impl<Ext, H> completion::CompletionModel for GenericResponsesCompletionModel<Ext, H>
+where
+    crate::client::Client<Ext, H>:
+        HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
+    Ext: crate::client::Provider
+        + ResponsesProviderExt
+        + crate::client::DebugExt
+        + Clone
+        + WasmCompatSend
+        + WasmCompatSync
+        + 'static,
+    H: Clone + Default + std::fmt::Debug + WasmCompatSend + WasmCompatSync + 'static,
+{
+    fn capabilities(&self) -> completion::ProviderCapabilities {
+        // The OpenAI Responses API constrains only the final assistant message via
+        // `text.format`; tools are still called across turns, so native structured
+        // output composes with tool calls. See issue #1928.
+        completion::ProviderCapabilities::default().with_native_output_tool_composition(true)
+    }
+
+    async fn completion(
+        &self,
+        completion_request: crate::completion::CompletionRequest,
+    ) -> Result<completion::CompletionResponse, CompletionError> {
+        let response = self.raw_completion(completion_request).await?;
+        (Ext::PROVIDER_NAME, response).try_into()
+    }
 
     async fn stream(
         &self,
         request: crate::completion::CompletionRequest,
-    ) -> Result<
-        crate::streaming::StreamingCompletionResponse<Self::StreamingResponse>,
-        CompletionError,
-    > {
+    ) -> Result<crate::streaming::StreamingCompletionResponse, CompletionError> {
         GenericResponsesCompletionModel::stream(self, request).await
     }
 }
 
-impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionResponse> {
+impl<Ext, H> crate::client::ConstructCompletionModel<crate::client::Client<Ext, H>>
+    for GenericResponsesCompletionModel<Ext, H>
+where
+    crate::client::Client<Ext, H>: HttpClientExt + Clone + std::fmt::Debug + 'static,
+    Ext: crate::client::Provider + ResponsesProviderExt + Clone + 'static,
+    H: Clone + Default + std::fmt::Debug + 'static,
+{
+    fn construct(client: &crate::client::Client<Ext, H>, model: String) -> Self {
+        Self::new(client.clone(), model)
+    }
+}
+
+/// Normalize an OpenAI Responses API completion.
+///
+/// The provider descriptor name is an *input* rather than a constant: ChatGPT
+/// and Copilot return this exact wire shape, so hardcoding `"openai"` here would
+/// mislabel them. Taking it as part of the conversion makes the correct name
+/// impossible to forget.
+impl TryFrom<(&str, CompletionResponse)> for completion::CompletionResponse {
     type Error = CompletionError;
 
-    fn try_from(response: CompletionResponse) -> Result<Self, Self::Error> {
-        // Extract the msg_ ID from the first Output::Message item
+    fn try_from((provider, response): (&str, CompletionResponse)) -> Result<Self, Self::Error> {
+        // The assistant message ID (`msg_...`) from the first message output
+        // item. This is NOT `response.id` (`resp_...`), which identifies the
+        // whole response; only the message ID pairs reasoning items with their
+        // output items across turns.
         let message_id = response.output.iter().find_map(|item| match item {
             Output::Message(msg) => Some(msg.id.clone()),
             _ => None,
@@ -2348,15 +2475,16 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         let usage = response
             .usage
             .as_ref()
-            .map(GetTokenUsage::token_usage)
+            .map(crate::completion::Usage::from)
             .unwrap_or_default();
 
-        Ok(completion::CompletionResponse {
-            choice,
-            usage,
-            raw_response: response,
-            message_id,
-        })
+        let finish_reason =
+            map_finish_reason(&response.status, response.incomplete_details.as_ref());
+
+        Ok(completion::CompletionResponse::new(choice, usage, provider)
+            .with_optional_message_id(message_id)
+            .with_optional_model(Some(response.model.as_str()).filter(|model| !model.is_empty()))
+            .with_optional_finish_reason(finish_reason))
     }
 }
 
@@ -3739,7 +3867,7 @@ mod tests {
             total_tokens: 150,
         };
 
-        let token_usage = usage.token_usage();
+        let token_usage = crate::completion::Usage::from(&usage);
 
         assert_eq!(token_usage.input_tokens, 100);
         assert_eq!(token_usage.cached_input_tokens, 25);
@@ -3762,7 +3890,7 @@ mod tests {
 
         assert!(usage.output_tokens_details.is_none());
 
-        let token_usage = usage.token_usage();
+        let token_usage = crate::completion::Usage::from(&usage);
 
         assert_eq!(token_usage.input_tokens, 100);
         assert_eq!(token_usage.cached_input_tokens, 25);
@@ -3811,8 +3939,9 @@ mod tests {
             json!("thinking through the answer")
         );
 
-        let completion: completion::CompletionResponse<CompletionResponse> =
-            response.try_into().expect("response should convert");
+        let completion: completion::CompletionResponse = ("openai", response)
+            .try_into()
+            .expect("response should convert");
         let items = completion.choice.iter().collect::<Vec<_>>();
         assert!(matches!(
             items[0],
@@ -3867,7 +3996,7 @@ mod tests {
         }))
         .expect("reasoning-only response should deserialize");
 
-        let completion: completion::CompletionResponse<CompletionResponse> = response
+        let completion: completion::CompletionResponse = ("openai", response)
             .try_into()
             .expect("reasoning-only response should convert");
         let items = completion.choice.iter().collect::<Vec<_>>();
@@ -3892,12 +4021,210 @@ mod tests {
         }))
         .expect("empty response shape should deserialize");
 
-        let err = completion::CompletionResponse::<CompletionResponse>::try_from(response)
+        let err = completion::CompletionResponse::try_from(("openai", response))
             .expect_err("empty response without reasoning should be rejected");
 
         assert!(
             err.to_string()
                 .contains("Response contained no message or tool call")
+        );
+    }
+
+    fn incomplete_because(reason: &str) -> IncompleteDetailsReason {
+        IncompleteDetailsReason {
+            reason: reason.to_string(),
+        }
+    }
+
+    #[test]
+    fn finish_reason_maps_every_documented_terminal_state() {
+        assert_eq!(
+            map_finish_reason(&ResponseStatus::Completed, None),
+            Some(completion::FinishReason::Stop)
+        );
+        assert_eq!(
+            map_finish_reason(
+                &ResponseStatus::Incomplete,
+                Some(&incomplete_because("max_output_tokens"))
+            ),
+            Some(completion::FinishReason::Length)
+        );
+        assert_eq!(
+            map_finish_reason(
+                &ResponseStatus::Incomplete,
+                Some(&incomplete_because("content_filter"))
+            ),
+            Some(completion::FinishReason::ContentFilter)
+        );
+        // `incomplete_details` on a completed turn is not a termination reason.
+        assert_eq!(
+            map_finish_reason(
+                &ResponseStatus::Completed,
+                Some(&incomplete_because("noise"))
+            ),
+            Some(completion::FinishReason::Stop)
+        );
+        // In-flight statuses are not terminations at all.
+        assert_eq!(map_finish_reason(&ResponseStatus::InProgress, None), None);
+        assert_eq!(map_finish_reason(&ResponseStatus::Queued, None), None);
+    }
+
+    #[test]
+    fn finish_reason_preserves_unknown_values_verbatim() {
+        // A reason OpenAI adds later must survive in OpenAI's own spelling
+        // rather than being smoothed into a natural stop.
+        assert_eq!(
+            map_finish_reason(
+                &ResponseStatus::Incomplete,
+                Some(&incomplete_because("MAX_TOOL_CALLS"))
+            ),
+            Some(completion::FinishReason::Other(
+                "MAX_TOOL_CALLS".to_string()
+            ))
+        );
+        // So must a terminal status with no normalized counterpart, and an
+        // `incomplete` that states no reason.
+        assert_eq!(
+            map_finish_reason(&ResponseStatus::Failed, None),
+            Some(completion::FinishReason::Other("failed".to_string()))
+        );
+        assert_eq!(
+            map_finish_reason(&ResponseStatus::Cancelled, None),
+            Some(completion::FinishReason::Other("cancelled".to_string()))
+        );
+        assert_eq!(
+            map_finish_reason(&ResponseStatus::Incomplete, None),
+            Some(completion::FinishReason::Other("incomplete".to_string()))
+        );
+        assert_eq!(
+            map_finish_reason(&ResponseStatus::Incomplete, Some(&incomplete_because(""))),
+            Some(completion::FinishReason::Other("incomplete".to_string()))
+        );
+    }
+
+    #[test]
+    fn completion_response_carries_the_message_id_not_the_response_id() {
+        let response: CompletionResponse = serde_json::from_value(json!({
+            "id": "resp_123",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "model": "gpt-5.4",
+            "output": [{
+                "type": "message",
+                "id": "msg_456",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{
+                    "type": "output_text",
+                    "annotations": [],
+                    "text": "done"
+                }]
+            }],
+            "tools": []
+        }))
+        .expect("response should deserialize");
+
+        let completion: completion::CompletionResponse = ("openai", response)
+            .try_into()
+            .expect("response should convert");
+
+        // The two IDs are distinct in this API: `resp_...` names the response,
+        // `msg_...` names the assistant message.
+        assert_eq!(completion.message_id.as_deref(), Some("msg_456"));
+        assert_eq!(completion.provider, "openai");
+        assert_eq!(completion.model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(
+            completion.finish_reason,
+            Some(completion::FinishReason::Stop)
+        );
+    }
+
+    #[test]
+    fn completion_response_provider_name_is_an_input() {
+        let response: CompletionResponse = serde_json::from_value(json!({
+            "id": "resp_123",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "model": "gpt-5.3-codex",
+            "output": [{
+                "type": "message",
+                "id": "msg_456",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{ "type": "output_text", "annotations": [], "text": "done" }]
+            }],
+            "tools": []
+        }))
+        .expect("response should deserialize");
+
+        let completion: completion::CompletionResponse = ("chatgpt", response)
+            .try_into()
+            .expect("response should convert");
+
+        assert_eq!(completion.provider, "chatgpt");
+    }
+
+    #[test]
+    fn completion_response_completed_with_tool_call_reports_tool_calls() {
+        let response: CompletionResponse = serde_json::from_value(json!({
+            "id": "resp_123",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "model": "gpt-5.4",
+            "output": [{
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_1",
+                "name": "get_weather",
+                "arguments": "{\"city\":\"London\"}",
+                "status": "completed"
+            }],
+            "tools": []
+        }))
+        .expect("response should deserialize");
+
+        let completion: completion::CompletionResponse = ("openai", response)
+            .try_into()
+            .expect("response should convert");
+
+        // `completed` is reconciled up to `ToolCalls` because the turn carried
+        // a function call.
+        assert_eq!(
+            completion.finish_reason,
+            Some(completion::FinishReason::ToolCalls)
+        );
+    }
+
+    #[test]
+    fn completion_response_incomplete_reports_the_truncation_reason() {
+        let response: CompletionResponse = serde_json::from_value(json!({
+            "id": "resp_123",
+            "object": "response",
+            "created_at": 0,
+            "status": "incomplete",
+            "incomplete_details": { "reason": "max_output_tokens" },
+            "model": "gpt-5.4",
+            "output": [{
+                "type": "message",
+                "id": "msg_456",
+                "status": "incomplete",
+                "role": "assistant",
+                "content": [{ "type": "output_text", "annotations": [], "text": "half an ans" }]
+            }],
+            "tools": []
+        }))
+        .expect("response should deserialize");
+
+        let completion: completion::CompletionResponse = ("openai", response)
+            .try_into()
+            .expect("response should convert");
+
+        assert_eq!(
+            completion.finish_reason,
+            Some(completion::FinishReason::Length)
         );
     }
 
@@ -3952,8 +4279,9 @@ mod tests {
             })
         );
 
-        let completion: completion::CompletionResponse<CompletionResponse> =
-            response.try_into().expect("response should convert");
+        let completion: completion::CompletionResponse = ("openai", response)
+            .try_into()
+            .expect("response should convert");
         let items = completion.choice.iter().collect::<Vec<_>>();
         assert_eq!(items.len(), 1);
         assert!(matches!(items[0], completion::AssistantContent::Text(_)));
@@ -4158,8 +4486,9 @@ mod tests {
         }))
         .expect("response should deserialize");
 
-        let completion: completion::CompletionResponse<CompletionResponse> =
-            response.try_into().expect("response should convert");
+        let completion: completion::CompletionResponse = ("openai", response)
+            .try_into()
+            .expect("response should convert");
         let reasoning_count = completion
             .choice
             .iter()
@@ -4519,7 +4848,7 @@ mod tests {
         };
 
         let usage = lhs + rhs;
-        let token_usage = usage.token_usage();
+        let token_usage = crate::completion::Usage::from(&usage);
 
         assert_eq!(token_usage.input_tokens, 13);
         assert_eq!(token_usage.cached_input_tokens, 2);

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -1,10 +1,12 @@
 //! The streaming module for the OpenAI Responses API.
 //! Please see the `openai_streaming` or `openai_streaming_with_tools` example for more practical usage.
-use crate::completion::{self, CompletionError, GetTokenUsage};
+use crate::completion::{self, CompletionError};
 use crate::http_client::HttpClientExt;
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::message::ReasoningContent;
-use crate::providers::openai::responses_api::{ReasoningSummary, ResponsesUsage};
+use crate::providers::openai::responses_api::{
+    IncompleteDetailsReason, ReasoningSummary, ResponseStatus, ResponsesUsage,
+};
 use crate::streaming;
 use crate::streaming::RawStreamingChoice;
 use crate::telemetry::{CompletionOperation, CompletionSpanBuilder};
@@ -15,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{Level, debug, enabled};
 use tracing_futures::Instrument as _;
 
-use super::{CompletionResponse, GenericResponsesCompletionModel, Output};
+use super::{CompletionResponse, GenericResponsesCompletionModel, Output, ResponsesProviderExt};
 
 type StreamingRawChoice = RawStreamingChoice<StreamingCompletionResponse>;
 
@@ -35,6 +37,11 @@ pub enum StreamingCompletionChunk {
 }
 
 /// The final streaming response from the OpenAI Responses API.
+///
+/// This is the provider-native terminal record carried by
+/// [`GenericResponsesCompletionModel::raw_stream`]. The normalized path maps it
+/// once, through [`crate::streaming::normalize_stream`], into a
+/// [`streaming::StreamFinal`].
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct StreamingCompletionResponse {
     /// Token usage
@@ -45,6 +52,80 @@ pub struct StreamingCompletionResponse {
     /// The effective reasoning context from the terminal response event.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_context: Option<String>,
+    /// The `status` reported by the terminal `response.completed` event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<ResponseStatus>,
+    /// Why the response stopped short, when the provider said so.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub incomplete_details: Option<IncompleteDetailsReason>,
+    /// The assistant message ID (`msg_...`) carried by the terminal response's
+    /// output items.
+    ///
+    /// Distinct from the response ID (`resp_...`), which names the whole
+    /// response and is recorded on telemetry rather than here.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<String>,
+    /// The model identifier reported by the terminal response event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+}
+
+impl StreamingCompletionResponse {
+    /// Create a terminal record carrying only usage; the remaining metadata is
+    /// filled in from the terminal `response.completed` event as it arrives.
+    pub fn new(usage: ResponsesUsage) -> Self {
+        Self {
+            usage,
+            reasoning_metadata: None,
+            reasoning_context: None,
+            status: None,
+            incomplete_details: None,
+            message_id: None,
+            model: None,
+        }
+    }
+}
+
+/// Normalize the Responses API's terminal stream record.
+///
+/// The provider descriptor name is an input for the same reason it is on the
+/// unary conversion: ChatGPT and Copilot stream this exact wire shape, so a
+/// baked-in `"openai"` would mislabel them.
+///
+/// The finish reason is left exactly as the provider reported it;
+/// [`crate::streaming::normalize_stream`] applies the tool-call reconciliation
+/// afterwards, using the calls the stream actually emitted.
+impl From<(&str, StreamingCompletionResponse)> for streaming::StreamFinal {
+    fn from((provider, response): (&str, StreamingCompletionResponse)) -> Self {
+        let finish_reason = response.status.as_ref().and_then(|status| {
+            super::map_finish_reason(status, response.incomplete_details.as_ref())
+        });
+
+        streaming::StreamFinal::new(provider, crate::completion::Usage::from(&response.usage))
+            .with_optional_finish_reason(finish_reason)
+            .with_optional_message_id(response.message_id)
+            .with_optional_model(response.model)
+    }
+}
+
+/// Normalize a provider-native Responses stream for `provider`.
+///
+/// Maps only the terminal record; every incremental event passes through
+/// untouched.
+pub(crate) fn normalize_responses_stream(
+    provider: &str,
+    raw: streaming::RawStreamingResult<StreamingCompletionResponse>,
+) -> streaming::StreamingCompletionResponse {
+    let provider = provider.to_owned();
+    let mapped_provider = provider.clone();
+    let normalized = streaming::normalize_stream(raw, move |response| {
+        Ok(streaming::StreamFinal::from((
+            mapped_provider.as_str(),
+            response,
+        )))
+    });
+
+    streaming::StreamingCompletionResponse::stream(provider, normalized)
 }
 
 pub(crate) fn reasoning_choices_from_done_item(
@@ -81,9 +162,9 @@ pub(crate) fn reasoning_choices_from_done_item(
     choices
 }
 
-impl GetTokenUsage for StreamingCompletionResponse {
-    fn token_usage(&self) -> crate::completion::Usage {
-        self.usage.token_usage()
+impl From<&StreamingCompletionResponse> for crate::completion::Usage {
+    fn from(response: &StreamingCompletionResponse) -> Self {
+        Self::from(&response.usage)
     }
 }
 
@@ -221,6 +302,10 @@ struct RawChoiceAccumulator {
     final_usage: ResponsesUsage,
     reasoning_metadata: Option<serde_json::Map<String, serde_json::Value>>,
     reasoning_context: Option<String>,
+    status: Option<ResponseStatus>,
+    incomplete_details: Option<IncompleteDetailsReason>,
+    message_id: Option<String>,
+    model: Option<String>,
     tool_calls: Vec<StreamingRawChoice>,
     tool_call_internal_ids: std::collections::HashMap<String, String>,
 }
@@ -231,6 +316,10 @@ impl RawChoiceAccumulator {
             final_usage: initial_usage,
             reasoning_metadata: None,
             reasoning_context: None,
+            status: None,
+            incomplete_details: None,
+            message_id: None,
+            model: None,
             tool_calls: Vec::new(),
             tool_call_internal_ids: std::collections::HashMap::new(),
         }
@@ -318,6 +407,19 @@ impl RawChoiceAccumulator {
     ) -> Result<(), CompletionError> {
         match kind {
             ResponseChunkKind::ResponseCompleted => {
+                // The terminal event is the only place the stream learns how the
+                // turn ended, which model answered, and which assistant message
+                // (`msg_...`, not the response's `resp_...`) carried the output.
+                if let Some(message_id) = message_id_from_response(&response) {
+                    self.message_id = Some(message_id);
+                }
+                if !response.model.is_empty() {
+                    self.model = Some(response.model.clone());
+                }
+                self.status = Some(response.status);
+                if response.incomplete_details.is_some() {
+                    self.incomplete_details = response.incomplete_details;
+                }
                 if let Some(usage) = response.usage {
                     self.final_usage = usage;
                 }
@@ -396,6 +498,10 @@ impl RawChoiceAccumulator {
                 usage: self.final_usage,
                 reasoning_metadata: self.reasoning_metadata,
                 reasoning_context: self.reasoning_context,
+                status: self.status,
+                incomplete_details: self.incomplete_details,
+                message_id: self.message_id,
+                model: self.model,
             },
         ));
         choices
@@ -533,9 +639,10 @@ pub(crate) fn raw_choices_from_sse_body(
 }
 
 pub(crate) async fn completion_response_from_sse_body(
+    provider: &str,
     body: &str,
     raw_response: CompletionResponse,
-) -> Result<completion::CompletionResponse<CompletionResponse>, CompletionError> {
+) -> Result<completion::CompletionResponse, CompletionError> {
     let raw_choices = raw_choices_from_sse_body(
         body,
         raw_response
@@ -549,7 +656,7 @@ pub(crate) async fn completion_response_from_sse_body(
             .map(Ok::<_, CompletionError>)
             .collect::<Vec<_>>(),
     );
-    let mut stream = crate::streaming::StreamingCompletionResponse::stream(Box::pin(stream));
+    let mut stream = normalize_responses_stream(provider, Box::pin(stream));
 
     while let Some(item) = stream.next().await {
         item?;
@@ -561,19 +668,37 @@ pub(crate) async fn completion_response_from_sse_body(
         ));
     }
 
-    Ok(completion::CompletionResponse {
-        usage: stream
-            .response
-            .as_ref()
-            .map(GetTokenUsage::token_usage)
-            .unwrap_or_else(|| usage_from_raw_response(&raw_response)),
-        message_id: stream
-            .message_id
-            .clone()
-            .or_else(|| message_id_from_response(&raw_response)),
-        choice: stream.choice,
-        raw_response,
-    })
+    // The replayed stream is authoritative where it reported something; the
+    // parsed terminal response fills any gap it left.
+    let terminal = stream.response.clone();
+    let usage = terminal
+        .as_ref()
+        .map(|terminal| terminal.usage)
+        .unwrap_or_else(|| usage_from_raw_response(&raw_response));
+    let message_id = stream
+        .message_id
+        .clone()
+        .or_else(|| message_id_from_response(&raw_response));
+    let finish_reason = terminal
+        .as_ref()
+        .and_then(|terminal| terminal.finish_reason.clone())
+        .or_else(|| {
+            super::map_finish_reason(
+                &raw_response.status,
+                raw_response.incomplete_details.as_ref(),
+            )
+        });
+    let model = terminal
+        .as_ref()
+        .and_then(|terminal| terminal.model.clone())
+        .or_else(|| Some(raw_response.model.clone()).filter(|model| !model.is_empty()));
+
+    Ok(
+        completion::CompletionResponse::new(stream.choice.clone(), usage, provider)
+            .with_optional_message_id(message_id)
+            .with_optional_model(model)
+            .with_optional_finish_reason(finish_reason),
+    )
 }
 
 fn choice_is_empty(choice: &crate::OneOrMany<completion::AssistantContent>) -> bool {
@@ -596,26 +721,30 @@ fn usage_from_raw_response(response: &CompletionResponse) -> completion::Usage {
     response
         .usage
         .as_ref()
-        .map(GetTokenUsage::token_usage)
+        .map(completion::Usage::from)
         .unwrap_or_default()
 }
 
-pub(crate) fn stream_from_event_source<HttpClient, RequestBody>(
+/// Open a Responses SSE stream whose terminal record stays provider-native.
+///
+/// Pass the result through [`normalize_responses_stream`] to obtain the
+/// normalized stream that [`completion::CompletionModel::stream`] returns.
+pub(crate) fn raw_stream_from_event_source<HttpClient, RequestBody>(
     event_source: GenericEventSource<HttpClient, RequestBody>,
     span: tracing::Span,
-) -> streaming::StreamingCompletionResponse<StreamingCompletionResponse>
+) -> streaming::RawStreamingResult<StreamingCompletionResponse>
 where
     HttpClient: HttpClientExt + Clone + 'static,
     RequestBody: Into<bytes::Bytes> + Clone + WasmCompatSend + 'static,
 {
-    stream_from_event_source_with_options(event_source, span, ResponsesStreamOptions::strict())
+    raw_stream_from_event_source_with_options(event_source, span, ResponsesStreamOptions::strict())
 }
 
-pub(crate) fn stream_from_event_source_with_options<HttpClient, RequestBody>(
+pub(crate) fn raw_stream_from_event_source_with_options<HttpClient, RequestBody>(
     mut event_source: GenericEventSource<HttpClient, RequestBody>,
     span: tracing::Span,
     options: ResponsesStreamOptions,
-) -> streaming::StreamingCompletionResponse<StreamingCompletionResponse>
+) -> streaming::RawStreamingResult<StreamingCompletionResponse>
 where
     HttpClient: HttpClientExt + Clone + 'static,
     RequestBody: Into<bytes::Bytes> + Clone + WasmCompatSend + 'static,
@@ -716,7 +845,7 @@ where
     }
     .instrument(span);
 
-    streaming::StreamingCompletionResponse::stream(Box::pin(stream))
+    Box::pin(stream)
 }
 
 /// An item message chunk from OpenAI's Responses API.
@@ -853,14 +982,21 @@ impl<Ext, H> GenericResponsesCompletionModel<Ext, H>
 where
     crate::client::Client<Ext, H>:
         HttpClientExt + Clone + std::fmt::Debug + WasmCompatSend + 'static,
-    Ext: crate::client::Provider + super::ResponsesProviderExt + Clone + 'static,
+    Ext: crate::client::Provider + ResponsesProviderExt + Clone + 'static,
     H: Clone + Default + std::fmt::Debug + WasmCompatSend + 'static,
 {
-    pub(crate) async fn stream(
+    /// Open a stream whose terminal record stays provider-native.
+    ///
+    /// This is the escape hatch for Responses-API terminal fields rig does not
+    /// normalize. It shares the request builder, transport, telemetry, and
+    /// error handling with
+    /// [`CompletionModel::stream`](completion::CompletionModel::stream), which
+    /// calls it and normalizes the terminal record — one network request either
+    /// way.
+    pub async fn raw_stream(
         &self,
         completion_request: crate::completion::CompletionRequest,
-    ) -> Result<streaming::StreamingCompletionResponse<StreamingCompletionResponse>, CompletionError>
-    {
+    ) -> Result<streaming::RawStreamingResult<StreamingCompletionResponse>, CompletionError> {
         let system_instructions = completion_request.preamble.clone();
         let record_telemetry_content = completion_request.record_telemetry_content;
         let mut request = self.create_completion_request(completion_request)?;
@@ -883,7 +1019,7 @@ where
             .map_err(|e| CompletionError::HttpError(e.into()))?;
 
         let span = CompletionSpanBuilder::new(
-            "openai",
+            Ext::PROVIDER_NAME,
             &request.model,
             CompletionOperation::ChatStreaming,
         )
@@ -892,7 +1028,16 @@ where
         let client = self.client.clone();
         let event_source = GenericEventSource::new(client, req);
 
-        Ok(stream_from_event_source(event_source, span))
+        Ok(raw_stream_from_event_source(event_source, span))
+    }
+
+    pub(crate) async fn stream(
+        &self,
+        completion_request: crate::completion::CompletionRequest,
+    ) -> Result<streaming::StreamingCompletionResponse, CompletionError> {
+        let raw = self.raw_stream(completion_request).await?;
+
+        Ok(normalize_responses_stream(Ext::PROVIDER_NAME, raw))
     }
 }
 
@@ -957,6 +1102,7 @@ mod tests {
             .expect_err("stream should surface a provider error")
     }
 
+    /// The provider-native terminal record, as `raw_stream` exposes it.
     async fn final_response_from_event(
         event: serde_json::Value,
     ) -> super::StreamingCompletionResponse {
@@ -969,12 +1115,40 @@ mod tests {
             .expect("client should build");
         let model = client.completion_model("gpt-5.4");
         let request = model.completion_request("hello").build();
+        let mut stream = model
+            .raw_stream(request)
+            .await
+            .expect("stream should start");
+
+        while let Some(item) = stream.next().await {
+            if let RawStreamingChoice::FinalResponse(response) =
+                item.expect("completed stream should not error")
+            {
+                return response;
+            }
+        }
+
+        panic!("stream should yield a final response");
+    }
+
+    /// The normalized terminal record, as `stream` exposes it.
+    async fn stream_final_from_event(event: serde_json::Value) -> crate::streaming::StreamFinal {
+        let client = openai::Client::builder()
+            .http_client(MockStreamingClient {
+                sse_bytes: sse_bytes_from_json_events(&[event]),
+            })
+            .api_key("test-key")
+            .build()
+            .expect("client should build");
+        let model = client.completion_model("gpt-5.4");
+        let request = model.completion_request("hello").build();
         let mut stream = model.stream(request).await.expect("stream should start");
 
         while let Some(item) = stream.next().await {
-            match item.expect("completed stream should not error") {
-                StreamedAssistantContent::Final(response) => return response,
-                _ => continue,
+            if let StreamedAssistantContent::Final(response) =
+                item.expect("completed stream should not error")
+            {
+                return response;
             }
         }
 
@@ -1479,7 +1653,10 @@ mod tests {
             .expect("request should build");
         let event_source = GenericEventSource::new(client, req);
         let span = tracing::Span::none();
-        let mut stream = super::stream_from_event_source(event_source, span);
+        let mut stream = super::normalize_responses_stream(
+            "openai",
+            super::raw_stream_from_event_source(event_source, span),
+        );
 
         let err = stream
             .next()
@@ -1534,7 +1711,10 @@ mod tests {
             .expect("request should build");
         let event_source = GenericEventSource::new(client, req);
         let span = tracing::Span::none();
-        let mut stream = super::stream_from_event_source(event_source, span);
+        let mut stream = super::normalize_responses_stream(
+            "openai",
+            super::raw_stream_from_event_source(event_source, span),
+        );
 
         let err = stream
             .next()
@@ -1598,6 +1778,121 @@ mod tests {
         let response = final_response_from_event(event).await;
         assert_eq!(response.reasoning_context.as_deref(), Some("all_turns"));
         assert_eq!(response.reasoning_metadata.as_ref(), metadata.as_object());
+    }
+
+    #[tokio::test]
+    async fn terminal_record_normalizes_into_the_stream_final() {
+        let mut response = sample_response(ResponseStatus::Completed);
+        response.usage = Some(ResponsesUsage {
+            input_tokens: 10,
+            input_tokens_details: None,
+            output_tokens: 5,
+            output_tokens_details: None,
+            total_tokens: 15,
+        });
+
+        let mut event = json!({
+            "type": "response.completed",
+            "sequence_number": 1,
+            "response": response,
+        });
+        event["response"]["output"] = json!([{
+            "type": "message",
+            "id": "msg_stream_1",
+            "status": "completed",
+            "role": "assistant",
+            "content": [{ "type": "output_text", "annotations": [], "text": "hi" }]
+        }]);
+
+        let final_response = stream_final_from_event(event).await;
+
+        assert_eq!(final_response.provider, "openai");
+        assert_eq!(final_response.model.as_deref(), Some("gpt-5.4"));
+        // The assistant message ID (`msg_...`), never the response ID
+        // (`resp_123`) that the same event carries.
+        assert_eq!(final_response.message_id.as_deref(), Some("msg_stream_1"));
+        assert_eq!(
+            final_response.finish_reason,
+            Some(crate::completion::FinishReason::Stop)
+        );
+        assert_eq!(final_response.usage.input_tokens, 10);
+        assert_eq!(final_response.usage.output_tokens, 5);
+        assert_eq!(final_response.usage.total_tokens, 15);
+    }
+
+    #[tokio::test]
+    async fn terminal_record_reports_tool_calls_when_the_stream_called_a_tool() {
+        let tool_call_done = json!({
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "sequence_number": 1,
+            "item": {
+                "type": "function_call",
+                "id": "fc_123",
+                "arguments": "{}",
+                "call_id": "call_123",
+                "name": "example_tool",
+                "status": "completed"
+            }
+        });
+        let completed = json!({
+            "type": "response.completed",
+            "sequence_number": 2,
+            "response": sample_response(ResponseStatus::Completed),
+        });
+
+        let client = openai::Client::builder()
+            .http_client(MockStreamingClient {
+                sse_bytes: sse_bytes_from_json_events(&[tool_call_done, completed]),
+            })
+            .api_key("test-key")
+            .build()
+            .expect("client should build");
+        let model = client.completion_model("gpt-5.4");
+        let request = model.completion_request("hello").build();
+        let mut stream = model.stream(request).await.expect("stream should start");
+
+        let mut final_response = None;
+        while let Some(item) = stream.next().await {
+            if let StreamedAssistantContent::Final(response) =
+                item.expect("completed stream should not error")
+            {
+                final_response = Some(response);
+            }
+        }
+
+        // `completed` is reconciled up to `ToolCalls` by `normalize_stream`,
+        // using the call the stream actually emitted.
+        assert_eq!(
+            final_response
+                .expect("stream should yield a final response")
+                .finish_reason,
+            Some(crate::completion::FinishReason::ToolCalls)
+        );
+    }
+
+    #[test]
+    fn terminal_record_preserves_an_unknown_incomplete_reason() {
+        let response = super::StreamingCompletionResponse {
+            status: Some(ResponseStatus::Incomplete),
+            incomplete_details: Some(IncompleteDetailsReason {
+                reason: "MAX_TOOL_CALLS".to_string(),
+            }),
+            model: Some("gpt-5.4".to_string()),
+            message_id: Some("msg_1".to_string()),
+            ..super::StreamingCompletionResponse::new(ResponsesUsage::new())
+        };
+
+        let final_response = crate::streaming::StreamFinal::from(("openai", response));
+
+        assert_eq!(
+            final_response.finish_reason,
+            Some(crate::completion::FinishReason::Other(
+                "MAX_TOOL_CALLS".to_string()
+            ))
+        );
+        assert_eq!(final_response.message_id.as_deref(), Some("msg_1"));
+        assert_eq!(final_response.model.as_deref(), Some("gpt-5.4"));
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/openai/responses_api/websocket.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/websocket.rs
@@ -431,14 +431,31 @@ where
         Ok(response.id)
     }
 
-    /// Sends a completion turn and collects the final OpenAI response.
+    /// Sends a completion turn and collects the final OpenAI response,
+    /// normalized.
+    ///
+    /// Use [`ResponsesWebSocketSession::raw_completion`] when the provider's own
+    /// wire response is needed.
     pub async fn completion(
         &mut self,
         completion_request: crate::completion::CompletionRequest,
-    ) -> Result<completion::CompletionResponse<CompletionResponse>, CompletionError> {
+    ) -> Result<completion::CompletionResponse, CompletionError> {
+        let provider = self.model.provider_name();
+        let response = self.raw_completion(completion_request).await?;
+        (provider, response).try_into()
+    }
+
+    /// Sends a completion turn and returns the provider's own wire response.
+    ///
+    /// Shares the send/receive path with
+    /// [`ResponsesWebSocketSession::completion`], which calls it and then
+    /// applies the provider-local mapping — one websocket turn either way.
+    pub async fn raw_completion(
+        &mut self,
+        completion_request: crate::completion::CompletionRequest,
+    ) -> Result<CompletionResponse, CompletionError> {
         self.send(completion_request).await?;
-        let response = self.wait_for_completed_response().await?;
-        response.try_into()
+        self.wait_for_completed_response().await
     }
 
     /// Closes the websocket connection.

--- a/crates/rig-core/src/providers/openai/responses_api/websocket.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/websocket.rs
@@ -4,6 +4,7 @@
 //! sequential session. Each connection supports a single in-flight response at a
 //! time, which matches OpenAI's current protocol constraints.
 
+use crate::completion::NormalizeCompletionResponse;
 use crate::completion::{self, CompletionError};
 use crate::http_client::HttpClientExt;
 use crate::providers::openai::responses_api::streaming::{
@@ -442,7 +443,7 @@ where
     ) -> Result<completion::CompletionResponse, CompletionError> {
         let provider = self.model.provider_name();
         let response = self.raw_completion(completion_request).await?;
-        (provider, response).try_into()
+        response.normalize(provider)
     }
 
     /// Sends a completion turn and returns the provider's own wire response.

--- a/crates/rig-core/src/providers/openrouter/client.rs
+++ b/crates/rig-core/src/providers/openrouter/client.rs
@@ -3,7 +3,6 @@ use crate::{
         self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
         ProviderClient,
     },
-    completion::GetTokenUsage,
     http_client,
 };
 use http::HeaderValue;
@@ -120,22 +119,35 @@ impl std::fmt::Display for Usage {
     }
 }
 
-impl GetTokenUsage for Usage {
-    fn token_usage(&self) -> crate::completion::Usage {
-        let (cached_input, cache_creation) = self
+impl From<&Usage> for crate::completion::Usage {
+    fn from(value: &Usage) -> crate::completion::Usage {
+        let (cached_input, cache_creation) = value
             .prompt_tokens_details
             .as_ref()
             .map(|d| (d.cached_tokens as u64, d.cache_write_tokens as u64))
             .unwrap_or((0, 0));
         crate::completion::Usage {
-            input_tokens: self.prompt_tokens as u64,
-            output_tokens: self.completion_tokens as u64,
-            total_tokens: self.total_tokens as u64,
+            input_tokens: value.prompt_tokens as u64,
+            // Reported completion tokens, falling back to saturating
+            // total - prompt for gateways that omit the field (it
+            // deserializes to 0).
+            output_tokens: if value.completion_tokens > 0 {
+                value.completion_tokens as u64
+            } else {
+                value.total_tokens.saturating_sub(value.prompt_tokens) as u64
+            },
+            total_tokens: value.total_tokens as u64,
             cached_input_tokens: cached_input,
             cache_creation_input_tokens: cache_creation,
             tool_use_prompt_tokens: 0,
             reasoning_tokens: 0,
         }
+    }
+}
+
+impl From<Usage> for crate::completion::Usage {
+    fn from(value: Usage) -> crate::completion::Usage {
+        crate::completion::Usage::from(&value)
     }
 }
 impl<ApiKey, H> client::ClientBuilder<OpenRouterExtBuilder, ApiKey, H> {

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -589,13 +589,49 @@ pub struct CompletionResponse {
 /// reason the gateway could not translate is still reported rather than lost.
 /// Either way an unrecognized value is preserved verbatim in
 /// [`FinishReason::Other`](completion::FinishReason::Other).
+/// Normalize OpenRouter's terminal reason for a choice.
+///
+/// OpenRouter reports two fields: `finish_reason`, normalized by OpenRouter to
+/// the OpenAI vocabulary, and `native_finish_reason`, which is whatever the
+/// upstream provider said. The normalized field is preferred; the native one is
+/// only a fallback, and it must not be read with the OpenAI vocabulary — routing
+/// Gemini's `STOP` or Anthropic's `end_turn` through
+/// [`map_openai_finish_reason`] would report a plain natural stop as
+/// [`completion::FinishReason::Other`].
 pub(crate) fn map_finish_reason(choice: &Choice) -> Option<completion::FinishReason> {
-    choice
+    if let Some(reason) = choice
         .finish_reason
         .as_deref()
-        .or(choice.native_finish_reason.as_deref())
         .filter(|reason| !reason.is_empty())
-        .map(map_openai_finish_reason)
+    {
+        return Some(map_openai_finish_reason(reason));
+    }
+
+    choice
+        .native_finish_reason
+        .as_deref()
+        .filter(|reason| !reason.is_empty())
+        .map(map_native_finish_reason)
+}
+
+/// Map an upstream provider's own terminal reason, as forwarded by OpenRouter.
+///
+/// This covers the vocabularies OpenRouter routes to, matched
+/// case-insensitively because they disagree on casing (Gemini screams,
+/// Anthropic does not). Anything unrecognized is still carried verbatim in the
+/// spelling the upstream provider used.
+pub(crate) fn map_native_finish_reason(reason: &str) -> completion::FinishReason {
+    match reason.to_ascii_lowercase().as_str() {
+        // OpenAI-compatible upstreams, plus Anthropic's `end_turn`/`stop_sequence`
+        // and Gemini's `STOP`.
+        "stop" | "end_turn" | "stop_sequence" | "complete" => completion::FinishReason::Stop,
+        "length" | "max_tokens" | "model_length" => completion::FinishReason::Length,
+        "tool_calls" | "function_call" | "tool_use" => completion::FinishReason::ToolCalls,
+        "content_filter" | "safety" | "blocklist" | "prohibited_content" | "spii" => {
+            completion::FinishReason::ContentFilter
+        }
+        _ => completion::FinishReason::Other(reason.to_owned()),
+    }
 }
 
 /// Normalize an OpenRouter chat completion response.
@@ -604,10 +640,9 @@ pub(crate) fn map_finish_reason(choice: &Choice) -> Option<completion::FinishRea
 /// shared OpenAI one; taking it as part of the conversion keeps the shape
 /// consistent with the OpenAI-compatible path even though only OpenRouter
 /// produces this envelope.
-impl TryFrom<(&str, CompletionResponse)> for completion::CompletionResponse {
-    type Error = CompletionError;
-
-    fn try_from((provider, response): (&str, CompletionResponse)) -> Result<Self, Self::Error> {
+impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
+    fn normalize(self, provider: &str) -> Result<completion::CompletionResponse, CompletionError> {
+        let response = self;
         let choice = response.choices.first().ok_or_else(|| {
             CompletionError::ResponseError("Response contained no choices".to_owned())
         })?;
@@ -1517,7 +1552,8 @@ pub type CompletionModel<H = reqwest::Client> =
     openai::completion::GenericCompletionModel<OpenRouterExt, H>;
 
 /// Final streaming response, shared with the OpenAI Chat Completions path.
-pub type StreamingCompletionResponse = openai::completion::streaming::StreamingCompletionResponse;
+pub type StreamingCompletionResponse =
+    openai::completion::streaming::StreamingCompletionResponse<Usage>;
 
 impl<H> openai::completion::GenericCompletionModel<OpenRouterExt, H> {
     /// Enable explicit prompt caching for supported OpenRouter models.
@@ -1535,6 +1571,7 @@ impl<H> openai::completion::GenericCompletionModel<OpenRouterExt, H> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::completion::NormalizeCompletionResponse;
     use crate::message::{AudioMediaType, ImageDetail, VideoMediaType};
     use serde_json::json;
 
@@ -1853,8 +1890,7 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted =
-            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
+        let converted = response.normalize(PROVIDER_NAME).unwrap();
         assert_eq!(converted.usage.output_tokens, 10);
     }
 
@@ -1874,8 +1910,7 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted =
-            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
+        let converted = response.normalize(PROVIDER_NAME).unwrap();
         assert_eq!(converted.usage.output_tokens, 10);
     }
 
@@ -1906,8 +1941,7 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted =
-            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
+        let converted = response.normalize(PROVIDER_NAME).unwrap();
 
         assert_eq!(converted.usage.input_tokens, 500);
         assert_eq!(converted.usage.output_tokens, 10);
@@ -1938,8 +1972,7 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted =
-            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
+        let converted = response.normalize(PROVIDER_NAME).unwrap();
 
         assert_eq!(converted.usage.cached_input_tokens, 0);
         assert_eq!(converted.usage.cache_creation_input_tokens, 0);
@@ -1973,8 +2006,7 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted =
-            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
+        let converted = response.normalize(PROVIDER_NAME).unwrap();
 
         // The normalized response carries the model OpenRouter reported, which
         // is routinely not the one that was requested.
@@ -2065,8 +2097,7 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted =
-            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
+        let converted = response.normalize(PROVIDER_NAME).unwrap();
 
         assert_eq!(
             converted.finish_reason,
@@ -2952,8 +2983,7 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted =
-            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
+        let converted = response.normalize(PROVIDER_NAME).unwrap();
         let items: Vec<completion::AssistantContent> = converted.choice.into_iter().collect();
 
         assert!(items.iter().any(|item| matches!(
@@ -3134,8 +3164,7 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted =
-            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
+        let converted = response.normalize(PROVIDER_NAME).unwrap();
         let items: Vec<completion::AssistantContent> = converted.choice.into_iter().collect();
         let reasoning_blocks: Vec<_> = items
             .into_iter()
@@ -3462,8 +3491,7 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted =
-            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
+        let converted = response.normalize(PROVIDER_NAME).unwrap();
         let items: Vec<completion::AssistantContent> = converted.choice.into_iter().collect();
         let reasoning_blocks: Vec<_> = items
             .into_iter()
@@ -3823,8 +3851,7 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted =
-            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
+        let converted = response.normalize(PROVIDER_NAME).unwrap();
         let items: Vec<completion::AssistantContent> = converted.choice.into_iter().collect();
         assert_eq!(items.len(), 2);
 
@@ -3872,8 +3899,7 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted =
-            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
+        let converted = response.normalize(PROVIDER_NAME).unwrap();
         let items: Vec<completion::AssistantContent> = converted.choice.into_iter().collect();
         assert_eq!(items.len(), 2);
 

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -5,6 +5,7 @@ use crate::{
     OneOrMany,
     completion::{self, CompletionError, CompletionRequest},
     json_utils,
+    providers::internal::openai_chat_completions_compatible::map_openai_finish_reason,
     providers::openai,
 };
 use serde::{Deserialize, Serialize};
@@ -22,6 +23,10 @@ pub const CLAUDE_3_7_SONNET: &str = "anthropic/claude-3.7-sonnet";
 pub const PERPLEXITY_SONAR_PRO: &str = "perplexity/sonar-pro";
 /// The `google/gemini-2.0-flash-001` model. Find more models at <https://openrouter.ai/models>.
 pub const GEMINI_FLASH_2_0: &str = "google/gemini-2.0-flash-001";
+
+/// Stable descriptor name recorded on telemetry spans and on every normalized
+/// response produced by this provider.
+pub(crate) const PROVIDER_NAME: &str = "openrouter";
 
 // ================================================================
 // Provider Selection and Prioritization
@@ -575,13 +580,38 @@ pub struct CompletionResponse {
     pub usage: Option<Usage>,
 }
 
-impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionResponse> {
+/// Map an OpenRouter `finish_reason` onto the normalized vocabulary.
+///
+/// OpenRouter normalizes upstream providers onto the OpenAI Chat Completions
+/// vocabulary in `finish_reason` and keeps the upstream provider's own spelling
+/// in `native_finish_reason` (e.g. Gemini's `"STOP"`). The normalized field
+/// wins; the native one is only consulted when OpenRouter omitted it, so a
+/// reason the gateway could not translate is still reported rather than lost.
+/// Either way an unrecognized value is preserved verbatim in
+/// [`FinishReason::Other`](completion::FinishReason::Other).
+pub(crate) fn map_finish_reason(choice: &Choice) -> Option<completion::FinishReason> {
+    choice
+        .finish_reason
+        .as_deref()
+        .or(choice.native_finish_reason.as_deref())
+        .filter(|reason| !reason.is_empty())
+        .map(map_openai_finish_reason)
+}
+
+/// Normalize an OpenRouter chat completion response.
+///
+/// The provider descriptor name is an *input* because the message model is the
+/// shared OpenAI one; taking it as part of the conversion keeps the shape
+/// consistent with the OpenAI-compatible path even though only OpenRouter
+/// produces this envelope.
+impl TryFrom<(&str, CompletionResponse)> for completion::CompletionResponse {
     type Error = CompletionError;
 
-    fn try_from(response: CompletionResponse) -> Result<Self, Self::Error> {
+    fn try_from((provider, response): (&str, CompletionResponse)) -> Result<Self, Self::Error> {
         let choice = response.choices.first().ok_or_else(|| {
             CompletionError::ResponseError("Response contained no choices".to_owned())
         })?;
+        let finish_reason = map_finish_reason(choice);
 
         let content = match &choice.message {
             Message::Assistant {
@@ -703,37 +733,16 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         let usage = response
             .usage
             .as_ref()
-            .map(|usage| {
-                let (cached_input, cache_creation) = usage
-                    .prompt_tokens_details
-                    .as_ref()
-                    .map(|d| (d.cached_tokens as u64, d.cache_write_tokens as u64))
-                    .unwrap_or((0, 0));
-                completion::Usage {
-                    input_tokens: usage.prompt_tokens as u64,
-                    // Reported completion tokens (like the streaming path),
-                    // falling back to saturating total - prompt for gateways
-                    // that omit the field (it deserializes to 0).
-                    output_tokens: if usage.completion_tokens > 0 {
-                        usage.completion_tokens as u64
-                    } else {
-                        usage.total_tokens.saturating_sub(usage.prompt_tokens) as u64
-                    },
-                    total_tokens: usage.total_tokens as u64,
-                    cached_input_tokens: cached_input,
-                    cache_creation_input_tokens: cache_creation,
-                    tool_use_prompt_tokens: 0,
-                    reasoning_tokens: 0,
-                }
-            })
+            .map(completion::Usage::from)
             .unwrap_or_default();
 
-        Ok(completion::CompletionResponse {
-            choice,
-            usage,
-            raw_response: response,
-            message_id: None,
-        })
+        Ok(
+            // OpenRouter's `id` identifies the generation, not an assistant
+            // message, so it is deliberately not carried as a message ID.
+            completion::CompletionResponse::new(choice, usage, provider)
+                .with_model(response.model)
+                .with_optional_finish_reason(finish_reason),
+        )
     }
 }
 
@@ -1442,7 +1451,7 @@ impl TryFrom<(&str, CompletionRequest)> for OpenrouterCompletionRequest {
 }
 
 impl openai::completion::OpenAICompatibleProvider for OpenRouterExt {
-    const PROVIDER_NAME: &'static str = "openrouter";
+    const PROVIDER_NAME: &'static str = self::PROVIDER_NAME;
 
     type StreamingUsage = Usage;
     type Response = CompletionResponse;
@@ -1497,12 +1506,18 @@ impl openai::completion::OpenAICompatibleProvider for OpenRouterExt {
 }
 
 /// OpenRouter completion model, driven by the shared OpenAI Chat Completions path.
+///
+/// The provider-native escape hatches come with it:
+/// [`raw_completion`](openai::completion::GenericCompletionModel::raw_completion)
+/// returns OpenRouter's own [`CompletionResponse`] and
+/// [`raw_stream`](openai::completion::GenericCompletionModel::raw_stream) a
+/// stream whose terminal record stays provider-native — both over the same
+/// single request path as the normalized methods.
 pub type CompletionModel<H = reqwest::Client> =
     openai::completion::GenericCompletionModel<OpenRouterExt, H>;
 
 /// Final streaming response, shared with the OpenAI Chat Completions path.
-pub type StreamingCompletionResponse =
-    openai::completion::streaming::StreamingCompletionResponse<Usage>;
+pub type StreamingCompletionResponse = openai::completion::streaming::StreamingCompletionResponse;
 
 impl<H> openai::completion::GenericCompletionModel<OpenRouterExt, H> {
     /// Enable explicit prompt caching for supported OpenRouter models.
@@ -1522,6 +1537,20 @@ mod tests {
     use super::*;
     use crate::message::{AudioMediaType, ImageDetail, VideoMediaType};
     use serde_json::json;
+
+    #[test]
+    fn openrouter_client_constructs_a_completion_model() {
+        // Also a compile guard: it instantiates the shared chat-completions
+        // model over `OpenRouterExt`, which is what proves this provider's
+        // response conversion satisfies the normalization bound.
+        use crate::client::CompletionClient;
+
+        let client =
+            crate::providers::openrouter::Client::new("dummy-key").expect("Client::new() failed");
+        let model = client.completion_model(GEMINI_FLASH_2_0);
+
+        assert_eq!(model.model, GEMINI_FLASH_2_0);
+    }
 
     #[test]
     fn mixed_user_content_preserves_order_around_tool_results() {
@@ -1824,7 +1853,8 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted = completion::CompletionResponse::try_from(response).unwrap();
+        let converted =
+            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
         assert_eq!(converted.usage.output_tokens, 10);
     }
 
@@ -1844,7 +1874,8 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted = completion::CompletionResponse::try_from(response).unwrap();
+        let converted =
+            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
         assert_eq!(converted.usage.output_tokens, 10);
     }
 
@@ -1875,8 +1906,8 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted: completion::CompletionResponse<CompletionResponse> =
-            response.try_into().unwrap();
+        let converted =
+            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
 
         assert_eq!(converted.usage.input_tokens, 500);
         assert_eq!(converted.usage.output_tokens, 10);
@@ -1907,8 +1938,8 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted: completion::CompletionResponse<CompletionResponse> =
-            response.try_into().unwrap();
+        let converted =
+            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
 
         assert_eq!(converted.usage.cached_input_tokens, 0);
         assert_eq!(converted.usage.cache_creation_input_tokens, 0);
@@ -1942,17 +1973,105 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted: completion::CompletionResponse<CompletionResponse> =
-            response.try_into().unwrap();
+        let converted =
+            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
 
+        // The normalized response carries the model OpenRouter reported, which
+        // is routinely not the one that was requested.
         assert_eq!(
-            converted.raw_response.model,
-            "google/gemini-2.5-pro-exp-03-25:free"
+            converted.model.as_deref(),
+            Some("google/gemini-2.5-pro-exp-03-25:free")
         );
+        assert_eq!(converted.provider, "openrouter");
         assert!(matches!(
             converted.choice.first(),
             completion::AssistantContent::Text(text) if text.text == "CONTENT"
         ));
+    }
+
+    #[test]
+    fn openrouter_finish_reasons_map_and_preserve_unknown_values() {
+        use crate::completion::FinishReason;
+
+        let choice = |finish_reason: Option<&str>, native: Option<&str>| Choice {
+            index: 0,
+            native_finish_reason: native.map(str::to_string),
+            message: Message::Assistant {
+                content: vec![],
+                reasoning: None,
+                refusal: None,
+                audio: None,
+                name: None,
+                tool_calls: vec![],
+                reasoning_details: vec![],
+                images: vec![],
+            },
+            finish_reason: finish_reason.map(str::to_string),
+        };
+
+        assert_eq!(
+            map_finish_reason(&choice(Some("stop"), Some("STOP"))),
+            Some(FinishReason::Stop)
+        );
+        assert_eq!(
+            map_finish_reason(&choice(Some("length"), None)),
+            Some(FinishReason::Length)
+        );
+        assert_eq!(
+            map_finish_reason(&choice(Some("tool_calls"), None)),
+            Some(FinishReason::ToolCalls)
+        );
+        assert_eq!(
+            map_finish_reason(&choice(Some("content_filter"), None)),
+            Some(FinishReason::ContentFilter)
+        );
+        // A reason OpenRouter could not translate survives verbatim rather
+        // than reading as a natural stop.
+        assert_eq!(
+            map_finish_reason(&choice(Some("error"), None)),
+            Some(FinishReason::Other("error".to_string()))
+        );
+        // No normalized reason: the upstream provider's own spelling is
+        // reported, in its own casing.
+        assert_eq!(
+            map_finish_reason(&choice(None, Some("MALFORMED_FUNCTION_CALL"))),
+            Some(FinishReason::Other("MALFORMED_FUNCTION_CALL".to_string()))
+        );
+        assert_eq!(map_finish_reason(&choice(None, None)), None);
+    }
+
+    #[test]
+    fn openrouter_stop_with_tool_call_reports_tool_calls() {
+        // OpenRouter gateways routinely report a plain `stop` on a turn that
+        // carried tool calls; the normalized response upgrades it.
+        let json = json!({
+            "id": "gen-tool",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "anthropic/claude-3.5-sonnet",
+            "choices": [{
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"}
+                    }]
+                }
+            }]
+        });
+
+        let response: CompletionResponse = serde_json::from_value(json).unwrap();
+        let converted =
+            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
+
+        assert_eq!(
+            converted.finish_reason,
+            Some(crate::completion::FinishReason::ToolCalls)
+        );
     }
 
     #[test]
@@ -2833,8 +2952,8 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted: completion::CompletionResponse<CompletionResponse> =
-            response.try_into().unwrap();
+        let converted =
+            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
         let items: Vec<completion::AssistantContent> = converted.choice.into_iter().collect();
 
         assert!(items.iter().any(|item| matches!(
@@ -3015,8 +3134,8 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted: completion::CompletionResponse<CompletionResponse> =
-            response.try_into().unwrap();
+        let converted =
+            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
         let items: Vec<completion::AssistantContent> = converted.choice.into_iter().collect();
         let reasoning_blocks: Vec<_> = items
             .into_iter()
@@ -3343,8 +3462,8 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted: completion::CompletionResponse<CompletionResponse> =
-            response.try_into().unwrap();
+        let converted =
+            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
         let items: Vec<completion::AssistantContent> = converted.choice.into_iter().collect();
         let reasoning_blocks: Vec<_> = items
             .into_iter()
@@ -3704,8 +3823,8 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted: completion::CompletionResponse<CompletionResponse> =
-            response.try_into().unwrap();
+        let converted =
+            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
         let items: Vec<completion::AssistantContent> = converted.choice.into_iter().collect();
         assert_eq!(items.len(), 2);
 
@@ -3753,8 +3872,8 @@ mod tests {
         });
 
         let response: CompletionResponse = serde_json::from_value(json).unwrap();
-        let converted: completion::CompletionResponse<CompletionResponse> =
-            response.try_into().unwrap();
+        let converted =
+            completion::CompletionResponse::try_from((PROVIDER_NAME, response)).unwrap();
         let items: Vec<completion::AssistantContent> = converted.choice.into_iter().collect();
         assert_eq!(items.len(), 2);
 

--- a/crates/rig-core/src/providers/xai/completion.rs
+++ b/crates/rig-core/src/providers/xai/completion.rs
@@ -11,12 +11,14 @@ use tracing::{Instrument, Level, enabled};
 use super::api::{ApiResponse, Message, ToolDefinition};
 use super::client::Client;
 use crate::OneOrMany;
-use crate::completion::{self, CompletionError, CompletionRequest, GetTokenUsage};
+use crate::completion::{self, CompletionError, CompletionRequest};
 use crate::http_client::HttpClientExt;
 use crate::providers::openai::responses_api::ToolChoice;
-use crate::providers::openai::responses_api::streaming::StreamingCompletionResponse;
-use crate::providers::openai::responses_api::{Output, ResponsesUsage};
-use crate::streaming::StreamingCompletionResponse as BaseStreamingCompletionResponse;
+use crate::providers::openai::responses_api::{IncompleteDetailsReason, Output, ResponsesUsage};
+
+/// Stable descriptor name recorded on telemetry spans and on every normalized
+/// response produced by this provider.
+pub(crate) const PROVIDER_NAME: &str = "xai";
 
 /// xAI completion models as of 2025-06-04
 pub const GROK_2_1212: &str = "grok-2-1212";
@@ -128,10 +130,60 @@ pub struct CompletionResponse {
     pub object: String,
     #[serde(default)]
     pub status: Option<String>,
+    /// Why an `incomplete` response stopped early. Only the Responses API's
+    /// `incomplete` status distinguishes a token-limit truncation from a
+    /// filtered one, and it does so here rather than on `status`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub incomplete_details: Option<IncompleteDetailsReason>,
     pub usage: Option<ResponsesUsage>,
 }
 
-impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionResponse> {
+/// Map an xAI Responses API terminal state onto the normalized vocabulary.
+///
+/// Mirrors
+/// [`responses_api::map_finish_reason`](crate::providers::openai::responses_api)
+/// decision for decision — the two APIs share this vocabulary — but reads the
+/// status as a string, because xAI's `status` is kept untyped here so a status
+/// xAI adds later still deserializes (and still surfaces) instead of failing
+/// the whole response.
+///
+/// The API splits "why did generation end" across two fields: `status` says
+/// whether the turn ran to completion, and `incomplete_details.reason` says why
+/// it did not. Anything unrecognized is carried verbatim in
+/// [`FinishReason::Other`](completion::FinishReason::Other) so it never reads
+/// as a natural stop; in-flight statuses report no reason at all.
+///
+/// Tool-call termination has no distinct status: xAI reports `completed` on a
+/// turn whose output carries `function_call` items. That upgrade to
+/// [`FinishReason::ToolCalls`](completion::FinishReason::ToolCalls) is applied
+/// once, centrally, by
+/// [`completion::CompletionResponse::with_optional_finish_reason`].
+pub(crate) fn map_finish_reason(
+    status: &str,
+    incomplete_details: Option<&IncompleteDetailsReason>,
+) -> Option<completion::FinishReason> {
+    match status {
+        "completed" => Some(completion::FinishReason::Stop),
+        "incomplete" => Some(
+            match incomplete_details
+                .map(|details| details.reason.as_str())
+                .filter(|reason| !reason.is_empty())
+            {
+                Some("max_output_tokens") => completion::FinishReason::Length,
+                Some("content_filter") => completion::FinishReason::ContentFilter,
+                Some(other) => completion::FinishReason::Other(other.to_owned()),
+                // Incomplete without a stated reason: the status itself is all
+                // the provider told us.
+                None => completion::FinishReason::Other(status.to_owned()),
+            },
+        ),
+        // The turn has not terminated, so there is genuinely no reason yet.
+        "in_progress" | "queued" => None,
+        other => Some(completion::FinishReason::Other(other.to_owned())),
+    }
+}
+
+impl TryFrom<CompletionResponse> for completion::CompletionResponse {
     type Error = CompletionError;
 
     fn try_from(response: CompletionResponse) -> Result<Self, Self::Error> {
@@ -149,19 +201,24 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         let usage = response
             .usage
             .as_ref()
-            .map(GetTokenUsage::token_usage)
+            .map(crate::completion::Usage::from)
             .unwrap_or_default();
         let message_id = response.output.iter().find_map(|item| match item {
             Output::Message(message) => Some(message.id.clone()),
             _ => None,
         });
+        let finish_reason = response
+            .status
+            .as_deref()
+            .filter(|status| !status.is_empty())
+            .and_then(|status| map_finish_reason(status, response.incomplete_details.as_ref()));
 
-        Ok(completion::CompletionResponse {
-            choice,
-            usage,
-            raw_response: response,
-            message_id,
-        })
+        Ok(
+            completion::CompletionResponse::new(choice, usage, PROVIDER_NAME)
+                .with_optional_message_id(message_id)
+                .with_model(response.model)
+                .with_optional_finish_reason(finish_reason),
+        )
     }
 }
 
@@ -184,30 +241,30 @@ impl<T> CompletionModel<T> {
     }
 }
 
-impl<T> completion::CompletionModel for CompletionModel<T>
+impl<T> CompletionModel<T>
 where
     T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
 {
-    type Response = CompletionResponse;
-    type StreamingResponse = StreamingCompletionResponse;
-
-    type Client = Client<T>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
-
-    async fn completion(
+    /// Execute a completion and return xAI's own wire response.
+    ///
+    /// This is the escape hatch for provider-specific fields rig does not
+    /// normalize. It shares the request builder, transport, telemetry, and
+    /// error handling with
+    /// [`CompletionModel::completion`](completion::CompletionModel::completion),
+    /// which calls it and then applies the provider-local mapping — one
+    /// network request either way.
+    pub async fn raw_completion(
         &self,
         completion_request: completion::CompletionRequest,
-    ) -> Result<completion::CompletionResponse<CompletionResponse>, CompletionError> {
+    ) -> Result<CompletionResponse, CompletionError> {
         let system_instructions = completion_request.preamble.clone();
         let record_telemetry_content = completion_request.record_telemetry_content;
         let request =
             XAICompletionRequest::try_from((self.model.to_string().as_ref(), completion_request))?;
-        let span = CompletionSpanBuilder::new("xai", &request.model, CompletionOperation::Chat)
-            .system_instructions(system_instructions.as_deref(), record_telemetry_content)
-            .build();
+        let span =
+            CompletionSpanBuilder::new(PROVIDER_NAME, &request.model, CompletionOperation::Chat)
+                .system_instructions(system_instructions.as_deref(), record_telemetry_content)
+                .build();
 
         if enabled!(Level::TRACE) {
             tracing::trace!(target: "rig::completions",
@@ -235,7 +292,7 @@ where
                         span.record("gen_ai.response.id", response.id.as_str());
                         span.record("gen_ai.response.model", response.model.as_str());
                         if let Some(usage) = &response.usage {
-                            span.record_token_usage(usage);
+                            span.record_token_usage(&crate::completion::Usage::from(usage));
                         }
 
                         if enabled!(Level::TRACE) {
@@ -245,7 +302,7 @@ where
                             );
                         }
 
-                        response.try_into()
+                        Ok(response)
                     }
                     ApiResponse::Error(error) => {
                         tracing::warn!(message = %error.message(), "provider returned an error response");
@@ -265,12 +322,33 @@ where
         .instrument(span)
         .await
     }
+}
+
+impl<T> completion::CompletionModel for CompletionModel<T>
+where
+    T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+{
+    async fn completion(
+        &self,
+        completion_request: completion::CompletionRequest,
+    ) -> Result<completion::CompletionResponse, CompletionError> {
+        self.raw_completion(completion_request).await?.try_into()
+    }
 
     async fn stream(
         &self,
         request: CompletionRequest,
-    ) -> Result<BaseStreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
-        self.stream(request).await
+    ) -> Result<crate::streaming::StreamingCompletionResponse, CompletionError> {
+        CompletionModel::stream(self, request).await
+    }
+}
+
+impl<H> crate::client::ConstructCompletionModel<Client<H>> for CompletionModel<H>
+where
+    Client<H>: Clone,
+{
+    fn construct(client: &Client<H>, model: String) -> Self {
+        Self::new(client.clone(), model)
     }
 }
 
@@ -439,6 +517,117 @@ mod tests {
         assert_eq!(converted.usage.cached_input_tokens, 3);
         assert_eq!(converted.usage.output_tokens, 8);
         assert_eq!(converted.usage.reasoning_tokens, 5);
+        assert_eq!(converted.provider, "xai");
+        // The provider-reported model, not the one the handle was created with.
+        assert_eq!(converted.model.as_deref(), Some("grok-4.3"));
+        // The fixture reports no top-level status, so no reason is invented.
+        assert_eq!(converted.finish_reason, None);
+    }
+
+    #[test]
+    fn xai_finish_reasons_map_and_preserve_unknown_values() {
+        use crate::completion::FinishReason;
+        use crate::providers::openai::responses_api::IncompleteDetailsReason;
+
+        let incomplete = |reason: &str| IncompleteDetailsReason {
+            reason: reason.to_string(),
+        };
+
+        assert_eq!(
+            super::map_finish_reason("completed", None),
+            Some(FinishReason::Stop)
+        );
+        assert_eq!(
+            super::map_finish_reason("incomplete", Some(&incomplete("max_output_tokens"))),
+            Some(FinishReason::Length)
+        );
+        assert_eq!(
+            super::map_finish_reason("incomplete", Some(&incomplete("content_filter"))),
+            Some(FinishReason::ContentFilter)
+        );
+        // An unknown incomplete reason survives verbatim rather than being
+        // flattened into a natural stop.
+        assert_eq!(
+            super::map_finish_reason("incomplete", Some(&incomplete("moderation_hold"))),
+            Some(FinishReason::Other("moderation_hold".to_string()))
+        );
+        assert_eq!(
+            super::map_finish_reason("incomplete", None),
+            Some(FinishReason::Other("incomplete".to_string()))
+        );
+        assert_eq!(
+            super::map_finish_reason("failed", None),
+            Some(FinishReason::Other("failed".to_string()))
+        );
+        // A terminal status xAI has not documented is reported, not smoothed
+        // into a natural stop.
+        assert_eq!(
+            super::map_finish_reason("throttled", None),
+            Some(FinishReason::Other("throttled".to_string()))
+        );
+        // In-flight statuses genuinely have no terminal reason yet.
+        assert_eq!(super::map_finish_reason("in_progress", None), None);
+        assert_eq!(super::map_finish_reason("queued", None), None);
+    }
+
+    #[test]
+    fn xai_response_reports_length_for_truncated_output() {
+        let raw: super::CompletionResponse = serde_json::from_value(serde_json::json!({
+            "id": "resp_trunc",
+            "model": "grok-4-0709",
+            "status": "incomplete",
+            "incomplete_details": { "reason": "max_output_tokens" },
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg_trunc",
+                    "role": "assistant",
+                    "status": "incomplete",
+                    "content": [
+                        { "type": "output_text", "text": "partial", "annotations": [] }
+                    ]
+                }
+            ]
+        }))
+        .expect("fixture should deserialize");
+
+        let converted = crate::completion::CompletionResponse::try_from(raw)
+            .expect("xAI response should convert");
+
+        assert_eq!(
+            converted.finish_reason,
+            Some(crate::completion::FinishReason::Length)
+        );
+    }
+
+    #[test]
+    fn xai_completed_response_with_tool_call_reports_tool_calls() {
+        // xAI reports `completed` even when the turn ended to call a tool;
+        // the reconciliation on the normalized response upgrades it.
+        let raw: super::CompletionResponse = serde_json::from_value(serde_json::json!({
+            "id": "resp_tool",
+            "model": "grok-4-0709",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "call_1",
+                    "name": "example_tool",
+                    "arguments": "{}",
+                    "status": "completed"
+                }
+            ]
+        }))
+        .expect("fixture should deserialize");
+
+        let converted = crate::completion::CompletionResponse::try_from(raw)
+            .expect("xAI response should convert");
+
+        assert_eq!(
+            converted.finish_reason,
+            Some(crate::completion::FinishReason::ToolCalls)
+        );
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/xai/streaming.rs
+++ b/crates/rig-core/src/providers/xai/streaming.rs
@@ -12,20 +12,26 @@ use crate::http_client::HttpClientExt;
 use crate::http_client::sse::GenericEventSource;
 use crate::json_utils;
 use crate::providers::openai::responses_api::streaming::{
-    ResponsesStreamOptions, StreamingCompletionResponse, stream_from_event_source_with_options,
+    ResponsesStreamOptions, StreamingCompletionResponse, normalize_responses_stream,
+    raw_stream_from_event_source_with_options,
 };
-use crate::providers::xai::completion::{CompletionModel, XAICompletionRequest};
-use crate::streaming;
+use crate::providers::xai::completion::{CompletionModel, PROVIDER_NAME, XAICompletionRequest};
+use crate::streaming::{self, RawStreamingResult};
 
 impl<T> CompletionModel<T>
 where
     T: HttpClientExt + Clone + 'static,
 {
-    pub(crate) async fn stream(
+    /// Open a stream whose terminal record stays xAI-native.
+    ///
+    /// This is the escape hatch for provider-specific streaming fields rig
+    /// does not normalize. The normalized
+    /// [`stream`](crate::completion::CompletionModel::stream) path calls it and
+    /// maps the terminal record once, so both paths open exactly one stream.
+    pub async fn raw_stream(
         &self,
         completion_request: CompletionRequest,
-    ) -> Result<streaming::StreamingCompletionResponse<StreamingCompletionResponse>, CompletionError>
-    {
+    ) -> Result<RawStreamingResult<StreamingCompletionResponse>, CompletionError> {
         let preamble = completion_request.preamble.clone();
         let record_telemetry_content = completion_request.record_telemetry_content;
         let mut request =
@@ -52,29 +58,41 @@ where
             .body(body)
             .map_err(|e| CompletionError::HttpError(e.into()))?;
 
-        let span =
-            CompletionSpanBuilder::new("xai", &request.model, CompletionOperation::ChatStreaming)
-                .system_instructions(preamble.as_deref(), record_telemetry_content)
-                .build();
+        let span = CompletionSpanBuilder::new(
+            PROVIDER_NAME,
+            &request.model,
+            CompletionOperation::ChatStreaming,
+        )
+        .system_instructions(preamble.as_deref(), record_telemetry_content)
+        .build();
 
         send_xai_streaming_request(self.client.clone(), req)
             .instrument(span)
             .await
     }
+
+    pub(crate) async fn stream(
+        &self,
+        completion_request: CompletionRequest,
+    ) -> Result<streaming::StreamingCompletionResponse, CompletionError> {
+        let stream = self.raw_stream(completion_request).await?;
+
+        Ok(normalize_responses_stream(PROVIDER_NAME, stream))
+    }
 }
 
-/// Send a streaming request
+/// Send a streaming request, keeping the terminal record provider-native.
 pub(crate) async fn send_xai_streaming_request<T>(
     http_client: T,
     req: http::Request<Vec<u8>>,
-) -> Result<streaming::StreamingCompletionResponse<StreamingCompletionResponse>, CompletionError>
+) -> Result<RawStreamingResult<StreamingCompletionResponse>, CompletionError>
 where
     T: HttpClientExt + Clone + 'static,
 {
     let span = tracing::Span::current();
     let event_source = GenericEventSource::new(http_client, req);
 
-    Ok(stream_from_event_source_with_options(
+    Ok(raw_stream_from_event_source_with_options(
         event_source,
         span,
         ResponsesStreamOptions::strict_with_immediate_tool_calls(),
@@ -177,9 +195,10 @@ mod tests {
             .body(Vec::new())
             .expect("request should build");
 
-        let mut stream = send_xai_streaming_request(client, req)
+        let raw = send_xai_streaming_request(client, req)
             .await
             .expect("stream should start");
+        let mut stream = super::normalize_responses_stream(super::PROVIDER_NAME, raw);
 
         match stream
             .next()

--- a/crates/rig-core/src/streaming.rs
+++ b/crates/rig-core/src/streaming.rs
@@ -764,10 +764,6 @@ mod tests {
         StreamFinal::new(TEST_PROVIDER, usage)
     }
 
-    fn mock_final_usage(usage: Usage) -> StreamFinal {
-        StreamFinal::new(TEST_PROVIDER, usage)
-    }
-
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     fn to_stream_result(
         stream: impl futures::Stream<Item = Result<RawStreamingChoice, CompletionError>>

--- a/crates/rig-core/src/streaming.rs
+++ b/crates/rig-core/src/streaming.rs
@@ -6,10 +6,11 @@
 //! events without depending on a runtime.
 
 use crate::OneOrMany;
-use crate::completion::{CompletionError, CompletionResponse, GetTokenUsage, Usage};
+use crate::completion::{CompletionError, CompletionResponse, Usage};
 use crate::message::{
     AssistantContent, Reasoning, ReasoningContent, Text, ToolCall, ToolFunction, ToolResult,
 };
+use crate::wasm_compat::WasmCompatSend;
 use futures::stream::{AbortHandle, Abortable};
 use futures::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -65,12 +66,111 @@ pub enum ToolCallDeltaContent {
     Delta(String),
 }
 
-/// Enum representing a streaming chunk from the model
+/// Discriminant for [`StreamFinal`].
+///
+/// [`StreamedAssistantContent`] is `#[serde(untagged)]` and its
+/// [`StreamedAssistantContent::Unknown`] variant matches any JSON value, so the
+/// terminal record needs a field that identifies it structurally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StreamFinalKind {
+    /// The provider's terminal stream event.
+    Final,
+}
+
+/// The provider's terminal stream record, normalized.
+///
+/// This replaces the provider-typed final payload that streams used to carry:
+/// usage is a plain field rather than a trait method, and the finish reason is
+/// normalized exactly as on the unary [`CompletionResponse`].
+///
+/// Providers that want their own terminal type keep it behind
+/// [`RawStreamingResult`] and map it once with [`normalize_stream`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct StreamFinal {
+    /// Discriminating field; always [`StreamFinalKind::Final`].
+    pub kind: StreamFinalKind,
+    /// Token usage reported by the provider for this streamed completion.
+    /// Zero-valued usage is the documented sentinel for missing metrics.
+    pub usage: Usage,
+    /// Why the model stopped generating, when the provider reported it.
+    ///
+    /// [`normalize_stream`] applies
+    /// [`FinishReason::reconcile_with_output`](crate::completion::FinishReason::reconcile_with_output)
+    /// to this value using the tool calls actually seen on the stream, so a
+    /// provider mapper does not need to (and cannot — it has no view of the
+    /// preceding events).
+    pub finish_reason: Option<crate::completion::FinishReason>,
+    /// Provider-assigned message ID, when available.
+    pub message_id: Option<String>,
+    /// Stable descriptor name of the provider that produced this stream.
+    pub provider: String,
+    /// Provider-reported model identifier, when available.
+    pub model: Option<String>,
+}
+
+impl StreamFinal {
+    /// Create a terminal record for `provider` with `usage`; optional metadata
+    /// starts unset and is filled in with the `with_*` helpers.
+    pub fn new(provider: impl Into<String>, usage: Usage) -> Self {
+        Self {
+            kind: StreamFinalKind::Final,
+            usage,
+            finish_reason: None,
+            message_id: None,
+            provider: provider.into(),
+            model: None,
+        }
+    }
+
+    /// Attach the normalized finish reason.
+    pub fn with_finish_reason(self, finish_reason: crate::completion::FinishReason) -> Self {
+        self.with_optional_finish_reason(Some(finish_reason))
+    }
+
+    /// Attach the normalized finish reason when the provider reported one.
+    pub fn with_optional_finish_reason(
+        mut self,
+        finish_reason: Option<crate::completion::FinishReason>,
+    ) -> Self {
+        self.finish_reason = finish_reason;
+        self
+    }
+
+    /// Attach the provider-assigned message ID.
+    pub fn with_message_id(self, message_id: impl Into<String>) -> Self {
+        self.with_optional_message_id(Some(message_id.into()))
+    }
+
+    /// Attach the provider-assigned message ID when the provider reported one.
+    pub fn with_optional_message_id(mut self, message_id: Option<impl Into<String>>) -> Self {
+        self.message_id = message_id.map(Into::into);
+        self
+    }
+
+    /// Attach the provider-reported model identifier.
+    pub fn with_model(self, model: impl Into<String>) -> Self {
+        self.with_optional_model(Some(model.into()))
+    }
+
+    /// Attach the provider-reported model identifier when the stream reported
+    /// one.
+    pub fn with_optional_model(mut self, model: Option<impl Into<String>>) -> Self {
+        self.model = model.map(Into::into);
+        self
+    }
+}
+
+/// Enum representing a streaming chunk from the model.
+///
+/// `R` is the terminal record type. Ordinary streams use the normalized
+/// [`StreamFinal`] default; a provider's inherent `raw_stream` method
+/// substitutes its own native terminal type over the same event vocabulary,
+/// which is what keeps [`crate::completion::CompletionModel`] free of response
+/// associated types.
 #[derive(Debug, Clone)]
-pub enum RawStreamingChoice<R>
-where
-    R: Clone,
-{
+pub enum RawStreamingChoice<R = StreamFinal> {
     /// A text chunk from a message response
     Message(String),
 
@@ -130,6 +230,40 @@ where
     /// [`StreamedAssistantContent::Unknown`] but not folded into the accumulated
     /// assistant message (there is no `AssistantContent::Unknown` history slot).
     Unknown(serde_json::Value),
+}
+
+impl<R> RawStreamingChoice<R> {
+    /// Convert only the terminal record, preserving every incremental content
+    /// event unchanged.
+    pub fn try_map_final<S>(
+        self,
+        map: impl FnOnce(R) -> Result<S, CompletionError>,
+    ) -> Result<RawStreamingChoice<S>, CompletionError> {
+        Ok(match self {
+            Self::Message(text) => RawStreamingChoice::Message(text),
+            Self::TextStart { additional_params } => {
+                RawStreamingChoice::TextStart { additional_params }
+            }
+            Self::TextAdditionalParams(params) => RawStreamingChoice::TextAdditionalParams(params),
+            Self::ToolCall(call) => RawStreamingChoice::ToolCall(call),
+            Self::ToolCallDelta {
+                id,
+                internal_call_id,
+                content,
+            } => RawStreamingChoice::ToolCallDelta {
+                id,
+                internal_call_id,
+                content,
+            },
+            Self::Reasoning { id, content } => RawStreamingChoice::Reasoning { id, content },
+            Self::ReasoningDelta { id, reasoning } => {
+                RawStreamingChoice::ReasoningDelta { id, reasoning }
+            }
+            Self::FinalResponse(response) => RawStreamingChoice::FinalResponse(map(response)?),
+            Self::MessageId(id) => RawStreamingChoice::MessageId(id),
+            Self::Unknown(value) => RawStreamingChoice::Unknown(value),
+        })
+    }
 }
 
 /// Describes a streaming tool call response (in its entirety)
@@ -219,45 +353,88 @@ impl From<RawStreamingToolCall> for ToolCall {
 }
 
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-/// Provider stream of raw completion chunks on native targets.
-pub type StreamingResult<R> =
+/// Provider stream whose terminal record is the provider-native `R`, on native
+/// targets.
+pub type RawStreamingResult<R> =
     Pin<Box<dyn Stream<Item = Result<RawStreamingChoice<R>, CompletionError>> + Send>>;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-/// Provider stream of raw completion chunks on wasm targets.
-pub type StreamingResult<R> =
+/// Provider stream whose terminal record is the provider-native `R`, on wasm
+/// targets.
+pub type RawStreamingResult<R> =
     Pin<Box<dyn Stream<Item = Result<RawStreamingChoice<R>, CompletionError>>>>;
+
+/// Normalized provider stream, as consumed by [`StreamingCompletionResponse`].
+pub type StreamingResult = RawStreamingResult<StreamFinal>;
+
+/// Normalize the terminal record of a provider-native stream.
+///
+/// Every incremental event passes through untouched; only
+/// [`RawStreamingChoice::FinalResponse`] is converted, by `map`. On the way
+/// through, the stream remembers whether it emitted any tool call and applies
+/// [`FinishReason::reconcile_with_output`](crate::completion::FinishReason::reconcile_with_output)
+/// to the mapped record — the streaming counterpart of what
+/// [`CompletionResponse::with_finish_reason`] does on the unary path, so both
+/// paths agree about a `stop` that was really a tool call.
+pub fn normalize_stream<R, F>(stream: RawStreamingResult<R>, mut map: F) -> StreamingResult
+where
+    R: 'static,
+    F: FnMut(R) -> Result<StreamFinal, CompletionError> + WasmCompatSend + 'static,
+{
+    let mut emitted_tool_call = false;
+    Box::pin(stream.map(move |item| {
+        item.and_then(|choice| {
+            if matches!(
+                &choice,
+                RawStreamingChoice::ToolCall(_) | RawStreamingChoice::ToolCallDelta { .. }
+            ) {
+                emitted_tool_call = true;
+            }
+            choice.try_map_final(|response| {
+                let mut response = map(response)?;
+                response.finish_reason = response
+                    .finish_reason
+                    .map(|reason| reason.reconcile_with_output(emitted_tool_call));
+                Ok(response)
+            })
+        })
+    }))
+}
 
 /// The response from a streaming completion request;
 /// message and response are populated at the end of the
 /// `inner` stream.
-pub struct StreamingCompletionResponse<R>
-where
-    R: Clone + Unpin + GetTokenUsage,
-{
-    pub(crate) inner: Abortable<StreamingResult<R>>,
+pub struct StreamingCompletionResponse {
+    pub(crate) inner: Abortable<StreamingResult>,
     pub(crate) abort_handle: AbortHandle,
     pub(crate) pause_control: PauseControl,
     assistant_items: Vec<AssistantContent>,
     text_item_index: Option<usize>,
     reasoning_item_index: Option<usize>,
+    /// Stable descriptor name of the provider producing this stream.
+    ///
+    /// Known when the stream is opened rather than when it terminates, so a
+    /// stream that errors or is cancelled before its terminal record still
+    /// names its provider.
+    provider: String,
     /// The final aggregated message from the stream
     /// contains all text and tool calls generated
     pub choice: OneOrMany<AssistantContent>,
-    /// The final response from the stream, may be `None`
+    /// The provider's normalized terminal record, may be `None`
     /// if the provider didn't yield it during the stream
-    pub response: Option<R>,
+    pub response: Option<StreamFinal>,
     pub final_response_yielded: AtomicBool,
     /// Provider-assigned message ID (e.g. OpenAI Responses API `msg_` ID).
     pub message_id: Option<String>,
 }
 
-impl<R> StreamingCompletionResponse<R>
-where
-    R: Clone + Unpin + GetTokenUsage,
-{
+impl StreamingCompletionResponse {
     /// Wrap a provider stream and initialize aggregation state.
-    pub fn stream(inner: StreamingResult<R>) -> StreamingCompletionResponse<R> {
+    ///
+    /// `provider` is the stable descriptor name of the provider producing the
+    /// stream; it is recorded up front so it is available even when the stream
+    /// never reaches its terminal record.
+    pub fn stream(provider: impl Into<String>, inner: StreamingResult) -> Self {
         let (abort_handle, abort_registration) = AbortHandle::new_pair();
         let abortable_stream = Abortable::new(inner, abort_registration);
         let pause_control = PauseControl::new();
@@ -268,6 +445,7 @@ where
             assistant_items: vec![],
             text_item_index: None,
             reasoning_item_index: None,
+            provider: provider.into(),
             choice: OneOrMany::one(AssistantContent::text("")),
             response: None,
             final_response_yielded: AtomicBool::new(false),
@@ -275,12 +453,17 @@ where
         }
     }
 
+    /// Stable descriptor name of the provider producing this stream.
+    pub fn provider(&self) -> &str {
+        &self.provider
+    }
+
     /// Cancel the stream and immediately drop the provider's inner stream.
     /// Cancellation is surfaced as normal stream termination.
     pub fn cancel(&mut self) {
         self.abort_handle.abort();
         let (abort_handle, abort_registration) = AbortHandle::new_pair();
-        let empty: StreamingResult<R> = Box::pin(futures::stream::poll_fn(|_| Poll::Ready(None)));
+        let empty: StreamingResult = Box::pin(futures::stream::poll_fn(|_| Poll::Ready(None)));
         self.inner = Abortable::new(empty, abort_registration);
         self.abort_handle = abort_handle;
     }
@@ -307,7 +490,10 @@ where
     /// usage — this returns [`Usage::new`], the zero-valued sentinel for missing
     /// usage metrics.
     pub fn usage(&self) -> Usage {
-        self.response.token_usage()
+        self.response
+            .as_ref()
+            .map(|response| response.usage)
+            .unwrap_or_default()
     }
 
     fn append_text_chunk(&mut self, text: &str) {
@@ -404,28 +590,30 @@ fn merge_text_additional_params(existing: &mut serde_json::Value, incoming: serd
     }
 }
 
-impl<R> From<StreamingCompletionResponse<R>> for CompletionResponse<Option<R>>
-where
-    R: Clone + Unpin + GetTokenUsage,
-{
-    fn from(value: StreamingCompletionResponse<R>) -> CompletionResponse<Option<R>> {
-        CompletionResponse {
-            choice: value.choice,
-            // Derive usage from the final response. `Option<R>: GetTokenUsage`
-            // yields the provider's usage when present and the zero sentinel
-            // (`Usage::new`) when the stream produced no final response.
-            usage: value.response.token_usage(),
-            raw_response: value.response,
-            message_id: value.message_id,
-        }
+impl From<StreamingCompletionResponse> for CompletionResponse {
+    fn from(value: StreamingCompletionResponse) -> CompletionResponse {
+        // Usage is the zero sentinel (`Usage::new`) when the stream produced no
+        // terminal record. `provider` comes from the stream itself rather than
+        // the terminal record, so it is populated even then.
+        let terminal = value.response.as_ref();
+        CompletionResponse::new(
+            value.choice,
+            terminal.map(|response| response.usage).unwrap_or_default(),
+            value.provider,
+        )
+        // An explicit `MessageId` event outranks the terminal record's ID.
+        .with_optional_message_id(
+            value
+                .message_id
+                .or_else(|| terminal.and_then(|response| response.message_id.clone())),
+        )
+        .with_optional_finish_reason(terminal.and_then(|response| response.finish_reason.clone()))
+        .with_optional_model(terminal.and_then(|response| response.model.clone()))
     }
 }
 
-impl<R> Stream for StreamingCompletionResponse<R>
-where
-    R: Clone + Unpin + GetTokenUsage,
-{
-    type Item = Result<StreamedAssistantContent<R>, CompletionError>;
+impl Stream for StreamingCompletionResponse {
+    type Item = Result<StreamedAssistantContent, CompletionError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let stream = self.get_mut();
@@ -527,7 +715,12 @@ where
                     {
                         stream.poll_next_unpin(cx)
                     } else {
-                        // Set the final response field and return the next item in the stream
+                        // Set the final response field and return the next item in the stream.
+                        // An explicit `MessageId` event keeps precedence; the
+                        // terminal record only fills a gap.
+                        if stream.message_id.is_none() {
+                            stream.message_id = response.message_id.clone();
+                        }
                         stream.response = Some(response.clone());
                         stream
                             .final_response_yielded
@@ -557,28 +750,41 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
-    use crate::test_utils::MockResponse;
+    use crate::completion::FinishReason;
     use async_stream::stream;
     use tokio::time::sleep;
 
+    /// Provider descriptor used by the mock streams in this module.
+    const TEST_PROVIDER: &str = "test-provider";
+
+    /// Terminal record with a known total-token count.
+    fn mock_final_with_total_tokens(total_tokens: u64) -> StreamFinal {
+        let mut usage = Usage::new();
+        usage.total_tokens = total_tokens;
+        StreamFinal::new(TEST_PROVIDER, usage)
+    }
+
+    fn mock_final_usage(usage: Usage) -> StreamFinal {
+        StreamFinal::new(TEST_PROVIDER, usage)
+    }
+
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     fn to_stream_result(
-        stream: impl futures::Stream<Item = Result<RawStreamingChoice<MockResponse>, CompletionError>>
+        stream: impl futures::Stream<Item = Result<RawStreamingChoice, CompletionError>>
         + Send
         + 'static,
-    ) -> StreamingResult<MockResponse> {
+    ) -> StreamingResult {
         Box::pin(stream)
     }
 
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     fn to_stream_result(
-        stream: impl futures::Stream<Item = Result<RawStreamingChoice<MockResponse>, CompletionError>>
-        + 'static,
-    ) -> StreamingResult<MockResponse> {
+        stream: impl futures::Stream<Item = Result<RawStreamingChoice, CompletionError>> + 'static,
+    ) -> StreamingResult {
         Box::pin(stream)
     }
 
-    fn create_mock_stream() -> StreamingCompletionResponse<MockResponse> {
+    fn create_mock_stream() -> StreamingCompletionResponse {
         let stream = stream! {
             yield Ok(RawStreamingChoice::Message("hello 1".to_string()));
             sleep(Duration::from_millis(100)).await;
@@ -586,13 +792,13 @@ mod tests {
             sleep(Duration::from_millis(100)).await;
             yield Ok(RawStreamingChoice::Message("hello 3".to_string()));
             sleep(Duration::from_millis(100)).await;
-            yield Ok(RawStreamingChoice::FinalResponse(MockResponse::with_total_tokens(15)));
+            yield Ok(RawStreamingChoice::FinalResponse(mock_final_with_total_tokens(15)));
         };
 
-        StreamingCompletionResponse::stream(to_stream_result(stream))
+        StreamingCompletionResponse::stream(TEST_PROVIDER, to_stream_result(stream))
     }
 
-    fn create_reasoning_stream() -> StreamingCompletionResponse<MockResponse> {
+    fn create_reasoning_stream() -> StreamingCompletionResponse {
         let stream = stream! {
             yield Ok(RawStreamingChoice::Reasoning {
                 id: Some("rs_1".to_string()),
@@ -602,25 +808,25 @@ mod tests {
                 },
             });
             yield Ok(RawStreamingChoice::Message("final answer".to_string()));
-            yield Ok(RawStreamingChoice::FinalResponse(MockResponse::with_total_tokens(5)));
+            yield Ok(RawStreamingChoice::FinalResponse(mock_final_with_total_tokens(5)));
         };
 
-        StreamingCompletionResponse::stream(to_stream_result(stream))
+        StreamingCompletionResponse::stream(TEST_PROVIDER, to_stream_result(stream))
     }
 
-    fn create_reasoning_only_stream() -> StreamingCompletionResponse<MockResponse> {
+    fn create_reasoning_only_stream() -> StreamingCompletionResponse {
         let stream = stream! {
             yield Ok(RawStreamingChoice::Reasoning {
                 id: Some("rs_only".to_string()),
                 content: ReasoningContent::Summary("hidden summary".to_string()),
             });
-            yield Ok(RawStreamingChoice::FinalResponse(MockResponse::with_total_tokens(2)));
+            yield Ok(RawStreamingChoice::FinalResponse(mock_final_with_total_tokens(2)));
         };
 
-        StreamingCompletionResponse::stream(to_stream_result(stream))
+        StreamingCompletionResponse::stream(TEST_PROVIDER, to_stream_result(stream))
     }
 
-    fn create_interleaved_stream() -> StreamingCompletionResponse<MockResponse> {
+    fn create_interleaved_stream() -> StreamingCompletionResponse {
         let stream = stream! {
             yield Ok(RawStreamingChoice::Reasoning {
                 id: Some("rs_interleaved".to_string()),
@@ -637,13 +843,13 @@ mod tests {
                     serde_json::json!({"arg": 1}),
                 ),
             ));
-            yield Ok(RawStreamingChoice::FinalResponse(MockResponse::with_total_tokens(3)));
+            yield Ok(RawStreamingChoice::FinalResponse(mock_final_with_total_tokens(3)));
         };
 
-        StreamingCompletionResponse::stream(to_stream_result(stream))
+        StreamingCompletionResponse::stream(TEST_PROVIDER, to_stream_result(stream))
     }
 
-    fn create_text_tool_text_stream() -> StreamingCompletionResponse<MockResponse> {
+    fn create_text_tool_text_stream() -> StreamingCompletionResponse {
         let stream = stream! {
             yield Ok(RawStreamingChoice::Message("first".to_string()));
             yield Ok(RawStreamingChoice::ToolCall(
@@ -654,13 +860,13 @@ mod tests {
                 ),
             ));
             yield Ok(RawStreamingChoice::Message("second".to_string()));
-            yield Ok(RawStreamingChoice::FinalResponse(MockResponse::with_total_tokens(3)));
+            yield Ok(RawStreamingChoice::FinalResponse(mock_final_with_total_tokens(3)));
         };
 
-        StreamingCompletionResponse::stream(to_stream_result(stream))
+        StreamingCompletionResponse::stream(TEST_PROVIDER, to_stream_result(stream))
     }
 
-    fn create_text_metadata_stream() -> StreamingCompletionResponse<MockResponse> {
+    fn create_text_metadata_stream() -> StreamingCompletionResponse {
         let stream = stream! {
             yield Ok(RawStreamingChoice::TextStart {
                 additional_params: None,
@@ -690,10 +896,10 @@ mod tests {
                 })),
             });
             yield Ok(RawStreamingChoice::Message("second".to_string()));
-            yield Ok(RawStreamingChoice::FinalResponse(MockResponse::with_total_tokens(3)));
+            yield Ok(RawStreamingChoice::FinalResponse(mock_final_with_total_tokens(3)));
         };
 
-        StreamingCompletionResponse::stream(to_stream_result(stream))
+        StreamingCompletionResponse::stream(TEST_PROVIDER, to_stream_result(stream))
     }
 
     #[tokio::test]
@@ -707,16 +913,134 @@ mod tests {
         assert_eq!(stream.usage().total_tokens, 15);
 
         // ...and the From conversion carries it instead of a zero sentinel.
-        let response: CompletionResponse<Option<MockResponse>> = stream.into();
+        let response: CompletionResponse = stream.into();
         assert_eq!(response.usage.total_tokens, 15);
+        assert_eq!(response.provider, TEST_PROVIDER);
+    }
+
+    #[tokio::test]
+    async fn a_stream_without_a_terminal_record_still_names_its_provider() {
+        // The provider is known when the stream is opened, so a stream that
+        // errors or is truncated before its terminal record must not degrade
+        // `provider` to an empty string — every other missing value has a
+        // documented sentinel (`Usage::new`, `None`) and this one should too.
+        let mut stream = StreamingCompletionResponse::stream(
+            TEST_PROVIDER,
+            to_stream_result(stream! {
+                yield Ok(RawStreamingChoice::Message("truncated".to_string()));
+            }),
+        );
+        while stream.next().await.is_some() {}
+
+        let response: CompletionResponse = stream.into();
+        assert_eq!(response.provider, TEST_PROVIDER);
+        assert_eq!(response.usage, Usage::new());
+        assert_eq!(response.finish_reason, None);
+        assert_eq!(response.model, None);
+    }
+
+    #[tokio::test]
+    async fn normalize_stream_upgrades_a_stop_that_carried_a_tool_call() {
+        // Several gateways report a plain `stop` on a tool-calling turn. The
+        // streaming path must reconcile it exactly as the unary path does.
+        let raw: RawStreamingResult<Usage> = Box::pin(stream! {
+            yield Ok(RawStreamingChoice::ToolCall(RawStreamingToolCall {
+                id: "call_1".to_string(),
+                call_id: None,
+                internal_call_id: "internal_1".to_string(),
+                name: "lookup".to_string(),
+                arguments: serde_json::json!({}),
+                signature: None,
+                additional_params: None,
+            }));
+            yield Ok(RawStreamingChoice::FinalResponse(Usage::new()));
+        });
+
+        let normalized = normalize_stream(raw, |usage| {
+            Ok(StreamFinal::new(TEST_PROVIDER, usage).with_finish_reason(FinishReason::Stop))
+        });
+
+        let mut stream = StreamingCompletionResponse::stream(TEST_PROVIDER, normalized);
+        while stream.next().await.is_some() {}
+
+        assert_eq!(
+            stream
+                .response
+                .as_ref()
+                .and_then(|final_record| final_record.finish_reason.clone()),
+            Some(FinishReason::ToolCalls),
+        );
+    }
+
+    #[tokio::test]
+    async fn normalize_stream_leaves_a_stop_without_tool_calls_alone() {
+        let raw: RawStreamingResult<Usage> = Box::pin(stream! {
+            yield Ok(RawStreamingChoice::Message("done".to_string()));
+            yield Ok(RawStreamingChoice::FinalResponse(Usage::new()));
+        });
+
+        let normalized = normalize_stream(raw, |usage| {
+            Ok(StreamFinal::new(TEST_PROVIDER, usage).with_finish_reason(FinishReason::Stop))
+        });
+
+        let mut stream = StreamingCompletionResponse::stream(TEST_PROVIDER, normalized);
+        while stream.next().await.is_some() {}
+
+        assert_eq!(
+            stream
+                .response
+                .as_ref()
+                .and_then(|final_record| final_record.finish_reason.clone()),
+            Some(FinishReason::Stop),
+        );
+    }
+
+    #[test]
+    fn stream_final_round_trips_and_is_distinguishable_from_unknown_content() {
+        let final_record = StreamFinal::new(
+            "example",
+            Usage {
+                input_tokens: 4,
+                output_tokens: 6,
+                total_tokens: 10,
+                cached_input_tokens: 1,
+                cache_creation_input_tokens: 2,
+                tool_use_prompt_tokens: 3,
+                reasoning_tokens: 4,
+            },
+        )
+        .with_finish_reason(FinishReason::Other("future_reason".to_owned()))
+        .with_message_id("msg_123")
+        .with_model("provider-model-v2");
+
+        let encoded = serde_json::to_value(StreamedAssistantContent::Final(final_record.clone()))
+            .expect("serialize final item");
+        assert_eq!(encoded["kind"], serde_json::json!("final"));
+
+        let decoded = serde_json::from_value::<StreamedAssistantContent>(encoded)
+            .expect("deserialize final item");
+        assert_eq!(decoded, StreamedAssistantContent::Final(final_record));
+
+        // An unmodeled provider item must still land in `Unknown` rather than
+        // being mistaken for a terminal record.
+        let provider_item = serde_json::json!({
+            "provider_native_event": "future_terminal",
+            "usage": {"total_tokens": 10}
+        });
+        let decoded = serde_json::from_value::<StreamedAssistantContent>(provider_item.clone())
+            .expect("deserialize unknown item");
+        assert_eq!(decoded, StreamedAssistantContent::Unknown(provider_item));
     }
 
     #[tokio::test]
     async fn usage_is_zero_sentinel_before_final_response() {
         // A stream that never yields a FinalResponse reports the zero sentinel.
-        let stream = StreamingCompletionResponse::stream(to_stream_result(stream! {
-            yield Ok(RawStreamingChoice::Message("no final response".to_string()));
-        }));
+        let stream = StreamingCompletionResponse::stream(
+            TEST_PROVIDER,
+            to_stream_result(stream! {
+                yield Ok(RawStreamingChoice::Message("no final response".to_string()));
+            }),
+        );
         assert_eq!(stream.usage().total_tokens, 0);
     }
 
@@ -868,9 +1192,10 @@ mod tests {
         let stream = stream! {
             yield Ok(RawStreamingChoice::Unknown(yielded));
             yield Ok(RawStreamingChoice::Message("done".to_string()));
-            yield Ok(RawStreamingChoice::FinalResponse(MockResponse::with_total_tokens(1)));
+            yield Ok(RawStreamingChoice::FinalResponse(mock_final_with_total_tokens(1)));
         };
-        let mut stream = StreamingCompletionResponse::stream(to_stream_result(stream));
+        let mut stream =
+            StreamingCompletionResponse::stream(TEST_PROVIDER, to_stream_result(stream));
 
         let mut consumer_unknown = None;
         let mut consumer_text = String::new();
@@ -956,7 +1281,7 @@ mod tests {
 /// Describes responses from a streamed provider response which is either text, a tool call or a final usage response.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(untagged)]
-pub enum StreamedAssistantContent<R> {
+pub enum StreamedAssistantContent {
     /// Text delta emitted by the assistant.
     Text(Text),
     /// Complete tool call emitted by the assistant.
@@ -983,8 +1308,8 @@ pub enum StreamedAssistantContent<R> {
         /// Partial reasoning text.
         reasoning: String,
     },
-    /// Final provider response object, if yielded by the provider stream.
-    Final(R),
+    /// The provider's normalized terminal record, if yielded by the stream.
+    Final(StreamFinal),
     /// A provider-native output item rig does not model, preserved verbatim —
     /// e.g. an OpenAI Responses hosted-tool result (`web_search_call`,
     /// `file_search_call`, `computer_call`, `code_interpreter_call`). It is
@@ -995,17 +1320,14 @@ pub enum StreamedAssistantContent<R> {
     Unknown(serde_json::Value),
 }
 
-impl<R> StreamedAssistantContent<R>
-where
-    R: Clone + Unpin,
-{
+impl StreamedAssistantContent {
     /// Create a text stream item.
     pub fn text(text: &str) -> Self {
         Self::Text(Text::new(text.to_string()))
     }
 
     /// Create a final response stream item.
-    pub fn final_response(res: R) -> Self {
+    pub fn final_response(res: StreamFinal) -> Self {
         Self::Final(res)
     }
 }

--- a/crates/rig-core/src/streaming.rs
+++ b/crates/rig-core/src/streaming.rs
@@ -384,10 +384,13 @@ where
     let mut emitted_tool_call = false;
     Box::pin(stream.map(move |item| {
         item.and_then(|choice| {
-            if matches!(
-                &choice,
-                RawStreamingChoice::ToolCall(_) | RawStreamingChoice::ToolCallDelta { .. }
-            ) {
+            // Only a completed `ToolCall` counts, because only that becomes an
+            // `AssistantContent::ToolCall` in the aggregated choice — which is
+            // exactly what the unary path reconciles against. Counting deltas
+            // here would make a stream whose tool call never assembled report
+            // `ToolCalls` while the same data converted to a unary response
+            // reported `Stop`.
+            if matches!(&choice, RawStreamingChoice::ToolCall(_)) {
                 emitted_tool_call = true;
             }
             choice.try_map_final(|response| {

--- a/crates/rig-core/src/telemetry/mod.rs
+++ b/crates/rig-core/src/telemetry/mod.rs
@@ -4,7 +4,7 @@
 //! and more.
 
 use crate::OneOrMany;
-use crate::completion::{AssistantContent, GetTokenUsage, Message};
+use crate::completion::{AssistantContent, Message, Usage};
 use crate::message::{
     DocumentSourceKind, Image, MimeType, Reasoning, ReasoningContent, ToolResult,
     ToolResultContent, UserContent,
@@ -773,9 +773,7 @@ pub trait ProviderResponseExt {
 /// Implemented for [`tracing::Span`] to record GenAI semantic convention fields.
 pub trait SpanCombinator {
     /// Record Rig-normalized token usage fields on the span.
-    fn record_token_usage<U>(&self, usage: &U)
-    where
-        U: GetTokenUsage;
+    fn record_token_usage(&self, usage: &Usage);
 
     /// Record provider response metadata such as response ID and model name.
     fn record_response_metadata<R>(&self, response: &R)
@@ -784,15 +782,11 @@ pub trait SpanCombinator {
 }
 
 impl SpanCombinator for tracing::Span {
-    fn record_token_usage<U>(&self, usage: &U)
-    where
-        U: GetTokenUsage,
-    {
+    fn record_token_usage(&self, usage: &Usage) {
         if self.is_disabled() {
             return;
         }
 
-        let usage = usage.token_usage();
         // Zero-valued usage is the documented sentinel for missing provider
         // usage metrics; leave the span fields unset.
         if usage.has_values() {
@@ -835,22 +829,13 @@ impl SpanCombinator for tracing::Span {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::completion::{AssistantContent, GetTokenUsage, Message, Usage};
+    use crate::completion::{AssistantContent, Message, Usage};
     use serde_json::json;
     use std::sync::{Arc, Mutex};
     use tracing::field::{Field, Visit};
     use tracing::{Id, Subscriber};
     use tracing_subscriber::layer::{Context, SubscriberExt};
     use tracing_subscriber::{Layer, Registry, registry::LookupSpan};
-
-    #[derive(Clone)]
-    struct TestUsage(Usage);
-
-    impl GetTokenUsage for TestUsage {
-        fn token_usage(&self) -> Usage {
-            self.0
-        }
-    }
 
     #[test]
     fn content_attributes_follow_gen_ai_semantic_convention_json_shapes() {
@@ -1827,7 +1812,7 @@ mod tests {
         let subscriber = Registry::default().with(FieldCaptureLayer {
             fields: fields.clone(),
         });
-        let usage = TestUsage(Usage {
+        let usage = Usage {
             input_tokens: 1,
             output_tokens: 2,
             total_tokens: 15,
@@ -1835,7 +1820,7 @@ mod tests {
             cache_creation_input_tokens: 4,
             tool_use_prompt_tokens: 12,
             reasoning_tokens: 5,
-        });
+        };
 
         // Scoped-subscriber tests must not run concurrently; see
         // `test_utils::scoped_tracing_subscriber_guard`.

--- a/crates/rig-core/src/test_utils/completion.rs
+++ b/crates/rig-core/src/test_utils/completion.rs
@@ -15,7 +15,7 @@ use crate::{
     streaming::{StreamingCompletionResponse, StreamingResult},
 };
 
-use super::streaming::{MockResponse, MockStreamEvent};
+use super::streaming::{MOCK_PROVIDER, MockStreamEvent};
 
 /// Scripted error returned by [`MockCompletionModel`].
 #[derive(Clone, Debug)]
@@ -144,14 +144,12 @@ impl MockTurn {
         self
     }
 
-    fn into_completion_response(self) -> Result<CompletionResponse<MockResponse>, CompletionError> {
+    fn into_completion_response(self) -> Result<CompletionResponse, CompletionError> {
         let response = self.response.map_err(MockError::into_completion_error)?;
-        Ok(CompletionResponse {
-            choice: response.choice,
-            usage: response.usage,
-            raw_response: MockResponse::with_usage(response.usage),
-            message_id: response.message_id,
-        })
+        Ok(
+            CompletionResponse::new(response.choice, response.usage, MOCK_PROVIDER)
+                .with_optional_message_id(response.message_id),
+        )
     }
 }
 
@@ -257,18 +255,10 @@ impl MockCompletionModel {
 }
 
 impl CompletionModel for MockCompletionModel {
-    type Response = MockResponse;
-    type StreamingResponse = MockResponse;
-    type Client = ();
-
-    fn make(_: &Self::Client, _: impl Into<String>) -> Self {
-        Self::default()
-    }
-
     async fn completion(
         &self,
         request: CompletionRequest,
-    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+    ) -> Result<CompletionResponse, CompletionError> {
         self.record_request(request);
         let Some(turn) = self.next_turn() else {
             return Err(CompletionError::ProviderError(
@@ -282,7 +272,7 @@ impl CompletionModel for MockCompletionModel {
     async fn stream(
         &self,
         request: CompletionRequest,
-    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+    ) -> Result<StreamingCompletionResponse, CompletionError> {
         self.record_request(request);
         let Some(events) = self.next_stream_turn() else {
             return Err(CompletionError::ProviderError(
@@ -295,8 +285,8 @@ impl CompletionModel for MockCompletionModel {
                 yield event.into_raw_choice();
             }
         };
-        let stream: StreamingResult<Self::StreamingResponse> = Box::pin(stream);
-        Ok(StreamingCompletionResponse::stream(stream))
+        let stream: StreamingResult = Box::pin(stream);
+        Ok(StreamingCompletionResponse::stream(MOCK_PROVIDER, stream))
     }
 }
 
@@ -304,7 +294,6 @@ impl CompletionModel for MockCompletionModel {
 mod tests {
     use super::*;
     use crate::{
-        completion::GetTokenUsage,
         message::Message,
         streaming::{StreamedAssistantContent, ToolCallDeltaContent},
     };
@@ -415,7 +404,7 @@ mod tests {
                 }
                 StreamedAssistantContent::Final(response) => {
                     saw_final = matches!(
-                        response.token_usage(),
+                        response.usage,
                         Usage {
                             total_tokens: 7,
                             ..

--- a/crates/rig-core/src/test_utils/internal_streaming_profiles.rs
+++ b/crates/rig-core/src/test_utils/internal_streaming_profiles.rs
@@ -1,16 +1,17 @@
 //! Crate-internal streaming profile helpers for compatible provider tests.
 
 use crate::{
-    completion::CompletionError,
+    completion::{CompletionError, Usage},
     providers::internal::openai_chat_completions_compatible::{
         CompatibleChoice, CompatibleChunk, CompatibleFinishReason, CompatibleStreamProfile,
-        CompatibleToolCallChunk,
+        CompatibleTerminal, CompatibleToolCallChunk,
     },
+    streaming::StreamFinal,
 };
 
-use super::MockResponse;
+use super::MOCK_PROVIDER;
 
-fn test_chunk(choice: CompatibleChoice<()>) -> CompatibleChunk<MockResponse, ()> {
+fn test_chunk(choice: CompatibleChoice<()>) -> CompatibleChunk<Usage, ()> {
     CompatibleChunk {
         response_id: None,
         response_model: None,
@@ -51,9 +52,9 @@ fn tool_call_chunk(
 pub(crate) struct ErrorAfterPendingToolCallProfile;
 
 impl CompatibleStreamProfile for ErrorAfterPendingToolCallProfile {
-    type Usage = MockResponse;
+    type Usage = Usage;
     type Detail = ();
-    type FinalResponse = MockResponse;
+    type FinalResponse = StreamFinal;
 
     fn normalize_chunk(
         &self,
@@ -61,7 +62,7 @@ impl CompatibleStreamProfile for ErrorAfterPendingToolCallProfile {
     ) -> Result<Option<CompatibleChunk<Self::Usage, Self::Detail>>, CompletionError> {
         match data {
             "start" => Ok(Some(test_chunk(tool_call_choice(
-                CompatibleFinishReason::Other,
+                CompatibleFinishReason::Absent,
                 vec![tool_call_chunk(0, Some("call_123"), Some("ping"), Some(""))],
             )))),
             "bad" => Err(CompletionError::ProviderError(
@@ -71,8 +72,12 @@ impl CompatibleStreamProfile for ErrorAfterPendingToolCallProfile {
         }
     }
 
-    fn build_final_response(&self, _usage: Self::Usage) -> Self::FinalResponse {
-        MockResponse::new()
+    fn build_final_response(
+        &self,
+        terminal: CompatibleTerminal<Self::Usage>,
+    ) -> Self::FinalResponse {
+        StreamFinal::new(MOCK_PROVIDER, terminal.usage)
+            .with_optional_finish_reason(terminal.finish_reason)
     }
 }
 
@@ -81,9 +86,9 @@ impl CompatibleStreamProfile for ErrorAfterPendingToolCallProfile {
 pub(crate) struct DistinctToolCallEvictionProfile;
 
 impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
-    type Usage = MockResponse;
+    type Usage = Usage;
     type Detail = ();
-    type FinalResponse = MockResponse;
+    type FinalResponse = StreamFinal;
 
     fn normalize_chunk(
         &self,
@@ -91,7 +96,7 @@ impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
     ) -> Result<Option<CompatibleChunk<Self::Usage, Self::Detail>>, CompletionError> {
         let choice = match data {
             "first_start" => Some(tool_call_choice(
-                CompatibleFinishReason::Other,
+                CompatibleFinishReason::Absent,
                 vec![tool_call_chunk(
                     0,
                     Some("call_aaa"),
@@ -100,7 +105,7 @@ impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
                 )],
             )),
             "first_args" => Some(tool_call_choice(
-                CompatibleFinishReason::Other,
+                CompatibleFinishReason::Absent,
                 vec![tool_call_chunk(0, None, None, Some("{\"query\":\"one\"}"))],
             )),
             // A partial (still-streaming) argument fragment: the accumulator
@@ -108,11 +113,11 @@ impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
             // `{...}` object. If the first call is evicted at this point, its
             // arguments are a non-object string — the exact #1958 leak condition.
             "first_args_partial" => Some(tool_call_choice(
-                CompatibleFinishReason::Other,
+                CompatibleFinishReason::Absent,
                 vec![tool_call_chunk(0, None, None, Some("{\"query\":"))],
             )),
             "second_start" => Some(tool_call_choice(
-                CompatibleFinishReason::Other,
+                CompatibleFinishReason::Absent,
                 vec![tool_call_chunk(
                     0,
                     Some("call_bbb"),
@@ -121,11 +126,11 @@ impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
                 )],
             )),
             "second_args" => Some(tool_call_choice(
-                CompatibleFinishReason::Other,
+                CompatibleFinishReason::Absent,
                 vec![tool_call_chunk(0, None, None, Some("{\"query\":\"two\"}"))],
             )),
             "finish" => Some(tool_call_choice(
-                CompatibleFinishReason::ToolCalls,
+                CompatibleFinishReason::Reported(crate::completion::FinishReason::ToolCalls),
                 Vec::new(),
             )),
             _ => None,
@@ -134,8 +139,12 @@ impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
         Ok(choice.map(test_chunk))
     }
 
-    fn build_final_response(&self, _usage: Self::Usage) -> Self::FinalResponse {
-        MockResponse::new()
+    fn build_final_response(
+        &self,
+        terminal: CompatibleTerminal<Self::Usage>,
+    ) -> Self::FinalResponse {
+        StreamFinal::new(MOCK_PROVIDER, terminal.usage)
+            .with_optional_finish_reason(terminal.finish_reason)
     }
 
     fn uses_distinct_tool_call_eviction(&self) -> bool {
@@ -148,9 +157,9 @@ impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
 pub(crate) struct FinishReasonCleanupProfile;
 
 impl CompatibleStreamProfile for FinishReasonCleanupProfile {
-    type Usage = MockResponse;
+    type Usage = Usage;
     type Detail = ();
-    type FinalResponse = MockResponse;
+    type FinalResponse = StreamFinal;
 
     fn normalize_chunk(
         &self,
@@ -158,7 +167,7 @@ impl CompatibleStreamProfile for FinishReasonCleanupProfile {
     ) -> Result<Option<CompatibleChunk<Self::Usage, Self::Detail>>, CompletionError> {
         let choice = match data {
             "start" => Some(tool_call_choice(
-                CompatibleFinishReason::Other,
+                CompatibleFinishReason::Absent,
                 vec![tool_call_chunk(
                     0,
                     Some("call_123"),
@@ -167,7 +176,7 @@ impl CompatibleStreamProfile for FinishReasonCleanupProfile {
                 )],
             )),
             "finish" => Some(tool_call_choice(
-                CompatibleFinishReason::ToolCalls,
+                CompatibleFinishReason::Reported(crate::completion::FinishReason::ToolCalls),
                 Vec::new(),
             )),
             _ => None,
@@ -176,7 +185,11 @@ impl CompatibleStreamProfile for FinishReasonCleanupProfile {
         Ok(choice.map(test_chunk))
     }
 
-    fn build_final_response(&self, _usage: Self::Usage) -> Self::FinalResponse {
-        MockResponse::new()
+    fn build_final_response(
+        &self,
+        terminal: CompatibleTerminal<Self::Usage>,
+    ) -> Self::FinalResponse {
+        StreamFinal::new(MOCK_PROVIDER, terminal.usage)
+            .with_optional_finish_reason(terminal.finish_reason)
     }
 }

--- a/crates/rig-core/src/test_utils/mod.rs
+++ b/crates/rig-core/src/test_utils/mod.rs
@@ -18,7 +18,7 @@ pub use http::{
 };
 pub use memory::{AppendFailingMemory, CountingMemory, FailingMemory};
 pub use model_listing::MockModelLister;
-pub use streaming::{MockResponse, MockStreamEvent};
+pub use streaming::{MOCK_PROVIDER, MockStreamEvent, mock_final, mock_final_with_total_tokens};
 pub use tracing_isolation::{
     scoped_tracing_subscriber_guard, scoped_tracing_subscriber_guard_blocking,
 };

--- a/crates/rig-core/src/test_utils/streaming.rs
+++ b/crates/rig-core/src/test_utils/streaming.rs
@@ -1,44 +1,24 @@
 //! Streaming helpers for [`MockCompletionModel`](super::MockCompletionModel).
 
 use crate::{
-    completion::{CompletionError, GetTokenUsage, Usage},
+    completion::{CompletionError, Usage},
     message::ReasoningContent,
-    streaming::{RawStreamingChoice, RawStreamingToolCall, ToolCallDeltaContent},
+    streaming::{RawStreamingChoice, RawStreamingToolCall, StreamFinal, ToolCallDeltaContent},
 };
-use serde::{Deserialize, Serialize};
 
-/// Raw mock response used by completion and streaming test utilities.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct MockResponse {
-    usage: Usage,
+/// Provider descriptor name reported by the test doubles.
+pub const MOCK_PROVIDER: &str = "mock";
+
+/// Build the terminal record the mock model yields, carrying `usage`.
+pub fn mock_final(usage: Usage) -> StreamFinal {
+    StreamFinal::new(MOCK_PROVIDER, usage)
 }
 
-impl MockResponse {
-    /// Create a mock raw response without token usage (zero-valued usage,
-    /// [`Usage`]'s documented sentinel for missing provider metrics).
-    pub fn new() -> Self {
-        Self {
-            usage: Usage::new(),
-        }
-    }
-
-    /// Create a mock raw response carrying token usage.
-    pub fn with_usage(usage: Usage) -> Self {
-        Self { usage }
-    }
-
-    /// Create a mock raw response whose usage has only `total_tokens` set.
-    pub fn with_total_tokens(total_tokens: u64) -> Self {
-        let mut usage = Usage::new();
-        usage.total_tokens = total_tokens;
-        Self::with_usage(usage)
-    }
-}
-
-impl GetTokenUsage for MockResponse {
-    fn token_usage(&self) -> Usage {
-        self.usage
-    }
+/// Build a terminal record whose usage has only `total_tokens` set.
+pub fn mock_final_with_total_tokens(total_tokens: u64) -> StreamFinal {
+    let mut usage = Usage::new();
+    usage.total_tokens = total_tokens;
+    mock_final(usage)
 }
 
 /// Scripted streaming event yielded by [`MockCompletionModel`](super::MockCompletionModel).
@@ -80,7 +60,7 @@ pub enum MockStreamEvent {
     /// Provider-native output item that Rig does not model.
     Unknown(serde_json::Value),
     /// Final raw response carrying optional usage.
-    FinalResponse(MockResponse),
+    FinalResponse(StreamFinal),
     /// Stream error.
     Error(MockError),
 }
@@ -190,17 +170,17 @@ impl MockStreamEvent {
 
     /// Create a final response event with usage.
     pub fn final_response(usage: Usage) -> Self {
-        Self::FinalResponse(MockResponse::with_usage(usage))
+        Self::FinalResponse(mock_final(usage))
     }
 
     /// Create a final response event with default zero usage.
     pub fn final_response_with_default_usage() -> Self {
-        Self::FinalResponse(MockResponse::with_usage(Usage::new()))
+        Self::FinalResponse(mock_final(Usage::new()))
     }
 
     /// Create a final response event whose usage has only `total_tokens` set.
     pub fn final_response_with_total_tokens(total_tokens: u64) -> Self {
-        Self::FinalResponse(MockResponse::with_total_tokens(total_tokens))
+        Self::FinalResponse(mock_final_with_total_tokens(total_tokens))
     }
 
     /// Create a stream error event.
@@ -208,9 +188,7 @@ impl MockStreamEvent {
         Self::Error(MockError::provider(message))
     }
 
-    pub(crate) fn into_raw_choice(
-        self,
-    ) -> Result<RawStreamingChoice<MockResponse>, CompletionError> {
+    pub(crate) fn into_raw_choice(self) -> Result<RawStreamingChoice, CompletionError> {
         match self {
             Self::Text(text) => Ok(RawStreamingChoice::Message(text)),
             Self::TextStart { additional_params } => {

--- a/crates/rig-gemini-grpc/src/completion.rs
+++ b/crates/rig-gemini-grpc/src/completion.rs
@@ -41,19 +41,47 @@ impl CompletionModel {
     }
 }
 
-impl completion::CompletionModel for CompletionModel {
-    type Response = GenerateContentResponse;
-    type StreamingResponse = super::streaming::StreamingCompletionResponse;
-    type Client = super::Client;
+/// Stable descriptor name reported on normalized responses from this provider.
+pub const PROVIDER_NAME: &str = "gemini-grpc";
 
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
+/// Map Gemini's protobuf `finishReason` onto rig's normalized vocabulary.
+///
+/// The wire value is a prost enum discriminant; unmapped values are carried
+/// verbatim in their SCREAMING_SNAKE proto spelling so a reason Google adds
+/// later surfaces rather than reading as a natural stop.
+pub fn map_finish_reason(reason: i32) -> Option<completion::FinishReason> {
+    use proto::candidate::FinishReason as Wire;
 
-    async fn completion(
+    let Ok(reason) = Wire::try_from(reason) else {
+        return Some(completion::FinishReason::Other(format!(
+            "FINISH_REASON_{reason}"
+        )));
+    };
+
+    let normalized = match reason {
+        // The proto default; Gemini reports it when no reason applies.
+        Wire::Unspecified => return None,
+        Wire::Stop => completion::FinishReason::Stop,
+        Wire::MaxTokens => completion::FinishReason::Length,
+        Wire::Safety | Wire::Blocklist | Wire::ProhibitedContent | Wire::Spii => {
+            completion::FinishReason::ContentFilter
+        }
+        other => completion::FinishReason::Other(other.as_str_name().to_owned()),
+    };
+
+    Some(normalized)
+}
+
+impl CompletionModel {
+    /// Execute a completion and return Gemini's own protobuf response.
+    ///
+    /// This is the escape hatch for fields rig does not normalize;
+    /// [`completion::CompletionModel::completion`] calls it and maps the
+    /// result, so there is exactly one RPC either way.
+    pub async fn raw_completion(
         &self,
         completion_request: CompletionRequest,
-    ) -> Result<completion::CompletionResponse<GenerateContentResponse>, CompletionError> {
+    ) -> Result<GenerateContentResponse, CompletionError> {
         let request = create_grpc_request(self.model.clone(), completion_request)?;
 
         let mut grpc_client = self
@@ -67,16 +95,34 @@ impl completion::CompletionModel for CompletionModel {
             .map_err(rpc_error)?
             .into_inner();
 
-        response.try_into()
+        Ok(response)
+    }
+
+    /// Open a stream whose terminal record stays Gemini's own protobuf
+    /// response.
+    pub async fn raw_stream(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<
+        rig_core::streaming::RawStreamingResult<super::streaming::StreamingCompletionResponse>,
+        CompletionError,
+    > {
+        super::streaming::raw_stream(self.client.clone(), self.model.clone(), request).await
+    }
+}
+
+impl completion::CompletionModel for CompletionModel {
+    async fn completion(
+        &self,
+        completion_request: CompletionRequest,
+    ) -> Result<completion::CompletionResponse, CompletionError> {
+        self.raw_completion(completion_request).await?.try_into()
     }
 
     async fn stream(
         &self,
         request: CompletionRequest,
-    ) -> Result<
-        rig_core::streaming::StreamingCompletionResponse<Self::StreamingResponse>,
-        CompletionError,
-    > {
+    ) -> Result<rig_core::streaming::StreamingCompletionResponse, CompletionError> {
         super::streaming::stream(self.client.clone(), self.model.clone(), request).await
     }
 }
@@ -392,7 +438,7 @@ fn rig_assistant_content_to_grpc_part(
 }
 
 // Convert gRPC GenerateContentResponse to Rig CompletionResponse
-impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<GenerateContentResponse> {
+impl TryFrom<GenerateContentResponse> for completion::CompletionResponse {
     type Error = CompletionError;
 
     fn try_from(response: GenerateContentResponse) -> Result<Self, Self::Error> {
@@ -495,12 +541,20 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
             })
             .unwrap_or_default();
 
-        Ok(completion::CompletionResponse {
-            choice,
-            usage,
-            raw_response: response,
-            message_id: None,
-        })
+        let finish_reason = response
+            .candidates
+            .first()
+            .and_then(|candidate| map_finish_reason(candidate.finish_reason));
+        let model = Some(response.model_version.clone()).filter(|model| !model.is_empty());
+        let message_id =
+            Some(response.response_id.clone()).filter(|response_id| !response_id.is_empty());
+
+        Ok(
+            completion::CompletionResponse::new(choice, usage, PROVIDER_NAME)
+                .with_optional_finish_reason(finish_reason)
+                .with_optional_message_id(message_id)
+                .with_optional_model(model),
+        )
     }
 }
 

--- a/crates/rig-gemini-grpc/src/completion.rs
+++ b/crates/rig-gemini-grpc/src/completion.rs
@@ -546,13 +546,9 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse {
             .first()
             .and_then(|candidate| map_finish_reason(candidate.finish_reason));
         let model = Some(response.model_version.clone()).filter(|model| !model.is_empty());
-        let message_id =
-            Some(response.response_id.clone()).filter(|response_id| !response_id.is_empty());
-
         Ok(
             completion::CompletionResponse::new(choice, usage, PROVIDER_NAME)
                 .with_optional_finish_reason(finish_reason)
-                .with_optional_message_id(message_id)
                 .with_optional_model(model),
         )
     }

--- a/crates/rig-gemini-grpc/src/lib.rs
+++ b/crates/rig-gemini-grpc/src/lib.rs
@@ -36,10 +36,11 @@ pub use proto::{
     GenerateContentResponse, Part, generative_service_client::GenerativeServiceClient,
 };
 
-// Implement GetTokenUsage for proto::GenerateContentResponse to support streaming
-impl rig_core::completion::GetTokenUsage for proto::GenerateContentResponse {
-    fn token_usage(&self) -> rig_core::completion::Usage {
-        self.usage_metadata
+// Normalize Gemini's protobuf usage metadata into rig's usage record.
+impl From<&proto::GenerateContentResponse> for rig_core::completion::Usage {
+    fn from(response: &proto::GenerateContentResponse) -> Self {
+        response
+            .usage_metadata
             .as_ref()
             .map(|u| rig_core::completion::Usage {
                 input_tokens: u.prompt_token_count as u64,

--- a/crates/rig-gemini-grpc/src/streaming.rs
+++ b/crates/rig-gemini-grpc/src/streaming.rs
@@ -16,11 +16,12 @@ use super::proto;
 
 pub type StreamingCompletionResponse = GenerateContentResponse;
 
-pub(crate) async fn stream(
+/// Open a stream whose terminal record stays Gemini's own protobuf response.
+pub(crate) async fn raw_stream(
     client: Client,
     model: String,
     completion_request: CompletionRequest,
-) -> Result<streaming::StreamingCompletionResponse<StreamingCompletionResponse>, CompletionError> {
+) -> Result<streaming::RawStreamingResult<StreamingCompletionResponse>, CompletionError> {
     let request = super::completion::create_grpc_request(model, completion_request)?;
 
     let mut grpc_client = client
@@ -111,9 +112,52 @@ pub(crate) async fn stream(
         yield Ok(streaming::RawStreamingChoice::FinalResponse(resp));
     };
 
-    Ok(streaming::StreamingCompletionResponse::stream(Box::pin(
-        stream,
-    )))
+    Ok(Box::pin(stream))
+}
+
+/// Open a stream normalized to rig's [`streaming::StreamFinal`] terminal
+/// record. Delegates to [`raw_stream`] — one RPC either way.
+pub(crate) async fn stream(
+    client: Client,
+    model: String,
+    completion_request: CompletionRequest,
+) -> Result<streaming::StreamingCompletionResponse, CompletionError> {
+    let raw = raw_stream(client, model, completion_request).await?;
+    let normalized = streaming::normalize_stream(raw, |response| {
+        let usage = response
+            .usage_metadata
+            .as_ref()
+            .map(|usage| rig_core::completion::Usage {
+                input_tokens: usage.prompt_token_count as u64,
+                output_tokens: usage.candidates_token_count as u64,
+                total_tokens: usage.total_token_count as u64,
+                cached_input_tokens: usage.cached_content_token_count as u64,
+                cache_creation_input_tokens: 0,
+                tool_use_prompt_tokens: 0,
+                reasoning_tokens: 0,
+            })
+            .unwrap_or_default();
+        let finish_reason = response
+            .candidates
+            .first()
+            .and_then(|candidate| super::completion::map_finish_reason(candidate.finish_reason));
+
+        Ok(
+            streaming::StreamFinal::new(super::completion::PROVIDER_NAME, usage)
+                .with_optional_finish_reason(finish_reason)
+                .with_optional_message_id(
+                    Some(response.response_id.clone()).filter(|id| !id.is_empty()),
+                )
+                .with_optional_model(
+                    Some(response.model_version.clone()).filter(|model| !model.is_empty()),
+                ),
+        )
+    });
+
+    Ok(streaming::StreamingCompletionResponse::stream(
+        super::completion::PROVIDER_NAME,
+        normalized,
+    ))
 }
 
 fn encode_signature(bytes: &[u8]) -> Option<String> {

--- a/crates/rig-vertexai/src/completion.rs
+++ b/crates/rig-vertexai/src/completion.rs
@@ -5,11 +5,9 @@ use crate::types::{
     completion_request::VertexCompletionRequest, completion_response::VertexGenerateContentOutput,
 };
 use rig_core::completion::{
-    CompletionError, CompletionModel as CompletionModelTrait, CompletionRequest,
-    CompletionResponse, GetTokenUsage,
+    CompletionError, CompletionModel as CompletionModelTrait, CompletionRequest, CompletionResponse,
 };
 use rig_core::streaming::StreamingCompletionResponse;
-use serde::{Deserialize, Serialize};
 
 /// `gemini-1.5-pro`
 pub const GEMINI_1_5_PRO: &str = "gemini-1.5-pro";
@@ -32,15 +30,6 @@ pub const GEMINI_2_5_PRO: &str = "gemini-2.5-pro";
 pub struct CompletionModel {
     pub(crate) client: crate::client::Client,
     pub model: String,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-pub struct PlaceholderStreamingResponse;
-
-impl GetTokenUsage for PlaceholderStreamingResponse {
-    fn token_usage(&self) -> rig_core::completion::Usage {
-        rig_core::completion::Usage::new()
-    }
 }
 
 impl CompletionModel {
@@ -68,20 +57,16 @@ impl CompletionModel {
     }
 }
 
-impl CompletionModelTrait for CompletionModel {
-    type Response = VertexGenerateContentOutput;
-    type StreamingResponse = PlaceholderStreamingResponse;
-
-    type Client = Client;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model.into())
-    }
-
-    async fn completion(
+impl CompletionModel {
+    /// Execute a completion and return Vertex AI's own wire response.
+    ///
+    /// This is the escape hatch for fields rig does not normalize;
+    /// [`CompletionModelTrait::completion`] calls it and maps the result, so
+    /// there is exactly one RPC either way.
+    pub async fn raw_completion(
         &self,
         request: CompletionRequest,
-    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+    ) -> Result<VertexGenerateContentOutput, CompletionError> {
         tracing::debug!(
             target: "rig_core::vertexai",
             "Vertex AI completion request: {request:?}"
@@ -128,19 +113,41 @@ impl CompletionModelTrait for CompletionModel {
             "Vertex AI completion response: {response:?}"
         );
 
-        let vertex_output = VertexGenerateContentOutput(response);
-        let completion_response = vertex_output.try_into()?;
+        Ok(VertexGenerateContentOutput(response))
+    }
 
-        Ok(completion_response)
+    /// Vertex AI streaming is not implemented in this integration.
+    ///
+    /// Present for parity with the other providers' escape hatches so callers
+    /// get the same error from the raw and normalized paths.
+    pub async fn raw_stream(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<rig_core::streaming::RawStreamingResult<VertexGenerateContentOutput>, CompletionError>
+    {
+        Err(streaming_unsupported())
+    }
+}
+
+fn streaming_unsupported() -> CompletionError {
+    CompletionError::ProviderError(
+        "Streaming is not supported for Vertex AI in this integration".to_string(),
+    )
+}
+
+impl CompletionModelTrait for CompletionModel {
+    async fn completion(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<CompletionResponse, CompletionError> {
+        self.raw_completion(request).await?.try_into()
     }
 
     async fn stream(
         &self,
         _request: CompletionRequest,
-    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
-        Err(CompletionError::ProviderError(
-            "Streaming is not supported for Vertex AI in this integration".to_string(),
-        ))
+    ) -> Result<StreamingCompletionResponse, CompletionError> {
+        Err(streaming_unsupported())
     }
 }
 

--- a/crates/rig-vertexai/src/types/completion_response.rs
+++ b/crates/rig-vertexai/src/types/completion_response.rs
@@ -33,7 +33,16 @@ pub fn map_finish_reason(
         }
         // `Unspecified` is Vertex's "no reason reported" value, not a reason.
         Wire::Unspecified => return None,
-        other => Normalized::Other(format!("{other:?}").to_uppercase()),
+        // Everything else keeps Vertex's own spelling. `name()` yields the wire
+        // form (`MALFORMED_FUNCTION_CALL`); a value the SDK does not model
+        // falls back to `Display`, which prints the raw enum value. Formatting
+        // the variant with `Debug` would silently drop the underscores.
+        ref other => Normalized::Other(
+            other
+                .name()
+                .map(ToOwned::to_owned)
+                .unwrap_or_else(|| other.to_string()),
+        ),
     };
 
     Some(normalized)

--- a/crates/rig-vertexai/src/types/completion_response.rs
+++ b/crates/rig-vertexai/src/types/completion_response.rs
@@ -12,7 +12,34 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Serialize, Deserialize)]
 pub struct VertexGenerateContentOutput(pub vertexai::model::GenerateContentResponse);
 
-impl TryFrom<VertexGenerateContentOutput> for CompletionResponse<VertexGenerateContentOutput> {
+/// Stable descriptor name reported on normalized Vertex AI responses.
+pub const PROVIDER_NAME: &str = "vertexai";
+
+/// Map Vertex AI's `finishReason` onto rig's normalized vocabulary.
+///
+/// Unmapped values are carried verbatim in their wire SCREAMING_SNAKE spelling
+/// so a reason Vertex adds later surfaces instead of reading as a natural stop.
+pub fn map_finish_reason(
+    reason: vertexai::model::candidate::FinishReason,
+) -> Option<rig_core::completion::FinishReason> {
+    use rig_core::completion::FinishReason as Normalized;
+    use vertexai::model::candidate::FinishReason as Wire;
+
+    let normalized = match reason {
+        Wire::Stop => Normalized::Stop,
+        Wire::MaxTokens => Normalized::Length,
+        Wire::Safety | Wire::Blocklist | Wire::ProhibitedContent | Wire::Spii => {
+            Normalized::ContentFilter
+        }
+        // `Unspecified` is Vertex's "no reason reported" value, not a reason.
+        Wire::Unspecified => return None,
+        other => Normalized::Other(format!("{other:?}").to_uppercase()),
+    };
+
+    Some(normalized)
+}
+
+impl TryFrom<VertexGenerateContentOutput> for CompletionResponse {
     type Error = CompletionError;
 
     fn try_from(value: VertexGenerateContentOutput) -> Result<Self, Self::Error> {
@@ -137,12 +164,12 @@ impl TryFrom<VertexGenerateContentOutput> for CompletionResponse<VertexGenerateC
             })
             .unwrap_or_default();
 
-        Ok(CompletionResponse {
-            choice,
-            usage,
-            raw_response: value,
-            message_id: None,
-        })
+        let finish_reason = map_finish_reason(candidate.finish_reason.clone());
+        let model = Some(response.model_version.clone()).filter(|model| !model.is_empty());
+
+        Ok(CompletionResponse::new(choice, usage, PROVIDER_NAME)
+            .with_optional_finish_reason(finish_reason)
+            .with_optional_model(model))
     }
 }
 
@@ -229,10 +256,9 @@ mod tests {
     #[test]
     fn test_tool_call_response_captures_thought_signature() {
         let raw = b"\x00\x01\x02thinking-sig\xff";
-        let response: CompletionResponse<VertexGenerateContentOutput> =
-            create_signed_tool_call_response("add", raw)
-                .try_into()
-                .unwrap();
+        let response: CompletionResponse = create_signed_tool_call_response("add", raw)
+            .try_into()
+            .unwrap();
         match response.choice.first() {
             AssistantContent::ToolCall(tc) => assert_eq!(tc.signature, Some(BASE64.encode(raw))),
             _ => panic!("Expected ToolCall"),
@@ -241,7 +267,7 @@ mod tests {
 
     #[test]
     fn test_tool_call_response_without_signature_is_none() {
-        let response: CompletionResponse<VertexGenerateContentOutput> =
+        let response: CompletionResponse =
             create_tool_call_response("add", serde_json::json!({"x": 1}))
                 .try_into()
                 .unwrap();
@@ -264,7 +290,7 @@ mod tests {
         let candidate = vertexai::model::Candidate::new().set_content(content);
         let response = vertexai::model::GenerateContentResponse::new().set_candidates([candidate]);
 
-        let response: CompletionResponse<VertexGenerateContentOutput> =
+        let response: CompletionResponse =
             VertexGenerateContentOutput(response).try_into().unwrap();
 
         match response.choice.first() {
@@ -282,8 +308,7 @@ mod tests {
     #[test]
     fn test_text_response_conversion() {
         let vertex_output = create_text_response("Hello, world!");
-        let completion_response: Result<CompletionResponse<VertexGenerateContentOutput>, _> =
-            vertex_output.try_into();
+        let completion_response: Result<CompletionResponse, _> = vertex_output.try_into();
 
         assert!(completion_response.is_ok());
         let response = completion_response.unwrap();
@@ -302,8 +327,7 @@ mod tests {
             "y": 3
         });
         let vertex_output = create_tool_call_response("add", args.clone());
-        let completion_response: Result<CompletionResponse<VertexGenerateContentOutput>, _> =
-            vertex_output.try_into();
+        let completion_response: Result<CompletionResponse, _> = vertex_output.try_into();
 
         assert!(completion_response.is_ok());
         let response = completion_response.unwrap();
@@ -321,7 +345,7 @@ mod tests {
     #[test]
     fn inline_image_response_converts_raw_bytes_to_base64_with_mime_type() {
         let raw = vec![0, 1, 2, 255];
-        let response: CompletionResponse<VertexGenerateContentOutput> =
+        let response: CompletionResponse =
             create_parts_response([inline_data_part("image/png", raw.clone())])
                 .try_into()
                 .expect("image response should convert");
@@ -339,7 +363,7 @@ mod tests {
     #[test]
     fn mixed_text_and_image_response_preserves_part_order() {
         let raw = vec![1, 2, 3];
-        let response: CompletionResponse<VertexGenerateContentOutput> = create_parts_response([
+        let response: CompletionResponse = create_parts_response([
             vertexai::model::Part::new().set_text("before"),
             inline_data_part("image/jpeg", raw.clone()),
             vertexai::model::Part::new().set_text("after"),
@@ -361,7 +385,7 @@ mod tests {
 
     #[test]
     fn mixed_text_and_thought_image_response_keeps_only_visible_text_in_order() {
-        let response: CompletionResponse<VertexGenerateContentOutput> = create_parts_response([
+        let response: CompletionResponse = create_parts_response([
             vertexai::model::Part::new().set_text("before"),
             inline_data_part("image/png", vec![1, 2, 3]).set_thought(true),
             vertexai::model::Part::new().set_text("after"),
@@ -377,10 +401,11 @@ mod tests {
 
     #[test]
     fn thought_image_only_response_fails_without_visible_assistant_content() {
-        let result =
-            CompletionResponse::<VertexGenerateContentOutput>::try_from(create_parts_response([
-                inline_data_part("image/png", vec![1, 2, 3]).set_thought(true),
-            ]));
+        let result = CompletionResponse::try_from(create_parts_response([inline_data_part(
+            "image/png",
+            vec![1, 2, 3],
+        )
+        .set_thought(true)]));
 
         let error = match result {
             Err(error) => error,
@@ -397,9 +422,10 @@ mod tests {
     #[test]
     fn inline_audio_and_non_image_media_are_rejected() {
         for mime_type in ["audio/wav", "application/pdf", "application/octet-stream"] {
-            let result = CompletionResponse::<VertexGenerateContentOutput>::try_from(
-                create_parts_response([inline_data_part(mime_type, vec![0])]),
-            );
+            let result = CompletionResponse::try_from(create_parts_response([inline_data_part(
+                mime_type,
+                vec![0],
+            )]));
             let error = match result {
                 Err(error) => error,
                 Ok(_) => panic!("unsupported inline media must fail"),
@@ -412,9 +438,10 @@ mod tests {
     #[test]
     fn inline_gif_and_svg_images_are_rejected() {
         for mime_type in ["image/gif", "image/svg+xml"] {
-            let result = CompletionResponse::<VertexGenerateContentOutput>::try_from(
-                create_parts_response([inline_data_part(mime_type, vec![0])]),
-            );
+            let result = CompletionResponse::try_from(create_parts_response([inline_data_part(
+                mime_type,
+                vec![0],
+            )]));
             let error = match result {
                 Err(error) => error,
                 Ok(_) => panic!("non-replayable inline image must fail"),
@@ -431,10 +458,7 @@ mod tests {
     #[test]
     fn signed_inline_image_is_rejected() {
         let part = inline_data_part("image/png", vec![0]).set_thought_signature(vec![1, 2, 3]);
-        let result =
-            CompletionResponse::<VertexGenerateContentOutput>::try_from(create_parts_response([
-                part,
-            ]));
+        let result = CompletionResponse::try_from(create_parts_response([part]));
         let error = match result {
             Err(error) => error,
             Ok(_) => panic!("signed inline image must fail"),
@@ -453,8 +477,7 @@ mod tests {
         response = response.set_usage_metadata(usage_metadata);
 
         let vertex_output = VertexGenerateContentOutput(response);
-        let completion_response: Result<CompletionResponse<VertexGenerateContentOutput>, _> =
-            vertex_output.try_into();
+        let completion_response: Result<CompletionResponse, _> = vertex_output.try_into();
 
         assert!(completion_response.is_ok());
         let response = completion_response.unwrap();
@@ -468,8 +491,7 @@ mod tests {
         // Create a response with no candidates
         let response = vertexai::model::GenerateContentResponse::new();
         let vertex_output = VertexGenerateContentOutput(response);
-        let completion_response: Result<CompletionResponse<VertexGenerateContentOutput>, _> =
-            vertex_output.try_into();
+        let completion_response: Result<CompletionResponse, _> = vertex_output.try_into();
 
         assert!(completion_response.is_err());
     }

--- a/crates/rig-vertexai/src/types/message.rs
+++ b/crates/rig-vertexai/src/types/message.rs
@@ -343,10 +343,9 @@ mod tests {
                     ]),
             ),
         ]);
-        let response: CompletionResponse<VertexGenerateContentOutput> =
-            VertexGenerateContentOutput(response)
-                .try_into()
-                .expect("image response should convert");
+        let response: CompletionResponse = VertexGenerateContentOutput(response)
+            .try_into()
+            .expect("image response should convert");
 
         let content: vertexai::model::Content = RigMessage(Message::Assistant {
             id: None,

--- a/examples/agent_stream_chat/src/main.rs
+++ b/examples/agent_stream_chat/src/main.rs
@@ -10,7 +10,7 @@ use rig::providers::openai;
 const PREAMBLE: &str = "You are a comedian here to entertain the user using humour and jokes.";
 const PROMPT: &str = "Entertain me!";
 
-async fn collect_stream_final_response<R>(stream: &mut StreamingResult<R>) -> Result<String> {
+async fn collect_stream_final_response(stream: &mut StreamingResult) -> Result<String> {
     let mut final_response = None;
 
     while let Some(item) = stream.next().await {

--- a/examples/agent_with_memory_streaming/src/main.rs
+++ b/examples/agent_with_memory_streaming/src/main.rs
@@ -13,7 +13,7 @@ use rig::prelude::*;
 use rig::providers::openai;
 use rig::streaming::StreamingPrompt;
 
-async fn collect_final<R>(stream: &mut StreamingResult<R>) -> Result<String> {
+async fn collect_final(stream: &mut StreamingResult) -> Result<String> {
     let mut final_response = None;
     while let Some(item) = stream.next().await {
         if let MultiTurnStreamItem::FinalResponse(response) = item? {

--- a/examples/candle_local/src/main.rs
+++ b/examples/candle_local/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use futures::StreamExt;
 use rig::candle::{CandleModel, ModelData};
 use rig::completion::CompletionModel;
-use rig::streaming::StreamedAssistantContent;
+use rig::streaming::RawStreamingChoice;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -25,30 +25,37 @@ async fn main() -> anyhow::Result<()> {
         tokenizer: std::fs::read(model_dir.join("tokenizer.json"))?,
         weights: std::fs::read(model_dir.join("model.gguf"))?,
     })?;
-    let mut response = model
+    let request = model
         .completion_request(prompt)
         .preamble("You are a concise and helpful assistant.".to_string())
         .temperature(0.0)
         .max_tokens(64)
-        .stream()
-        .await?;
+        .build();
+
+    // The local generation metrics printed below (throughput, prefill time,
+    // time-to-first-token) are Candle's own — Rig's normalized `StreamFinal`
+    // carries usage and a finish reason, not these. `raw_stream` keeps the
+    // provider's terminal record typed so they stay reachable; use
+    // `CompletionModel::stream` when the normalized metadata is enough.
+    let mut stream = model.raw_stream(request).await?;
     let mut final_response = None;
-    while let Some(item) = response.next().await {
+    while let Some(item) = stream.next().await {
         match item? {
-            StreamedAssistantContent::Text(fragment) => {
-                print!("{}", fragment.text);
+            RawStreamingChoice::Message(fragment) => {
+                print!("{fragment}");
                 std::io::stdout().flush()?;
             }
-            StreamedAssistantContent::Final(raw) => final_response = Some(raw),
+            RawStreamingChoice::FinalResponse(final_record) => final_response = Some(final_record),
             _ => {}
         }
     }
     println!();
     let raw = final_response.context("Candle stream ended without final metadata")?;
-    let usage = response.usage();
     println!(
         "tokens: prompt={}, generated={}, total={}",
-        usage.input_tokens, usage.output_tokens, usage.total_tokens
+        raw.prompt_tokens,
+        raw.generated_tokens,
+        raw.prompt_tokens.saturating_add(raw.generated_tokens)
     );
     let throughput = match raw.tokens_per_second {
         Some(value) => format!("{value:.2} tokens/s"),

--- a/examples/gemini_default_api_recovery/src/main.rs
+++ b/examples/gemini_default_api_recovery/src/main.rs
@@ -225,7 +225,7 @@ fn gemini_canary_additional_params() -> Result<serde_json::Value, serde_json::Er
 }
 
 async fn consume_workspace_like_stream(
-    mut stream: StreamingResult<gemini::streaming::StreamingCompletionResponse>,
+    mut stream: StreamingResult,
 ) -> Result<WorkspaceStreamObservation, String> {
     let mut observation = WorkspaceStreamObservation::default();
 

--- a/examples/gemini_stream_kill_token_count/src/main.rs
+++ b/examples/gemini_stream_kill_token_count/src/main.rs
@@ -49,7 +49,7 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 
 use futures::{Stream, StreamExt};
-use rig::completion::{CompletionError, CompletionModel, GetTokenUsage, Usage};
+use rig::completion::{CompletionError, CompletionModel, Usage};
 use rig::prelude::*;
 use rig::providers::gemini;
 use rig::providers::gemini::completion::gemini_api_types::{
@@ -81,22 +81,16 @@ enum Disruption {
 /// Wraps a live `StreamingCompletionResponse` and injects a disruption after
 /// `after_chars` of output has been forwarded. This lets us exercise every
 /// disruption shape against a genuine Gemini stream's partial output.
-struct Disrupt<R>
-where
-    R: Clone + Unpin + GetTokenUsage,
-{
-    inner: StreamingCompletionResponse<R>,
+struct Disrupt {
+    inner: StreamingCompletionResponse,
     mode: Disruption,
     after_chars: usize,
     seen_chars: usize,
     fired: bool,
 }
 
-impl<R> Disrupt<R>
-where
-    R: Clone + Unpin + GetTokenUsage,
-{
-    fn new(inner: StreamingCompletionResponse<R>, mode: Disruption, after_chars: usize) -> Self {
+impl Disrupt {
+    fn new(inner: StreamingCompletionResponse, mode: Disruption, after_chars: usize) -> Self {
         // For `None`, make the trigger unreachable so it never fires.
         let after_chars = match mode {
             Disruption::None => usize::MAX,
@@ -112,11 +106,8 @@ where
     }
 }
 
-impl<R> Stream for Disrupt<R>
-where
-    R: Clone + Unpin + GetTokenUsage,
-{
-    type Item = Result<StreamedAssistantContent<R>, CompletionError>;
+impl Stream for Disrupt {
+    type Item = Result<StreamedAssistantContent, CompletionError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
@@ -163,7 +154,7 @@ where
 }
 
 /// Length of human-visible text in a stream item (text + reasoning deltas).
-fn visible_len<R>(item: &StreamedAssistantContent<R>) -> usize {
+fn visible_len(item: &StreamedAssistantContent) -> usize {
     match item {
         StreamedAssistantContent::Text(t) => t.text.chars().count(),
         StreamedAssistantContent::ReasoningDelta { reasoning, .. } => reasoning.chars().count(),
@@ -192,7 +183,7 @@ struct Report {
 /// each read with a timeout. If the stream ends — by `None`, `Err`, a zeroed
 /// `Final`, or a stall — without authoritative usage, it estimates tokens from
 /// the partial output via `countTokens`.
-async fn drain_with_accounting<S, R>(
+async fn drain_with_accounting<S>(
     label: &'static str,
     mut stream: S,
     http: &reqwest::Client,
@@ -200,8 +191,7 @@ async fn drain_with_accounting<S, R>(
     prompt_text: &str,
 ) -> anyhow::Result<Report>
 where
-    S: Stream<Item = Result<StreamedAssistantContent<R>, CompletionError>> + Unpin,
-    R: Clone + Unpin + GetTokenUsage,
+    S: Stream<Item = Result<StreamedAssistantContent, CompletionError>> + Unpin,
 {
     let mut output = String::new();
     let mut authoritative: Option<Usage> = None;
@@ -237,7 +227,7 @@ where
                 StreamedAssistantContent::Final(resp) => {
                     // Authoritative usage — but only trust it if non-zero. A
                     // premature clean close yields a zeroed Final (shape #3).
-                    let usage = resp.token_usage();
+                    let usage = resp.usage;
                     if usage.has_values() {
                         authoritative = Some(usage);
                     }

--- a/tests/common/reasoning.rs
+++ b/tests/common/reasoning.rs
@@ -17,7 +17,6 @@ use rig::message::{
 };
 use rig::streaming::{StreamedAssistantContent, StreamedUserContent};
 use rig::tool::Tool;
-use rig::wasm_compat::WasmCompatSend;
 use serde::Deserialize;
 use serde_json::json;
 
@@ -54,7 +53,6 @@ where
 pub(crate) async fn run_reasoning_roundtrip_streaming<M>(agent: ReasoningRoundtripAgent<M>)
 where
     M: CompletionModel,
-    M::StreamingResponse: WasmCompatSend,
 {
     run_reasoning_roundtrip_streaming_with_final(agent, |_| {}).await;
 }
@@ -64,8 +62,7 @@ pub(crate) async fn run_reasoning_roundtrip_streaming_with_final<M, F>(
     mut inspect_final: F,
 ) where
     M: CompletionModel,
-    M::StreamingResponse: WasmCompatSend,
-    F: FnMut(&M::StreamingResponse),
+    F: FnMut(&rig::streaming::StreamFinal),
 {
     let turn1_prompt = Message::User {
         content: OneOrMany::one(UserContent::text(ROUNDTRIP_TURN1_TEXT)),
@@ -423,8 +420,8 @@ fn record_reasoning(stats: &mut StreamStats, reasoning: &Reasoning, provider: &s
     );
 }
 
-pub(crate) async fn collect_stream_stats<R>(
-    stream: impl futures::Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>>,
+pub(crate) async fn collect_stream_stats(
+    stream: impl futures::Stream<Item = Result<MultiTurnStreamItem, StreamingError>>,
     provider: &str,
 ) -> StreamStats {
     let mut stats = StreamStats::new();

--- a/tests/common/support.rs
+++ b/tests/common/support.rs
@@ -4,7 +4,7 @@
 use futures::StreamExt;
 use rig::{
     agent::{MultiTurnStreamItem, StreamingError, StreamingResult},
-    completion::{AssistantContent, GetTokenUsage, ToolDefinition},
+    completion::{AssistantContent, ToolDefinition},
     embeddings::Embedding,
     streaming::{StreamedAssistantContent, StreamedUserContent, StreamingCompletionResponse},
     tool::PortableTool,
@@ -477,8 +477,8 @@ pub(crate) fn assert_embeddings_nonempty_and_consistent(
     }
 }
 
-pub(crate) async fn collect_stream_final_response<R>(
-    stream: &mut StreamingResult<R>,
+pub(crate) async fn collect_stream_final_response(
+    stream: &mut StreamingResult,
 ) -> Result<String, StreamingError> {
     let mut final_response = None;
 
@@ -491,9 +491,9 @@ pub(crate) async fn collect_stream_final_response<R>(
     Ok(final_response.expect("stream should yield a final response"))
 }
 
-pub(crate) async fn collect_stream_final_response_and_provider_final<R>(
-    stream: &mut StreamingResult<R>,
-) -> Result<(String, R), StreamingError> {
+pub(crate) async fn collect_stream_final_response_and_provider_final(
+    stream: &mut StreamingResult,
+) -> Result<(String, rig::streaming::StreamFinal), StreamingError> {
     let mut final_response = None;
     let mut provider_final = None;
 
@@ -515,13 +515,11 @@ pub(crate) async fn collect_stream_final_response_and_provider_final<R>(
     ))
 }
 
-pub(crate) async fn assert_stream_contains_zero_arg_tool_call_named<R>(
-    mut stream: StreamingCompletionResponse<R>,
+pub(crate) async fn assert_stream_contains_zero_arg_tool_call_named(
+    mut stream: StreamingCompletionResponse,
     expected_name: &str,
     expect_final_response: bool,
-) where
-    R: Clone + Unpin + GetTokenUsage,
-{
+) {
     let mut saw_final = false;
     let mut saw_matching_tool_call = false;
 
@@ -604,9 +602,7 @@ impl RawStreamObservation {
     }
 }
 
-pub(crate) async fn collect_stream_observation<R>(
-    stream: &mut StreamingResult<R>,
-) -> StreamObservation {
+pub(crate) async fn collect_stream_observation(stream: &mut StreamingResult) -> StreamObservation {
     let mut observation = StreamObservation::new();
 
     while let Some(item) = stream.next().await {
@@ -663,11 +659,10 @@ pub(crate) async fn collect_stream_observation<R>(
     observation
 }
 
-pub(crate) async fn collect_raw_stream_observation<R>(
-    mut stream: StreamingCompletionResponse<R>,
+pub(crate) async fn collect_raw_stream_observation(
+    mut stream: StreamingCompletionResponse,
 ) -> RawStreamObservation
 where
-    R: Clone + Unpin + GetTokenUsage,
 {
     let mut observation = RawStreamObservation::new();
 

--- a/tests/core/reasoning_stream_stats.rs
+++ b/tests/core/reasoning_stream_stats.rs
@@ -25,7 +25,7 @@ async fn collect_stream_stats_tracks_only_final_turn_text() {
 
     let items = vec![
         Ok(MultiTurnStreamItem::StreamAssistantItem(
-            StreamedAssistantContent::<()>::text("Sure! Let me check the weather right away!"),
+            StreamedAssistantContent::text("Sure! Let me check the weather right away!"),
         )),
         Ok(MultiTurnStreamItem::StreamAssistantItem(
             StreamedAssistantContent::ToolCall {
@@ -37,7 +37,7 @@ async fn collect_stream_stats_tracks_only_final_turn_text() {
             StreamedUserContent::tool_result(tool_result, internal_call_id),
         )),
         Ok(MultiTurnStreamItem::StreamAssistantItem(
-            StreamedAssistantContent::<()>::text("It's 72F and sunny in Tokyo."),
+            StreamedAssistantContent::text("It's 72F and sunny in Tokyo."),
         )),
         Ok(MultiTurnStreamItem::final_response(
             OneOrMany::one(AssistantContent::text("It's 72F and sunny in Tokyo.")),

--- a/tests/providers/anthropic/cassette/messages_behaviors.rs
+++ b/tests/providers/anthropic/cassette/messages_behaviors.rs
@@ -7,7 +7,7 @@
 //! Run cassette tests in replay mode by default, or set
 //! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
 
-use rig::completion::CompletionModel;
+use rig::completion::{CompletionModel, FinishReason};
 use rig::message::AssistantContent;
 use rig::prelude::*;
 use rig::providers::anthropic;
@@ -34,8 +34,8 @@ async fn max_tokens_truncation_preserves_stop_reason_and_partial_text() {
                 .expect("a truncated response should still convert, not error");
 
             assert_eq!(
-                response.raw_response.stop_reason.as_deref(),
-                Some("max_tokens"),
+                response.finish_reason,
+                Some(FinishReason::Length),
                 "hitting max_tokens should preserve the max_tokens stop reason"
             );
             let text: String = response

--- a/tests/providers/anthropic/cassette/messages_sessions.rs
+++ b/tests/providers/anthropic/cassette/messages_sessions.rs
@@ -11,7 +11,7 @@
 
 use futures::StreamExt;
 use rig::agent::MultiTurnStreamItem;
-use rig::completion::{Chat, CompletionModel, Message};
+use rig::completion::{Chat, CompletionModel, FinishReason, Message};
 use rig::message::{AssistantContent, UserContent};
 use rig::prelude::*;
 use rig::providers::anthropic;
@@ -288,8 +288,8 @@ async fn long_history_replay_nonstreaming() {
                 })
                 .expect("first turn should call lookup_harbor_label");
             assert_eq!(
-                first_response.raw_response.stop_reason.as_deref(),
-                Some("tool_use"),
+                first_response.finish_reason,
+                Some(FinishReason::ToolCalls),
                 "a tool-using turn should preserve the tool_use stop reason"
             );
 
@@ -348,12 +348,19 @@ async fn long_history_replay_nonstreaming() {
                 "answer should recall the replayed tool result, got {text:?}"
             );
             assert_eq!(
-                response.raw_response.stop_reason.as_deref(),
-                Some("end_turn"),
+                response.finish_reason,
+                Some(FinishReason::Stop),
                 "a plain answer should preserve the end_turn stop reason"
             );
             assert!(
-                !response.raw_response.model.is_empty() && !response.raw_response.id.is_empty(),
+                response
+                    .model
+                    .as_deref()
+                    .is_some_and(|model| !model.is_empty())
+                    && response
+                        .message_id
+                        .as_deref()
+                        .is_some_and(|id| !id.is_empty()),
                 "provider response should preserve model and message id"
             );
             assert!(

--- a/tests/providers/anthropic/cassette/messages_tool_choice.rs
+++ b/tests/providers/anthropic/cassette/messages_tool_choice.rs
@@ -7,7 +7,7 @@
 //! Run cassette tests in replay mode by default, or set
 //! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
 
-use rig::completion::CompletionModel;
+use rig::completion::{CompletionModel, FinishReason};
 use rig::message::{AssistantContent, ToolChoice};
 use rig::prelude::*;
 use rig::providers::anthropic;
@@ -57,8 +57,8 @@ async fn required_maps_to_any_and_forces_tool_use() {
                 "only the provided tool can be called, saw {names:?}"
             );
             assert_eq!(
-                response.raw_response.stop_reason.as_deref(),
-                Some("tool_use"),
+                response.finish_reason,
+                Some(FinishReason::ToolCalls),
                 "a forced tool_use turn should preserve the tool_use stop reason"
             );
         },
@@ -106,8 +106,8 @@ async fn none_suppresses_tool_use() {
                 "model should answer directly without tools, got {text:?}"
             );
             assert_eq!(
-                response.raw_response.stop_reason.as_deref(),
-                Some("end_turn"),
+                response.finish_reason,
+                Some(FinishReason::Stop),
                 "a plain answer should preserve the end_turn stop reason"
             );
         },

--- a/tests/providers/anthropic/cassette/opus_4_8.rs
+++ b/tests/providers/anthropic/cassette/opus_4_8.rs
@@ -1,7 +1,8 @@
 //! Dedicated Claude Opus 4.8 cassette coverage.
 
 use rig::completion::{
-    AssistantContent, CompletionModel, Document, Message, ProviderToolDefinition,
+    AssistantContent, CompletionModel, CompletionResponse as RigCompletionResponse, Document,
+    Message, ProviderToolDefinition,
 };
 use rig::message::Text;
 use rig::prelude::*;
@@ -12,6 +13,10 @@ use serde_json::Value;
 use serde_json::json;
 
 use crate::support::{assert_contains_any_case_insensitive, assistant_text_response};
+
+/// Descriptor name the Anthropic client normalizes responses under; needed
+/// when a test converts a `raw_completion` response itself.
+const ANTHROPIC_PROVIDER: &str = "anthropic";
 
 const SYSTEM_ROLE_INSTRUCTION: &str = "For the rest of this conversation, answer in Spanish only.";
 const DOCUMENT_GLOBAL_SYSTEM_INSTRUCTION: &str = "Answer in Spanish only. Use one short sentence.";
@@ -24,7 +29,7 @@ async fn web_search_with_dynamic_filtering_succeeds() {
         "opus_4_8/web_search_with_dynamic_filtering_succeeds",
         |client| async move {
             let model = client.completion_model(CLAUDE_OPUS_4_8);
-            let response = model
+            let request = model
                 .completion_request(
                     "Search for the current prices of AAPL and GOOGL, then calculate which has a better P/E ratio.",
                 )
@@ -33,9 +38,18 @@ async fn web_search_with_dynamic_filtering_succeeds() {
                         .with_config("name", json!("web_search")),
                 )
                 .max_tokens(1024)
-                .send()
+                .build();
+            // One request, two views: `raw_completion` returns Anthropic's own
+            // response and the same value normalizes into rig's, so the
+            // provider-text fallback below still costs a single interaction.
+            let raw = model
+                .raw_completion(request)
                 .await
                 .expect("Opus 4.8 dynamic web-search request should succeed");
+            let raw_text = raw.get_text_response();
+            let response: RigCompletionResponse = (ANTHROPIC_PROVIDER, raw)
+                .try_into()
+                .expect("Opus 4.8 dynamic web-search response should normalize");
 
             assert!(
                 response.choice.iter().any(|content| {
@@ -45,7 +59,7 @@ async fn web_search_with_dynamic_filtering_succeeds() {
             );
             assert!(
                 assistant_text_response(&response.choice)
-                    .or_else(|| response.raw_response.get_text_response())
+                    .or(raw_text)
                     .is_some_and(|text| !text.trim().is_empty()),
                 "dynamic web-search response should contain assistant text",
             );
@@ -60,7 +74,7 @@ async fn messages_preserve_mid_conversation_system_role() {
         "opus_4_8/messages_preserve_mid_conversation_system_role",
         |client| async move {
             let model = client.completion_model(CLAUDE_OPUS_4_8);
-            let response = model
+            let request = model
                 .completion_request(
                     "What color is a clear daytime sky? Reply with one lowercase Spanish word.",
                 )
@@ -70,12 +84,18 @@ async fn messages_preserve_mid_conversation_system_role() {
                     Message::assistant("Entendido."),
                 ])
                 .max_tokens(64)
-                .send()
+                .build();
+            let raw = model
+                .raw_completion(request)
                 .await
                 .expect("Opus 4.8 system-role request should succeed");
+            let raw_text = raw.get_text_response();
+            let response: RigCompletionResponse = (ANTHROPIC_PROVIDER, raw)
+                .try_into()
+                .expect("Opus 4.8 system-role response should normalize");
 
             let text = assistant_text_response(&response.choice)
-                .or_else(|| response.raw_response.get_text_response())
+                .or(raw_text)
                 .expect("response should contain assistant text");
             assert_contains_any_case_insensitive(&text, &["azul"]);
         },
@@ -109,7 +129,7 @@ async fn messages_preserve_system_role_after_server_tool_result() {
             let server_tool_assistant_message =
                 server_tool_assistant_message_from_response(first_response.choice);
 
-            let response = model
+            let request = model
                 .completion_request(
                     "What color is a clear daytime sky? Reply with one lowercase Spanish word.",
                 )
@@ -119,14 +139,17 @@ async fn messages_preserve_system_role_after_server_tool_result() {
                     Message::assistant("Entendido."),
                 ])
                 .max_tokens(64)
-                .send()
-                .await
-                .expect(
-                    "Opus 4.8 request with system role after server tool result should succeed",
-                );
+                .build();
+            let raw = model.raw_completion(request).await.expect(
+                "Opus 4.8 request with system role after server tool result should succeed",
+            );
+            let raw_text = raw.get_text_response();
+            let response: RigCompletionResponse = (ANTHROPIC_PROVIDER, raw).try_into().expect(
+                "Opus 4.8 response with system role after server tool result should normalize",
+            );
 
             let text = assistant_text_response(&response.choice)
-                .or_else(|| response.raw_response.get_text_response())
+                .or(raw_text)
                 .expect("response should contain assistant text");
             assert_contains_any_case_insensitive(&text, &["azul"]);
         },
@@ -145,7 +168,7 @@ async fn documents_keep_leading_system_message_top_level() {
         "opus_4_8/documents_keep_leading_system_message_top_level",
         |client| async move {
             let model = client.completion_model(CLAUDE_OPUS_4_8);
-            let response = model
+            let request = model
                 .completion_request(
                     "According to the document, what color is the clear daytime sky?",
                 )
@@ -159,14 +182,17 @@ async fn documents_keep_leading_system_message_top_level() {
                     additional_props: Default::default(),
                 })
                 .max_tokens(64)
-                .send()
-                .await
-                .expect(
-                    "Opus 4.8 request with documents and a leading system message should succeed",
-                );
+                .build();
+            let raw = model.raw_completion(request).await.expect(
+                "Opus 4.8 request with documents and a leading system message should succeed",
+            );
+            let raw_text = raw.get_text_response();
+            let response: RigCompletionResponse = (ANTHROPIC_PROVIDER, raw).try_into().expect(
+                "Opus 4.8 response with documents and a leading system message should normalize",
+            );
 
             let text = assistant_text_response(&response.choice)
-                .or_else(|| response.raw_response.get_text_response())
+                .or(raw_text)
                 .expect("response should contain assistant text");
             assert_contains_any_case_insensitive(&text, &["azul"]);
         },

--- a/tests/providers/anthropic/cassette/opus_4_8.rs
+++ b/tests/providers/anthropic/cassette/opus_4_8.rs
@@ -1,5 +1,6 @@
 //! Dedicated Claude Opus 4.8 cassette coverage.
 
+use rig::completion::NormalizeCompletionResponse;
 use rig::completion::{
     AssistantContent, CompletionModel, CompletionResponse as RigCompletionResponse, Document,
     Message, ProviderToolDefinition,
@@ -47,8 +48,7 @@ async fn web_search_with_dynamic_filtering_succeeds() {
                 .await
                 .expect("Opus 4.8 dynamic web-search request should succeed");
             let raw_text = raw.get_text_response();
-            let response: RigCompletionResponse = (ANTHROPIC_PROVIDER, raw)
-                .try_into()
+            let response: RigCompletionResponse = raw.normalize(ANTHROPIC_PROVIDER)
                 .expect("Opus 4.8 dynamic web-search response should normalize");
 
             assert!(
@@ -90,8 +90,8 @@ async fn messages_preserve_mid_conversation_system_role() {
                 .await
                 .expect("Opus 4.8 system-role request should succeed");
             let raw_text = raw.get_text_response();
-            let response: RigCompletionResponse = (ANTHROPIC_PROVIDER, raw)
-                .try_into()
+            let response: RigCompletionResponse = raw
+                .normalize(ANTHROPIC_PROVIDER)
                 .expect("Opus 4.8 system-role response should normalize");
 
             let text = assistant_text_response(&response.choice)
@@ -144,7 +144,7 @@ async fn messages_preserve_system_role_after_server_tool_result() {
                 "Opus 4.8 request with system role after server tool result should succeed",
             );
             let raw_text = raw.get_text_response();
-            let response: RigCompletionResponse = (ANTHROPIC_PROVIDER, raw).try_into().expect(
+            let response: RigCompletionResponse = raw.normalize(ANTHROPIC_PROVIDER).expect(
                 "Opus 4.8 response with system role after server tool result should normalize",
             );
 
@@ -187,7 +187,7 @@ async fn documents_keep_leading_system_message_top_level() {
                 "Opus 4.8 request with documents and a leading system message should succeed",
             );
             let raw_text = raw.get_text_response();
-            let response: RigCompletionResponse = (ANTHROPIC_PROVIDER, raw).try_into().expect(
+            let response: RigCompletionResponse = raw.normalize(ANTHROPIC_PROVIDER).expect(
                 "Opus 4.8 response with documents and a leading system message should normalize",
             );
 

--- a/tests/providers/anthropic/cassette/plaintext_document.rs
+++ b/tests/providers/anthropic/cassette/plaintext_document.rs
@@ -1,6 +1,7 @@
 //! Migrated from `examples/anthropic_plaintext_document.rs`.
 
 use rig::OneOrMany;
+use rig::completion::NormalizeCompletionResponse;
 use rig::completion::{CompletionModel, Prompt};
 use rig::message::{Document, DocumentMediaType, DocumentSourceKind, Message, UserContent};
 use rig::prelude::*;
@@ -189,10 +190,9 @@ async fn document_citations_followup_preserves_assistant_citation_history() {
                 .await
                 .expect("first document citation turn should succeed");
             let first_turn_raw_text = first_turn_raw.get_text_response();
-            let first_turn: rig::completion::CompletionResponse =
-                (ANTHROPIC_PROVIDER, first_turn_raw)
-                    .try_into()
-                    .expect("first document citation turn should normalize");
+            let first_turn: rig::completion::CompletionResponse = first_turn_raw
+                .normalize(ANTHROPIC_PROVIDER)
+                .expect("first document citation turn should normalize");
 
             let first_turn_text = assistant_text(&first_turn.choice);
             assert_nonempty_response(&first_turn_text);

--- a/tests/providers/anthropic/cassette/plaintext_document.rs
+++ b/tests/providers/anthropic/cassette/plaintext_document.rs
@@ -15,6 +15,10 @@ use crate::support::{
     assert_contains_any_case_insensitive, assert_nonempty_response, collect_stream_final_response,
 };
 
+/// Descriptor name the Anthropic client normalizes responses under; needed
+/// when a test converts a `raw_completion` response itself.
+const ANTHROPIC_PROVIDER: &str = "anthropic";
+
 fn rust_document() -> String {
     r#"
 The Rust Programming Language
@@ -169,7 +173,7 @@ async fn document_citations_followup_preserves_assistant_citation_history() {
             let model = client.completion_model(CLAUDE_SONNET_4_6);
             let prompt = citation_prompt();
 
-            let first_turn = model
+            let first_request = model
                 .completion_request(prompt.clone())
                 .preamble(
                     "Answer using the supplied document and preserve citation metadata."
@@ -177,9 +181,18 @@ async fn document_citations_followup_preserves_assistant_citation_history() {
                 )
                 .max_tokens(256)
                 .temperature(0.0)
-                .send()
+                .build();
+            // Raw-vs-normalized parity on a single recorded interaction: take
+            // Anthropic's own response once, then normalize that same value.
+            let first_turn_raw = model
+                .raw_completion(first_request)
                 .await
                 .expect("first document citation turn should succeed");
+            let first_turn_raw_text = first_turn_raw.get_text_response();
+            let first_turn: rig::completion::CompletionResponse =
+                (ANTHROPIC_PROVIDER, first_turn_raw)
+                    .try_into()
+                    .expect("first document citation turn should normalize");
 
             let first_turn_text = assistant_text(&first_turn.choice);
             assert_nonempty_response(&first_turn_text);
@@ -188,7 +201,7 @@ async fn document_citations_followup_preserves_assistant_citation_history() {
                 &["safety", "speed", "concurrency"],
             );
             assert_eq!(
-                first_turn.raw_response.get_text_response().as_deref(),
+                first_turn_raw_text.as_deref(),
                 Some(first_turn_text.as_str())
             );
 

--- a/tests/providers/anthropic/cassette/prompt_caching.rs
+++ b/tests/providers/anthropic/cassette/prompt_caching.rs
@@ -2,8 +2,8 @@
 
 use futures::StreamExt;
 use rig::completion::{
-    AssistantContent, CompletionModel, CompletionResponse as RigCompletionResponse, GetTokenUsage,
-    ToolDefinition, Usage,
+    AssistantContent, CompletionModel, CompletionResponse as RigCompletionResponse, ToolDefinition,
+    Usage,
 };
 use rig::message::ToolChoice;
 use rig::prelude::*;
@@ -142,7 +142,7 @@ async fn send_cache_probe(
     prompt: &'static str,
     preamble: String,
     tools: Vec<ToolDefinition>,
-) -> RigCompletionResponse<anthropic::completion::CompletionResponse> {
+) -> RigCompletionResponse {
     model
         .completion_request(prompt)
         .preamble(preamble)
@@ -185,7 +185,7 @@ async fn send_streaming_cache_probe(
         match item.expect("streaming prompt-cached Anthropic item should succeed") {
             StreamedAssistantContent::Text(delta) => text.push_str(&delta.text),
             StreamedAssistantContent::Final(response) => {
-                usage = Some(response.token_usage());
+                usage = Some(response.usage);
             }
             _ => {}
         }
@@ -197,10 +197,7 @@ async fn send_streaming_cache_probe(
     }
 }
 
-fn assert_response_contains_cache_probe(
-    response: &RigCompletionResponse<anthropic::completion::CompletionResponse>,
-    expected: &str,
-) {
+fn assert_response_contains_cache_probe(response: &RigCompletionResponse, expected: &str) {
     let text = response_text(response);
     assert_text_contains_cache_probe(&text, expected);
 }
@@ -220,9 +217,7 @@ fn assert_cache_created_or_read(usage: &Usage, context: &str) {
     );
 }
 
-fn response_text(
-    response: &RigCompletionResponse<anthropic::completion::CompletionResponse>,
-) -> String {
+fn response_text(response: &RigCompletionResponse) -> String {
     response
         .choice
         .iter()

--- a/tests/providers/anthropic/cassette/streaming.rs
+++ b/tests/providers/anthropic/cassette/streaming.rs
@@ -1,6 +1,5 @@
 //! Anthropic streaming smoke test.
 
-use rig::completion::GetTokenUsage;
 use rig::prelude::*;
 use rig::providers::anthropic;
 use rig::streaming::StreamingPrompt;
@@ -20,13 +19,14 @@ async fn streaming_smoke() {
             .build();
 
         let mut stream = agent.stream_prompt(STREAMING_PROMPT).await;
-        let (response, provider_final): (_, anthropic::streaming::StreamingCompletionResponse) =
+        let (response, provider_final): (_, rig::streaming::StreamFinal) =
             collect_stream_final_response_and_provider_final(&mut stream)
                 .await
                 .expect("streaming prompt should succeed");
 
         assert_nonempty_response(&response);
-        assert!(provider_final.token_usage().total_tokens > 0);
+        assert_eq!(provider_final.provider, "anthropic");
+        assert!(provider_final.usage.total_tokens > 0);
     })
     .await;
 }

--- a/tests/providers/anthropic/cassette/streaming_tools.rs
+++ b/tests/providers/anthropic/cassette/streaming_tools.rs
@@ -262,8 +262,8 @@ struct ConcurrentToolObservation {
     events: Vec<&'static str>,
 }
 
-async fn collect_concurrent_tool_observation<R>(
-    stream: &mut StreamingResult<R>,
+async fn collect_concurrent_tool_observation(
+    stream: &mut StreamingResult,
 ) -> ConcurrentToolObservation {
     let mut observation = ConcurrentToolObservation::default();
     let mut tool_names_by_id = HashMap::new();

--- a/tests/providers/bedrock/cassette/raw_completion.rs
+++ b/tests/providers/bedrock/cassette/raw_completion.rs
@@ -16,21 +16,28 @@ async fn raw_response_text_matches_normalized_choice_text() {
     with_bedrock_cassette(
         "raw_completion/raw_response_text_matches_normalized_choice_text",
         |client| async move {
-            let response = client
-                .completion_model(bedrock::completion::AMAZON_NOVA_LITE)
+            let model = client.completion_model(bedrock::completion::AMAZON_NOVA_LITE);
+            let request = model
                 .completion_request(RAW_TEXT_RESPONSE_PROMPT)
                 .preamble(RAW_TEXT_RESPONSE_PREAMBLE.to_string())
                 .temperature(0.0)
-                .send()
+                .build();
+
+            // `completion` is `raw_completion` followed by exactly this
+            // conversion, so raw-vs-normalized parity is still checked against
+            // one recorded interaction.
+            let raw = model
+                .raw_completion(request)
                 .await
                 .expect("raw Bedrock request should succeed");
-
-            let normalized_text = assistant_text_response(&response.choice)
-                .expect("normalized Bedrock response should contain assistant text");
-            let raw_text = response
-                .raw_response
+            let raw_text = raw
                 .get_text_response()
                 .expect("raw Bedrock response should contain assistant text");
+            let response: rig::completion::CompletionResponse = raw
+                .try_into()
+                .expect("raw Bedrock response should normalize");
+            let normalized_text = assistant_text_response(&response.choice)
+                .expect("normalized Bedrock response should contain assistant text");
 
             assert_nonempty_response(&normalized_text);
             assert_nonempty_response(&raw_text);

--- a/tests/providers/chatgpt/cassette/codex_behaviors.rs
+++ b/tests/providers/chatgpt/cassette/codex_behaviors.rs
@@ -13,7 +13,7 @@ use rig::providers::chatgpt;
 use rig::tool::Tool;
 
 use super::super::support::{with_chatgpt_cassette, with_chatgpt_cassette_default_instructions};
-use crate::support::{Adder, TOOLS_PREAMBLE, assistant_text_response};
+use crate::support::{Adder, TOOLS_PREAMBLE};
 
 #[tokio::test]
 async fn strict_tools_opt_in_roundtrip() {
@@ -77,8 +77,16 @@ async fn store_false_and_prompt_cache_fields_roundtrip() {
         "codex_behaviors/store_false_and_prompt_cache_fields_roundtrip",
         |client| async move {
             let model = client.completion_model(chatgpt::GPT_5_4);
-            let response = model
-                .completion(
+            // `store` and `prompt_cache_key` are Responses-API wire fields with
+            // no normalized home, so they are read off the backend's own
+            // response type. ChatGPT's terminal `response.completed` payload
+            // carries no output items, so this raw record cannot be normalized
+            // locally (the SSE rebuild `CompletionModel::completion` performs is
+            // crate-private) and the cassette records a single interaction, so
+            // the assistant-text check that used to ride along here now lives
+            // only in `codex_sessions`.
+            let raw = model
+                .raw_completion(
                     model
                         .completion_request("Reply with exactly this marker: CODEX-STORE-FALSE")
                         .preamble("Return only the requested marker.".to_string())
@@ -87,27 +95,24 @@ async fn store_false_and_prompt_cache_fields_roundtrip() {
                 .await
                 .expect("basic ChatGPT/Codex completion should succeed");
 
-            let text = assistant_text_response(&response.choice).expect("response text");
-            assert!(
-                text.contains("CODEX-STORE-FALSE"),
-                "final answer should preserve the requested marker, got {text:?}"
-            );
             assert_eq!(
-                response.raw_response.additional_parameters.store,
+                raw.additional_parameters.store,
                 Some(false),
                 "ChatGPT provider must force store=false"
             );
             assert!(
-                response
-                    .raw_response
-                    .additional_parameters
+                raw.additional_parameters
                     .prompt_cache_key
                     .as_deref()
                     .is_some_and(|value| !value.is_empty()),
                 "ChatGPT backend should return a prompt cache key that cassettes scrub"
             );
-            assert!(response.usage.input_tokens > 0);
-            assert!(response.usage.output_tokens > 0);
+            let usage = raw
+                .usage
+                .as_ref()
+                .expect("ChatGPT/Codex completion should report usage");
+            assert!(usage.input_tokens > 0);
+            assert!(usage.output_tokens > 0);
         },
     )
     .await;

--- a/tests/providers/chatgpt/cassette/streaming_tools.rs
+++ b/tests/providers/chatgpt/cassette/streaming_tools.rs
@@ -9,7 +9,29 @@ use rig::streaming::StreamedAssistantContent;
 use serde_json::json;
 
 use super::super::support::with_chatgpt_cassette;
+use crate::cassettes::cassette_path;
 use crate::support::zero_arg_tool_definition;
+
+/// Assert that the recorded terminal `response.completed` event carries no
+/// output items, which is the precondition this whole scenario exercises.
+fn assert_terminal_response_has_no_output(scenario: &str) {
+    let cassette = std::fs::read_to_string(cassette_path("chatgpt", scenario))
+        .expect("cassette should be readable");
+    let terminal = cassette
+        .lines()
+        .filter_map(|line| line.trim_start().strip_prefix("data:"))
+        .filter_map(|data| serde_json::from_str::<serde_json::Value>(data.trim()).ok())
+        .find(|event| {
+            event.get("type").and_then(serde_json::Value::as_str) == Some("response.completed")
+        })
+        .expect("cassette should contain a response.completed event");
+
+    assert_eq!(
+        terminal["response"]["output"],
+        json!([]),
+        "cassette should keep the terminal response.completed output empty"
+    );
+}
 
 #[tokio::test]
 async fn nonstreaming_tool_call_completed_response_without_output() {
@@ -25,15 +47,23 @@ async fn nonstreaming_tool_call_completed_response_without_output() {
                 .tool_choice(ToolChoice::Required)
                 .build();
 
+            // The premise of the scenario: the terminal `response.completed`
+            // event carries no output items, so the non-streaming path has to
+            // rebuild the tool call from the event stream. That used to be read
+            // off `response.raw_response`. The normalized response no longer
+            // carries the wire payload, ChatGPT's raw wire response is exactly
+            // that empty terminal record (its choice is only recoverable through
+            // the crate-private SSE fallback), and the cassette records a single
+            // interaction — so the premise is asserted against the recorded
+            // terminal event rather than by issuing a second request.
+            assert_terminal_response_has_no_output(
+                "streaming_tools/tool_call_completed_response_without_output",
+            );
+
             let response = model
                 .completion(request)
                 .await
                 .expect("non-streaming completion should reconstruct streamed tool call");
-
-            assert!(
-                response.raw_response.output.is_empty(),
-                "cassette should keep the terminal response.completed output empty"
-            );
 
             let tool_call = response.choice.iter().find_map(|content| match content {
                 AssistantContent::ToolCall(tool_call) if tool_call.function.name == "ping" => {

--- a/tests/providers/copilot/reasoning_roundtrip.rs
+++ b/tests/providers/copilot/reasoning_roundtrip.rs
@@ -1,10 +1,79 @@
 //! Copilot reasoning roundtrip tests.
 
+use std::sync::{Arc, Mutex};
+
+use futures::StreamExt;
+use rig::completion::{
+    CompletionError, CompletionModel, CompletionRequest, CompletionResponse, ProviderCapabilities,
+};
 use rig::prelude::*;
-use rig::providers::copilot::CopilotStreamingResponse;
+use rig::providers::copilot::{self, CopilotStreamingResponse};
+use rig::streaming::{RawStreamingChoice, StreamingCompletionResponse, normalize_stream};
 
 use crate::copilot::{live_responses_model, with_copilot_cassette};
 use crate::reasoning::{self, ReasoningRoundtripAgent};
+
+/// Copilot's own terminal stream record carries reasoning metadata that rig's
+/// normalized `StreamFinal` does not model, and the roundtrip cassette records
+/// exactly one interaction per turn. This wrapper lets the shared roundtrip
+/// drive the same requests through `raw_stream` while the test keeps a copy of
+/// Copilot's provider-native terminal records.
+#[derive(Clone)]
+struct CapturingProviderFinals {
+    inner: copilot::CompletionModel,
+    finals: Arc<Mutex<Vec<CopilotStreamingResponse>>>,
+}
+
+impl CapturingProviderFinals {
+    fn new(inner: copilot::CompletionModel) -> Self {
+        Self {
+            inner,
+            finals: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn finals(&self) -> Arc<Mutex<Vec<CopilotStreamingResponse>>> {
+        Arc::clone(&self.finals)
+    }
+}
+
+impl CompletionModel for CapturingProviderFinals {
+    async fn completion(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<CompletionResponse, CompletionError> {
+        self.inner.completion(request).await
+    }
+
+    async fn stream(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse, CompletionError> {
+        let raw = self.inner.raw_stream(request).await?;
+        let finals = self.finals();
+        let captured = raw.map(move |item| {
+            if let Ok(RawStreamingChoice::FinalResponse(response)) = &item {
+                finals
+                    .lock()
+                    .expect("captured provider finals should not be poisoned")
+                    .push(response.clone());
+            }
+
+            item
+        });
+
+        Ok(StreamingCompletionResponse::stream(
+            copilot::PROVIDER_NAME,
+            normalize_stream(Box::pin(captured), |response| {
+                Ok((copilot::PROVIDER_NAME, response).into())
+            }),
+        ))
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        self.inner.capabilities()
+    }
+}
 
 #[tokio::test]
 async fn streaming() {
@@ -14,22 +83,28 @@ async fn streaming() {
             "effort": "medium",
             "summary": null
         });
-        reasoning::run_reasoning_roundtrip_streaming_with_final(
-            ReasoningRoundtripAgent::new(
-                client.completion_model(live_responses_model()),
-                Some(serde_json::json!({
-                    "reasoning": { "effort": "medium" }
-                })),
-            ),
-            |response| {
-                let CopilotStreamingResponse::Responses(response) = response else {
-                    panic!("Copilot reasoning stream should use the Responses route");
-                };
-                assert_eq!(response.reasoning_context.as_deref(), Some("current_turn"));
-                assert_eq!(response.reasoning_metadata.as_ref(), expected.as_object());
-            },
-        )
+        let model = CapturingProviderFinals::new(client.completion_model(live_responses_model()));
+        let finals = model.finals();
+
+        reasoning::run_reasoning_roundtrip_streaming(ReasoningRoundtripAgent::new(
+            model,
+            Some(serde_json::json!({
+                "reasoning": { "effort": "medium" }
+            })),
+        ))
         .await;
+
+        let finals = finals
+            .lock()
+            .expect("captured provider finals should not be poisoned");
+        let response = finals
+            .first()
+            .expect("Copilot reasoning stream should yield a provider final response");
+        let CopilotStreamingResponse::Responses(response) = response else {
+            panic!("Copilot reasoning stream should use the Responses route");
+        };
+        assert_eq!(response.reasoning_context.as_deref(), Some("current_turn"));
+        assert_eq!(response.reasoning_metadata.as_ref(), expected.as_object());
     })
     .await;
 }

--- a/tests/providers/deepseek/agent_tool_sessions.rs
+++ b/tests/providers/deepseek/agent_tool_sessions.rs
@@ -403,27 +403,41 @@ fn assert_history_records_sequential_tool_roundtrips(history: &[Message], expect
     }
 }
 
+/// Run one completion and return both DeepSeek's own wire response and the
+/// normalized response the completion path derives from it.
+///
+/// `raw_completion` is the escape hatch for the provider-specific fields the
+/// normalized response no longer carries (per-choice finish reasons, DeepSeek's
+/// `completion_tokens_details`); converting its result locally keeps the
+/// raw-vs-normalized parity checks below on a single cassette interaction.
+async fn raw_and_normalized_completion(
+    model: &deepseek::CompletionModel,
+    request: rig::completion::CompletionRequest,
+) -> Result<(
+    deepseek::CompletionResponse,
+    rig::completion::CompletionResponse,
+)> {
+    let raw = model.raw_completion(request).await?;
+    let normalized: rig::completion::CompletionResponse = ("deepseek", raw.clone()).try_into()?;
+    Ok((raw, normalized))
+}
+
 fn assert_response_metadata(
-    response: &rig::completion::CompletionResponse<deepseek::CompletionResponse>,
+    response: &rig::completion::CompletionResponse,
+    raw: &deepseek::CompletionResponse,
 ) {
     assert_nonempty_response(
-        response
-            .raw_response
-            .id
+        raw.id
             .as_deref()
             .expect("raw DeepSeek response should preserve id"),
     );
     assert_nonempty_response(
-        response
-            .raw_response
-            .model
+        raw.model
             .as_deref()
             .expect("raw DeepSeek response should preserve model"),
     );
     assert!(
-        response
-            .raw_response
-            .choices
+        raw.choices
             .iter()
             .all(|choice| !choice.finish_reason.is_empty()),
         "raw DeepSeek choices should preserve finish reasons"
@@ -703,12 +717,12 @@ async fn long_history_replay_with_tool_result_continuation() -> Result<()> {
                 .additional_params(non_thinking_params())
                 .build();
 
-            let response = model.completion(request).await?;
+            let (raw, response) = raw_and_normalized_completion(&model, request).await?;
             let text = assistant_text_response(&response.choice)
                 .ok_or_else(|| anyhow::anyhow!("response should include assistant text"))?;
 
             assert_contains_all_case_insensitive(&text, &["teal", ALPHA_SIGNAL_OUTPUT, "canary"]);
-            assert_response_metadata(&response);
+            assert_response_metadata(&response, &raw);
 
             Ok(())
         },
@@ -816,7 +830,7 @@ async fn reasoning_enabled_preserves_reasoning_content_deltas_and_usage() -> Res
                 .additional_params(thinking_params())
                 .build();
 
-            let response = model.completion(request).await?;
+            let (raw, response) = raw_and_normalized_completion(&model, request).await?;
 
             anyhow::ensure!(
                 response
@@ -830,8 +844,7 @@ async fn reasoning_enabled_preserves_reasoning_content_deltas_and_usage() -> Res
                 "core usage should preserve DeepSeek reasoning tokens: {:?}",
                 response.usage
             );
-            let raw_reasoning_tokens = response
-                .raw_response
+            let raw_reasoning_tokens = raw
                 .usage
                 .completion_tokens_details
                 .as_ref()
@@ -841,7 +854,7 @@ async fn reasoning_enabled_preserves_reasoning_content_deltas_and_usage() -> Res
                 response.usage.reasoning_tokens == raw_reasoning_tokens && raw_reasoning_tokens > 0,
                 "usage reasoning tokens should match raw provider details"
             );
-            assert_response_metadata(&response);
+            assert_response_metadata(&response, &raw);
 
             let stream_request = model
                 .completion_request("Briefly solve 2 + 2, then answer with the number.")
@@ -943,14 +956,14 @@ async fn json_object_response_format_roundtrip() -> Result<()> {
                 })))
                 .build();
 
-            let response = model.completion(request).await?;
+            let (raw, response) = raw_and_normalized_completion(&model, request).await?;
             let text = assistant_text_response(&response.choice)
                 .ok_or_else(|| anyhow::anyhow!("JSON response should contain text"))?;
             let plan: serde_json::Value = serde_json::from_str(&text)?;
 
             let serialized = plan.to_string();
             assert_contains_all_case_insensitive(&serialized, &["canary", "low", "compile", "replay"]);
-            assert_response_metadata(&response);
+            assert_response_metadata(&response, &raw);
 
             Ok(())
         },

--- a/tests/providers/deepseek/agent_tool_sessions.rs
+++ b/tests/providers/deepseek/agent_tool_sessions.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use rig::OneOrMany;
+use rig::completion::NormalizeCompletionResponse;
 use rig::completion::{Chat, CompletionModel, Message};
 use rig::message::{AssistantContent, ToolChoice, UserContent};
 use rig::prelude::*;
@@ -418,7 +419,7 @@ async fn raw_and_normalized_completion(
     rig::completion::CompletionResponse,
 )> {
     let raw = model.raw_completion(request).await?;
-    let normalized: rig::completion::CompletionResponse = ("deepseek", raw.clone()).try_into()?;
+    let normalized: rig::completion::CompletionResponse = raw.clone().normalize("deepseek")?;
     Ok((raw, normalized))
 }
 

--- a/tests/providers/gemini/cassette/agent_run_streamed.rs
+++ b/tests/providers/gemini/cassette/agent_run_streamed.rs
@@ -14,7 +14,7 @@ use rig::agent::{
     AgentHook, InvalidToolCallAction, MultiTurnStreamItem, StreamingError,
     ToolCall as ToolCallEvent, ToolCallAction,
 };
-use rig::completion::{GetTokenUsage, PromptError, Usage};
+use rig::completion::{PromptError, Usage};
 use rig::message::{Message, ToolChoice, ToolResult};
 use rig::prelude::*;
 use rig::providers::gemini;
@@ -136,13 +136,12 @@ async fn run_streamed_turn(
     Ok(TurnEnd::Finished)
 }
 
-async fn drain_stream_usage<R>(stream: &mut rig::streaming::StreamingCompletionResponse<R>) -> Usage
+async fn drain_stream_usage(stream: &mut rig::streaming::StreamingCompletionResponse) -> Usage
 where
-    R: Clone + Unpin + GetTokenUsage,
 {
     while let Some(item) = stream.next().await {
         if let Ok(StreamedAssistantContent::Final(final_response)) = item {
-            return final_response.token_usage();
+            return final_response.usage;
         }
     }
     Usage::new()

--- a/tests/providers/gemini/cassette/generate_behaviors.rs
+++ b/tests/providers/gemini/cassette/generate_behaviors.rs
@@ -8,11 +8,10 @@
 //! Run cassette tests in replay mode by default, or set
 //! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
 
-use rig::completion::{CompletionModel, Prompt};
+use rig::completion::{CompletionModel, FinishReason, Prompt};
 use rig::message::AssistantContent;
 use rig::prelude::*;
 use rig::providers::gemini;
-use rig::providers::gemini::completion::gemini_api_types::FinishReason;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -60,16 +59,12 @@ async fn max_tokens_truncation_preserves_finish_reason_and_partial_text() {
                 .await
                 .expect("a truncated response should still convert, not error");
 
-            let candidate = response
-                .raw_response
-                .candidates
-                .first()
-                .expect("response should carry a candidate");
+            // Gemini's MAX_TOKENS normalizes to `FinishReason::Length`.
             assert!(
-                matches!(candidate.finish_reason, Some(FinishReason::MaxTokens)),
+                matches!(response.finish_reason, Some(FinishReason::Length)),
                 "hitting maxOutputTokens should preserve the MAX_TOKENS finish reason, \
                  got {:?}",
-                candidate.finish_reason
+                response.finish_reason
             );
             let text: String = response
                 .choice
@@ -85,8 +80,7 @@ async fn max_tokens_truncation_preserves_finish_reason_and_partial_text() {
             );
             assert!(
                 response
-                    .raw_response
-                    .model_version
+                    .model
                     .as_deref()
                     .is_some_and(|version| !version.is_empty()),
                 "provider response should preserve the model version"

--- a/tests/providers/gemini/cassette/generate_sessions.rs
+++ b/tests/providers/gemini/cassette/generate_sessions.rs
@@ -257,8 +257,7 @@ async fn long_history_replay_nonstreaming() {
             );
             assert!(
                 response
-                    .raw_response
-                    .model_version
+                    .model
                     .as_deref()
                     .is_some_and(|version| !version.is_empty()),
                 "provider response should preserve the model version"

--- a/tests/providers/gemini/cassette/interactions_api.rs
+++ b/tests/providers/gemini/cassette/interactions_api.rs
@@ -45,17 +45,20 @@ async fn basic_interaction_returns_id() {
                 .preamble("Be concise.".to_string())
                 .additional_params(serde_json::to_value(params).expect("params should serialize"))
                 .build();
-            let response = model
-                .completion(request)
+            // The interaction id is Gemini's continuation handle (fed back as
+            // `previous_interaction_id`), not an assistant message id, so it
+            // lives on the provider's own response rather than on the
+            // normalized one.
+            let raw = model
+                .raw_completion(request)
                 .await
                 .expect("completion should succeed");
 
+            let response: rig::completion::CompletionResponse =
+                raw.clone().try_into().expect("response should normalize");
             assert_nonempty_response(&extract_text(&response.choice));
             assert!(
-                response
-                    .message_id
-                    .as_deref()
-                    .is_some_and(|id| !id.is_empty()),
+                !raw.id.is_empty(),
                 "interactions api should return an interaction id"
             );
         },
@@ -70,7 +73,7 @@ async fn followup_with_previous_interaction_id() {
         |client| async move {
             let model = client.completion_model("gemini-3-flash-preview");
             let initial = model
-                .completion(
+                .raw_completion(
                     model
                         .completion_request("Give me one short fact about hummingbirds.")
                         .additional_params(
@@ -84,10 +87,9 @@ async fn followup_with_previous_interaction_id() {
                 )
                 .await
                 .expect("initial completion should succeed");
-            let interaction_id = initial
-                .message_id
-                .clone()
-                .expect("expected an interaction id");
+            // Gemini's continuation handle lives on the provider's own
+            // response; it is what `previous_interaction_id` echoes back.
+            let interaction_id = initial.id.clone();
             assert!(!interaction_id.is_empty(), "expected an interaction id");
 
             let followup = model
@@ -171,7 +173,7 @@ async fn tool_result_roundtrip() {
             };
 
             let initial = model
-                .completion(
+                .raw_completion(
                     model
                         .completion_request("Use the add tool to sum 7 and 11.")
                         .tool(tool)
@@ -188,16 +190,19 @@ async fn tool_result_roundtrip() {
                 .await
                 .expect("tool call completion should succeed");
 
+            // Gemini's continuation handle lives on the provider's own
+            // response; the normalized view of that same value supplies the
+            // tool call, so this still costs one interaction.
+            let interaction_id = initial.id.clone();
+            assert!(!interaction_id.is_empty(), "expected an interaction id");
+            let initial: rig::completion::CompletionResponse =
+                initial.try_into().expect("response should normalize");
+
             let tool_call = first_tool_call(&initial.choice).expect("expected a tool call");
             let call_id = tool_call
                 .call_id
                 .clone()
                 .unwrap_or_else(|| tool_call.id.clone());
-            let interaction_id = initial
-                .message_id
-                .clone()
-                .expect("expected an interaction id");
-            assert!(!interaction_id.is_empty(), "expected an interaction id");
 
             let followup = model
                 .completion(

--- a/tests/providers/gemini/cassette/interactions_api.rs
+++ b/tests/providers/gemini/cassette/interactions_api.rs
@@ -2,7 +2,7 @@
 
 use futures::StreamExt;
 use rig::OneOrMany;
-use rig::completion::{CompletionModel, GetTokenUsage};
+use rig::completion::CompletionModel;
 use rig::message::{
     AssistantContent, Message, ToolCall, ToolChoice, ToolResultContent, UserContent,
 };
@@ -52,7 +52,10 @@ async fn basic_interaction_returns_id() {
 
             assert_nonempty_response(&extract_text(&response.choice));
             assert!(
-                !response.raw_response.id.is_empty(),
+                response
+                    .message_id
+                    .as_deref()
+                    .is_some_and(|id| !id.is_empty()),
                 "interactions api should return an interaction id"
             );
         },
@@ -81,7 +84,10 @@ async fn followup_with_previous_interaction_id() {
                 )
                 .await
                 .expect("initial completion should succeed");
-            let interaction_id = initial.raw_response.id.clone();
+            let interaction_id = initial
+                .message_id
+                .clone()
+                .expect("expected an interaction id");
             assert!(!interaction_id.is_empty(), "expected an interaction id");
 
             let followup = model
@@ -112,8 +118,11 @@ async fn google_search_tool_interaction() {
         "interactions_api/google_search_tool_interaction",
         |client| async move {
             let model = client.completion_model("gemini-3-flash-preview");
-            let response = model
-                .completion(
+            // The hosted-tool exchange log is provider-specific, so this asserts
+            // against the Interactions payload itself and then normalizes that same
+            // payload — one request, exactly as the cassette recorded it.
+            let raw = model
+                .raw_completion(
                     model
                         .completion_request("Who won the Euro 2024 tournament?")
                         .additional_params(
@@ -128,11 +137,15 @@ async fn google_search_tool_interaction() {
                 .await
                 .expect("search completion should succeed");
 
-            assert_nonempty_response(&extract_text(&response.choice));
             assert!(
-                !response.raw_response.google_search_exchanges().is_empty(),
+                !raw.google_search_exchanges().is_empty(),
                 "expected a search-backed exchange"
             );
+
+            let response: rig::completion::CompletionResponse = raw
+                .try_into()
+                .expect("interaction should normalize into a completion response");
+            assert_nonempty_response(&extract_text(&response.choice));
         },
     )
     .await;
@@ -180,7 +193,10 @@ async fn tool_result_roundtrip() {
                 .call_id
                 .clone()
                 .unwrap_or_else(|| tool_call.id.clone());
-            let interaction_id = initial.raw_response.id.clone();
+            let interaction_id = initial
+                .message_id
+                .clone()
+                .expect("expected an interaction id");
             assert!(!interaction_id.is_empty(), "expected an interaction id");
 
             let followup = model
@@ -229,7 +245,7 @@ async fn streaming_interaction() {
                 match chunk.expect("stream chunk should succeed") {
                     StreamedAssistantContent::Text(delta) => text.push_str(&delta.text),
                     StreamedAssistantContent::Final(response) => {
-                        saw_usage = response.token_usage().has_values();
+                        saw_usage = response.usage.has_values();
                     }
                     _ => {}
                 }
@@ -266,8 +282,8 @@ async fn streaming_final_metadata_exposes_model_version() {
                     StreamedAssistantContent::Text(delta) => text.push_str(&delta.text),
                     StreamedAssistantContent::Final(response) => {
                         final_response_count += 1;
-                        saw_usage = response.token_usage().has_values();
-                        final_model_version = response.model_version.clone();
+                        saw_usage = response.usage.has_values();
+                        final_model_version = response.model.clone();
                     }
                     _ => {}
                 }

--- a/tests/providers/gemini/cassette/streaming.rs
+++ b/tests/providers/gemini/cassette/streaming.rs
@@ -1,13 +1,14 @@
 //! Gemini streaming coverage, including the migrated example path.
 
 use futures::StreamExt;
-use rig::completion::{CompletionModel, GetTokenUsage};
+use rig::completion::CompletionModel;
+use rig::completion::FinishReason;
 use rig::prelude::*;
 use rig::providers::gemini;
 use rig::providers::gemini::completion::gemini_api_types::{
-    AdditionalParameters, FinishReason, GenerationConfig, ThinkingConfig, ThinkingLevel,
+    AdditionalParameters, GenerationConfig, ThinkingConfig, ThinkingLevel,
 };
-use rig::streaming::{StreamedAssistantContent, StreamingPrompt};
+use rig::streaming::{StreamFinal, StreamedAssistantContent, StreamingPrompt};
 
 use crate::support::{
     STREAMING_PREAMBLE, STREAMING_PROMPT, assert_nonempty_response, collect_stream_final_response,
@@ -37,13 +38,13 @@ async fn streaming_smoke() {
             .build();
 
         let mut stream = agent.stream_prompt(STREAMING_PROMPT).await;
-        let (response, provider_final): (_, gemini::streaming::StreamingCompletionResponse) =
+        let (response, provider_final): (_, StreamFinal) =
             collect_stream_final_response_and_provider_final(&mut stream)
                 .await
                 .expect("streaming prompt should succeed");
 
         assert_nonempty_response(&response);
-        assert!(provider_final.token_usage().total_tokens > 0);
+        assert!(provider_final.usage.total_tokens > 0);
     })
     .await;
 }
@@ -120,12 +121,12 @@ async fn final_metadata_exposes_finish_reason_and_model_version() {
                 final_response.finish_reason
             );
             assert_eq!(
-                final_response.model_version.as_deref(),
+                final_response.model.as_deref(),
                 Some(gemini::completion::GEMINI_2_5_FLASH),
                 "expected resolved Gemini model version to be surfaced"
             );
             assert!(
-                final_response.token_usage().has_values(),
+                final_response.usage.has_values(),
                 "expected final response to expose token usage"
             );
         },
@@ -171,11 +172,11 @@ async fn final_metadata_handles_terminal_finish_reason_chunk() {
                 final_response.finish_reason
             );
             assert_eq!(
-                final_response.model_version.as_deref(),
+                final_response.model.as_deref(),
                 Some(gemini::completion::GEMINI_2_5_FLASH),
                 "expected modelVersion from terminal chunks to be retained"
             );
-            let usage = final_response.token_usage();
+            let usage = final_response.usage;
             assert!(
                 usage.input_tokens > 0,
                 "expected positive input token usage, got {usage:?}"

--- a/tests/providers/groq/agent_tool_sessions.rs
+++ b/tests/providers/groq/agent_tool_sessions.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::Result;
 use futures::StreamExt;
 use rig::OneOrMany;
+use rig::completion::NormalizeCompletionResponse;
 use rig::completion::{Chat, CompletionModel, Message};
 use rig::message::{AssistantContent, ToolChoice};
 use rig::prelude::*;
@@ -490,7 +491,7 @@ async fn raw_and_normalized_completion(
 ) -> Result<(RawResponseMetadata, rig::completion::CompletionResponse)> {
     let raw = model.raw_completion(request).await?;
     let metadata = RawResponseMetadata::capture(&raw);
-    let normalized: rig::completion::CompletionResponse = ("groq", raw).try_into()?;
+    let normalized: rig::completion::CompletionResponse = raw.normalize("groq")?;
     Ok((metadata, normalized))
 }
 

--- a/tests/providers/groq/agent_tool_sessions.rs
+++ b/tests/providers/groq/agent_tool_sessions.rs
@@ -10,10 +10,10 @@ use std::sync::{Arc, Mutex};
 use anyhow::Result;
 use futures::StreamExt;
 use rig::OneOrMany;
-use rig::completion::{Chat, CompletionModel, GetTokenUsage, Message};
+use rig::completion::{Chat, CompletionModel, Message};
 use rig::message::{AssistantContent, ToolChoice};
 use rig::prelude::*;
-use rig::providers::openai;
+use rig::providers::{groq, openai};
 use rig::streaming::{StreamedAssistantContent, StreamingChat, StreamingPrompt};
 use rig::tool::Tool;
 use schemars::JsonSchema;
@@ -449,24 +449,67 @@ fn assert_history_records_sequential_tool_roundtrips(history: &[Message], expect
     }
 }
 
+/// The Groq wire metadata the normalized response deliberately does not carry.
+///
+/// The provider-local conversion consumes the raw response and Groq's wire type
+/// is not `Clone`, so the fields the parity assertions need are captured first.
+struct RawResponseMetadata {
+    id: String,
+    model: String,
+    system_fingerprint: Option<String>,
+    finish_reasons: Vec<String>,
+    usage: Option<openai::Usage>,
+}
+
+impl RawResponseMetadata {
+    fn capture(raw: &openai::CompletionResponse) -> Self {
+        Self {
+            id: raw.id.clone(),
+            model: raw.model.clone(),
+            system_fingerprint: raw.system_fingerprint.clone(),
+            finish_reasons: raw
+                .choices
+                .iter()
+                .map(|choice| choice.finish_reason.clone())
+                .collect(),
+            usage: raw.usage.clone(),
+        }
+    }
+}
+
+/// Run one completion and return both Groq's own wire metadata and the
+/// normalized response the completion path derives from the same wire response.
+///
+/// `raw_completion` is the escape hatch for the provider-specific fields the
+/// normalized response no longer carries (`system_fingerprint`, Groq's queue and
+/// total timings); converting its result locally keeps the raw-vs-normalized
+/// parity checks below on a single cassette interaction.
+async fn raw_and_normalized_completion(
+    model: &groq::CompletionModel,
+    request: rig::completion::CompletionRequest,
+) -> Result<(RawResponseMetadata, rig::completion::CompletionResponse)> {
+    let raw = model.raw_completion(request).await?;
+    let metadata = RawResponseMetadata::capture(&raw);
+    let normalized: rig::completion::CompletionResponse = ("groq", raw).try_into()?;
+    Ok((metadata, normalized))
+}
+
 fn assert_response_metadata(
-    response: &rig::completion::CompletionResponse<openai::CompletionResponse>,
+    response: &rig::completion::CompletionResponse,
+    raw: &RawResponseMetadata,
 ) {
-    assert_nonempty_response(&response.raw_response.id);
-    assert_nonempty_response(&response.raw_response.model);
-    if let Some(system_fingerprint) = &response.raw_response.system_fingerprint {
+    assert_nonempty_response(&raw.id);
+    assert_nonempty_response(&raw.model);
+    if let Some(system_fingerprint) = &raw.system_fingerprint {
         assert_nonempty_response(system_fingerprint);
     }
     assert!(
-        response
-            .raw_response
-            .choices
+        raw.finish_reasons
             .iter()
-            .all(|choice| !choice.finish_reason.is_empty()),
+            .all(|finish_reason| !finish_reason.is_empty()),
         "raw Groq choices should preserve finish reasons"
     );
-    let raw_usage = response
-        .raw_response
+    let raw_usage = raw
         .usage
         .as_ref()
         .expect("raw response should preserve usage");
@@ -764,12 +807,12 @@ async fn long_history_replay_with_tool_result_continuation() -> Result<()> {
                 .tool_choice(ToolChoice::None)
                 .build();
 
-            let response = model.completion(request).await?;
+            let (raw, response) = raw_and_normalized_completion(&model, request).await?;
             let text = assistant_text_response(&response.choice)
                 .ok_or_else(|| anyhow::anyhow!("response should include assistant text"))?;
 
             assert_contains_all_case_insensitive(&text, &["teal", ALPHA_SIGNAL_OUTPUT, "canary"]);
-            assert_response_metadata(&response);
+            assert_response_metadata(&response, &raw);
 
             Ok(())
         },
@@ -888,7 +931,7 @@ async fn json_object_response_format_roundtrip() -> Result<()> {
                 .max_tokens(128)
                 .build();
 
-            let response = model.completion(request).await?;
+            let (raw, response) = raw_and_normalized_completion(&model, request).await?;
             let text = assistant_text_response(&response.choice)
                 .ok_or_else(|| anyhow::anyhow!("JSON response should contain text"))?;
             let plan: serde_json::Value = serde_json::from_str(&text)?;
@@ -898,7 +941,7 @@ async fn json_object_response_format_roundtrip() -> Result<()> {
                 &serialized,
                 &["canary", "low", "compile", "replay"],
             );
-            assert_response_metadata(&response);
+            assert_response_metadata(&response, &raw);
 
             Ok(())
         },
@@ -934,7 +977,7 @@ async fn json_schema_structured_output_roundtrip() -> Result<()> {
                 .max_tokens(128)
                 .build();
 
-            let response = model.completion(request).await?;
+            let (raw, response) = raw_and_normalized_completion(&model, request).await?;
             let text = assistant_text_response(&response.choice)
                 .ok_or_else(|| anyhow::anyhow!("structured response should contain text"))?;
             let plan: StructuredReleasePlan = serde_json::from_str(&text)?;
@@ -943,7 +986,7 @@ async fn json_schema_structured_output_roundtrip() -> Result<()> {
             anyhow::ensure!(plan.risk.eq_ignore_ascii_case("low"));
             anyhow::ensure!(plan.checks.compile);
             anyhow::ensure!(plan.checks.replay);
-            assert_response_metadata(&response);
+            assert_response_metadata(&response, &raw);
 
             Ok(())
         },
@@ -979,7 +1022,7 @@ async fn low_latency_streaming_text_surfaces_final_usage() -> Result<()> {
                         }
                     }
                     StreamedAssistantContent::Final(response) => {
-                        final_usage = Some(response.token_usage());
+                        final_usage = Some(response.usage);
                     }
                     _ => {}
                 }

--- a/tests/providers/llamacpp/completions_api.rs
+++ b/tests/providers/llamacpp/completions_api.rs
@@ -1,6 +1,7 @@
 //! Migrated from `examples/openai_agent_completions_api.rs` against a local llama.cpp server.
 
 use rig::completion::CompletionModel;
+use rig::completion::NormalizeCompletionResponse;
 use rig::completion::Prompt;
 use rig::prelude::*;
 use rig::telemetry::ProviderResponseExt;
@@ -49,8 +50,8 @@ async fn completions_api_raw_response_text_matches_normalized_choice_text() {
     let raw_text = raw
         .get_text_response()
         .expect("raw completions api response should contain assistant text");
-    let response: rig::completion::CompletionResponse = ("openai", raw)
-        .try_into()
+    let response: rig::completion::CompletionResponse = raw
+        .normalize("openai")
         .expect("raw completions api response should normalize");
 
     let normalized_text = assistant_text_response(&response.choice)

--- a/tests/providers/llamacpp/completions_api.rs
+++ b/tests/providers/llamacpp/completions_api.rs
@@ -34,20 +34,27 @@ async fn completions_api_agent_prompt() {
 #[ignore = "requires a local llama.cpp OpenAI-compatible server"]
 async fn completions_api_raw_response_text_matches_normalized_choice_text() {
     let client = support::completions_client();
-    let response = client
-        .completion_model(support::model_name())
+    let model = client.completion_model(support::model_name());
+    let request = model
         .completion_request(RAW_TEXT_RESPONSE_PROMPT)
         .preamble(RAW_TEXT_RESPONSE_PREAMBLE.to_string())
-        .send()
+        .build();
+    // One request, two views: `raw_completion` returns llama.cpp's own wire
+    // response and the provider-local conversion produces exactly what
+    // `CompletionModel::completion` would have returned for it.
+    let raw = model
+        .raw_completion(request)
         .await
         .expect("raw completions api request should succeed");
+    let raw_text = raw
+        .get_text_response()
+        .expect("raw completions api response should contain assistant text");
+    let response: rig::completion::CompletionResponse = ("openai", raw)
+        .try_into()
+        .expect("raw completions api response should normalize");
 
     let normalized_text = assistant_text_response(&response.choice)
         .expect("normalized completions api response should contain assistant text");
-    let raw_text = response
-        .raw_response
-        .get_text_response()
-        .expect("raw completions api response should contain assistant text");
 
     assert_nonempty_response(&normalized_text);
     assert_nonempty_response(&raw_text);

--- a/tests/providers/mistral/agent_tool_sessions.rs
+++ b/tests/providers/mistral/agent_tool_sessions.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use rig::OneOrMany;
+use rig::completion::NormalizeCompletionResponse;
 use rig::completion::{Chat, CompletionModel, Message};
 use rig::message::{AssistantContent, ToolChoice};
 use rig::prelude::*;
@@ -461,7 +462,7 @@ async fn raw_and_normalized_completion(
     rig::completion::CompletionResponse,
 )> {
     let raw = model.raw_completion(request).await?;
-    let normalized: rig::completion::CompletionResponse = ("mistral", raw.clone()).try_into()?;
+    let normalized: rig::completion::CompletionResponse = raw.clone().normalize("mistral")?;
     Ok((raw, normalized))
 }
 

--- a/tests/providers/mistral/agent_tool_sessions.rs
+++ b/tests/providers/mistral/agent_tool_sessions.rs
@@ -447,25 +447,38 @@ fn assert_history_records_sequential_tool_roundtrips(history: &[Message], expect
     }
 }
 
+/// Run one completion and return both Mistral's own wire response and the
+/// normalized response the completion path derives from it.
+///
+/// `raw_completion` is the escape hatch for the provider-specific fields the
+/// normalized response no longer carries; converting its result locally keeps
+/// the raw-vs-normalized parity checks below on a single cassette interaction.
+async fn raw_and_normalized_completion(
+    model: &mistral::CompletionModel,
+    request: rig::completion::CompletionRequest,
+) -> Result<(
+    mistral::CompletionResponse,
+    rig::completion::CompletionResponse,
+)> {
+    let raw = model.raw_completion(request).await?;
+    let normalized: rig::completion::CompletionResponse = ("mistral", raw.clone()).try_into()?;
+    Ok((raw, normalized))
+}
+
 fn assert_response_metadata(
-    response: &rig::completion::CompletionResponse<mistral::CompletionResponse>,
+    response: &rig::completion::CompletionResponse,
+    raw: &mistral::CompletionResponse,
 ) {
-    assert_nonempty_response(&response.raw_response.id);
-    assert_eq!(
-        response.message_id.as_deref(),
-        Some(response.raw_response.id.as_str())
-    );
-    assert_nonempty_response(&response.raw_response.model);
+    assert_nonempty_response(&raw.id);
+    assert_eq!(response.message_id.as_deref(), Some(raw.id.as_str()));
+    assert_nonempty_response(&raw.model);
     assert!(
-        response
-            .raw_response
-            .choices
+        raw.choices
             .iter()
             .all(|choice| !choice.finish_reason.is_empty()),
         "raw Mistral choices should preserve finish reasons"
     );
-    let raw_usage = response
-        .raw_response
+    let raw_usage = raw
         .usage
         .as_ref()
         .expect("raw response should preserve usage");
@@ -749,12 +762,12 @@ async fn long_history_replay_with_tool_result_continuation() -> Result<()> {
                 .tool_choice(ToolChoice::None)
                 .build();
 
-            let response = model.completion(request).await?;
+            let (raw, response) = raw_and_normalized_completion(&model, request).await?;
             let text = assistant_text_response(&response.choice)
                 .ok_or_else(|| anyhow::anyhow!("response should include assistant text"))?;
 
             assert_contains_all_case_insensitive(&text, &["teal", ALPHA_SIGNAL_OUTPUT, "canary"]);
-            assert_response_metadata(&response);
+            assert_response_metadata(&response, &raw);
 
             Ok(())
         },
@@ -872,14 +885,14 @@ async fn json_object_response_format_roundtrip() -> Result<()> {
                 .additional_params(json!({"response_format": { "type": "json_object" }}))
                 .build();
 
-            let response = model.completion(request).await?;
+            let (raw, response) = raw_and_normalized_completion(&model, request).await?;
             let text = assistant_text_response(&response.choice)
                 .ok_or_else(|| anyhow::anyhow!("JSON response should contain text"))?;
             let plan: serde_json::Value = serde_json::from_str(&text)?;
 
             let serialized = plan.to_string();
             assert_contains_all_case_insensitive(&serialized, &["canary", "low", "compile", "replay"]);
-            assert_response_metadata(&response);
+            assert_response_metadata(&response, &raw);
 
             Ok(())
         },
@@ -914,7 +927,7 @@ async fn json_schema_structured_output_roundtrip() -> Result<()> {
                 .output_schema(schemars::schema_for!(StructuredReleasePlan))
                 .build();
 
-            let response = model.completion(request).await?;
+            let (raw, response) = raw_and_normalized_completion(&model, request).await?;
             let text = assistant_text_response(&response.choice)
                 .ok_or_else(|| anyhow::anyhow!("structured response should contain text"))?;
             let plan: StructuredReleasePlan = serde_json::from_str(&text)?;
@@ -923,7 +936,7 @@ async fn json_schema_structured_output_roundtrip() -> Result<()> {
             anyhow::ensure!(plan.risk.eq_ignore_ascii_case("low"));
             anyhow::ensure!(plan.checks.compile);
             anyhow::ensure!(plan.checks.replay);
-            assert_response_metadata(&response);
+            assert_response_metadata(&response, &raw);
 
             Ok(())
         },

--- a/tests/providers/mistralrs/cassette/chat_completions.rs
+++ b/tests/providers/mistralrs/cassette/chat_completions.rs
@@ -1,5 +1,6 @@
 //! Cassette coverage for mistral.rs `/v1/chat/completions` responses.
 
+use rig::completion::NormalizeCompletionResponse;
 use rig::completion::{CompletionModel, Prompt};
 use rig::prelude::*;
 use serde_json::Value;
@@ -27,8 +28,7 @@ async fn raw_chat_completion_surfaces_reasoning_or_text() {
                 .expect("raw chat completion should succeed");
             let raw = serde_json::to_value(&wire_response)
                 .expect("raw chat completion response should serialize");
-            let _normalized: rig::completion::CompletionResponse = ("openai", wire_response)
-                .try_into()
+            let _normalized: rig::completion::CompletionResponse = wire_response.normalize("openai")
                 .expect("raw chat completion should normalize");
             let message = &raw["choices"][0]["message"];
             let text = message

--- a/tests/providers/mistralrs/cassette/chat_completions.rs
+++ b/tests/providers/mistralrs/cassette/chat_completions.rs
@@ -11,18 +11,25 @@ async fn raw_chat_completion_surfaces_reasoning_or_text() {
     with_mistralrs_completions_cassette(
         "chat_completions/raw_chat_completion_surfaces_reasoning_or_text",
         |client| async move {
-            let response = client
-                .completion_model(model_name())
+            let model = client.completion_model(model_name());
+            let request = model
                 .completion_request(
                     "Think briefly, then answer in one sentence why token usage should be reported.",
                 )
                 .preamble(SYSTEM_PROMPT.to_string())
                 .max_tokens(256)
-                .send()
+                .build();
+            // A single cassette interaction: take mistral.rs's own wire response
+            // and still exercise the normalization the completion path applies.
+            let wire_response = model
+                .raw_completion(request)
                 .await
                 .expect("raw chat completion should succeed");
-            let raw = serde_json::to_value(&response.raw_response)
+            let raw = serde_json::to_value(&wire_response)
                 .expect("raw chat completion response should serialize");
+            let _normalized: rig::completion::CompletionResponse = ("openai", wire_response)
+                .try_into()
+                .expect("raw chat completion should normalize");
             let message = &raw["choices"][0]["message"];
             let text = message
                 .get("content")

--- a/tests/providers/mistralrs/cassette/responses_api.rs
+++ b/tests/providers/mistralrs/cassette/responses_api.rs
@@ -1,5 +1,6 @@
 //! Cassette coverage for mistral.rs through Rig's OpenAI Responses API client.
 
+use rig::completion::NormalizeCompletionResponse;
 use rig::completion::{Chat, CompletionModel, Prompt};
 use rig::message::AssistantContent;
 use rig::prelude::*;
@@ -54,8 +55,7 @@ async fn responses_api_reasoning_plus_answer_completes() {
                 .raw_completion(request)
                 .await
                 .expect("Responses API reasoning plus answer prompt should succeed");
-            let response: rig::completion::CompletionResponse = ("openai", raw.clone())
-                .try_into()
+            let response: rig::completion::CompletionResponse = raw.clone().normalize("openai")
                 .expect("Responses API response should normalize");
             let text = response
                 .choice

--- a/tests/providers/mistralrs/cassette/responses_api.rs
+++ b/tests/providers/mistralrs/cassette/responses_api.rs
@@ -46,10 +46,17 @@ async fn responses_api_reasoning_plus_answer_completes() {
                 .preamble(SYSTEM_PROMPT.to_owned())
                 .max_tokens(512)
                 .build();
-            let response = model
-                .completion(request)
+            // One cassette interaction: `raw_completion` yields the Responses API
+            // wire response (whose reasoning fields are provider-specific and not
+            // normalized), and the provider-local conversion yields exactly what
+            // `CompletionModel::completion` would have returned for it.
+            let raw = model
+                .raw_completion(request)
                 .await
                 .expect("Responses API reasoning plus answer prompt should succeed");
+            let response: rig::completion::CompletionResponse = ("openai", raw.clone())
+                .try_into()
+                .expect("Responses API response should normalize");
             let text = response
                 .choice
                 .iter()
@@ -61,15 +68,13 @@ async fn responses_api_reasoning_plus_answer_completes() {
 
             assert_nonempty_response(&text);
             assert!(
-                response
-                    .raw_response
-                    .provider_reasoning
+                raw.provider_reasoning
                     .as_deref()
                     .is_some_and(|reasoning| !reasoning.trim().is_empty()),
                 "string-shaped provider reasoning should remain available"
             );
-            assert_eq!(response.raw_response.reasoning_metadata, None);
-            assert_eq!(response.raw_response.reasoning_context, None);
+            assert_eq!(raw.reasoning_metadata, None);
+            assert_eq!(raw.reasoning_context, None);
         },
     )
     .await;

--- a/tests/providers/mistralrs/cassette/usage.rs
+++ b/tests/providers/mistralrs/cassette/usage.rs
@@ -11,16 +11,24 @@ async fn chat_completion_usage_without_output_tokens_details_deserializes() {
     with_mistralrs_completions_cassette(
         "usage/chat_completion_usage_without_output_tokens_details_deserializes",
         |client| async move {
-            let response = client
-                .completion_model(model_name())
+            let model = client.completion_model(model_name());
+            let request = model
                 .completion_request("/no_think Explain usage accounting in one sentence.")
                 .preamble(SYSTEM_PROMPT.to_string())
                 .max_tokens(64)
-                .send()
+                .build();
+            // A single cassette interaction: keep mistral.rs's own wire response
+            // for the usage-shape assertions, and still check that the
+            // normalization the completion path applies accepts it.
+            let wire_response = model
+                .raw_completion(request)
                 .await
                 .expect("usage check completion should succeed");
-            let raw = serde_json::to_value(&response.raw_response)
+            let raw = serde_json::to_value(&wire_response)
                 .expect("raw chat completion response should serialize");
+            let _normalized: rig::completion::CompletionResponse = ("openai", wire_response)
+                .try_into()
+                .expect("usage check completion should normalize");
             let usage = raw
                 .get("usage")
                 .expect("mistral.rs response should include usage");

--- a/tests/providers/mistralrs/cassette/usage.rs
+++ b/tests/providers/mistralrs/cassette/usage.rs
@@ -1,6 +1,7 @@
 //! Cassette coverage for mistral.rs usage without OpenAI `output_tokens_details`.
 
 use rig::completion::CompletionModel;
+use rig::completion::NormalizeCompletionResponse;
 use rig::prelude::*;
 use serde_json::Value;
 
@@ -26,8 +27,8 @@ async fn chat_completion_usage_without_output_tokens_details_deserializes() {
                 .expect("usage check completion should succeed");
             let raw = serde_json::to_value(&wire_response)
                 .expect("raw chat completion response should serialize");
-            let _normalized: rig::completion::CompletionResponse = ("openai", wire_response)
-                .try_into()
+            let _normalized: rig::completion::CompletionResponse = wire_response
+                .normalize("openai")
                 .expect("usage check completion should normalize");
             let usage = raw
                 .get("usage")

--- a/tests/providers/openai/cassette/completions_api.rs
+++ b/tests/providers/openai/cassette/completions_api.rs
@@ -49,20 +49,28 @@ async fn completions_api_raw_response_text_matches_normalized_choice_text() {
     with_openai_completions_cassette(
         "completions_api/completions_api_raw_response_text_matches_normalized_choice_text",
         |client| async move {
-            let response = client
-                .completion_model(openai::GPT_4O)
+            let model = client.completion_model(openai::GPT_4O);
+            let request = model
                 .completion_request(RAW_TEXT_RESPONSE_PROMPT)
                 .preamble(RAW_TEXT_RESPONSE_PREAMBLE.to_string())
-                .send()
+                .build();
+
+            // The cassette records exactly one interaction, so the raw wire
+            // response is fetched once and normalized through the provider's own
+            // conversion instead of issuing a second identical request.
+            let raw = model
+                .raw_completion(request)
                 .await
                 .expect("raw completions api request should succeed");
-
-            let normalized_text = assistant_text_response(&response.choice)
-                .expect("normalized completions api response should contain assistant text");
-            let raw_text = response
-                .raw_response
+            let raw_text = raw
                 .get_text_response()
                 .expect("raw completions api response should contain assistant text");
+
+            let response: rig::completion::CompletionResponse = ("openai", raw)
+                .try_into()
+                .expect("raw completions api response should normalize");
+            let normalized_text = assistant_text_response(&response.choice)
+                .expect("normalized completions api response should contain assistant text");
 
             assert_nonempty_response(&normalized_text);
             assert_nonempty_response(&raw_text);

--- a/tests/providers/openai/cassette/completions_api.rs
+++ b/tests/providers/openai/cassette/completions_api.rs
@@ -2,6 +2,7 @@
 
 use rig::OneOrMany;
 use rig::completion::CompletionModel;
+use rig::completion::NormalizeCompletionResponse;
 use rig::completion::Prompt;
 use rig::message::{AssistantContent, Message, ToolChoice};
 use rig::prelude::*;
@@ -66,8 +67,8 @@ async fn completions_api_raw_response_text_matches_normalized_choice_text() {
                 .get_text_response()
                 .expect("raw completions api response should contain assistant text");
 
-            let response: rig::completion::CompletionResponse = ("openai", raw)
-                .try_into()
+            let response: rig::completion::CompletionResponse = raw
+                .normalize("openai")
                 .expect("raw completions api response should normalize");
             let normalized_text = assistant_text_response(&response.choice)
                 .expect("normalized completions api response should contain assistant text");

--- a/tests/providers/openai/cassette/gpt_5_6_reasoning.rs
+++ b/tests/providers/openai/cassette/gpt_5_6_reasoning.rs
@@ -13,7 +13,7 @@ use rig::completion::{CompletionModel, CompletionResponse};
 use rig::message::{AssistantContent, Message, Reasoning};
 use rig::prelude::*;
 use rig::providers::openai;
-use rig::streaming::StreamedAssistantContent;
+use rig::streaming::RawStreamingChoice;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
@@ -57,22 +57,34 @@ struct StoredStreamingTurn {
     final_response: openai::responses_api::streaming::StreamingCompletionResponse,
 }
 
-async fn prompt_with_reasoning<M>(
-    model: &M,
+/// Issue one GPT-5.6 completion and return both the normalized response and the
+/// Responses API's own wire response, which is the only carrier of the
+/// reasoning metadata these tests lock down.
+///
+/// Each cassette records a single interaction, so the normalized response is
+/// derived from the same raw response through the provider's own conversion
+/// rather than by issuing a second identical request.
+async fn prompt_with_reasoning(
+    model: &openai::responses_api::ResponsesCompletionModel,
     reasoning: serde_json::Value,
-) -> CompletionResponse<M::Response>
-where
-    M: CompletionModel,
-{
+) -> (
+    CompletionResponse,
+    openai::responses_api::CompletionResponse,
+) {
     let request = model
         .completion_request(PROMPT)
         .additional_params(json!({ "reasoning": reasoning }))
         .build();
 
-    model
-        .completion(request)
+    let raw_response = model
+        .raw_completion(request)
         .await
-        .expect("completion with GPT-5.6 reasoning controls should succeed")
+        .expect("completion with GPT-5.6 reasoning controls should succeed");
+    let response = ("openai", raw_response.clone())
+        .try_into()
+        .expect("GPT-5.6 reasoning response should normalize");
+
+    (response, raw_response)
 }
 
 #[test]
@@ -84,27 +96,33 @@ fn model_constants() {
 }
 
 fn assert_reasoning_metadata(
-    response: &CompletionResponse<openai::responses_api::CompletionResponse>,
+    raw_response: &openai::responses_api::CompletionResponse,
     expected: Value,
 ) {
     let expected = expected
         .as_object()
         .expect("expected reasoning metadata should be an object");
     assert_eq!(
-        response.raw_response.reasoning_context.as_deref(),
+        raw_response.reasoning_context.as_deref(),
         expected.get("context").and_then(Value::as_str)
     );
+    assert_eq!(raw_response.reasoning_metadata.as_ref(), Some(expected));
     assert_eq!(
-        response.raw_response.reasoning_metadata.as_ref(),
-        Some(expected)
-    );
-    assert_eq!(
-        serde_json::to_value(&response.raw_response).expect("raw response should serialize")["reasoning"],
+        serde_json::to_value(raw_response).expect("raw response should serialize")["reasoning"],
         Value::Object(expected.clone())
     );
 }
 
-fn assert_has_text(response: &CompletionResponse<openai::responses_api::CompletionResponse>) {
+/// Rebuild the reasoning block the normalized stream would have produced for a
+/// [`RawStreamingChoice::Reasoning`] event: the same id and the single content
+/// block, verbatim. [`Reasoning`] is `#[non_exhaustive]`, so it is round-tripped
+/// through serde rather than constructed field-by-field.
+fn reasoning_block(id: Option<String>, content: rig::message::ReasoningContent) -> Reasoning {
+    serde_json::from_value(json!({ "id": id, "content": [content] }))
+        .expect("streamed reasoning block should rebuild")
+}
+
+fn assert_has_text(response: &CompletionResponse) {
     let text: String = response
         .choice
         .iter()
@@ -123,10 +141,11 @@ fn assert_has_text(response: &CompletionResponse<openai::responses_api::Completi
 async fn effort_max() {
     with_openai_cassette("gpt_5_6_reasoning/effort_max", |client| async move {
         let model = client.completion_model(openai::GPT_5_6);
-        let response = prompt_with_reasoning(&model, json!({ "effort": "max" })).await;
+        let (response, raw_response) =
+            prompt_with_reasoning(&model, json!({ "effort": "max" })).await;
         assert_has_text(&response);
         assert_reasoning_metadata(
-            &response,
+            &raw_response,
             json!({
                 "context": "all_turns",
                 "effort": "max",
@@ -144,11 +163,11 @@ async fn mode_pro_with_independent_effort() {
         "gpt_5_6_reasoning/mode_pro_with_independent_effort",
         |client| async move {
             let model = client.completion_model(openai::GPT_5_6_SOL);
-            let response =
+            let (response, raw_response) =
                 prompt_with_reasoning(&model, json!({ "effort": "high", "mode": "pro" })).await;
             assert_has_text(&response);
             assert_reasoning_metadata(
-                &response,
+                &raw_response,
                 json!({
                     "context": "all_turns",
                     "effort": "high",
@@ -167,14 +186,14 @@ async fn context_current_turn() {
         "gpt_5_6_reasoning/context_current_turn",
         |client| async move {
             let model = client.completion_model(openai::GPT_5_6_SOL);
-            let response = prompt_with_reasoning(
+            let (response, raw_response) = prompt_with_reasoning(
                 &model,
                 json!({ "effort": "low", "context": "current_turn" }),
             )
             .await;
             assert_has_text(&response);
             assert_reasoning_metadata(
-                &response,
+                &raw_response,
                 json!({
                     "context": "current_turn",
                     "effort": "low",
@@ -217,12 +236,20 @@ async fn five_turn_reasoning_metadata_roundtrip() {
                         }
                     }))
                     .build();
-                let response = model.completion(request).await.unwrap_or_else(|error| {
+                // One request per turn: the raw wire response carries the
+                // reasoning metadata under test, and the normalized response is
+                // derived from it rather than re-requested.
+                let raw_response = model.raw_completion(request).await.unwrap_or_else(|error| {
                     panic!("turn {} should succeed: {error}", turn_index + 1)
                 });
+                let response: CompletionResponse = ("openai", raw_response.clone())
+                    .try_into()
+                    .unwrap_or_else(|error| {
+                        panic!("turn {} should normalize: {error}", turn_index + 1)
+                    });
 
                 assert_has_text(&response);
-                assert_reasoning_metadata(&response, expected_metadata.clone());
+                assert_reasoning_metadata(&raw_response, expected_metadata.clone());
                 let text = response
                     .choice
                     .iter()
@@ -238,8 +265,8 @@ async fn five_turn_reasoning_metadata_roundtrip() {
                     turn_index + 1
                 );
 
-                let raw_json = serde_json::to_value(&response.raw_response)
-                    .expect("raw response should serialize");
+                let raw_json =
+                    serde_json::to_value(&raw_response).expect("raw response should serialize");
                 let roundtripped: openai::responses_api::CompletionResponse =
                     serde_json::from_value(raw_json.clone())
                         .expect("raw response should deserialize after serialization");
@@ -257,7 +284,7 @@ async fn five_turn_reasoning_metadata_roundtrip() {
                         id: response.message_id,
                         content: response.choice,
                     },
-                    raw_response: response.raw_response,
+                    raw_response,
                 });
                 let stored_json =
                     serde_json::to_value(&stored_turns).expect("all stored turns should serialize");
@@ -319,27 +346,36 @@ async fn five_turn_streaming_reasoning_metadata_roundtrip() {
                         }
                     }))
                     .build();
-                let mut stream = model.stream(request).await.unwrap_or_else(|error| {
+                // The terminal record under test is the Responses API's own
+                // streaming response, so the turn is driven off `raw_stream`;
+                // the normalized stream would hand back `StreamFinal`, which
+                // does not carry the reasoning metadata.
+                let mut stream = model.raw_stream(request).await.unwrap_or_else(|error| {
                     panic!("turn {} stream should start: {error}", turn_index + 1)
                 });
                 let mut text = String::new();
                 let mut reasoning_blocks = Vec::new();
                 let mut reasoning_delta = String::new();
                 let mut final_response = None;
+                let mut message_id = None;
 
                 while let Some(item) = stream.next().await {
                     match item.unwrap_or_else(|error| {
                         panic!("turn {} stream should succeed: {error}", turn_index + 1)
                     }) {
-                        StreamedAssistantContent::Text(delta) => text.push_str(&delta.text),
-                        StreamedAssistantContent::Reasoning(reasoning) => {
-                            reasoning_blocks.push(AssistantContent::Reasoning(reasoning));
+                        RawStreamingChoice::Message(delta) => text.push_str(&delta),
+                        RawStreamingChoice::Reasoning { id, content } => {
+                            reasoning_blocks
+                                .push(AssistantContent::Reasoning(reasoning_block(id, content)));
                         }
-                        StreamedAssistantContent::ReasoningDelta { reasoning, .. } => {
+                        RawStreamingChoice::ReasoningDelta { reasoning, .. } => {
                             reasoning_delta.push_str(&reasoning);
                         }
-                        StreamedAssistantContent::Final(response) => {
+                        RawStreamingChoice::FinalResponse(response) => {
                             final_response = Some(response);
+                        }
+                        RawStreamingChoice::MessageId(id) => {
+                            message_id = Some(id);
                         }
                         _ => {}
                     }
@@ -354,6 +390,10 @@ async fn five_turn_streaming_reasoning_metadata_roundtrip() {
                 let final_response = final_response.unwrap_or_else(|| {
                     panic!("turn {} should yield a final response", turn_index + 1)
                 });
+                // Same precedence the normalized stream applies: an explicit
+                // `MessageId` event wins, and the terminal record only fills a
+                // gap it left.
+                let message_id = message_id.or_else(|| final_response.message_id.clone());
                 assert_eq!(
                     final_response.reasoning_context.as_deref(),
                     Some("all_turns")
@@ -384,7 +424,7 @@ async fn five_turn_streaming_reasoning_metadata_roundtrip() {
                 stored_turns.push(StoredStreamingTurn {
                     user: user_message,
                     assistant: Message::Assistant {
-                        id: stream.message_id.clone(),
+                        id: message_id,
                         content: rig::OneOrMany::many(reasoning_blocks)
                             .expect("streamed assistant message should not be empty"),
                     },
@@ -438,8 +478,10 @@ async fn streaming_reasoning_metadata() {
                     }
                 }))
                 .build();
+            // `raw_stream` keeps the terminal record provider-native; the
+            // normalized `StreamFinal` carries no reasoning metadata.
             let mut stream = model
-                .stream(request)
+                .raw_stream(request)
                 .await
                 .expect("GPT-5.6 reasoning stream should start");
             let expected = json!({
@@ -450,7 +492,7 @@ async fn streaming_reasoning_metadata() {
             });
 
             while let Some(item) = stream.next().await {
-                if let StreamedAssistantContent::Final(response) =
+                if let RawStreamingChoice::FinalResponse(response) =
                     item.expect("GPT-5.6 reasoning stream should succeed")
                 {
                     assert_eq!(response.reasoning_context.as_deref(), Some("current_turn"));

--- a/tests/providers/openai/cassette/gpt_5_6_reasoning.rs
+++ b/tests/providers/openai/cassette/gpt_5_6_reasoning.rs
@@ -9,6 +9,7 @@
 //! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
 
 use futures::StreamExt;
+use rig::completion::NormalizeCompletionResponse;
 use rig::completion::{CompletionModel, CompletionResponse};
 use rig::message::{AssistantContent, Message, Reasoning};
 use rig::prelude::*;
@@ -80,8 +81,9 @@ async fn prompt_with_reasoning(
         .raw_completion(request)
         .await
         .expect("completion with GPT-5.6 reasoning controls should succeed");
-    let response = ("openai", raw_response.clone())
-        .try_into()
+    let response = raw_response
+        .clone()
+        .normalize("openai")
         .expect("GPT-5.6 reasoning response should normalize");
 
     (response, raw_response)
@@ -242,8 +244,9 @@ async fn five_turn_reasoning_metadata_roundtrip() {
                 let raw_response = model.raw_completion(request).await.unwrap_or_else(|error| {
                     panic!("turn {} should succeed: {error}", turn_index + 1)
                 });
-                let response: CompletionResponse = ("openai", raw_response.clone())
-                    .try_into()
+                let response: CompletionResponse = raw_response
+                    .clone()
+                    .normalize("openai")
                     .unwrap_or_else(|error| {
                         panic!("turn {} should normalize: {error}", turn_index + 1)
                     });

--- a/tests/providers/openai/cassette/responses_behaviors.rs
+++ b/tests/providers/openai/cassette/responses_behaviors.rs
@@ -6,6 +6,7 @@
 //! Run cassette tests in replay mode by default, or set
 //! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
 
+use rig::completion::NormalizeCompletionResponse;
 use rig::completion::{Chat, CompletionModel, FinishReason, Message};
 use rig::message::AssistantContent;
 use rig::prelude::*;
@@ -108,8 +109,8 @@ async fn incomplete_response_surfaces_partial_output() {
                 "incomplete_details should carry the truncation reason"
             );
 
-            let response: rig::completion::CompletionResponse = ("openai", raw)
-                .try_into()
+            let response: rig::completion::CompletionResponse = raw
+                .normalize("openai")
                 .expect("an incomplete response should still convert, not error");
             assert_eq!(
                 response.finish_reason,

--- a/tests/providers/openai/cassette/responses_behaviors.rs
+++ b/tests/providers/openai/cassette/responses_behaviors.rs
@@ -6,7 +6,7 @@
 //! Run cassette tests in replay mode by default, or set
 //! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
 
-use rig::completion::{Chat, CompletionModel, Message};
+use rig::completion::{Chat, CompletionModel, FinishReason, Message};
 use rig::message::AssistantContent;
 use rig::prelude::*;
 use rig::providers::openai;
@@ -84,18 +84,21 @@ async fn incomplete_response_surfaces_partial_output() {
                 .max_tokens(16)
                 .build();
 
-            let response = model
-                .completion(request)
+            // `status` and `incomplete_details` are Responses-API wire fields, so
+            // they are read off the provider's own response type. The cassette
+            // records a single interaction, so the normalized response is derived
+            // from that same raw response rather than re-requested.
+            let raw = model
+                .raw_completion(request)
                 .await
                 .expect("an incomplete response should still convert, not error");
 
             assert_eq!(
-                response.raw_response.status,
+                raw.status,
                 ResponseStatus::Incomplete,
                 "hitting max_output_tokens should mark the response incomplete"
             );
-            let reason = response
-                .raw_response
+            let reason = raw
                 .incomplete_details
                 .as_ref()
                 .map(|details| details.reason.as_str());
@@ -103,6 +106,15 @@ async fn incomplete_response_surfaces_partial_output() {
                 reason,
                 Some("max_output_tokens"),
                 "incomplete_details should carry the truncation reason"
+            );
+
+            let response: rig::completion::CompletionResponse = ("openai", raw)
+                .try_into()
+                .expect("an incomplete response should still convert, not error");
+            assert_eq!(
+                response.finish_reason,
+                Some(FinishReason::Length),
+                "the incomplete/max_output_tokens pair should normalize to a length stop"
             );
             let text: String = response
                 .choice

--- a/tests/providers/openai/cassette/streaming.rs
+++ b/tests/providers/openai/cassette/streaming.rs
@@ -1,6 +1,5 @@
 //! OpenAI streaming coverage, including the migrated example path.
 
-use rig::completion::GetTokenUsage;
 use rig::prelude::*;
 use rig::providers::openai;
 use rig::streaming::StreamingPrompt;
@@ -20,15 +19,17 @@ async fn streaming_smoke() {
             .build();
 
         let mut stream = agent.stream_prompt(STREAMING_PROMPT).await;
-        let (response, provider_final): (
-            _,
-            openai::responses_api::streaming::StreamingCompletionResponse,
-        ) = collect_stream_final_response_and_provider_final(&mut stream)
-            .await
-            .expect("streaming prompt should succeed");
+        let (response, provider_final) =
+            collect_stream_final_response_and_provider_final(&mut stream)
+                .await
+                .expect("streaming prompt should succeed");
 
         assert_nonempty_response(&response);
-        assert!(provider_final.token_usage().total_tokens > 0);
+        assert_eq!(
+            provider_final.provider, "openai",
+            "the terminal stream record should be attributed to the OpenAI provider"
+        );
+        assert!(provider_final.usage.total_tokens > 0);
     })
     .await;
 }

--- a/tests/providers/openai/cassette/vllm.rs
+++ b/tests/providers/openai/cassette/vllm.rs
@@ -1,6 +1,7 @@
 //! vLLM OpenAI-compatible Responses API regression tests.
 
 use rig::completion::CompletionModel;
+use rig::completion::NormalizeCompletionResponse;
 use rig::prelude::*;
 use rig::providers::openai;
 use std::future::Future;
@@ -52,8 +53,7 @@ async fn responses_api_accepts_null_metadata() {
                 "vLLM returns metadata: null; Rig should preserve the public map API as an empty map"
             );
 
-            let response: rig::completion::CompletionResponse = ("openai", raw)
-                .try_into()
+            let response: rig::completion::CompletionResponse = raw.normalize("openai")
                 .expect("vLLM Responses API completion should normalize");
             assert!(
                 response.choice.iter().next().is_some(),

--- a/tests/providers/openai/cassette/vllm.rs
+++ b/tests/providers/openai/cassette/vllm.rs
@@ -38,19 +38,23 @@ async fn responses_api_accepts_null_metadata() {
                 .max_tokens(8)
                 .build();
 
-            let response = model
-                .completion(request)
+            // `metadata` is a provider-native wire field, so it is read off the
+            // Responses API's own response type. The cassette records a single
+            // interaction, so the normalized response is derived from that same
+            // raw response instead of issuing a second request.
+            let raw = model
+                .raw_completion(request)
                 .await
                 .expect("vLLM Responses API completion with null metadata should deserialize");
 
             assert!(
-                response
-                    .raw_response
-                    .additional_parameters
-                    .metadata
-                    .is_empty(),
+                raw.additional_parameters.metadata.is_empty(),
                 "vLLM returns metadata: null; Rig should preserve the public map API as an empty map"
             );
+
+            let response: rig::completion::CompletionResponse = ("openai", raw)
+                .try_into()
+                .expect("vLLM Responses API completion should normalize");
             assert!(
                 response.choice.iter().next().is_some(),
                 "response should contain assistant content"

--- a/tests/providers/openrouter/cassette/agent_tool_sessions.rs
+++ b/tests/providers/openrouter/cassette/agent_tool_sessions.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use rig::OneOrMany;
+use rig::completion::NormalizeCompletionResponse;
 use rig::completion::{Chat, CompletionModel, Message, TypedPrompt};
 use rig::message::{AssistantContent, ToolChoice, UserContent};
 use rig::prelude::*;
@@ -653,7 +654,7 @@ async fn long_history_replay_with_tool_result_continuation() -> Result<()> {
             // either way.
             let raw = model.raw_completion(request).await?;
             let response: rig::completion::CompletionResponse =
-                ("openrouter", raw.clone()).try_into()?;
+                raw.clone().normalize("openrouter")?;
             let text = response
                 .choice
                 .iter()

--- a/tests/providers/openrouter/cassette/agent_tool_sessions.rs
+++ b/tests/providers/openrouter/cassette/agent_tool_sessions.rs
@@ -647,7 +647,13 @@ async fn long_history_replay_with_tool_result_continuation() -> Result<()> {
                 .tool_choice(ToolChoice::None)
                 .build();
 
-            let response = model.completion(request).await?;
+            // The per-choice finish reasons live on OpenRouter's own wire
+            // response, so this reads them from `raw_completion` and applies
+            // the same conversion `completion` does — one cassette interaction
+            // either way.
+            let raw = model.raw_completion(request).await?;
+            let response: rig::completion::CompletionResponse =
+                ("openrouter", raw.clone()).try_into()?;
             let text = response
                 .choice
                 .iter()
@@ -664,14 +670,17 @@ async fn long_history_replay_with_tool_result_continuation() -> Result<()> {
                 response.usage
             );
             anyhow::ensure!(
-                response
-                    .raw_response
-                    .choices
+                raw.choices
                     .iter()
                     .all(|choice| choice.finish_reason.is_some()),
                 "raw response should preserve finish reasons"
             );
-            assert_nonempty_response(&response.raw_response.model);
+            anyhow::ensure!(
+                response.finish_reason.is_some(),
+                "normalized response should preserve the finish reason: {:?}",
+                response.finish_reason
+            );
+            assert_nonempty_response(&raw.model);
 
             Ok(())
         },

--- a/tests/providers/openrouter/cassette/openai_responses_compat.rs
+++ b/tests/providers/openrouter/cassette/openai_responses_compat.rs
@@ -15,19 +15,26 @@ async fn openai_responses_raw_response_accepts_service_tier_metadata() {
     with_openrouter_openai_cassette(
         "openai_responses_compat/openai_responses_raw_response_accepts_service_tier_metadata",
         |client| async move {
-            let response = client
+            let model = client
                 .completion_model(DEFAULT_OPENAI_COMPAT_MODEL)
-                .with_system_instructions_as_messages()
+                .with_system_instructions_as_messages();
+            let request = model
                 .completion_request("Reply with exactly: openrouter responses service tier ok")
                 .preamble(
                     "Return the requested text exactly, with no extra commentary.".to_string(),
                 )
-                .send()
+                .build();
+
+            // `service_tier` is Responses-API metadata rig does not normalize,
+            // so it is read off the provider's own wire response. `completion`
+            // sends exactly this request, so the cassette still sees one
+            // interaction.
+            let response = model
+                .raw_completion(request)
                 .await
                 .expect("OpenRouter Responses API completion should deserialize");
 
             let service_tier = response
-                .raw_response
                 .additional_parameters
                 .service_tier
                 .as_ref()

--- a/tests/providers/xai/agent_tool_sessions.rs
+++ b/tests/providers/xai/agent_tool_sessions.rs
@@ -394,15 +394,34 @@ fn assert_history_records_sequential_tool_roundtrips(history: &[Message], expect
     }
 }
 
-fn assert_response_metadata(
-    response: &rig::completion::CompletionResponse<xai::CompletionResponse>,
-) {
-    assert_nonempty_response(&response.raw_response.id);
-    assert_nonempty_response(&response.raw_response.model);
-    assert_eq!(response.raw_response.status.as_deref(), Some("completed"));
+/// Assert the provider-native metadata xAI reports on its own wire response.
+///
+/// The response id (`resp_...`), the untyped `status`, and the raw usage
+/// envelope have no normalized home, so they are read from
+/// [`xai::CompletionModel::raw_completion`]. `completion` is that same call
+/// followed by the same conversion, so a cassette still records exactly one
+/// interaction.
+fn assert_raw_response_metadata(raw: &xai::CompletionResponse) {
+    assert_nonempty_response(&raw.id);
+    assert_nonempty_response(&raw.model);
+    assert_eq!(raw.status.as_deref(), Some("completed"));
     assert!(
-        response.raw_response.usage.is_some(),
+        raw.usage.is_some(),
         "raw xAI response should preserve usage metadata"
+    );
+}
+
+fn assert_response_metadata(response: &rig::completion::CompletionResponse) {
+    assert_nonempty_response(
+        response
+            .model
+            .as_deref()
+            .expect("normalized xAI response should report the provider model"),
+    );
+    assert_eq!(
+        response.finish_reason,
+        Some(rig::completion::FinishReason::Stop),
+        "xAI `status: completed` should normalize to a stop finish reason"
     );
     assert!(
         response
@@ -682,7 +701,9 @@ async fn long_history_replay_with_tool_result_continuation() -> Result<()> {
                 .tool_choice(ToolChoice::None)
                 .build();
 
-            let response = model.completion(request).await?;
+            let raw = model.raw_completion(request).await?;
+            assert_raw_response_metadata(&raw);
+            let response: rig::completion::CompletionResponse = raw.try_into()?;
             let text = assistant_text_response(&response.choice)
                 .ok_or_else(|| anyhow::anyhow!("response should include assistant text"))?;
 
@@ -799,7 +820,23 @@ async fn reasoning_effort_preserves_reasoning_content_and_usage() -> Result<()> 
                 }))
                 .build();
 
-            let response = model.completion(request).await?;
+            let raw = model.raw_completion(request).await?;
+
+            anyhow::ensure!(
+                raw.output
+                    .iter()
+                    .any(|output| matches!(output, Output::Reasoning { .. })),
+                "raw xAI output should preserve provider reasoning item"
+            );
+            let raw_reasoning_tokens = raw
+                .usage
+                .as_ref()
+                .and_then(|usage| usage.output_tokens_details.as_ref())
+                .map(|details| details.reasoning_tokens)
+                .unwrap_or_default();
+            assert_raw_response_metadata(&raw);
+
+            let response: rig::completion::CompletionResponse = raw.try_into()?;
 
             anyhow::ensure!(
                 response
@@ -809,25 +846,10 @@ async fn reasoning_effort_preserves_reasoning_content_and_usage() -> Result<()> 
                 "xAI reasoning response should preserve a reasoning content block"
             );
             anyhow::ensure!(
-                response
-                    .raw_response
-                    .output
-                    .iter()
-                    .any(|output| matches!(output, Output::Reasoning { .. })),
-                "raw xAI output should preserve provider reasoning item"
-            );
-            anyhow::ensure!(
                 response.usage.reasoning_tokens > 0,
                 "core usage should preserve xAI reasoning tokens: {:?}",
                 response.usage
             );
-            let raw_reasoning_tokens = response
-                .raw_response
-                .usage
-                .as_ref()
-                .and_then(|usage| usage.output_tokens_details.as_ref())
-                .map(|details| details.reasoning_tokens)
-                .unwrap_or_default();
             anyhow::ensure!(
                 response.usage.reasoning_tokens == raw_reasoning_tokens && raw_reasoning_tokens > 0,
                 "usage reasoning tokens should match raw provider details"
@@ -890,7 +912,9 @@ async fn nested_json_schema_response_format_roundtrip() -> Result<()> {
                 }))
                 .build();
 
-            let response = model.completion(request).await?;
+            let raw = model.raw_completion(request).await?;
+            assert_raw_response_metadata(&raw);
+            let response: rig::completion::CompletionResponse = raw.try_into()?;
             let text = assistant_text_response(&response.choice)
                 .ok_or_else(|| anyhow::anyhow!("schema response should contain text"))?;
             let plan: serde_json::Value = serde_json::from_str(&text)?;


### PR DESCRIPTION
## Summary

This normalizes completion responses at the provider boundary so that
`CompletionModel` describes only what a model *does*, not what shape its
provider happens to answer in.

- `CompletionModel` loses `Response`, `StreamingResponse`, `Client`, and `make`.
- `CompletionResponse` and `StreamingCompletionResponse` are concrete.
- The normalized response carries what callers actually reached into
  `raw_response` for: `finish_reason`, `provider`, the provider-reported
  `model`, and `message_id`.
- Provider-native payloads stay reachable, and stay typed, through each model's
  inherent `raw_completion` / `raw_stream`.
- Model construction moves to the required `CompletionClient::completion_model`.
- `ProviderCapabilities` replaces `composes_native_output_with_tools` with plain
  data a runtime can snapshot.

Breaking API changes are intentional. This is the prerequisite for #2252 — the
associated types are exactly what prevents `Box<dyn CompletionModel>`, so they
have to go before an erased `ModelHandle` is expressible. It does not modify
#2252 or introduce any runtime model-selection machinery.

This is an independent implementation of the same prerequisite as #2254, not a
revision of it.

## Core API shape

```rust
pub trait CompletionModel: Clone + WasmCompatSend + WasmCompatSync {
    fn completion(&self, request: CompletionRequest)
        -> impl Future<Output = Result<CompletionResponse, CompletionError>> + WasmCompatSend;

    fn stream(&self, request: CompletionRequest)
        -> impl Future<Output = Result<StreamingCompletionResponse, CompletionError>> + WasmCompatSend;

    fn completion_request(&self, prompt: impl Into<Message>) -> CompletionRequestBuilder<Self> { .. }

    fn capabilities(&self) -> ProviderCapabilities { ProviderCapabilities::default() }
}

pub trait CompletionClient {
    type CompletionModel: CompletionModel;
    fn completion_model(&self, model: impl Into<String>) -> Self::CompletionModel;
}
```

`CompletionModel` no longer drags in a client type, so a model with no client at
all is now expressible — covered by a test in `client/completion.rs`.

## Three details that are load-bearing

**The `Stop` → `ToolCalls` reconciliation lives in exactly one place.**
Several OpenAI-compatible gateways report a bare `stop` on a turn that carried
tool calls. `FinishReason::reconcile_with_output` is the single implementation,
and it is applied by `CompletionResponse::with_finish_reason` /
`with_optional_finish_reason` on the unary path and by `normalize_stream` — using
the tool calls actually observed — on the streaming path. The `Option` setter
exists precisely so a provider holding an `Option<FinishReason>` never has to
choose between ergonomics and correctness by assigning the field directly. Only
a natural `Stop` is upgraded; `Length`, `ContentFilter`, and `Other` describe
terminations that remain true regardless of content.

**A conversion over a shared wire type takes the provider name as an input.**
`NormalizeCompletionResponse::normalize(self, provider)` is implemented by the
OpenAI chat-completions payload that ~16 providers share. Hardcoding `"openai"`
there would mislabel every one of them, and a "placeholder the caller overwrites
afterwards" would be correct only by convention. Threading the name through the
conversion makes it impossible to forget.

This is a trait rather than `TryFrom<(&str, T)>` for a concrete reason found
during review: a tuple is not a local type, so `impl TryFrom<(&str, TheirType)>
for CompletionResponse` is rejected by the orphan rule in every crate except
`rig-core`. The tuple form would have made external provider extensions
impossible to write. Implementing the trait on a provider's own response type is
allowed anywhere, which is verified by the four companion crates plus a probe.

**`provider` is known when a stream opens, not when it terminates.**
`StreamingCompletionResponse::stream` takes the descriptor name as its first
argument, so a stream that errors or is cancelled before its terminal record
still names its provider. Every other missing value has a documented sentinel
(`Usage::new()`, `None`); this one should not degrade to an empty string.

## Native-response escape hatches

Both `raw_completion` and `raw_stream` are implemented for every
completion-capable provider model:

| | Provider |
| --- | --- |
| rig-core | Anthropic (+ the anthropic-compatible family), OpenAI Chat Completions (`GenericCompletionModel<Ext, H>`, shared by Azure, DeepSeek, Doubleword, Groq, Hugging Face, Hyperbolic, Llamafile, MiniMax, Mira, Mistral, Moonshot, OpenRouter, Perplexity, Together, Xiaomi MiMo, Z.AI), OpenAI Responses, ChatGPT, Copilot (both routes), Gemini REST, Gemini Interactions, Cohere, Ollama, xAI |
| companion crates | Bedrock, Candle, Gemini gRPC, Vertex AI |

`raw_completion` returns the provider's own unary type. `raw_stream` returns
`RawStreamingResult<Native>`, whose terminal item is the provider's own type —
the normalized path maps it once with `normalize_stream`. The normalized method
calls the raw one, so there is exactly one network request either way, and both
share the request builder, transport, parser, telemetry and error-preservation
path.

## Finish-reason normalization

| Provider family | Native reason | Normalized |
| --- | --- | --- |
| OpenAI-compatible chat / Copilot chat | `stop`; `length` \| `max_tokens`; `tool_calls` \| `function_call`; `content_filter` | `Stop`; `Length`; `ToolCalls`; `ContentFilter` |
| OpenAI Responses / ChatGPT / Copilot Responses / xAI | `completed`; `incomplete` + `max_output_tokens`; `incomplete` + `content_filter`; `failed` \| `cancelled` | `Stop`; `Length`; `ContentFilter`; `Other(status)` |
| Anthropic | `end_turn` \| `stop_sequence`; `max_tokens`; `tool_use`; `refusal` | `Stop`; `Length`; `ToolCalls`; `ContentFilter` |
| Cohere | `COMPLETE` \| `STOP_SEQUENCE`; `MAX_TOKENS`; `TOOL_CALL`; `ERROR` | `Stop`; `Length`; `ToolCalls`; `Other("ERROR")` |
| Gemini REST / gRPC / Vertex | `STOP`; `MAX_TOKENS`; `SAFETY` \| `BLOCKLIST` \| `PROHIBITED_CONTENT` \| `SPII` | `Stop`; `Length`; `ContentFilter` |
| Gemini Interactions | `COMPLETED`; `REQUIRES_ACTION`; `BUDGET_EXCEEDED` | `Stop`; `ToolCalls`; `Length` |
| Ollama | `stop`; `length` | `Stop`; `Length` |
| Bedrock | `end_turn` \| `stop_sequence`; `max_tokens`; `tool_use`; `content_filtered` \| `guardrail_intervened` | `Stop`; `Length`; `ToolCalls`; `ContentFilter` |
| Candle (local) | EOS token sampled; max tokens | `Stop`; `Length` |

Unknown values are preserved verbatim in `Other(String)`, in the provider's own
spelling — Gemini's `RECITATION` stays `RECITATION`, Ollama's operational
`load`/`unload` stay themselves. Nothing is smoothed into `Stop`, and no variant
is stringified through `Debug`. `None` means the provider genuinely reported no
reason (an in-flight Responses status, Gemini's `FINISH_REASON_UNSPECIFIED`).

Where reconciliation applies, a `Stop` on a tool-calling turn becomes
`ToolCalls` — consistently on both the unary and streaming paths.

## Notes on the design

**Construction hook.** Rust's coherence rules rule out one blanket
`CompletionClient` impl per provider family (they would all overlap on
`Client<Ext, H>`), and a public bound such as `From<(Client<Ext, H>, String)>`
would push a synthetic conversion into every provider model's public API. The
blanket impl instead uses a `pub(crate) trait ConstructCompletionModel`, which
constrains only rig's own generic client. Provider crates outside `rig-core`
implement `CompletionClient` directly and never see it.

**Surviving associated types.** `OpenAICompatibleProvider::{Response,
StreamingUsage}` and `CompatibleStreamProfile::{Usage, Detail, FinalResponse}`
remain, because they name genuinely provider-native wire types at the provider's
own boundary. They do not appear in `CompletionModel`, the agent, or any
ordinary streaming type.

**One known limitation.** ChatGPT's `/responses` answers with an SSE body even
for a non-streaming request, and its terminal event sometimes carries an empty
`output`; the assistant content then exists only in the preceding events, which
`CompletionModel::completion` reassembles. So for that provider there is no
public single-request way to obtain both the raw wire response and the
normalized one — `raw_stream` is the full-fidelity escape hatch. This is
documented on `ResponsesCompletionModel::raw_completion`, and it cost one
assertion in `codex_behaviors::store_false_and_prompt_cache_fields_roundtrip`
(the namesake `store`/`prompt_cache_key` assertions are preserved; the assistant
text assertion it also carried is covered by `codex_sessions`).

## Independent review

A four-lens adversarial review ran over the complete diff (correctness,
raw/normalized parity, streaming behavior, API leakage), with every finding
re-checked by a separate agent instructed to refute it. 38 findings were raised;
14 were refuted and 24 confirmed. All 24 are fixed in this branch. The ones worth
knowing about:

- The provider-name conversion originally used `TryFrom<(&str, T)>`, which the
  orphan rule makes unimplementable outside `rig-core` — it would have silently
  blocked external provider extensions. Now a trait (see above).
- `normalize_stream` counted tool-call *deltas* toward the `Stop` → `ToolCalls`
  upgrade while the unary path counts only completed calls, so a stream whose
  tool call failed to assemble reported `ToolCalls` over a choice with none. A
  verifier reproduced this with a real SSE payload. Both paths now count only
  completed calls.
- `send_compatible_streaming_request` is public and stamped a hardcoded
  `"openai"` on every stream — the same placeholder hazard this change removes
  elsewhere. It now takes the descriptor name.
- Gemini populated `message_id` on the unary path but not the streaming one.
  Both do now.

> **Correction (superseding an earlier version of this description).** An
> earlier revision of this text claimed that request conversion drops
> `Message::Assistant`'s `id`, and used that to justify preserving
> response-scoped ids in `message_id`. **That claim was wrong.** It was based on
> checking only the chat-completions converter (`id: None`); the Responses API
> converter does the opposite and serializes that id onto the wire as an
> assistant output-message id
> (`providers/openai/responses_api/mod.rs:583-612`). A follow-up review caught
> it. See "Known issues under active fix" below.

Two findings were deliberately **not** changed, because they are pre-existing at
the merge base and fixing them here would be unrelated behavior changes:
bedrock's `MaxTokens` early yield, and Z.AI reporting `"zai"` on its OpenAI route
versus `"z.ai"` on its Anthropic route (both already fed
`gen_ai.provider.name`).

## Known issues under active fix

A follow-up review found three P1s in this branch. All three are **verified
against the code**, and fixes are in progress on this branch — do not merge until
they land.

1. **Response-scoped ids are replayed as assistant-message ids.** OpenAI Chat's
   `chatcmpl-…` reaches `CompletionResponse::message_id`
   (`openai/completion/mod.rs:1220`), is promoted into `Message::Assistant { id }`
   (`rig-agent/src/agent/run/mod.rs:540`), and is serialized by the Responses
   converter as an assistant output-message id
   (`openai/responses_api/mod.rs:583-612`). This gets worse under #2252, where
   switching provider between turns is the point. Fix: split `response_id` from
   `message_id`, so only genuine assistant-message ids are replayable.

2. **The construction hook is `pub(crate)`.** The blanket
   `impl CompletionClient for Client<Ext, H>` requires
   `ConstructCompletionModel`, which downstream crates cannot name; and
   `impl CompletionClient for Client<TheirExt, H>` is E0117 (verified with a
   probe). So an extension riding rig's generic client is locked out — the same
   class of break this PR fixed for the normalization trait. Fix: make it public
   and documented, with downstream compile coverage.

3. **Truncated streams still synthesize successful terminal records.** The
   `terminated_with_error` / `stream_failed` flags cover explicit errors but not
   truncation, so anthropic, cohere, Gemini REST and Gemini gRPC all yield a
   terminal record at clean EOF; gRPC fabricates one outright
   (`final_resp.or(last_resp).unwrap_or_default()`). Anthropic's malformed-SSE
   branch also yields an error without setting the flag or breaking, so one
   stream can emit both an error and a success record — contradicting an
   invariant stated above. Fix: guard each stream on the provider's genuine
   terminal event, with a regression test per provider.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features` — clean
- `cargo test --workspace --all-features -- --test-threads=1`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p rig-core -p rig-agent -p rig --no-deps`
- `cargo check --target wasm32-unknown-unknown -p rig-core -p rig-agent -p rig`
- `cargo check --workspace --all-targets --all-features` — zero errors, zero warnings

**`git diff <merge-base>..HEAD -- tests/cassettes` is empty.** Request
construction did not change, so no fixture was re-recorded and no request
matcher moved.
