### PR TITLE
ci: single-source the rig setup, drop every API key, and finish the deferred hardening

### DIFF
--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -29,8 +29,17 @@ inputs:
   target:
     description: Additional compilation target (e.g. wasm32-unknown-unknown)
     default: ""
+  cache:
+    description: Enable rust-cache (disable for jobs that compile nothing)
+    default: "true"
   sccache:
-    description: Enable sccache with the GitHub Actions cache backend
+    description: >-
+      Enable sccache with the GitHub Actions cache backend. Reserved for the
+      critical-path jobs: every enabled job adds thousands of small
+      per-compilation-unit cache entries, and the repo's 10GB Actions cache
+      quota is contended — exceeding it evicts rust-cache blobs LRU-style
+      and randomly re-colds whole jobs, which costs far more than sccache
+      saves.
     default: "false"
   nextest:
     description: Install cargo-nextest
@@ -76,6 +85,7 @@ runs:
         toolchain: ${{ env.RIG_CI_TOOLCHAIN }}
         components: ${{ inputs.components }}
         target: ${{ inputs.target }}
+        cache: ${{ inputs.cache }}
 
     # rust-cache (inside setup-rust-toolchain above) persists *dependency*
     # artifacts but always recompiles the workspace's own crates; sccache

--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -1,0 +1,113 @@
+# The single source for the Rust CI environment. Before this action existed,
+# the checkout+toolchain+sccache+nextest stanza was pasted into every job and
+# the cache-fingerprint env block was hand-copied between ci.yaml and
+# nightly.yaml with a comment begging the copies to stay identical — the same
+# copy-drift class check-toolchain-pin.sh polices for toolchain pins, with no
+# tripwire at all. A drifted copy would not fail: the two lanes would just
+# silently stop sharing build fingerprints.
+#
+# The toolchain is resolved from rust-toolchain.toml — the pin cargo itself
+# obeys — so no workflow carries a version copy anymore (RUST_VERSION is
+# gone). It is passed explicitly as the `toolchain` input rather than letting
+# setup-rust-toolchain discover the file natively, deliberately: native
+# discovery honors the file's `components`/`targets` pins (rust-analyzer,
+# rust-src, wasm — wanted for local development), which every CI job would
+# then download; the explicit input keeps CI installing only what each job
+# asks for via `components`/`target` here.
+#
+# NOT included, deliberately: `actions/checkout` (a repo-local action cannot
+# run before the repo exists) and the provider secrets (none are used — the
+# cassette suites replay with a dummy key and every live test is
+# `#[ignore]`-gated).
+name: Rust setup
+description: Toolchain from rust-toolchain.toml, shared cache env, and optional sccache/nextest/protoc
+
+inputs:
+  components:
+    description: Comma-separated toolchain components (e.g. clippy, rustfmt)
+    default: ""
+  target:
+    description: Additional compilation target (e.g. wasm32-unknown-unknown)
+    default: ""
+  sccache:
+    description: Enable sccache with the GitHub Actions cache backend
+    default: "false"
+  nextest:
+    description: Install cargo-nextest
+    default: "false"
+  protoc:
+    description: Install the system protoc (required whenever the lance chain builds)
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    # Runs BEFORE setup-rust-toolchain on purpose: its rust-cache computes
+    # the cache key from the env visible at restore time, so exporting the
+    # CARGO_* values first keeps every job's key derived from the same
+    # values — the whole point of single-sourcing them.
+    #
+    # Full debuginfo is the single largest avoidable compile cost in CI:
+    # `line-tables-only` keeps what CI actually consumes — file and line
+    # numbers in a panic backtrace — and drops variable/type debuginfo. Set
+    # as env rather than a `[profile]` in Cargo.toml so local `cargo test`
+    # keeps full debuginfo for debuggers, and as `dev` + `test` because test
+    # targets build under `test` while their dependencies build under `dev`.
+    # CARGO_INCREMENTAL is pinned off because sccache cannot cache
+    # incremental compilation and CI gains nothing from it anyway.
+    - name: Resolve toolchain and export shared cargo env
+      shell: bash
+      run: |
+        channel=$(grep -E '^\s*channel\s*=' rust-toolchain.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+        if [ -z "$channel" ]; then
+          echo "::error::could not read [toolchain] channel from rust-toolchain.toml"
+          exit 1
+        fi
+        {
+          echo "RIG_CI_TOOLCHAIN=$channel"
+          echo "CARGO_PROFILE_DEV_DEBUG=line-tables-only"
+          echo "CARGO_PROFILE_TEST_DEBUG=line-tables-only"
+          echo "CARGO_INCREMENTAL=0"
+        } >> "$GITHUB_ENV"
+
+    - name: Install Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ env.RIG_CI_TOOLCHAIN }}
+        components: ${{ inputs.components }}
+        target: ${{ inputs.target }}
+
+    # rust-cache (inside setup-rust-toolchain above) persists *dependency*
+    # artifacts but always recompiles the workspace's own crates; sccache
+    # caches individual rustc invocations in the GitHub Actions cache, so
+    # unchanged workspace members stop recompiling too. Opt-in per job: it
+    # only pays off where workspace crates compile (it cannot cache
+    # clippy-driver or rustdoc, which is why the clippy/doc jobs skip it).
+    - name: Run sccache
+      if: inputs.sccache == 'true'
+      uses: mozilla/sccache-action@v0.0.11
+
+    - name: Enable sccache as the rustc wrapper
+      if: inputs.sccache == 'true'
+      shell: bash
+      run: |
+        {
+          echo "SCCACHE_GHA_ENABLED=true"
+          echo "RUSTC_WRAPPER=sccache"
+        } >> "$GITHUB_ENV"
+
+    - name: Install nextest
+      if: inputs.nextest == 'true'
+      uses: taiki-e/install-action@v2
+      with:
+        tool: nextest
+
+    # apt rather than a prebuilt-binary installer: the lance build scripts
+    # shell out to a *system* protoc and also need its well-known-type
+    # includes on the include path; the distro package guarantees both. A
+    # cache hit can mask a broken protoc install until the first cold
+    # rebuild (see ci.yaml's history), so this stays the boring option.
+    - name: Install Protoc
+      if: inputs.protoc == 'true'
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y protobuf-compiler

