### PR TITLE
ci: split the PR gate from the full --all-features suite

### DIFF
--- a/.github/scripts/check-toolchain-pin.sh
+++ b/.github/scripts/check-toolchain-pin.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# `rust-toolchain.toml` is what cargo itself obeys, but every workflow also
+# carries a `RUST_VERSION` env used as the `setup-rust-toolchain` input. That
+# is four copies of one number, and a partial bump is silent: the gate goes
+# green on the new toolchain while a workflow that was missed — nightly.yaml
+# is also cd.yaml's pre-release gate — keeps compiling on the old one, so a
+# failure there gets misread as a runtime regression rather than a stale pin.
+#
+# Assert the copies agree. This is a text check on purpose: it must fail on a
+# workflow nobody remembered to update, which a parser keyed off the workflows
+# that *do* declare the variable would not do.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+channel=$(grep -E '^\s*channel\s*=' rust-toolchain.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+if [ -z "$channel" ]; then
+  echo "::error::could not read [toolchain] channel from rust-toolchain.toml"
+  exit 1
+fi
+
+status=0
+found=0
+for workflow in .github/workflows/*.yaml .github/workflows/*.yml; do
+  [ -e "$workflow" ] || continue
+  # Only workflows that declare the variable are checked; a workflow with no
+  # `RUST_VERSION` takes its toolchain from rust-toolchain.toml already.
+  while IFS= read -r pinned; do
+    found=1
+    if [ "$pinned" != "$channel" ]; then
+      echo "::error file=$workflow::RUST_VERSION is $pinned but rust-toolchain.toml pins $channel"
+      status=1
+    fi
+  done < <(grep -E '^\s*RUST_VERSION:' "$workflow" | sed -E 's/.*RUST_VERSION:[[:space:]]*//' | tr -d '"'"'"'')
+done
+
+if [ "$found" -eq 0 ]; then
+  echo "::error::no workflow declares RUST_VERSION — this guard is checking nothing, so either restore the pins or delete the guard"
+  exit 1
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "ok: every workflow RUST_VERSION matches rust-toolchain.toml ($channel)"
+fi
+exit "$status"

--- a/.github/scripts/check-toolchain-pin.sh
+++ b/.github/scripts/check-toolchain-pin.sh
@@ -43,6 +43,19 @@ for workflow in .github/workflows/*.yaml .github/workflows/*.yml; do
     fi
   done < <(grep -E '^\s*RUST_VERSION:' "$workflow" \
     | sed -E 's/\r$//; s/^[[:space:]]*RUST_VERSION:[[:space:]]*//; s/[[:space:]]+#.*$//; s/[[:space:]]+$//; s/^"([^"]*)"$/\1/; s/^'"'"'([^'"'"']*)'"'"'$/\1/')
+
+  # Also catch the bypass this env-var check cannot see: a job that pins a
+  # literal version directly in `setup-rust-toolchain`'s `with:` block
+  # (`toolchain: 1.93.0`) declares no RUST_VERSION and would pass vacuously
+  # while silently building on a stale toolchain. `${{ env.RUST_VERSION }}`
+  # references are skipped — they resolve to a value already checked above.
+  while IFS= read -r inline; do
+    if [ "$inline" != "$channel" ]; then
+      echo "::error file=$workflow::inline toolchain pin is $inline but rust-toolchain.toml pins $channel"
+      status=1
+    fi
+  done < <(grep -E '^\s*toolchain:' "$workflow" | grep -vF '${{' \
+    | sed -E 's/\r$//; s/^[[:space:]]*toolchain:[[:space:]]*//; s/[[:space:]]+#.*$//; s/[[:space:]]+$//; s/^"([^"]*)"$/\1/; s/^'"'"'([^'"'"']*)'"'"'$/\1/')
 done
 
 if [ "$status" -eq 0 ]; then

--- a/.github/scripts/check-toolchain-pin.sh
+++ b/.github/scripts/check-toolchain-pin.sh
@@ -9,6 +9,16 @@
 # Assert the copies agree. This is a text check on purpose: it must fail on a
 # workflow nobody remembered to update, which a parser keyed off the workflows
 # that *do* declare the variable would not do.
+#
+# Why the copies exist at all: omitting the `toolchain` input would make
+# `setup-rust-toolchain` read rust-toolchain.toml directly — no copies, no
+# desync, no script. But rust-toolchain.toml also pins components
+# (rust-analyzer, rust-src) and the wasm target for local development, and
+# honoring it in CI would download those in every job. Until that trade is
+# taken, this guard keeps the existing copies honest. A workflow with no
+# RUST_VERSION needs no checking (it takes its toolchain from
+# rust-toolchain.toml), so a repo that deletes every copy passes vacuously —
+# that is the desired end state, not an error to steer people away from.
 set -euo pipefail
 
 cd "$(dirname "$0")/../.."
@@ -20,26 +30,22 @@ if [ -z "$channel" ]; then
 fi
 
 status=0
-found=0
 for workflow in .github/workflows/*.yaml .github/workflows/*.yml; do
   [ -e "$workflow" ] || continue
-  # Only workflows that declare the variable are checked; a workflow with no
-  # `RUST_VERSION` takes its toolchain from rust-toolchain.toml already.
+  # Extract the scalar value only: strip a CR from a CRLF checkout, any
+  # trailing comment, surrounding quotes, and whitespace — a cosmetic edit
+  # like `RUST_VERSION: 1.94.0 # keep in sync` must not fail the gate by
+  # comparing a value with the comment text embedded in it.
   while IFS= read -r pinned; do
-    found=1
     if [ "$pinned" != "$channel" ]; then
       echo "::error file=$workflow::RUST_VERSION is $pinned but rust-toolchain.toml pins $channel"
       status=1
     fi
-  done < <(grep -E '^\s*RUST_VERSION:' "$workflow" | sed -E 's/.*RUST_VERSION:[[:space:]]*//' | tr -d '"'"'"'')
+  done < <(grep -E '^\s*RUST_VERSION:' "$workflow" \
+    | sed -E 's/\r$//; s/^[[:space:]]*RUST_VERSION:[[:space:]]*//; s/[[:space:]]+#.*$//; s/[[:space:]]+$//; s/^"([^"]*)"$/\1/; s/^'"'"'([^'"'"']*)'"'"'$/\1/')
 done
 
-if [ "$found" -eq 0 ]; then
-  echo "::error::no workflow declares RUST_VERSION — this guard is checking nothing, so either restore the pins or delete the guard"
-  exit 1
-fi
-
 if [ "$status" -eq 0 ]; then
-  echo "ok: every workflow RUST_VERSION matches rust-toolchain.toml ($channel)"
+  echo "ok: every declared RUST_VERSION matches rust-toolchain.toml ($channel)"
 fi
 exit "$status"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -6,6 +6,17 @@ on:
       - main
   workflow_dispatch:
 
+# The full-suite gate makes this workflow run ~25-30 minutes before
+# release-plz starts, so two pushes landing minutes apart (e.g. consecutive
+# merge-queue batches) would otherwise reach release-plz concurrently and
+# race on release-PR creation and crates.io publishes. Serialize runs per
+# ref; `cancel-in-progress: false` because a run that may already be
+# publishing must never be killed mid-release — later pushes queue behind it
+# and release the superset.
+concurrency:
+  group: release-plz-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   RUST_VERSION: 1.94.0
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -16,9 +16,17 @@ jobs:
     uses: ./.github/workflows/ci.yaml
     secrets: inherit
 
+  # ci.yaml is the fast PR gate; the `--all-features` suite (Docker-backed
+  # vector-store integrations, the facade build guard) lives in nightly.yaml.
+  # Calling it here keeps the pre-split guarantee: release-plz never runs on
+  # a commit the full suite has not passed.
+  run-full-ci:
+    uses: ./.github/workflows/nightly.yaml
+    secrets: inherit
+
   release-plz:
     name: Release-plz
-    needs: run-ci
+    needs: [run-ci, run-full-ci]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -33,7 +33,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -43,7 +43,8 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           cache: true
 
-      # Required to compile rig-lancedb
+      # Required to compile rig-lancedb, and the `lancedb` crate that the
+      # `rig` facade carries as an unconditional dev-dependency.
       - name: Install Protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -203,13 +203,16 @@ jobs:
   # build guard) lives in nightly.yaml: it runs on a schedule, on demand via
   # workflow_dispatch, and — via cd.yaml's `workflow_call` — on every push to
   # main, so nothing is released without the full suite. `--all-features`
