### PR TITLE
fix(openai): forward additional_params in image generation request

### DIFF
--- a/crates/rig-core/src/providers/openai/image_generation.rs
+++ b/crates/rig-core/src/providers/openai/image_generation.rs
@@ -103,6 +103,10 @@ where
             );
         }
 
+        if let Some(additional_params) = generation_request.additional_params {
+            merge_inplace(&mut request, additional_params);
+        }
+
         let body = serde_json::to_vec(&request)?;
 
         let request = self


### PR DESCRIPTION
## Description

The OpenAI provider built the /images/generations body from model, prompt and size only, silently dropping ImageGenerationRequest.additional_params (e.g. quality, reference-image inputs). Merge them in after the response_format default so caller-supplied params take precedence.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [  ] I have added tests that prove the fix is effective
- [x] New and existing unit tests pass locally with my changes