--- a/.github/scripts/check-toolchain-pin.sh
+++ b/.github/scripts/check-toolchain-pin.sh
@@ -1,24 +1,22 @@
 #!/usr/bin/env bash
-# `rust-toolchain.toml` is what cargo itself obeys, but every workflow also
-# carries a `RUST_VERSION` env used as the `setup-rust-toolchain` input. That
-# is four copies of one number, and a partial bump is silent: the gate goes
-# green on the new toolchain while a workflow that was missed — nightly.yaml
-# is also cd.yaml's pre-release gate — keeps compiling on the old one, so a
-# failure there gets misread as a runtime regression rather than a stale pin.
+# `rust-toolchain.toml` is the single toolchain source: the rust-setup
+# composite action (.github/actions/rust-setup) resolves its channel at run
+# time, and no workflow carries a RUST_VERSION copy anymore. This guard
+# exists to keep it that way — it fails on the two bypasses that would
+# silently build one job on a stale toolchain:
 #
-# Assert the copies agree. This is a text check on purpose: it must fail on a
-# workflow nobody remembered to update, which a parser keyed off the workflows
-# that *do* declare the variable would not do.
+#   * a reintroduced `RUST_VERSION:` env copy that drifts from the channel
+#     (the pre-single-source failure mode: the gate goes green on the new
+#     toolchain while a missed workflow — nightly.yaml is also cd.yaml's
+#     pre-release gate — keeps compiling on the old one, misread as a
+#     runtime regression);
+#   * an inline literal `toolchain:` input in a `with:` block, which
+#     sidesteps the composite action entirely.
 #
-# Why the copies exist at all: omitting the `toolchain` input would make
-# `setup-rust-toolchain` read rust-toolchain.toml directly — no copies, no
-# desync, no script. But rust-toolchain.toml also pins components
-# (rust-analyzer, rust-src) and the wasm target for local development, and
-# honoring it in CI would download those in every job. Until that trade is
-# taken, this guard keeps the existing copies honest. A workflow with no
-# RUST_VERSION needs no checking (it takes its toolchain from
-# rust-toolchain.toml), so a repo that deletes every copy passes vacuously —
-# that is the desired end state, not an error to steer people away from.
+# This is a text check on purpose: it must fail on a workflow nobody
+# remembered to convert, which a parser keyed off the workflows that use the
+# composite action would not do. With no matches anywhere it passes
+# vacuously — that IS the desired state.
 set -euo pipefail
 
 cd "$(dirname "$0")/../.."

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -17,15 +17,15 @@ concurrency:
   group: release-plz-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  RUST_VERSION: 1.94.0
-
 jobs:
+  # No `secrets: inherit` on either gate call: the test lanes are hermetic
+  # (cassette replay, dummy keys, `#[ignore]`-gated live tests) and reference
+  # no secrets, so inheriting them into jobs that execute the whole test
+  # suite would be pure exfiltration surface.
   run-ci:
     permissions:
       checks: write
     uses: ./.github/workflows/ci.yaml
-    secrets: inherit
 
   # ci.yaml is the fast PR gate; the `--all-features` suite (Docker-backed
   # vector-store integrations, the facade build guard) lives in nightly.yaml.
@@ -33,7 +33,6 @@ jobs:
   # a commit the full suite has not passed.
   run-full-ci:
     uses: ./.github/workflows/nightly.yaml
-    secrets: inherit
 
   release-plz:
     name: Release-plz
@@ -48,16 +47,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      # protoc: required to compile rig-lancedb, and the `lancedb` crate that
+      # the `rig` facade carries as an unconditional dev-dependency.
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/rust-setup
         with:
-          toolchain: ${{ env.RUST_VERSION }}
-          cache: true
-
-      # Required to compile rig-lancedb, and the `lancedb` crate that the
-      # `rig` facade carries as an unconditional dev-dependency.
-      - name: Install Protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+          protoc: "true"
 
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,28 +8,19 @@ on:
   merge_group:
   workflow_call:
 