-  # COMPILE coverage stays on the PR gate regardless: the clippy job lints
-  # `--all-features --all-targets`, and doctest/doc build all features too —
-  # with one deliberate exception: feature-unification means no
-  # `--all-features` build can catch a facade feature that forgets to forward
-  # a sub-feature, so that class of compile break is caught only by
-  # nightly.yaml's nested-`cargo check` guard (`tests/tool_facade_features.rs`,
-  # ~4 minutes, which is exactly why it is not on the gate).
+  # TYPE-CHECK coverage stays on the PR gate regardless: the clippy job lints
+  # `--all-features --all-targets`, and doctest/doc build all features too.
+  # Two narrower classes wait for the full lane: codegen/link of the
+  # feature-gated test binaries clippy only type-checks, and — because
+  # feature-unification means no `--all-features` build can catch a facade
+  # feature that forgets to forward a sub-feature — the per-feature facade
+  # compile breaks that only nightly.yaml's nested-`cargo check` guard
+  # (`tests/tool_facade_features.rs`, ~4 minutes, which is exactly why it is
+  # not on the gate) can see. Both surface in merge_group at the latest,
+  # before anything lands on main.
   test:
     name: stable / test
     runs-on: ubuntu-latest
@@ -272,8 +275,14 @@ jobs:
       # `--features bedrock` step below never reuses (~1-2 wasted minutes even
       # warm, since rust-cache never persists workspace-member artifacts).
       # `check` still runs build scripts, so the protoc requirement above is
-      # unchanged; link errors stay covered by the bedrock run below and by
-      # nightly's full sweep.
+      # unchanged. Be precise about what this trades away: the bedrock run
+      # below and nightly's sweep link *superset* feature configurations, so
+      # no lane anywhere links the pure default-feature binaries — a
+      # default-only codegen/link break would surface first in merge_group's
+      # full run. That gap is accepted as theoretical: `bedrock` is purely
+      # additive and the workspace has no `cfg(not(feature = …))` in test
+      # code, so a break that appears only with features *removed* has no
+      # known mechanism.
       - name: Check default-feature root test targets
         run: cargo check --locked -p rig --tests
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,16 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_VERSION: 1.94.0
+  # Full debuginfo is the single largest avoidable cost in this workflow: even
+  # on a *full* rust-cache hit the `test` job spent ~4m compiling and linking
+  # test binaries, most of it emitting and linking debug sections nothing here
+  # reads. `line-tables-only` keeps what CI actually consumes — file and line
+  # numbers in a panic backtrace — and drops variable/type debuginfo. Set as
+  # env rather than a `[profile]` in Cargo.toml so local `cargo test` keeps
+  # full debuginfo for debuggers, and as `dev` + `test` because test targets
+  # build under `test` while their dependencies build under `dev`.
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
 
 # ensure that the workflow is only triggered once per PR, subsequent pushes to the PR will cancel
 # and restart the workflow. See https://docs.github.com/en/actions/using-jobs/using-concurrency
@@ -24,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -37,6 +47,14 @@ jobs:
 
       - name: Check immutable migration guide preamble
         run: bash .github/scripts/check-migrating-guide-preamble.sh
+
+      # rust-toolchain.toml is the pin cargo obeys; each workflow's
+      # RUST_VERSION is a copy feeding `setup-rust-toolchain`. Assert they
+      # agree so a partial bump cannot leave nightly.yaml — which is also
+      # cd.yaml's pre-release gate — building on a toolchain the PR gate no
+      # longer enforces.
+      - name: Check workflow toolchain pins match rust-toolchain.toml
+        run: bash .github/scripts/check-toolchain-pin.sh
 
       # Guard against CWD-relative test fixture paths. `cargo test` runs from the
       # crate root while `cargo nextest` (CI's runner) runs from the workspace
@@ -56,23 +74,11 @@ jobs:
       - name: Test WASM chat worker runtime
         run: node --test examples/candle_wasm_chat/www/worker-runtime.test.mjs
 
-  # Special check to make sure rig-core is compatible with the wasm target
-  check-wasm:
-    name: stable / check rig-core wasm target
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Rust stable
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          target: wasm32-unknown-unknown
-          toolchain: ${{ env.RUST_VERSION }}
-
-      - name: Run cargo check wasm target
-        run: cargo check --package rig-core --target wasm32-unknown-unknown
-
+  # rig-core is in the matrix below rather than in a job of its own: the body
+  # was character-for-character identical, and `matrix.package` reproduces the
+  # same `stable / check rig-core wasm target` job name, so this is one fewer
+  # runner and one fewer copy to keep in sync — not a coverage change.
+  #
   # The runtime split adds wasm-sensitive code to rig-agent, feature forwarding
   # in the `rig` facade, and explicit feature wiring in the Candle runtime and
   # browser example, so check each on the wasm target too. These are plain
@@ -96,10 +102,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        package: [rig-agent, rig, rig-candle, candle_wasm_chat]
+        package: [rig-core, rig-agent, rig, rig-candle, candle_wasm_chat]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -121,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -166,7 +172,7 @@ jobs:
       checks: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -195,7 +201,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -207,16 +213,32 @@ jobs:
         with:
           tool: nextest
 
-      # No protoc here: it is only required to compile rig-lancedb, which is
-      # not in this job's default+bedrock graph (rig-gemini-grpc vendors its
-      # own via protoc-bin-vendored). The all-features jobs keep the install.
+      # Required here, and NOT only for the `lancedb` feature: the `rig`
+      # facade lists `lancedb` as an unconditional dev-dependency
+      # (Cargo.toml's `[dev-dependencies]`), so building its test targets —
+      # which both steps below do — compiles lance-encoding/-file/-table/
+      # -index and lance. Each of those build scripts calls
+      # `prost_build::compile_protos`, which shells out to a *system* protoc:
+      # the vendoring `protoc` feature that would pull `protobuf-src` is not
+      # enabled anywhere in Cargo.lock, and rig-gemini-grpc's
+      # protoc-bin-vendored is its own private build-dependency.
+      #
+      # ubuntu-latest does not ship protoc (this apt step reports
+      # `Selecting previously unselected package protobuf-compiler`), so
+      # dropping this install does not fail loudly — it fails only once the
+      # rust-cache entry for this job is invalidated and lance rebuilds,
+      # turning a Cargo.lock or toolchain bump into an unrelated-looking
+      # build-script error. Verify the dependency edge with:
+      #   cargo tree -i lance-encoding -e normal,dev --target all
+      - name: Install Protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       # `nextest` below runs with `--features bedrock`, which does not compile
       # the pure default-feature test graph. Build the root integration tests
       # with the default feature set so feature-gated test modules cannot
       # accidentally depend on APIs that only exist under optional features.
       - name: Compile default-feature root test targets
-        run: cargo test -p rig --tests --no-run
+        run: cargo test --locked -p rig --tests --no-run
 
       # The workspace sweep over the default members' default features, plus
       # the facade's `bedrock` feature. `bedrock` rides along because the
@@ -231,11 +253,13 @@ jobs:
       # recorded traffic without them: the few live tests that check for keys
       # at runtime keep running on same-repo PRs exactly as they did before
       # the fast/full split (fork PRs never received secrets either way).
+      #
+      # A plain `run:` rather than `actions-rs/cargo@v1`: that action was
+      # archived in 2023 and pins Node 20, which this workflow's own log
+      # already reports as force-upgraded to Node 24. It added nothing over
+      # invoking cargo directly.
       - name: Test with latest nextest release
-        uses: actions-rs/cargo@v1
-        with:
-          command: nextest
-          args: run --features bedrock --retries 2
+        run: cargo nextest run --locked --features bedrock --retries 2
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -252,7 +276,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -264,12 +288,16 @@ jobs:
         with:
           tool: nextest
 
-      # No protoc here either: none of the packages below (rig-agent,
-      # rig-core, rig-candle, rig-gemini-grpc) compile rig-lancedb, and
-      # rig-gemini-grpc vendors its own protoc.
+      # No protoc here, and unlike the `test` job that is genuinely true: the
+      # lance chain enters the graph through the `rig` facade's
+      # dev-dependencies, and every step below names `-p` packages
+      # (rig-agent, rig-core, rig-candle, rig-gemini-grpc) rather than the
+      # facade, so no lance build script runs. rig-gemini-grpc vendors its own
+      # protoc via protoc-bin-vendored. Adding a facade step here means adding
+      # the apt install back.
 
       - name: Test rig-agent agent unit tests with all features
-        run: cargo nextest run -p rig-agent --all-features -E 'test(agent::)' --retries 2
+        run: cargo nextest run --locked -p rig-agent --all-features -E 'test(agent::)' --retries 2
 
       # The full rig-core and rig-agent lib test sets under `--all-features`.
       # Before the fast/full split, the workspace-wide `--all-features` sweep
@@ -283,7 +311,7 @@ jobs:
       # enforced by the dedicated step below, exactly as it was when the
       # workspace sweep ran them with `--retries 2` alongside it.
       - name: Test rig-core and rig-agent unit tests with all features
-        run: cargo nextest run -p rig-core -p rig-agent --all-features --lib --retries 2
+        run: cargo nextest run --locked -p rig-core -p rig-agent --all-features --lib --retries 2
 
       # `cargo nextest run` (in the `test` job) selects the workspace's
       # *default members* — historically just the `rig` facade, which is why a
@@ -316,13 +344,13 @@ jobs:
       # and a drift tripwire that passes on the second attempt conceals exactly
       # the nondeterminism it exists to catch.
       - name: Test telemetry completion-parent contract
