### PR TITLE
docs(migrating): document release guide generation

### DIFF
--- a/.github/scripts/check-migrating-guide-preamble.sh
+++ b/.github/scripts/check-migrating-guide-preamble.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly guide="MIGRATING.md"
+readonly start_marker="<!-- MIGRATING-GUIDE-INSTRUCTIONS:START -->"
+readonly end_marker="<!-- MIGRATING-GUIDE-INSTRUCTIONS:END -->"
+readonly expected_hash="4ee35673f3dc6cd57d77814c9476b49ea63cfab1"
+
+start_matches="$(grep -nFx "${start_marker}" "${guide}" || true)"
+end_matches="$(grep -nFx "${end_marker}" "${guide}" || true)"
+
+if [[ "$(printf '%s\n' "${start_matches}" | sed '/^$/d' | wc -l | tr -d ' ')" != "1" ]] ||
+    [[ "$(printf '%s\n' "${end_matches}" | sed '/^$/d' | wc -l | tr -d ' ')" != "1" ]]; then
+    echo "MIGRATING.md must contain exactly one immutable preamble marker pair." >&2
+    exit 1
+fi
+
+start_line="${start_matches%%:*}"
+end_line="${end_matches%%:*}"
+
+if [[ "${start_line}" != "3" ]] || ((end_line <= start_line)); then
+    echo "The immutable MIGRATING.md preamble must start immediately after the title." >&2
+    exit 1
+fi
+
+actual_hash="$(sed -n "${start_line},${end_line}p" "${guide}" | git hash-object --stdin)"
+
+if [[ "${actual_hash}" != "${expected_hash}" ]]; then
+    echo "The immutable MIGRATING.md preamble was modified." >&2
+    exit 1
+fi
+
+echo "The immutable MIGRATING.md preamble is intact."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,9 @@ jobs:
       - name: Run cargo fmt
         run: cargo fmt -- --check
 
+      - name: Check immutable migration guide preamble
+        run: bash .github/scripts/check-migrating-guide-preamble.sh
+
       # Guard against CWD-relative test fixture paths. `cargo test` runs from the
       # crate root while `cargo nextest` (CI's runner) runs from the workspace
       # root, so a bare `tests/data/...` path passes under one and fails under the

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,81 @@
 # Migrating Rig
 
+<!-- MIGRATING-GUIDE-INSTRUCTIONS:START -->
+
+## Maintainers: generate this guide for every release
+
+> [!IMPORTANT]
+> This section is the immutable preamble. Keep it at the top of this file,
+> unchanged and between these markers, when updating the migration guide. Edit
+> the release material below the end marker. CI pins both its placement and its
+> contents.
+
+`MIGRATING.md` is an editorial synthesis, not the output of one generator. Use
+the public API diff as its exhaustive spine, the changelogs for release context,
+and the relevant pull requests for migration details. This is the process used
+to produce the guide in [#2216](https://github.com/0xPlaygrounds/rig/pull/2216).
+
+1. Choose the previous release tag and the release ref (`HEAD` while preparing a
+   release, or the new tag when auditing a completed release). Run API diffs in
+   a separate, up-to-date, clean worktree and do not edit the guide there.
+   `cargo public-api` checks out both refs in place and restores the original
+   checkout, so uncommitted changes will prevent a tag-to-ref diff.
+2. Install [`cargo-public-api`](https://github.com/cargo-public-api/cargo-public-api)
+   and ensure `jq` is available. With the clean worktree checked out at each ref
+   in turn, enumerate the publishable library and proc-macro packages. Take the
+   union of both lists so packages added or removed during the release are not
+   missed:
+
+   ```console
+   cargo metadata --no-deps --format-version 1 | \
+     jq -r '.packages[] | select(.publish != []) | select(any(.targets[]; any(.kind[]; . == "lib" or . == "proc-macro"))) | .name'
+   ```
+
+   Diff every package in that union, including re-exporting facades such as
+   `rig`:
+
+   ```console
+   cargo install cargo-public-api --locked
+   cargo public-api -p PACKAGE --simplified diff PREVIOUS_TAG..RELEASE_REF
+   # Example while preparing the release after v0.41.0:
+   cargo public-api -p rig-core --simplified diff v0.41.0..HEAD
+   ```
+
+   Repeat the diff with `--all-features` or the relevant `--features` when the
+   release changed feature-gated APIs. Review and classify every added, removed,
+   or changed item, even when the diff is only one line: additions such as enum
+   variants, public fields, or required trait items can also break downstream
+   code. If a package exists at only one ref, inspect its complete public API and
+   document the package-level addition or removal instead of expecting a range
+   diff to work.
+3. Read the matching entries in the root and affected crate `CHANGELOG.md`
+   files. Use their breaking-change entries to explain intent and identify the
+   replacement API, but do not assume the changelogs are exhaustive.
+4. Inspect the pull request, commits, tests, and documentation for each change
+   found by the API diff or changelogs. Record the old form, the new form, and
+   the smallest useful migration example. Do not summarize every merged pull
+   request; investigate the changes that affect downstream users.
+5. Review the release range for behavior changes that a public API diff cannot
+   detect, including changed defaults, serialization or wire formats, provider
+   behavior, feature semantics, and error handling. Put these under **Silent
+   behavior changes** because compiling successfully does not make them safe.
+6. Add the newest release section first, update **Which sections apply to
+   you**, and update the old-to-new symbol appendix. Keep each release section
+   self-contained. When an API changes again in a later release, tell users who
+   are skipping versions which intermediate form they can skip.
+7. Before release, verify every named symbol and feature against the release
+   tree, check every internal Markdown link, and compile or test code snippets
+   where practical. Clearly label snippets that are illustrative or transcribed
+   instead of compiled. Rebase, update or recreate the clean API-diff worktree,
+   repeat the diffs for newly merged changes, and replace `next` with the final
+   version number immediately before tagging.
+
+The public API diff finds compiler-visible changes; the changelogs and targeted
+history explain why and how to migrate; the final behavior review catches the
+changes that still compile. All three inputs are required for each release.
+
+<!-- MIGRATING-GUIDE-INSTRUCTIONS:END -->
+
 This guide covers every breaking change from 0.30 through the unreleased changes
 after 0.41. Releases 0.36, 0.37, 0.40 and 0.41 were the disruptive ones; 0.40
 alone carried 31 breaking changes, and 0.37 renamed `rig-core`'s library


### PR DESCRIPTION
## Summary

- add a permanent maintainer runbook at the top of `MIGRATING.md`
- document the release-by-release workflow used by #2216: public API diffs as the exhaustive spine, changelogs for intent, targeted PR history for migration details, and a separate silent-behavior review
- enumerate publishable library and proc-macro packages at both release refs so added and removed crates are covered
- pin the preamble's placement and exact contents with a CI guard

## Why

PR #2216 did not use a one-shot generator. It synthesized `cargo public-api` output, breaking changelog entries, and targeted source/PR context, then verified symbols, anchors, snippets, and late release changes. Keeping that process in the guide gives each release a repeatable checklist while preserving the editorial work needed for downstream users.

## Impact

Documentation and CI validation only. The migration content below the immutable preamble is unchanged.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- `cargo test --doc --workspace --all-features`
- `bash .github/scripts/check-migrating-guide-preamble.sh`
- `bash -n .github/scripts/check-migrating-guide-preamble.sh`
- parsed `.github/workflows/ci.yaml`
- validated all 25 internal links against 122 headings
- independently reviewed the complete diff; no remaining findings