+# The toolchain (from rust-toolchain.toml) and the shared cargo env
+# (debuginfo trim, CARGO_INCREMENTAL) are single-sourced in
+# .github/actions/rust-setup — see its header. No RUST_VERSION copy exists
+# anymore, in any workflow.
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.94.0
-  # Full debuginfo is the single largest avoidable cost in this workflow: even
-  # on a *full* rust-cache hit the `test` job spent ~4m compiling and linking
-  # test binaries, most of it emitting and linking debug sections nothing here
-  # reads. `line-tables-only` keeps what CI actually consumes — file and line
-  # numbers in a panic backtrace — and drops variable/type debuginfo. Set as
-  # env rather than a `[profile]` in Cargo.toml so local `cargo test` keeps
-  # full debuginfo for debuggers, and as `dev` + `test` because test targets
-  # build under `test` while their dependencies build under `dev`.
-  CARGO_PROFILE_DEV_DEBUG: line-tables-only
-  CARGO_PROFILE_TEST_DEBUG: line-tables-only
-  # sccache (enabled per-job below) cannot cache incremental compilation, and
-  # CI never benefits from incremental anyway — every run starts from a fresh
-  # checkout — so pin it off for every job.
-  CARGO_INCREMENTAL: 0
 
-# ensure that the workflow is only triggered once per PR, subsequent pushes to the PR will cancel
-# and restart the workflow. See https://docs.github.com/en/actions/using-jobs/using-concurrency
+# Ensure the workflow runs once per PR: a newer push cancels and restarts the
+# in-flight run. Keyed on the PR number rather than `head_ref` because two
+# forks PRing from identically-named branches share a head_ref — under the
+# old key they cancelled each other's runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -41,10 +32,9 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Rust stable
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/rust-setup
         with:
           components: rustfmt
-          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Run cargo fmt
         run: cargo fmt -- --check
@@ -52,11 +42,12 @@ jobs:
       - name: Check immutable migration guide preamble
         run: bash .github/scripts/check-migrating-guide-preamble.sh
 
-      # rust-toolchain.toml is the pin cargo obeys; each workflow's
-      # RUST_VERSION is a copy feeding `setup-rust-toolchain`. Assert they
-      # agree so a partial bump cannot leave nightly.yaml — which is also
-      # cd.yaml's pre-release gate — building on a toolchain the PR gate no
-      # longer enforces.
+      # rust-toolchain.toml is the single toolchain source: the rust-setup
+      # composite action resolves its channel, and no workflow carries a
+      # RUST_VERSION copy anymore. This guard's remaining job is to keep it
+      # that way — it fails on any reintroduced RUST_VERSION copy or inline
+      # literal `toolchain:` pin that drifts from the channel, the bypasses
+      # that would silently build one job on a stale toolchain.
       - name: Check workflow toolchain pins match rust-toolchain.toml
         run: bash .github/scripts/check-toolchain-pin.sh
 
@@ -117,10 +108,9 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Rust stable
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/rust-setup
         with:
           target: wasm32-unknown-unknown
-          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Run cargo check wasm target
         run: cargo check --package ${{ matrix.package }} --target wasm32-unknown-unknown
@@ -139,10 +129,9 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Rust stable
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/rust-setup
         with:
           target: wasm32-unknown-unknown
-          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Assert the native-only diagnostic is the only error
         run: |
@@ -183,15 +172,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # protoc: the lance build scripts run here too (clippy compiles every
+      # dependency's build script). No sccache: it cannot cache
+      # clippy-driver invocations.
       - name: Install Rust stable
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/rust-setup
         with:
           components: clippy
-          toolchain: ${{ env.RUST_VERSION }}
-
-      # Required to compile rig-lancedb
-      - name: Install Protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+          protoc: "true"
 
       - name: Run clippy action
         uses: clechasseur/rs-clippy-check@v3
@@ -216,53 +204,25 @@ jobs:
   test:
     name: stable / test
     runs-on: ubuntu-latest
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Install Rust stable
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-
-      # rust-cache (inside setup-rust-toolchain above) persists *dependency*
-      # artifacts but always recompiles the workspace's own crates; sccache
-      # caches individual rustc invocations in the GitHub Actions cache, so
-      # unchanged workspace members stop recompiling too. That workspace-member
-      # compile is this job's residual floor, which is why the compile-heavy
-      # jobs (test, test guards, doctest, nightly) opt in via the job-level
-      # env above — a workflow-wide RUSTC_WRAPPER would instead break every
-      # job that skips this install step.
-      - name: Run sccache
-        uses: mozilla/sccache-action@v0.0.11
-
-      - name: Install nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: nextest
-
-      # Required here, and NOT only for the `lancedb` feature: the `rig`
-      # facade lists `lancedb` as an unconditional dev-dependency
-      # (Cargo.toml's `[dev-dependencies]`), so building its test targets —
-      # which both steps below do — compiles lance-encoding/-file/-table/
-      # -index and lance. Each of those build scripts calls
-      # `prost_build::compile_protos`, which shells out to a *system* protoc:
-      # the vendoring `protoc` feature that would pull `protobuf-src` is not
-      # enabled anywhere in Cargo.lock, and rig-gemini-grpc's
-      # protoc-bin-vendored is its own private build-dependency.
-      #
-      # ubuntu-latest does not ship protoc (this apt step reports
-      # `Selecting previously unselected package protobuf-compiler`), so
-      # dropping this install does not fail loudly — it fails only once the
-      # rust-cache entry for this job is invalidated and lance rebuilds,
-      # turning a Cargo.lock or toolchain bump into an unrelated-looking
-      # build-script error. Verify the dependency edge with:
+      # protoc is required here, and NOT only for the `lancedb` feature: the
+      # `rig` facade lists `lancedb` as an unconditional dev-dependency, so
+      # building its test targets — which both steps below do — compiles the
+      # lance chain, whose build scripts shell out to a *system* protoc.
+      # ubuntu-latest does not ship one, and dropping the install does not
+      # fail loudly — it fails only once the rust-cache entry is invalidated
+      # and lance rebuilds, turning a Cargo.lock or toolchain bump into an
+      # unrelated-looking build-script error. Verify the dependency edge with:
       #   cargo tree -i lance-encoding -e normal,dev --target all