-        run: cargo nextest run -p rig-core -p rig-agent --all-features -E 'test(telemetry::) + test(span_safety_net::)'
+        run: cargo nextest run --locked -p rig-core -p rig-agent --all-features -E 'test(telemetry::) + test(span_safety_net::)'
 
       # This compiles a standalone downstream consumer that renames rig-core
       # and has no direct tracing dependency. Keep it outside the workspace so
       # release tooling cannot discover it as a publishable package.
       - name: Test telemetry macro hygiene
-        run: cargo test -p rig-core --test macro_hygiene
+        run: cargo test --locked -p rig-core --test macro_hygiene
 
       # Same default-members problem as the telemetry step above, with two
       # distinct casualties:
@@ -354,7 +382,7 @@ jobs:
       # the second attempt would conceal nondeterminism rather than tolerate a
       # flaky network.
       - name: Test out-of-facade streaming conformance and structural guards
-        run: cargo nextest run -p rig-core -p rig-candle -p rig-gemini-grpc --all-features -E 'binary(streaming_conformance) + binary(streaming_conformance_websocket) + binary(driver_adoption)'
+        run: cargo nextest run --locked -p rig-core -p rig-candle -p rig-gemini-grpc --all-features -E 'binary(streaming_conformance) + binary(streaming_conformance_websocket) + binary(driver_adoption)'
 
   # `cargo nextest` (used by the `test` job) does NOT run doctests, and the
   # `doc` job only builds documentation — so without this job nothing executes
@@ -364,7 +392,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -379,14 +407,14 @@ jobs:
       # provider examples are all `no_run`/compile-only), so this job stays
       # hermetic and non-flaky.
       - name: Run doctests
-        run: cargo test --doc --workspace --all-features
+        run: cargo test --locked --doc --workspace --all-features
 
   doc:
     name: stable / doc
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -399,6 +427,6 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Run cargo doc
-        run: cargo doc --no-deps --all-features
+        run: cargo doc --locked --no-deps --all-features
         env:
           RUSTDOCFLAGS: -D warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,6 +183,13 @@ jobs:
         with:
           args: --all-features --all-targets
 
+  # The PR gate's test sweep. The full `--all-features` run (companion vector
+  # stores, Docker-backed integration tests, the nested-`cargo check` facade
+  # build guard) lives in nightly.yaml: it runs on a schedule, on demand via
+  # workflow_dispatch, and — via cd.yaml's `workflow_call` — on every push to
+  # main, so nothing is released without the full suite. `--all-features`
+  # COMPILE coverage stays on the PR gate regardless: the clippy job lints
+  # `--all-features --all-targets`, and doctest/doc build all features too.
   test:
     name: stable / test
     runs-on: ubuntu-latest
@@ -200,30 +207,96 @@ jobs:
         with:
           tool: nextest
 
-      # Required to compile rig-lancedb
-      - name: Install Protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      # No protoc here: it is only required to compile rig-lancedb, which is
+      # not in this job's default+bedrock graph (rig-gemini-grpc vendors its
+      # own via protoc-bin-vendored). The all-features jobs keep the install.
 
-      # `nextest` below runs with `--all-features`, which does not compile the
-      # default-feature test graph. Build the root integration tests with the
-      # default feature set so feature-gated test modules cannot accidentally
-      # depend on APIs that only exist under optional features.
+      # `nextest` below runs with `--features bedrock`, which does not compile
+      # the pure default-feature test graph. Build the root integration tests
+      # with the default feature set so feature-gated test modules cannot
+      # accidentally depend on APIs that only exist under optional features.
       - name: Compile default-feature root test targets
         run: cargo test -p rig --tests --no-run
+
+      # The workspace sweep over the default members' default features, plus
+      # the facade's `bedrock` feature. `bedrock` rides along because the
+      # bedrock wire-conformance suite compiles into the facade's `bedrock`
+      # test binary and this step is the one
+      # `tests/core/streaming_conformance_registry.rs` names as executing it
+      # (rig-bedrock itself is already a default member, so the extra compile
+      # cost is marginal). Everything that needs the remaining optional
+      # features executes in nightly.yaml's identical-command full run.
+      #
+      # The provider keys stay here even though the cassette suites replay
+      # recorded traffic without them: the few live tests that check for keys
+      # at runtime keep running on same-repo PRs exactly as they did before
+      # the fast/full split (fork PRs never received secrets either way).
+      - name: Test with latest nextest release
+        uses: actions-rs/cargo@v1
+        with:
+          command: nextest
+          args: run --features bedrock --retries 2
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+
+  # The cross-crate contract tripwires, split from `test` so the two halves
+  # run in parallel: each step deliberately compiles a package set with its
+  # own feature configuration (see the comments below), which serializes
+  # poorly behind the default-feature sweep above.
+  test-guards:
+    name: stable / test guards
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      # No protoc here either: none of the packages below (rig-agent,
+      # rig-core, rig-candle, rig-gemini-grpc) compile rig-lancedb, and
+      # rig-gemini-grpc vendors its own protoc.
 
       - name: Test rig-agent agent unit tests with all features
         run: cargo nextest run -p rig-agent --all-features -E 'test(agent::)' --retries 2
 
-      # `cargo nextest run` (below) selects the workspace's *default members*,
-      # and this workspace's root manifest is itself the `rig` package with no
-      # `default-members` — so that run covers `rig` alone and a `crates/*` unit
-      # test executes in CI only when its package is named explicitly. The
+      # The full rig-core and rig-agent lib test sets under `--all-features`.
+      # Before the fast/full split, the workspace-wide `--all-features` sweep
+      # ran these on every PR; that sweep now lives in nightly.yaml, and this
+      # step keeps the feature-gated unit tests (the rmcp tool registry, the
+      # pdf/epub loaders, audio generation, …) from silently demoting to
+      # nightly-only coverage. It reuses the compile artifacts of the
+      # telemetry step below (same packages, same `--all-features`), so the
+      # cost is execution time only. The telemetry:: tests also run here with
+      # retries — harmless duplication: their no-retries discipline is
+      # enforced by the dedicated step below, exactly as it was when the
+      # workspace sweep ran them with `--retries 2` alongside it.
+      - name: Test rig-core and rig-agent unit tests with all features
+        run: cargo nextest run -p rig-core -p rig-agent --all-features --lib --retries 2
+
+      # `cargo nextest run` (in the `test` job) selects the workspace's
+      # *default members* — historically just the `rig` facade, which is why a
+      # `crates/*` unit test executed in CI only when its package was named
+      # explicitly; `default-members` now lists the core crates, but that
+      # sweep compiles them with *default* features and `--retries 2`. The
       # rig-agent half of the completion-parent contract rides along on the
-      # `agent::` filter above, but rig-core's `telemetry::` tests match nothing
-      # and would otherwise never run. They are the drift tripwires for the
-      # marker and the required `gen_ai.*` field set: unrun, the three forms of
-      # the contract can silently desync, which is the exact failure the
-      # `completion_parent_span!` macro exists to prevent.
+      # `agent::` filter above; this step is what runs rig-core's
+      # `telemetry::` tests under `--all-features` and without retries. They
+      # are the drift tripwires for the marker and the required `gen_ai.*`
+      # field set: unrun, the three forms of the contract can silently
+      # desync, which is the exact failure the `completion_parent_span!`
+      # macro exists to prevent.
       #
       # rig-agent is named explicitly even though `test(agent::)` above already
       # matches `span_safety_net::`, so the cross-crate tripwire keeps running
@@ -236,8 +309,8 @@ jobs:
       # concealing nondeterminism rather than tolerating a flaky network.
       #
       # This resolves rig-core with its own `--all-features` set, a different
-      # configuration from both the `-p rig-agent` step above and the root
-      # `-p rig` run below, so rig-core is compiled here rather than reused.
+      # configuration from both the `-p rig-agent` step above and the `test`
+      # job's facade sweep, so rig-core is compiled here rather than reused.
       # That cost is accepted deliberately: folding these tests into the
       # `agent::` step would share one build but hand them its `--retries 2`,
       # and a drift tripwire that passes on the second attempt conceals exactly
@@ -256,15 +329,15 @@ jobs:
       #
       #   * `crates/rig-core/tests/driver_adoption.rs` is a rig-core *package*
       #     target, so the single-policy-driver guard and the serde policy wall
-      #     never built in the `-p rig` run below. The mechanism that keeps
-      #     "one triage policy site" true over time was itself unrun.
+      #     never built in the facade-only `-p rig` run. The mechanism that
+      #     keeps "one triage policy site" true over time was itself unrun.
       #   * three wire-conformance families live in test binaries outside the
       #     `rig` facade — `openai_responses_websocket`
       #     (`rig-core/tests/streaming_conformance_websocket.rs`), `candle`
       #     (`rig-candle`) and `gemini_grpc` (`rig-gemini-grpc`) — so the
       #     registry reported them covered while nothing executed them.
-      #     (`bedrock`'s suite is feature-gated inside `rig`, so the run below
-      #     already covers it.)
+      #     (`bedrock`'s suite is feature-gated inside `rig`, so the `test`
+      #     job's `--features bedrock` sweep covers it.)
       #
       # `binary(...)`, not `test(...)`: nextest's `test()` predicate matches the
       # test's own name (`suite_is_complete`, …), never the binary it lives in,
@@ -282,18 +355,6 @@ jobs:
       # flaky network.
       - name: Test out-of-facade streaming conformance and structural guards
         run: cargo nextest run -p rig-core -p rig-candle -p rig-gemini-grpc --all-features -E 'binary(streaming_conformance) + binary(streaming_conformance_websocket) + binary(driver_adoption)'
-
-      - name: Test with latest nextest release
-        uses: actions-rs/cargo@v1
-        with:
-          command: nextest
-          args: run --all-features --retries 2
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
-          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
 
   # `cargo nextest` (used by the `test` job) does NOT run doctests, and the
   # `doc` job only builds documentation — so without this job nothing executes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,10 @@ env:
   # build under `test` while their dependencies build under `dev`.
   CARGO_PROFILE_DEV_DEBUG: line-tables-only
   CARGO_PROFILE_TEST_DEBUG: line-tables-only
+  # sccache (enabled per-job below) cannot cache incremental compilation, and
+  # CI never benefits from incremental anyway — every run starts from a fresh
+  # checkout — so pin it off for every job.
+  CARGO_INCREMENTAL: 0
 
 # ensure that the workflow is only triggered once per PR, subsequent pushes to the PR will cancel
 # and restart the workflow. See https://docs.github.com/en/actions/using-jobs/using-concurrency
@@ -101,6 +105,11 @@ jobs:
     name: stable / check ${{ matrix.package }} wasm target
     runs-on: ubuntu-latest
     strategy:
+      # The legs are independent packages, and the pre-fold standalone
+      # rig-core job always ran to completion: without `fail-fast: false`,
+      # one broken package would cancel the sibling legs mid-run and hide
+      # independent wasm breaks behind an extra CI round-trip.
+      fail-fast: false
       matrix:
         package: [rig-core, rig-agent, rig, rig-candle, candle_wasm_chat]
     steps:
@@ -195,10 +204,18 @@ jobs:
   # workflow_dispatch, and — via cd.yaml's `workflow_call` — on every push to
   # main, so nothing is released without the full suite. `--all-features`
   # COMPILE coverage stays on the PR gate regardless: the clippy job lints
-  # `--all-features --all-targets`, and doctest/doc build all features too.
+  # `--all-features --all-targets`, and doctest/doc build all features too —
+  # with one deliberate exception: feature-unification means no
+  # `--all-features` build can catch a facade feature that forgets to forward
+  # a sub-feature, so that class of compile break is caught only by
+  # nightly.yaml's nested-`cargo check` guard (`tests/tool_facade_features.rs`,
+  # ~4 minutes, which is exactly why it is not on the gate).
   test:
     name: stable / test
     runs-on: ubuntu-latest
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -207,6 +224,17 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
+
+      # rust-cache (inside setup-rust-toolchain above) persists *dependency*
+      # artifacts but always recompiles the workspace's own crates; sccache
+      # caches individual rustc invocations in the GitHub Actions cache, so
+      # unchanged workspace members stop recompiling too. That workspace-member
+      # compile is this job's residual floor, which is why the compile-heavy
+      # jobs (test, test guards, doctest, nightly) opt in via the job-level
+      # env above — a workflow-wide RUSTC_WRAPPER would instead break every
+      # job that skips this install step.
+      - name: Run sccache
+        uses: mozilla/sccache-action@v0.0.11
 
       - name: Install nextest
         uses: taiki-e/install-action@v2
@@ -234,11 +262,20 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       # `nextest` below runs with `--features bedrock`, which does not compile
-      # the pure default-feature test graph. Build the root integration tests
+      # the pure default-feature test graph. Check the root integration tests
       # with the default feature set so feature-gated test modules cannot
       # accidentally depend on APIs that only exist under optional features.
-      - name: Compile default-feature root test targets
-        run: cargo test --locked -p rig --tests --no-run
+      #
+      # `cargo check`, not `cargo test --no-run`: the guarded failure class is
+      # purely type-level, and `--no-run` additionally pays codegen + linking
+      # of every lance-heavy test binary under a default-feature hash the
+      # `--features bedrock` step below never reuses (~1-2 wasted minutes even
+      # warm, since rust-cache never persists workspace-member artifacts).
+      # `check` still runs build scripts, so the protoc requirement above is
+      # unchanged; link errors stay covered by the bedrock run below and by
+      # nightly's full sweep.
+      - name: Check default-feature root test targets
+        run: cargo check --locked -p rig --tests
 
       # The workspace sweep over the default members' default features, plus
       # the facade's `bedrock` feature. `bedrock` rides along because the
@@ -274,6 +311,9 @@ jobs:
   test-guards:
     name: stable / test guards
     runs-on: ubuntu-latest
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -282,6 +322,11 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
+
+      # See the `test` job's note: caches workspace-member rustc invocations,
+      # which rust-cache cannot.
+      - name: Run sccache
+        uses: mozilla/sccache-action@v0.0.11
 
       - name: Install nextest
         uses: taiki-e/install-action@v2
@@ -296,13 +341,10 @@ jobs:
       # protoc via protoc-bin-vendored. Adding a facade step here means adding
       # the apt install back.
 
-      - name: Test rig-agent agent unit tests with all features
-        run: cargo nextest run --locked -p rig-agent --all-features -E 'test(agent::)' --retries 2
-
-      # The full rig-core and rig-agent lib test sets under `--all-features`.
+      # The full rig-core and rig-agent test suites under `--all-features`.
       # Before the fast/full split, the workspace-wide `--all-features` sweep
       # ran these on every PR; that sweep now lives in nightly.yaml, and this
-      # step keeps the feature-gated unit tests (the rmcp tool registry, the
+      # step keeps the feature-gated tests (the rmcp tool registry, the
       # pdf/epub loaders, audio generation, …) from silently demoting to
       # nightly-only coverage. It reuses the compile artifacts of the
       # telemetry step below (same packages, same `--all-features`), so the
@@ -310,39 +352,40 @@ jobs:
       # retries — harmless duplication: their no-retries discipline is
       # enforced by the dedicated step below, exactly as it was when the
       # workspace sweep ran them with `--retries 2` alongside it.
-      - name: Test rig-core and rig-agent unit tests with all features
-        run: cargo nextest run --locked -p rig-core -p rig-agent --all-features --lib --retries 2
+      #
+      # All test targets, NOT `--lib`: rig-core's `identity_leak` trybuild
+      # suite is an *integration* test whose compile-fail proof (no `Serialize`
+      # path for `PartId`/`StreamPartId`) is only load-bearing under
+      # `--all-features`, because trybuild propagates the outer binary's
+      # enabled features into its scratch builds. `--lib` here would demote
+      # that proof — and rig-agent's non-lib targets such as
+      # `runtime_model_swapping` — to nightly-only coverage, exactly the
+      # silent narrowing this step exists to prevent.
+      - name: Test rig-core and rig-agent with all features
+        run: cargo nextest run --locked -p rig-core -p rig-agent --all-features --retries 2
 
       # `cargo nextest run` (in the `test` job) selects the workspace's
       # *default members* — historically just the `rig` facade, which is why a
       # `crates/*` unit test executed in CI only when its package was named
       # explicitly; `default-members` now lists the core crates, but that
-      # sweep compiles them with *default* features and `--retries 2`. The
-      # rig-agent half of the completion-parent contract rides along on the
-      # `agent::` filter above; this step is what runs rig-core's
-      # `telemetry::` tests under `--all-features` and without retries. They
-      # are the drift tripwires for the marker and the required `gen_ai.*`
-      # field set: unrun, the three forms of the contract can silently
-      # desync, which is the exact failure the `completion_parent_span!`
-      # macro exists to prevent.
+      # sweep compiles them with *default* features and `--retries 2`. This
+      # step re-runs the `telemetry::` and `span_safety_net::` tests under
+      # `--all-features` and without retries. They are the drift tripwires
+      # for the marker and the required `gen_ai.*` field set: unrun, the
+      # three forms of the contract can silently desync, which is the exact
+      # failure the `completion_parent_span!` macro exists to prevent.
       #
-      # rig-agent is named explicitly even though `test(agent::)` above already
-      # matches `span_safety_net::`, so the cross-crate tripwire keeps running
-      # if that filter is ever narrowed. The tests are cheap and the duplicate
-      # run is the price of not depending on an unrelated filter.
+      # The sweep above already *executes* these tests (same packages, same
+      # `--all-features`, so this step reuses its compile artifacts and costs
+      # execution time only) — but it runs them with `--retries 2`, and a
+      # drift tripwire that passes on the second attempt conceals exactly the
+      # nondeterminism it exists to catch. The dedicated no-retries run is
+      # the point of this step, not redundancy.
       #