-      - name: Install Protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Install Rust stable
+        uses: ./.github/actions/rust-setup
+        with:
+          sccache: "true"
+          nextest: "true"
+          protoc: "true"
 
       # `nextest` below runs with `--features bedrock`, which does not compile
       # the pure default-feature test graph. Check the root integration tests
@@ -295,10 +255,13 @@ jobs:
       # cost is marginal). Everything that needs the remaining optional
       # features executes in nightly.yaml's identical-command full run.
       #
-      # The provider keys stay here even though the cassette suites replay
-      # recorded traffic without them: the few live tests that check for keys
-      # at runtime keep running on same-repo PRs exactly as they did before
-      # the fast/full split (fork PRs never received secrets either way).
+      # No provider API keys, deliberately: the cassette suites replay
+      # recorded traffic with a dummy key, every live test is
+      # `#[ignore]`-gated (nextest never selects them), and the integration
+      # tests stub their embeddings — so nothing CI executes reads a real
+      # key. Keeping secrets in the environment of a job that runs the whole
+      # test suite is pure exfiltration surface; recording new cassettes is a
+      # local, human activity (see tests/common/cassettes.rs).
       #
       # A plain `run:` rather than `actions-rs/cargo@v1`: that action was
       # archived in 2023 and pins Node 20, which this workflow's own log
@@ -306,12 +269,6 @@ jobs:
       # invoking cargo directly.
       - name: Test with latest nextest release
         run: cargo nextest run --locked --features bedrock --retries 2
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
-          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
 
   # The cross-crate contract tripwires, split from `test` so the two halves
   # run in parallel: each step deliberately compiles a package set with its
@@ -320,27 +277,15 @@ jobs:
   test-guards:
     name: stable / test guards
     runs-on: ubuntu-latest
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
       - name: Install Rust stable
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/rust-setup
         with:
-          toolchain: ${{ env.RUST_VERSION }}
-
-      # See the `test` job's note: caches workspace-member rustc invocations,
-      # which rust-cache cannot.
-      - name: Run sccache
-        uses: mozilla/sccache-action@v0.0.11
-
-      - name: Install nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: nextest
+          sccache: "true"
+          nextest: "true"
 
       # No protoc here, and unlike the `test` job that is genuinely true: the
       # lance chain enters the graph through the `rig` facade's
@@ -442,27 +387,17 @@ jobs:
   doctest:
     name: stable / doctest
     runs-on: ubuntu-latest
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # protoc: required to compile rig-lancedb (and the facade's lance
+      # dev-dependency chain).
       - name: Install Rust stable
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/rust-setup
         with:
-          toolchain: ${{ env.RUST_VERSION }}
-
-      # See the `test` job's note: caches workspace-member rustc invocations,
-      # which rust-cache cannot. (rustdoc itself is not cached, which is why
-      # the `doc` job does not bother.)
-      - name: Run sccache
-        uses: mozilla/sccache-action@v0.0.11
-
-      # Required to compile rig-lancedb
-      - name: Install Protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+          sccache: "true"
+          protoc: "true"
 
       # No API keys needed: the doctests that actually execute are pure (the
       # provider examples are all `no_run`/compile-only), so this job stays
@@ -477,15 +412,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # protoc: required to compile rig-lancedb. No sccache: rustdoc
+      # invocations are not cacheable by it.
       - name: Install Rust stable
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/rust-setup
         with:
           components: rust-docs
-          toolchain: ${{ env.RUST_VERSION }}
-
-      # Required to compile rig-lancedb
-      - name: Install Protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+          protoc: "true"
 
       - name: Run cargo doc
         run: cargo doc --locked --no-deps --all-features

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,10 +31,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # cache: false — this job runs rustfmt and shell scripts, compiles
+      # nothing, and its rust-cache entry was 200MB of pure quota pressure.
       - name: Install Rust stable
         uses: ./.github/actions/rust-setup
         with:
           components: rustfmt
+          cache: "false"
 
       - name: Run cargo fmt
         run: cargo fmt -- --check
@@ -392,11 +395,12 @@ jobs:
         uses: actions/checkout@v5
 
       # protoc: required to compile rig-lancedb (and the facade's lance
-      # dev-dependency chain).
+      # dev-dependency chain). No sccache: this job is off the critical path
+      # and rustdoc's doctest execution is not cacheable anyway — see the
+      # quota note on the sccache input in the rust-setup action.
       - name: Install Rust stable
         uses: ./.github/actions/rust-setup
         with:
-          sccache: "true"
           protoc: "true"
 
       # No API keys needed: the doctests that actually execute are pure (the

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -93,35 +93,36 @@ on:
   workflow_dispatch: # cd.yaml already uses this; match it
   workflow_call:
 