-      # No `--retries`, deliberately, unlike the steps around it: these are
-      # static-metadata assertions (set equality against a `const`, field
-      # counts, callsite dedup), so a pass on the second attempt would be
-      # concealing nondeterminism rather than tolerating a flaky network.
-      #
-      # This resolves rig-core with its own `--all-features` set, a different
-      # configuration from both the `-p rig-agent` step above and the `test`
-      # job's facade sweep, so rig-core is compiled here rather than reused.
-      # That cost is accepted deliberately: folding these tests into the
-      # `agent::` step would share one build but hand them its `--retries 2`,
-      # and a drift tripwire that passes on the second attempt conceals exactly
-      # the nondeterminism it exists to catch.
+      # No `--retries`, deliberately: these are static-metadata assertions
+      # (set equality against a `const`, field counts, callsite dedup), so a
+      # pass on the second attempt would be concealing nondeterminism rather
+      # than tolerating a flaky network.
       - name: Test telemetry completion-parent contract
         run: cargo nextest run --locked -p rig-core -p rig-agent --all-features -E 'test(telemetry::) + test(span_safety_net::)'
 
@@ -390,6 +433,9 @@ jobs:
   doctest:
     name: stable / doctest
     runs-on: ubuntu-latest
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -398,6 +444,12 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
+
+      # See the `test` job's note: caches workspace-member rustc invocations,
+      # which rust-cache cannot. (rustdoc itself is not cached, which is why
+      # the `doc` job does not bother.)
+      - name: Run sccache
+        uses: mozilla/sccache-action@v0.0.11
 
       # Required to compile rig-lancedb
       - name: Install Protoc

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -13,17 +13,26 @@
 #
 # The PR gate still COMPILES all of the above on every PR: ci.yaml's clippy
 # job lints `--all-features --all-targets`, and doctest/doc build all
-# features, so a nightly failure is a runtime regression, never a stale
-# compile break discovered at 06:00.
+# features, so a nightly failure is almost always a runtime regression rather
+# than a stale compile break discovered at 06:00 — with one deliberate
+# exception. `tests/tool_facade_features.rs` nested-checks the facade in
+# *individual* feature configurations, and feature-unification means no
+# `--all-features` build on the gate can catch a facade feature that forgets
+# to forward a sub-feature, so that one class of compile break is caught only
+# here (it costs ~4 minutes, which is exactly why it is not on the gate).
 #
 # When it runs:
 #   * nightly at 06:00 UTC;
-#   * on any PR that touches a companion crate or the integration tests —
-#     without this, a PR editing `crates/rig-qdrant/` merges with zero runtime
-#     coverage of the code it changed, and the breakage surfaces either at
-#     06:00 or, worse, in cd.yaml's `run-full-ci`, where it blocks release-plz
-#     on an already-merged commit. These PRs are rare and share the scheduled
+#   * on any PR that touches a companion crate, the integration tests, or the
+#     root manifest/lockfile (where the companion crates' `workspace = true`
+#     dependency versions actually resolve) — without this, a PR editing
+#     `crates/rig-qdrant/` or bumping its driver in Cargo.toml merges with
+#     zero runtime coverage of the code it changed, and the breakage surfaces
+#     either at 06:00 or, worse, in cd.yaml's `run-full-ci`, where it blocks
+#     release-plz on an already-merged commit. These PRs share the scheduled
 #     run's rust-cache entry, so the common PR pays nothing;
+#   * in the merge queue (`merge_group`), because the squashed batch that
+#     actually lands on main is not any PR head the filters above validated;
 #   * on demand via `gh workflow run nightly.yaml`;
 #   * via `workflow_call` from cd.yaml on every push to main, so release-plz
 #     never publishes a commit the full suite has not passed.
@@ -49,6 +58,33 @@ on:
       - "tests/integrations/**"
       - "tests/integrations.rs"
       - ".github/workflows/nightly.yaml"
+      # The companion crates' dependency versions do not live under
+      # `crates/rig-*/`: they are `workspace = true` references resolved in
+      # the root manifest and lockfile. Without these two entries, a
+      # dependabot PR bumping mongodb/neo4rs/qdrant-client/lancedb touches
+      # only Cargo.toml + Cargo.lock, matches none of the globs above, and
+      # merges with zero integration-test coverage of the driver it changed —
+      # the exact failure mode this trigger exists to prevent. The cost is
+      # accepted: any PR that touches the root manifest or lockfile runs the
+      # full lane, because dependency changes are precisely the risk class
+      # this suite covers. (`crates/rig-core/**` is deliberately NOT listed:
+      # most PRs touch rig-core, and triggering the full lane on all of them
+      # would undo the fast/full split; a rig-core change that breaks a
+      # vector-store contract is caught by merge_group below at the latest.)
+      - "Cargo.toml"
+      - "Cargo.lock"
+  # The repo merges through a merge queue (ALLGREEN, squash, batches up to
+  # 5), so the commit that actually lands on main is the merge-group commit —
+  # not the PR head that the `pull_request` triggers above validated. Without
+  # this trigger, a companion-crate PR could go green on its head, get
+  # batched with other queued PRs, and land a combination the full suite
+  # never ran on, surfacing post-merge in cd.yaml where it blocks release-plz
+  # (the pre-split workflow ran the full sweep under merge_group, so this
+  # restores that guarantee). GitHub does not support `paths` filters on
+  # merge_group events, so every queued merge pays the full lane — accepted:
+  # the queue batches PRs, which amortizes the cost across everything in the
+  # batch.
+  merge_group:
   workflow_dispatch: # cd.yaml already uses this; match it
   workflow_call:
 
@@ -59,6 +95,9 @@ env:
   # fingerprints rather than invalidating each other's caches.
   CARGO_PROFILE_DEV_DEBUG: line-tables-only
   CARGO_PROFILE_TEST_DEBUG: line-tables-only
+  CARGO_INCREMENTAL: 0
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: sccache
 
 # The `full-` prefix keeps this group disjoint from ci.yaml's when both are
 # invoked from the same cd.yaml run (inside a called workflow,
@@ -91,6 +130,11 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
+
+      # See ci.yaml's `test` job note: caches workspace-member rustc
+      # invocations, which rust-cache cannot.
+      - name: Run sccache
+        uses: mozilla/sccache-action@v0.0.11
 
       - name: Install nextest
         uses: taiki-e/install-action@v2

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -57,6 +57,11 @@ on:
       - "crates/rig-vectorize/**"
       - "tests/integrations/**"
       - "tests/integrations.rs"
+      # The facade feature-forwarding guard is the one test whose failure
+      # class (a facade feature forgetting a sub-feature, invisible to any
+      # `--all-features` build — see the header) nothing on the PR gate can
+      # catch, so a PR that edits it must run it.
+      - "tests/tool_facade_features.rs"
       - ".github/workflows/nightly.yaml"
       # The companion crates' dependency versions do not live under
       # `crates/rig-*/`: they are `workspace = true` references resolved in

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -18,8 +18,13 @@
 #
 # When it runs:
 #   * nightly at 06:00 UTC;
-#   * on demand via `gh workflow run nightly.yaml` — a contributor touching a
-#     companion crate should trigger this instead of waiting for the cron;
+#   * on any PR that touches a companion crate or the integration tests —
+#     without this, a PR editing `crates/rig-qdrant/` merges with zero runtime
+#     coverage of the code it changed, and the breakage surfaces either at
+#     06:00 or, worse, in cd.yaml's `run-full-ci`, where it blocks release-plz
+#     on an already-merged commit. These PRs are rare and share the scheduled
+#     run's rust-cache entry, so the common PR pays nothing;
+#   * on demand via `gh workflow run nightly.yaml`;
 #   * via `workflow_call` from cd.yaml on every push to main, so release-plz
 #     never publishes a commit the full suite has not passed.
 name: Nightly Full Test
@@ -27,12 +32,33 @@ name: Nightly Full Test
 on:
   schedule:
     - cron: "0 6 * * *"
+  # Exactly the crates that `tests/integrations/` actually exercises. Other
+  # companion crates (rig-milvus, rig-surrealdb, rig-helixdb, …) are omitted
+  # deliberately: they have no suite here, so triggering this lane on them
+  # would cost 20+ minutes and run nothing that covers the changed code.
+  pull_request:
+    paths:
+      - "crates/rig-lancedb/**"
+      - "crates/rig-mongodb/**"
+      - "crates/rig-neo4j/**"
+      - "crates/rig-postgres/**"
+      - "crates/rig-qdrant/**"
+      - "crates/rig-scylladb/**"
+      - "crates/rig-sqlite/**"
+      - "crates/rig-vectorize/**"
+      - "tests/integrations/**"
+      - "tests/integrations.rs"
+      - ".github/workflows/nightly.yaml"
   workflow_dispatch: # cd.yaml already uses this; match it
   workflow_call:
 
 env:
   CARGO_TERM_COLOR: always
   RUST_VERSION: 1.94.0
+  # See ci.yaml for the rationale; kept identical so the two lanes share build
+  # fingerprints rather than invalidating each other's caches.
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
 
 # The `full-` prefix keeps this group disjoint from ci.yaml's when both are
 # invoked from the same cd.yaml run (inside a called workflow,
@@ -45,9 +71,21 @@ jobs:
   test-all-features:
     name: stable / test all features
     runs-on: ubuntu-latest
+    # `schedule` fires on any fork whose owner has enabled Actions, against the
+    # fork's default branch, where the provider secrets are empty — so without
+    # this guard every fork owner gets a failing run and a failure email at
+    # 06:00 daily for a suite they did not ask to run. Fork *PRs* into this
+    # repo are unaffected: `github.repository` is the upstream repo there, and
+    # the vector-store tests stub their embeddings with `api_key("TEST")`
+    # rather than calling a provider.
+    #
+    # This also covers the `workflow_call` path, where `github.repository` is
+    # still the caller's repo — a fork's own cd.yaml skips this job and, with
+    # it, its release-plz step, which is the correct outcome on a fork.
+    if: github.repository == '0xPlaygrounds/rig'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -59,18 +97,20 @@ jobs:
         with:
           tool: nextest
 
-      # Required to compile rig-lancedb
+      # Required to compile rig-lancedb — and also the `lancedb` crate itself,
+      # which the `rig` facade carries as an unconditional dev-dependency. See
+      # the longer note on ci.yaml's `test` job.
       - name: Install Protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       # The workspace-wide sweep over every feature. This is the step that
       # was ci.yaml's `Test with latest nextest release` before the fast/full
       # split narrowed that one to `--features bedrock`.
+      #
+      # A plain `run:` rather than `actions-rs/cargo@v1`: that action was
+      # archived in 2023 and pins Node 20.
       - name: Test with all features
-        uses: actions-rs/cargo@v1
-        with:
-          command: nextest
-          args: run --all-features --retries 2
+        run: cargo nextest run --locked --all-features --retries 2
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,79 @@
+# The full `--all-features` test suite, split out of the PR gate (ci.yaml).
+#
+# What runs only here and not on the PR gate:
+#   * the Docker-backed vector-store integration tests in `tests/integrations/`
+#     (lancedb, mongodb, neo4j, postgres, qdrant, scylladb — plus the
+#     no-container sqlite and vectorize suites), the only runtime coverage the
+#     companion crates' `VectorStoreIndex` implementations have;
+#   * `tests/tool_facade_features.rs` (`facade-build-tests`), the slow
+#     nested-`cargo check` facade build guard;
+#   * the `image`-feature generation smoke tests (gemini nano-banana, xai);
+#   * every root test binary's `--all-features` configuration — the PR gate
+#     runs the default feature set plus `bedrock`.
+#
+# The PR gate still COMPILES all of the above on every PR: ci.yaml's clippy
+# job lints `--all-features --all-targets`, and doctest/doc build all
+# features, so a nightly failure is a runtime regression, never a stale
+# compile break discovered at 06:00.
+#
+# When it runs:
+#   * nightly at 06:00 UTC;
+#   * on demand via `gh workflow run nightly.yaml` — a contributor touching a
+#     companion crate should trigger this instead of waiting for the cron;
+#   * via `workflow_call` from cd.yaml on every push to main, so release-plz
+#     never publishes a commit the full suite has not passed.
+name: Nightly Full Test
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch: # cd.yaml already uses this; match it
+  workflow_call:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_VERSION: 1.94.0
+
+# The `full-` prefix keeps this group disjoint from ci.yaml's when both are
+# invoked from the same cd.yaml run (inside a called workflow,
+# `github.workflow` resolves to the CALLER's name).
+concurrency:
+  group: full-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test-all-features:
+    name: stable / test all features
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      # Required to compile rig-lancedb
+      - name: Install Protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      # The workspace-wide sweep over every feature. This is the step that
+      # was ci.yaml's `Test with latest nextest release` before the fast/full
+      # split narrowed that one to `--features bedrock`.
+      - name: Test with all features
+        uses: actions-rs/cargo@v1
+        with:
+          command: nextest
+          args: run --all-features --retries 2
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}

--- a/tests/common/cassette_safety.rs
+++ b/tests/common/cassette_safety.rs
@@ -139,8 +139,65 @@ fn cassettes_do_not_contain_obvious_secrets() {
         return;
     }
 
+    // Each provider binary scans only its own `tests/cassettes/<provider>`
+    // directory. This module compiles into every provider test binary, and
+    // the scan (YAML parse + scrub + re-serialize + base64 decode + several
+    // regex families per file) is expensive — when every binary scanned the
+    // whole tree, CI ran the identical full-tree scan once per binary, and
+    // that duplication alone was the single largest execution cost in the PR
+    // gate's test sweep (~16s × 16 binaries per run).
+    //
+    // Scoping is safe because the partition below is asserted, in every
+    // binary, before anything is skipped:
+    //
+    //   * every top-level entry under `tests/cassettes` must be a directory
+    //     named after a suite registered in `PROVIDER_CASSETTE_SUITES` — a
+    //     stray file or an unregistered provider directory fails everywhere
+    //     rather than silently escaping the scan;
+    //   * every registered suite's `tests/<provider>.rs` must include this
+    //     module — so each registered directory is provably scanned by
+    //     exactly the binary that owns it, and adding a suite without wiring
+    //     the scan into its binary fails everywhere too.
     let mut failures = Vec::new();