+# The toolchain and the cache-fingerprint env (debuginfo trim,
+# CARGO_INCREMENTAL) come from .github/actions/rust-setup, the same single
+# source ci.yaml uses — which is what actually guarantees the two lanes
+# share build fingerprints instead of a comment asking copies to stay
+# identical.
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.94.0
-  # See ci.yaml for the rationale; kept identical so the two lanes share build
-  # fingerprints rather than invalidating each other's caches.
-  CARGO_PROFILE_DEV_DEBUG: line-tables-only
-  CARGO_PROFILE_TEST_DEBUG: line-tables-only
-  CARGO_INCREMENTAL: 0
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: sccache
 
 # The `full-` prefix keeps this group disjoint from ci.yaml's when both are
 # invoked from the same cd.yaml run (inside a called workflow,
-# `github.workflow` resolves to the CALLER's name).
+# `github.workflow` resolves to the CALLER's name). Keyed on the PR number
+# rather than `head_ref` because two forks PRing from identically-named
+# branches share a head_ref — under the old key they cancelled each other's
+# runs.
 concurrency:
-  group: full-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: full-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   test-all-features:
     name: stable / test all features
     runs-on: ubuntu-latest
-    # `schedule` fires on any fork whose owner has enabled Actions, against the
-    # fork's default branch, where the provider secrets are empty — so without
-    # this guard every fork owner gets a failing run and a failure email at
-    # 06:00 daily for a suite they did not ask to run. Fork *PRs* into this
-    # repo are unaffected: `github.repository` is the upstream repo there, and
-    # the vector-store tests stub their embeddings with `api_key("TEST")`
-    # rather than calling a provider.
+    # `schedule` fires on any fork whose owner has enabled Actions, against
+    # the fork's default branch — so without this guard every fork owner gets
+    # a daily 06:00 run (Docker pulls and a full workspace build) for a suite
+    # they did not ask for. Fork *PRs* into this repo are unaffected:
+    # `github.repository` is the upstream repo there, and the suite is fully
+    # hermetic — cassettes replay with a dummy key, the vector-store tests
+    # stub their embeddings with `api_key("TEST")`, and no job receives
+    # provider secrets anywhere in CI.
     #
     # This also covers the `workflow_call` path, where `github.repository` is
     # still the caller's repo — a fork's own cd.yaml skips this job and, with
@@ -131,38 +132,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # protoc: required to compile rig-lancedb — and the `lancedb` crate
+      # itself, which the `rig` facade carries as an unconditional
+      # dev-dependency. See the longer note on ci.yaml's `test` job.
       - name: Install Rust stable
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/rust-setup
         with:
-          toolchain: ${{ env.RUST_VERSION }}
-
-      # See ci.yaml's `test` job note: caches workspace-member rustc
-      # invocations, which rust-cache cannot.
-      - name: Run sccache
-        uses: mozilla/sccache-action@v0.0.11
-
-      - name: Install nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: nextest
-
-      # Required to compile rig-lancedb — and also the `lancedb` crate itself,
-      # which the `rig` facade carries as an unconditional dev-dependency. See
-      # the longer note on ci.yaml's `test` job.
-      - name: Install Protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+          sccache: "true"
+          nextest: "true"
+          protoc: "true"
 
       # The workspace-wide sweep over every feature. This is the step that
       # was ci.yaml's `Test with latest nextest release` before the fast/full
-      # split narrowed that one to `--features bedrock`.
+      # split narrowed that one to `--features bedrock`. No provider API keys
+      # here or anywhere in CI: everything that executes is hermetic (see
+      # ci.yaml's sweep-step note), and recording new cassettes is a local,
+      # human activity.
       #
       # A plain `run:` rather than `actions-rs/cargo@v1`: that action was
       # archived in 2023 and pins Node 20.
       - name: Test with all features
         run: cargo nextest run --locked --all-features --retries 2
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
-          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -135,10 +135,14 @@ jobs:
       # protoc: required to compile rig-lancedb — and the `lancedb` crate
       # itself, which the `rig` facade carries as an unconditional
       # dev-dependency. See the longer note on ci.yaml's `test` job.
+      #
+      # No sccache: the all-features sweep mints by far the most
+      # per-compilation-unit cache entries, this lane is not
+      # latency-critical, and the repo's 10GB Actions cache quota is
+      # contended — see the sccache input's note in the rust-setup action.
       - name: Install Rust stable
         uses: ./.github/actions/rust-setup
         with:
-          sccache: "true"
           nextest: "true"
           protoc: "true"
 

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -2,6 +2,7 @@
 mod embed_macro;
 mod loaders;
 mod name_keyed_serializers;
+mod nightly_paths_registry;
 mod prompt_response_messages;
 mod provider_layout;
 mod reasoning_stream_stats;