-    scan_dir(root, &mut failures);
+
+    let registered: BTreeSet<&str> = PROVIDER_CASSETTE_SUITES
+        .iter()
+        .map(|suite| suite.provider)
+        .collect();
+    for entry in fs::read_dir(root).expect("cassette root should be readable") {
+        let entry = entry.expect("cassette root entry should be readable");
+        let name = entry.file_name();
+        let name = name.to_string_lossy().into_owned();
+        if !entry.path().is_dir() {
+            failures.push(format!(
+                "tests/cassettes/{name} is not a provider directory; loose files under the \
+                 cassette root are scanned by no binary"
+            ));
+        } else if !registered.contains(name.as_str()) {
+            failures.push(format!(
+                "tests/cassettes/{name} has no PROVIDER_CASSETTE_SUITES entry, so no test \
+                 binary scans it for secrets — register it in \
+                 tests/common/cassette_safety.rs"
+            ));
+        }
+    }
+    for suite in PROVIDER_CASSETTE_SUITES {
+        let binary_source = repo_path(&format!("tests/{}.rs", suite.provider));
+        let includes_scan = fs::read_to_string(&binary_source)
+            .is_ok_and(|contents| contents.contains("common/cassette_safety.rs"));
+        if !includes_scan {
+            failures.push(format!(
+                "tests/{}.rs does not include common/cassette_safety.rs, so \
+                 tests/cassettes/{} is scanned for secrets by no binary",
+                suite.provider, suite.provider
+            ));
+        }
+    }
+
+    let own_dir = root.join(env!("CARGO_CRATE_NAME"));
+    if own_dir.is_dir() {
+        scan_dir(&own_dir, &mut failures);
+    }
 
     assert!(
         failures.is_empty(),

--- a/tests/common/cassette_safety.rs
+++ b/tests/common/cassette_safety.rs
@@ -157,7 +157,11 @@ fn cassettes_do_not_contain_obvious_secrets() {
     //   * every registered suite's `tests/<provider>.rs` must include this
     //     module — so each registered directory is provably scanned by
     //     exactly the binary that owns it, and adding a suite without wiring
-    //     the scan into its binary fails everywhere too.
+    //     the scan into its binary fails everywhere too;
+    //   * every registered provider name must be a valid crate identifier —
+    //     `env!("CARGO_CRATE_NAME")` mangles hyphens to underscores, so a
+    //     hyphenated provider would resolve `own_dir` to a path that never
+    //     exists and skip its own scan without a single failure.
     let mut failures = Vec::new();
 
     let registered: BTreeSet<&str> = PROVIDER_CASSETTE_SUITES
@@ -182,13 +186,23 @@ fn cassettes_do_not_contain_obvious_secrets() {
         }
     }
     for suite in PROVIDER_CASSETTE_SUITES {
-        let binary_source = repo_path(&format!("tests/{}.rs", suite.provider));
-        let includes_scan = fs::read_to_string(&binary_source)
-            .is_ok_and(|contents| contents.contains("common/cassette_safety.rs"));
-        if !includes_scan {
+        if !suite
+            .provider
+            .chars()
+            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_')
+        {
             failures.push(format!(
-                "tests/{}.rs does not include common/cassette_safety.rs, so \
-                 tests/cassettes/{} is scanned for secrets by no binary",
+                "provider {:?} is not equal to its test binary's CARGO_CRATE_NAME (hyphens and \
+                 other non-identifier characters are mangled), so its cassette directory would \
+                 be scanned by no binary — rename the provider or its directory",
+                suite.provider
+            ));
+        }
+        let binary_source = repo_path(&format!("tests/{}.rs", suite.provider));
+        if !binary_compiles_cassette_scan(&binary_source) {
+            failures.push(format!(
+                "tests/{}.rs does not include common/cassette_safety.rs as an unconditional \
+                 `mod`, so tests/cassettes/{} is scanned for secrets by no binary",
                 suite.provider, suite.provider
             ));
         }
@@ -335,6 +349,43 @@ fn collect_rust_files_in_dir(dir: &Path, files: &mut Vec<PathBuf>) {
             files.push(path);
         }
     }
+}
+
+/// Structural, not substring: the guarded claim is "this binary *compiles*
+/// the secret scan", so the check must parse the source and find an actual
+/// `#[path = ".../common/cassette_safety.rs"] mod …` item with no `#[cfg]`
+/// attached. A raw `contents.contains(...)` would stay satisfied by a
+/// commented-out include or by a cfg-gated one — a false green on the safety
+/// net itself, the same paper-claim failure mode the streaming-conformance
+/// registry's CI-step check guards against.
+fn binary_compiles_cassette_scan(source: &Path) -> bool {
+    let Ok(contents) = fs::read_to_string(source) else {
+        return false;
+    };
+    let Ok(syntax) = syn::parse_file(&contents) else {
+        return false;
+    };
+    syntax.items.iter().any(|item| {
+        let syn::Item::Mod(module) = item else {
+            return false;
+        };
+        let cfg_gated = module
+            .attrs
+            .iter()
+            .any(|attr| attr.path().is_ident("cfg") || attr.path().is_ident("cfg_attr"));
+        let includes_scan = module.attrs.iter().any(|attr| {
+            attr.path().is_ident("path")
+                && matches!(
+                    &attr.meta,
+                    syn::Meta::NameValue(name_value) if matches!(
+                        &name_value.value,
+                        Expr::Lit(ExprLit { lit: Lit::Str(path), .. })
+                            if path.value().ends_with("common/cassette_safety.rs")
+                    )
+                )
+        });
+        includes_scan && !cfg_gated
+    })
 }
 
 fn cassette_scenarios_in_file(

--- a/tests/core/streaming_conformance_registry.rs
+++ b/tests/core/streaming_conformance_registry.rs
@@ -177,7 +177,16 @@ fn out_of_binary_families_name_a_live_ci_step() {
     // non-comment lines whose content (after the `- ` list marker) begins
     // with `name:` — a `# - name: …` comment cannot satisfy the check — and
     // each step's selector/`-p` package list is looked for INSIDE that
-    // step's own block (up to the next step), not anywhere in the file.
+    // step's own block, not anywhere in the file. Two boundaries matter:
+    //
+    //   * the block ends at the next step OR at the job seam (any non-blank
+    //     line indented less than a step line, e.g. the next job's key) — a
+    //     job-final step must not absorb the following job's header;
+    //   * comment lines are dropped from the block BEFORE matching, so a
+    //     comment that merely *mentions* `--features bedrock` cannot keep
+    //     this check green after the actual flag is removed from the `run:`
+    //     command — that would be the paper-claim failure mode all over
+    //     again, hidden one level down.
     let step_block = |step: &str| -> Option<String> {
         let lines: Vec<&str> = text.lines().collect();
         let is_step_line = |line: &str| {
@@ -187,15 +196,20 @@ fn out_of_binary_families_name_a_live_ci_step() {
                     .strip_prefix("- ")
                     .is_some_and(|rest| rest.trim_start().starts_with("name:"))
         };
+        let step_indent = |line: &str| line.len() - line.trim_start().len();
         let start = lines.iter().position(|line| {
             is_step_line(line)
                 && line
                     .split_once("name:")
                     .is_some_and(|(_, value)| value.trim() == step)
         })?;
+        let job_seam = step_indent(lines[start]);
         let block: Vec<&str> = lines[start + 1..]
             .iter()
-            .take_while(|line| !is_step_line(line))
+            .take_while(|line| {
+                !is_step_line(line) && (line.trim().is_empty() || step_indent(line) >= job_seam)
+            })
+            .filter(|line| !line.trim_start().starts_with('#'))
             .copied()
             .collect();
         Some(block.join("\n"))
@@ -212,13 +226,18 @@ fn out_of_binary_families_name_a_live_ci_step() {
             )
         });
         if let Some(selector) = entry.ci_selector {
+            // A `--features X` selector asserts an *outcome* — the feature is
+            // enabled in that step — not a spelling: `--all-features` enables
+            // strictly more, so a step that broadens its sweep must not fail
+            // this check for gaining coverage.
+            let satisfied = block.contains(selector)
+                || (selector.starts_with("--features ") && block.contains("--all-features"));
             assert!(
-                block.contains(selector),
+                satisfied,
                 "{}'s CI step no longer carries the {:?} predicate INSIDE its own block, so its \
                  binary is selected by nothing — a nextest filter matching zero tests still \
                  exits 0",
-                entry.family,
-                selector,
+                entry.family, selector,
             );
         }
         if let Some(package) = entry.ci_package {

--- a/tests/core/streaming_conformance_registry.rs
+++ b/tests/core/streaming_conformance_registry.rs
@@ -89,8 +89,8 @@ const OUT_OF_BINARY_FAMILIES: &[OutOfBinaryFamily] = &[
         ci_selector: None,
         ci_package: None,
         reason: "lives in the `rig` facade but behind the `bedrock` feature, so it compiles into \
-                 the `bedrock` test binary rather than `core`; the workspace `--all-features` run \
-                 executes it",
+                 the `bedrock` test binary rather than `core`; the workspace sweep enables \
+                 `--features bedrock` specifically so this step keeps executing it",
     },
 ];
 

--- a/tests/core/streaming_conformance_registry.rs
+++ b/tests/core/streaming_conformance_registry.rs
@@ -86,7 +86,13 @@ const OUT_OF_BINARY_FAMILIES: &[OutOfBinaryFamily] = &[
         family: "bedrock",
         suite_file: "tests/providers/bedrock/streaming_conformance.rs",
         ci_step: FACADE_CI_STEP,
-        ci_selector: None,
+        // The PR gate's sweep runs `--features bedrock`, not `--all-features`,
+        // so this suite's existence now depends on that one flag: without it
+        // `tests/bedrock.rs` is `#[cfg(feature = "bedrock")]`-ed out and the
+        // whole binary — all 11 conformance tests — silently stops compiling.
+        // Asserting only the step *name* would leave that a paper claim, the
+        // exact failure mode this file's module doc describes.
+        ci_selector: Some("--features bedrock"),
         ci_package: None,
         reason: "lives in the `rig` facade but behind the `bedrock` feature, so it compiles into \
                  the `bedrock` test binary rather than `core`; the workspace sweep enables \

--- a/tests/core/streaming_conformance_registry.rs
+++ b/tests/core/streaming_conformance_registry.rs
@@ -88,10 +88,14 @@ const OUT_OF_BINARY_FAMILIES: &[OutOfBinaryFamily] = &[
         ci_step: FACADE_CI_STEP,
         // The PR gate's sweep runs `--features bedrock`, not `--all-features`,
         // so this suite's existence now depends on that one flag: without it
-        // `tests/bedrock.rs` is `#[cfg(feature = "bedrock")]`-ed out and the
-        // whole binary — all 11 conformance tests — silently stops compiling.
-        // Asserting only the step *name* would leave that a paper claim, the
-        // exact failure mode this file's module doc describes.
+        // the `#[cfg(feature = "bedrock")] mod bedrock` in `tests/bedrock.rs`
+        // is cfg-ed out and all 11 conformance tests silently stop compiling.
+        // (The binary itself still builds — its cassette-safety scan is
+        // deliberately ungated — so do NOT "fix" this by gating the whole
+        // file: that would drop the bedrock cassette secret scan from every
+        // default-feature run.) Asserting only the step *name* would leave
+        // the suite a paper claim, the exact failure mode this file's module
+        // doc describes.
         ci_selector: Some("--features bedrock"),
         ci_package: None,
         reason: "lives in the `rig` facade but behind the `bedrock` feature, so it compiles into \
@@ -207,7 +211,14 @@ fn out_of_binary_families_name_a_live_ci_step() {
         let block: Vec<&str> = lines[start + 1..]
             .iter()
             .take_while(|line| {
-                !is_step_line(line) && (line.trim().is_empty() || step_indent(line) >= job_seam)
+                // Comment lines pass the seam test unconditionally: comments
+                // are legal at any indentation, so a low-indent comment
+                // inside a step's span must not truncate the block (it is
+                // dropped by the filter below either way).
+                !is_step_line(line)
+                    && (line.trim().is_empty()
+                        || line.trim_start().starts_with('#')
+                        || step_indent(line) >= job_seam)
             })
             .filter(|line| !line.trim_start().starts_with('#'))
             .copied()

--- a/tests/integrations/mongodb.rs
+++ b/tests/integrations/mongodb.rs
@@ -152,7 +152,9 @@ async fn vector_search_test() {
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
 
     // Setup a local MongoDB Atlas container for testing. NOTE: docker service must be running.
-    let container = GenericImage::new("mongodb/mongodb-atlas-local", "latest")
+    // Pinned like `pgvector:pg17` / `scylla:5.4`: a floating `latest` defeats
+    // layer caching and lets a rerun silently test a different database version.
+    let container = GenericImage::new("mongodb/mongodb-atlas-local", "8.0.5")
         .with_exposed_port(MONGODB_PORT.tcp())
         .with_wait_for(WaitFor::Duration {
             length: std::time::Duration::from_secs(5),
@@ -289,7 +291,9 @@ async fn insert_documents_test() {
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
 
     // Setup MongoDB container
-    let container = GenericImage::new("mongodb/mongodb-atlas-local", "latest")
+    // Pinned like `pgvector:pg17` / `scylla:5.4`: a floating `latest` defeats
+    // layer caching and lets a rerun silently test a different database version.
+    let container = GenericImage::new("mongodb/mongodb-atlas-local", "8.0.5")
         .with_exposed_port(MONGODB_PORT.tcp())
         .with_wait_for(WaitFor::Duration {
             length: std::time::Duration::from_secs(5),

--- a/tests/integrations/neo4j.rs
+++ b/tests/integrations/neo4j.rs
@@ -50,7 +50,9 @@ async fn vector_search_test() {
     }
 
     // Setup a local Neo 4J container for testing. NOTE: docker service must be running.
-    let container = GenericImage::new("neo4j", "latest")
+    // Pinned like `pgvector:pg17` / `scylla:5.4`: a floating `latest` defeats
+    // layer caching and lets a rerun silently test a different database version.
+    let container = GenericImage::new("neo4j", "5.26.29")
         .with_wait_for(WaitFor::Duration {
             length: std::time::Duration::from_secs(5),
         })

--- a/tests/integrations/qdrant.rs
+++ b/tests/integrations/qdrant.rs
@@ -54,7 +54,9 @@ async fn vector_search_test() {
     }
 
     // Setup a local qdrant container for testing. NOTE: docker service must be running.
-    let container = GenericImage::new("qdrant/qdrant", "latest")
+    // Pinned like `pgvector:pg17` / `scylla:5.4`: a floating `latest` defeats
+    // layer caching and lets a rerun silently test a different database version.
+    let container = GenericImage::new("qdrant/qdrant", "v1.19.0")
         .with_wait_for(WaitFor::Duration {
             length: std::time::Duration::from_secs(5),
         })


### PR DESCRIPTION
Splits CI into a fast PR gate and a full `--all-features` lane (nightly + on-demand + every push to main), based on measured job timings rather than the assumed cost model.

## Phase 0 — measured baseline (median over the last 15 green runs)

| job | median | min | max |
|---|---|---|---|
| **stable / test** | **12.8m** | 10.6m | 32.9m |
| stable / doctest | 1.8m | 1.6m | 12.6m |
| stable / clippy | 1.7m | 1.3m | 8.4m |
| stable / doc | 1.4m | 1.3m | 8.1m |
| wasm checks (×6) | 0.6–0.8m | 0.5m | 1.2m |
| stable / fmt | 0.4m | 0.3m | 0.6m |

Critical path: `test` in 14 of 15 runs. The max column is cold-cache runs (lockfile/toolchain bumps).

Two premises of the original plan turned out stale on measurement:

1. **Caching already exists.** `actions-rust-lang/setup-rust-toolchain@v1` bundles `Swatinem/rust-cache` by default — that is why clippy finishes `--all-features --all-targets` in ~64s of lint time. There was no Phase-1 caching win left to take; the whole problem lives inside the `test` job.
2. **Execution is now a real share, not just compilation.** The final `--all-features` step in a representative warm run: ~2m compile + ~4.4m execution. The execution long pole is `portable_tool_facade_is_feature_additive` (123s of nested `cargo check`), then the Docker integration tests (mongodb 50s+44s, neo4j 46s, postgres 22s, lancedb 14s×2, qdrant 12s) and eight ~20s `cassette_safety` scans. (The lancedb tests **pass** on main — 14s each — contrary to the plan's premise; nothing needed fixing or dropping.)

Representative `test` job step timings (warm cache): setup+cache-restore 79s, protoc 29s, default-feature compile guard 49s, four targeted contract steps 137s, final `--all-features` run 391s.

## What changed

**PR gate (`ci.yaml`)** — `fmt`, the wasm checks, `check-rmcp-native-only`, `clippy` (still `--all-features --all-targets`), `doctest`, and `doc` are untouched. The `test` job splits in two parallel jobs:

- `test`: the default-feature compile guard (unchanged, still the only check of the pure default-feature test graph) + the workspace sweep as `cargo nextest run --features bedrock --retries 2`. `bedrock` rides along because the bedrock wire-conformance suite compiles into the facade's `bedrock` test binary and `tests/core/streaming_conformance_registry.rs` pins this step as the one executing it; rig-bedrock is already a workspace default member so the marginal compile cost is small. Provider API keys stay on this step (same-repo PRs keep exactly the pre-split live-test behaviour; fork PRs never had secrets).
- `test-guards`: the four existing contract tripwire steps, verbatim (agent unit tests, telemetry completion-parent contract with its deliberate no-retries, macro hygiene, out-of-facade conformance + structural guards), **plus one new step** running the full rig-core + rig-agent lib test sets under `--all-features` — without it, 81 fast feature-gated unit tests (rmcp tool registry, pdf/epub loaders, audio) would have demoted to nightly-only coverage. It reuses the telemetry step's compile artifacts.
- protoc is no longer installed in these two jobs: it exists only for rig-lancedb (not in either job's graph; rig-gemini-grpc vendors its own via `protoc-bin-vendored`). The three `--all-features` jobs keep it.

**Full lane (`nightly.yaml`, new)** — the exact `cargo nextest run --all-features --retries 2` step that left the gate, with protoc and the provider keys. Triggers: cron `0 6 * * *`, `workflow_dispatch` (a contributor touching a companion crate can run it on demand), and `workflow_call`.

**`cd.yaml`** — now calls `nightly.yaml` alongside `ci.yaml`, and `release-plz` needs both. Every push to main therefore still runs the full suite before any release; the split only changes *when* PRs pay for it, and reviewers keep the pre-split guarantee that nothing is released unverified. (This is why nightly.yaml needs no `merge_group` trigger: no merge-queue run has ever occurred on this repo, and the push-to-main path already covers landing.)

**Container tags** — `qdrant:latest` → `v1.19.0`, `neo4j:latest` → `5.26.29`, `mongodb-atlas-local:latest` → `8.0.5` (both call sites), matching the already-pinned `pgvector:pg17` / `scylla:5.4`. Floating tags defeat layer caching and let a rerun silently test a different database version.

## Test accounting (nothing deleted, nothing lost)

Diffed `cargo nextest list` between the gate's union (sweep + every test-guards step) and `--all-features`:

- **Gate ∪ nightly covers every test on main; zero tests run in neither.** (Also zero gate tests absent from the all-features set.)
- **Exactly 20 tests now execute only in the full lane** (nightly / push-to-main / on-demand): the 18 `tests/integrations.rs` tests (lancedb ×2, mongodb ×2, neo4j, postgres, qdrant, scylladb mock-setup, sqlite ×2, vectorize ×8), `portable_tool_facade_is_feature_additive`, and the two `image`-feature generation smoke tests (gemini nano-banana, xai).
- `--all-features` **compile** coverage is still on every PR: clippy lints `--all-features --all-targets`, doctest and doc build all features. A nightly failure can only be a runtime regression, never a stale compile break.

## Deviations from the plan, with reasons

- **Phase 1 (add caching) is a no-op** — caching was already in place (see above), which the plan itself anticipated ("one of the phases may make the others unnecessary").
- **`doctest`, `doc`, and full-fat `clippy` stay on the PR gate** rather than moving to nightly: at 1.4–1.8m each they are far off the critical path, moving them would save zero wall-clock, and they are what keeps all-features compile breaks out of main. This is the plan's own "prefer keeping clippy at `--all-features` if cheap" logic, applied to all three.
- **No containers were cut from the full lane**: they no longer cost any PR wall-clock, they run in parallel inside the sweep (biggest single contribution ~50s), the lancedb tests pass, and these are the only runtime coverage the companion crates' `VectorStoreIndex` implementations have. Cutting them would be all risk, no measurable win.

## Expected gate shape after the split

The gate's critical path becomes `test` ≈ setup + default+bedrock compile + ~2m execution, with `test-guards` similar and parallel — roughly **5–6m against the 12.8m baseline** on warm cache. The first run on this PR is a cold cache for the two new job cache keys; the number to judge is the steady state after merge. I will post the measured after-table as a comment once a few runs accumulate.

## Verification

- [ ] PR gate green with the new shape (this PR)
- [ ] Full-suite workflow proven green before merge via a dry-run branch (`ci/nightly-dryrun` — temporary `push` trigger, since `workflow_dispatch` cannot target a workflow that does not exist on the default branch yet)
- [x] `cargo nextest list` diff: every test accounted for in gate ∪ full lane