--- a/tests/core/nightly_paths_registry.rs
+++ b/tests/core/nightly_paths_registry.rs
@@ -1,0 +1,156 @@
+//! Tripwire binding nightly.yaml's `pull_request.paths` filter to the
+//! integration suites it exists to cover.
+//!
+//! The filter decides which PRs get the full Docker-backed lane before merge,
+//! and its glob list must mirror `tests/integrations/` by hand: when a new
+//! suite lands (say `tests/integrations/milvus.rs` covering
+//! `crates/rig-milvus`) and the glob is forgotten, every later PR touching
+//! only that crate merges with zero runtime coverage of the code it changed —
+//! the exact failure mode the filter's own header comment says it prevents,
+//! and (before this test) a seam with no tripwire, unlike its siblings: the
+//! streaming-conformance registry pins ci.yaml's steps and the cassette
+//! partition guard pins the suites/directories bijection.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+/// Suites in `tests/integrations/` that deliberately have no
+/// `crates/rig-<name>/**` glob, with the reason the omission is sound.
+const GLOB_EXEMPT_SUITES: &[(&str, &str)] = &[(
+    "bedrock",
+    "gated behind the `bedrock` feature, which ci.yaml's PR-gate sweep enables on every PR — \
+     the fast lane already executes this suite, so a full-lane trigger would add nothing",
+)];
+
+/// Path entries whose presence is load-bearing for reasons documented in
+/// nightly.yaml itself; deleting any of them silently reopens a coverage
+/// hole a past review closed.
+const REQUIRED_PATHS: &[&str] = &[
+    // The suites' own sources.
+    "tests/integrations/**",
+    "tests/integrations.rs",
+    // Companion-crate dependency versions are `workspace = true` references
+    // resolved in the root manifest and lockfile; without these, dependency
+    // bumps merge with zero integration coverage.
+    "Cargo.toml",
+    "Cargo.lock",
+    // The facade feature-forwarding guard: its failure class is invisible to
+    // every `--all-features` build on the PR gate.
+    "tests/tool_facade_features.rs",
+    // Editing the lane must run the lane.
+    ".github/workflows/nightly.yaml",
+];
+
+fn nightly_pull_request_paths() -> BTreeSet<String> {
+    let workflow = Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows/nightly.yaml");
+    let text = fs::read_to_string(&workflow).expect("nightly.yaml should be readable");
+    let doc: serde_yaml::Value =
+        serde_yaml::from_str(&text).expect("nightly.yaml should parse as YAML");
+    // YAML 1.1 resolves a bare `on` key to a boolean in some parsers; accept
+    // either representation rather than depending on serde_yaml's choice.
+    let triggers = doc
+        .get("on")
+        .or_else(|| doc.get(serde_yaml::Value::Bool(true)))
+        .expect("nightly.yaml should have an on: block");
+    triggers
+        .get("pull_request")
+        .and_then(|pull_request| pull_request.get("paths"))
+        .and_then(serde_yaml::Value::as_sequence)
+        .expect("nightly.yaml should filter pull_request by paths")
+        .iter()
+        .map(|path| {
+            path.as_str()
+                .expect("paths entries should be strings")
+                .to_string()
+        })
+        .collect()
+}
+
+fn integration_suites() -> BTreeSet<String> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/integrations");
+    fs::read_dir(&dir)
+        .expect("tests/integrations should be readable")
+        .map(|entry| {
+            let entry = entry.expect("tests/integrations entry should be readable");
+            let path = entry.path();
+            if path.is_dir() {
+                path.file_name()
+            } else {
+                path.file_stem()
+            }
+            .expect("suite entry should have a name")
+            .to_string_lossy()
+            .into_owned()
+        })
+        .collect()
+}
+
+#[test]
+fn nightly_paths_cover_every_integration_suite() {
+    let paths = nightly_pull_request_paths();
+    let suites = integration_suites();
+    let exempt: BTreeSet<&str> = GLOB_EXEMPT_SUITES.iter().map(|(name, _)| *name).collect();
+
+    let mut failures = Vec::new();
+
+    for (name, reason) in GLOB_EXEMPT_SUITES {
+        assert!(
+            !reason.is_empty(),
+            "exemption for {name} needs a reason the missing glob is sound"
+        );
+        if !suites.contains(*name) {
+            failures.push(format!(
+                "GLOB_EXEMPT_SUITES names {name:?}, but tests/integrations/ has no such suite — \
+                 delete the stale exemption"
+            ));
+        }
+    }
+
+    for suite in &suites {
+        if exempt.contains(suite.as_str()) {
+            continue;
+        }
+        let glob = format!("crates/rig-{suite}/**");
+        if !paths.contains(&glob) {
+            failures.push(format!(
+                "tests/integrations/{suite} has no {glob:?} entry in nightly.yaml's \
+                 pull_request paths, so a PR touching only crates/rig-{suite}/ merges with \
+                 zero runtime coverage of the code it changed — add the glob (or an exemption \
+                 here, with a reason)"
+            ));
+        }
+    }
+
+    // The mirror must hold in both directions: a glob whose suite is gone is
+    // dead weight that triggers 20+ minutes of full lane for nothing, and
+    // its presence suggests coverage that does not exist.
+    for path in &paths {
+        if let Some(name) = path
+            .strip_prefix("crates/rig-")
+            .and_then(|rest| rest.strip_suffix("/**"))
+            && !suites.contains(name)
+        {
+            failures.push(format!(
+                "nightly.yaml's paths list {path:?}, but tests/integrations/ has no {name} \
+                 suite — the glob triggers the full lane while covering nothing"
+            ));
+        }
+    }
+
+    for required in REQUIRED_PATHS {
+        if !paths.contains(*required) {
+            failures.push(format!(
+                "nightly.yaml's pull_request paths no longer include {required:?} — see \
+                 REQUIRED_PATHS in {} for why removing it reopens a closed coverage hole",
+                file!(),
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "nightly.yaml path filter drifted from tests/integrations/:\n{}",
+        failures.join("\n")
+    );
+}

--- a/tests/core/streaming_conformance_registry.rs
+++ b/tests/core/streaming_conformance_registry.rs
@@ -177,60 +177,40 @@ fn out_of_binary_families_name_a_live_ci_step() {
     let workflow = Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows/ci.yaml");
     let text = std::fs::read_to_string(&workflow).expect("ci.yaml should be readable");
 
-    // Structural, not substring: step names are matched only on
-    // non-comment lines whose content (after the `- ` list marker) begins
-    // with `name:` — a `# - name: …` comment cannot satisfy the check — and
-    // each step's selector/`-p` package list is looked for INSIDE that
-    // step's own block, not anywhere in the file. Two boundaries matter:
-    //
-    //   * the block ends at the next step OR at the job seam (any non-blank
-    //     line indented less than a step line, e.g. the next job's key) — a
-    //     job-final step must not absorb the following job's header;
-    //   * comment lines are dropped from the block BEFORE matching, so a
-    //     comment that merely *mentions* `--features bedrock` cannot keep
-    //     this check green after the actual flag is removed from the `run:`
-    //     command — that would be the paper-claim failure mode all over
-    //     again, hidden one level down.
-    let step_block = |step: &str| -> Option<String> {
-        let lines: Vec<&str> = text.lines().collect();
-        let is_step_line = |line: &str| {
-            let trimmed = line.trim_start();
-            !trimmed.starts_with('#')
-                && trimmed
-                    .strip_prefix("- ")
-                    .is_some_and(|rest| rest.trim_start().starts_with("name:"))
-        };
-        let step_indent = |line: &str| line.len() - line.trim_start().len();
-        let start = lines.iter().position(|line| {
-            is_step_line(line)
-                && line
-                    .split_once("name:")
-                    .is_some_and(|(_, value)| value.trim() == step)
-        })?;
-        let job_seam = step_indent(lines[start]);
-        let block: Vec<&str> = lines[start + 1..]
-            .iter()
-            .take_while(|line| {
-                // Comment lines pass the seam test unconditionally: comments
-                // are legal at any indentation, so a low-indent comment
-                // inside a step's span must not truncate the block (it is
-                // dropped by the filter below either way).
-                !is_step_line(line)
-                    && (line.trim().is_empty()
-                        || line.trim_start().starts_with('#')
-                        || step_indent(line) >= job_seam)
+    // A real YAML parse, not a line heuristic. Earlier versions of this
+    // check walked the raw text and accreted patches for each discovered
+    // hole — comments satisfying the match, job-final steps absorbing the
+    // next job's header, low-indent comments truncating blocks. Parsing
+    // `jobs.*.steps[]` gives exact step extents and comment-blindness by
+    // construction, and the selector/`-p` assertions run against the step's
+    // `run:` command alone — the only place where they are operative.
+    let doc: serde_yaml::Value = serde_yaml::from_str(&text).expect("ci.yaml should parse as YAML");
+    let jobs = doc
+        .get("jobs")
+        .and_then(serde_yaml::Value::as_mapping)
+        .expect("ci.yaml should have a jobs mapping");
+    let step_run = |step: &str| -> Option<String> {
+        jobs.values()
+            .filter_map(|job| job.get("steps").and_then(serde_yaml::Value::as_sequence))
+            .flatten()
+            .find(|candidate| {
+                candidate.get("name").and_then(serde_yaml::Value::as_str) == Some(step)
             })
-            .filter(|line| !line.trim_start().starts_with('#'))
-            .copied()
-            .collect();
-        Some(block.join("\n"))
+            .map(|found| {
+                found
+                    .get("run")
+                    .and_then(serde_yaml::Value::as_str)
+                    .unwrap_or_else(|| {
+                        panic!("CI step {step:?} exists but has no run: command to check")
+                    })
+                    .to_string()
+            })
     };
 
     for entry in OUT_OF_BINARY_FAMILIES {
-        let block = step_block(entry.ci_step).unwrap_or_else(|| {
+        let run = step_run(entry.ci_step).unwrap_or_else(|| {
             panic!(
-                "{} is annotated with CI step {:?}, which no longer exists in {} \
-                 (comments do not count)",
+                "{} is annotated with CI step {:?}, which no longer exists in {}",
                 entry.family,
                 entry.ci_step,
                 workflow.display(),
@@ -241,11 +221,11 @@ fn out_of_binary_families_name_a_live_ci_step() {
             // enabled in that step — not a spelling: `--all-features` enables
             // strictly more, so a step that broadens its sweep must not fail
             // this check for gaining coverage.
-            let satisfied = block.contains(selector)
-                || (selector.starts_with("--features ") && block.contains("--all-features"));
+            let satisfied = run.contains(selector)
+                || (selector.starts_with("--features ") && run.contains("--all-features"));
             assert!(
                 satisfied,
-                "{}'s CI step no longer carries the {:?} predicate INSIDE its own block, so its \
+                "{}'s CI step no longer carries the {:?} predicate in its run: command, so its \
                  binary is selected by nothing — a nextest filter matching zero tests still \
                  exits 0",
                 entry.family, selector,
@@ -253,7 +233,7 @@ fn out_of_binary_families_name_a_live_ci_step() {
         }
         if let Some(package) = entry.ci_package {
             assert!(
-                block.contains(&format!("-p {package}")),
+                run.contains(&format!("-p {package}")),
                 "{}'s CI step no longer compiles `-p {package}`, so its suite binary does not \
                  build there at all",
                 entry.family,

--- a/tests/integrations/mongodb.rs
+++ b/tests/integrations/mongodb.rs
@@ -38,6 +38,10 @@ struct Word {
 
 const VECTOR_SEARCH_INDEX_NAME: &str = "vector_index";
 const MONGODB_PORT: u16 = 27017;
+// Pinned like `pgvector:pg17` / `scylla:5.4`: a floating `latest` defeats
+// layer caching and lets a rerun silently test a different database version.
+const MONGODB_IMAGE: &str = "mongodb/mongodb-atlas-local";
+const MONGODB_TAG: &str = "8.0.5";
 const COLLECTION_NAME: &str = "words";
 const DATABASE_NAME: &str = "rig";
 const USERNAME: &str = "riguser";
@@ -152,9 +156,7 @@ async fn vector_search_test() {
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
 
     // Setup a local MongoDB Atlas container for testing. NOTE: docker service must be running.
-    // Pinned like `pgvector:pg17` / `scylla:5.4`: a floating `latest` defeats
-    // layer caching and lets a rerun silently test a different database version.
-    let container = GenericImage::new("mongodb/mongodb-atlas-local", "8.0.5")
+    let container = GenericImage::new(MONGODB_IMAGE, MONGODB_TAG)
         .with_exposed_port(MONGODB_PORT.tcp())
         .with_wait_for(WaitFor::Duration {
             length: std::time::Duration::from_secs(5),
@@ -291,9 +293,7 @@ async fn insert_documents_test() {
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
 
     // Setup MongoDB container
-    // Pinned like `pgvector:pg17` / `scylla:5.4`: a floating `latest` defeats
-    // layer caching and lets a rerun silently test a different database version.
-    let container = GenericImage::new("mongodb/mongodb-atlas-local", "8.0.5")
+    let container = GenericImage::new(MONGODB_IMAGE, MONGODB_TAG)
         .with_exposed_port(MONGODB_PORT.tcp())
         .with_wait_for(WaitFor::Duration {
             length: std::time::Duration::from_secs(5),


### PR DESCRIPTION
Follow-up to #2268, implementing its review's deferred items plus two policy changes.

## No provider API keys anywhere in CI

The five provider secrets (`OPENAI/ANTHROPIC/GEMINI/COHERE/PERPLEXITY_API_KEY`) are removed from both test lanes, and `secrets: inherit` is dropped from cd.yaml's gate calls. **This changes nothing CI executes**, verified by inspection of every consumer:

- the cassette suites read a real key only in **record** mode (`tests/common/cassettes.rs` — replay uses `DUMMY_API_KEY`), and recording is a local, human activity;
- every live test is `#[ignore]`-gated, and no workflow passes `--run-ignored`;
- the vector-store integration tests stub their embeddings with `api_key("TEST")`.

So the secrets were pure exfiltration surface in jobs that execute the entire test suite (including on same-repo PRs).

## No RUST_VERSION anywhere

The new `.github/actions/rust-setup` composite action resolves the toolchain channel from `rust-toolchain.toml` at run time, so the four hand-synced `RUST_VERSION` copies — and the partial-bump failure mode `check-toolchain-pin.sh` existed to police — are gone by construction. The channel is passed as an explicit input rather than letting `setup-rust-toolchain` discover the file natively, because native discovery would install the file's local-dev components (rust-analyzer, rust-src) and wasm target in every job. The pin script remains as the tripwire against reintroduced copies and inline literal `toolchain:` pins (both paths tested).

## Single-sourced setup (review finding: copy-drift surfaces)

The composite action also owns the cache-fingerprint env (`line-tables-only` debuginfo, `CARGO_INCREMENTAL=0`) — exported **before** rust-cache computes its key, so ci.yaml and nightly.yaml derive identical build fingerprints from one definition instead of a comment asking two copies to stay byte-identical — plus the optional sccache/nextest/protoc installs previously pasted into each job.

## Deferred guards from the #2268 review, now real

- The streaming-conformance registry's CI-step check parses ci.yaml with serde_yaml (`jobs.*.steps[]`) and asserts against the step's `run:` command alone, deleting the line-walking heuristic and its patch history. Mutation-verified: dropping `--features bedrock` from the run line fails the check; broadening to `--all-features` passes.
- New `tests/core/nightly_paths_registry.rs` binds nightly.yaml's `pull_request.paths` to `tests/integrations/` **in both directions** (mutation-verified), with an allowlisted exemption for bedrock (runs on the PR gate's `--features bedrock` sweep) and a `REQUIRED_PATHS` pin on the entries whose removal reopens closed coverage holes.
- Concurrency groups key on the PR number instead of `head_ref`, so two forks PRing from identically-named branches no longer cancel each other's runs.
- The duplicated `mongodb/mongodb-atlas-local:8.0.5` literal is hoisted to consts.

## Deliberately not done

- **protoc via a prebuilt-binary installer**: the lance build scripts need a system protoc with its well-known-type includes, and a rust-cache hit would mask a broken install until the first cold rebuild — the exact latent-break shape the #2268 review caught once already. Gain would be ~10s.
- **Per-test retry policy in nextest.toml** (replacing blanket `--retries 2`): a behavioral change to retry semantics that deserves its own PR.

## Notes for reviewers

- First run on this branch pays a one-time cold rebuild (the env now enters via `GITHUB_ENV`, which shifts rust-cache keys once); subsequent runs are warm.
- cd.yaml's composite-action use is exercised here only indirectly (ci.yaml/nightly.yaml use the same action on this PR); its first real run is the post-merge push to main.