### PR TITLE
ci: run rig-derive's test suite, which ran in no job at all

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -384,6 +384,43 @@ jobs:
       - name: Test out-of-facade streaming conformance and structural guards
         run: cargo nextest run --locked -p rig-core -p rig-candle -p rig-gemini-grpc --all-features -E 'binary(streaming_conformance) + binary(streaming_conformance_websocket) + binary(driver_adoption)'
 
+  # rig-derive's own test suite — 43 tests across 12 binaries, including 20
+  # trybuild cases and the dependency-rename fixtures. Until this job existed
+  # none of them ran anywhere in CI: rig-derive is deliberately outside
+  # `default-members` (see the note in the root Cargo.toml), so the `test`
+  # job's sweep never selects it, and no step named `-p rig-derive`. The
+  # workspace manifest asserted the coverage came from the `macro_hygiene`
+  # step "and rig-derive's own trybuild tests" — the first is real, the
+  # second ran nowhere, and that comment is corrected alongside this job.
+  #
+  # A non-compiling `tests/fixtures/*` sits on a green PR under that gap:
+  # the fixtures are separate cargo projects that only build when the test
+  # executes, so neither the workspace build nor `clippy --all-targets`
+  # touches them.
+  #
+  # Its own job rather than a step in `test-guards`: that job documents at
+  # length why it needs no protoc, and the fixtures shell out to a nested
+  # `cargo check` over the rig-agent and facade dependency graphs — a
+  # different build shape that should not silently invalidate that
+  # reasoning. It runs in parallel and finishes well inside the `test` job's
+  # critical path, so the wall-clock cost of the gate is zero.
+  #
+  # `cargo test`, not nextest: the suite is trybuild plus subprocess-driven
+  # fixture checks, and the sibling `macro_hygiene` step uses plain
+  # `cargo test` for the same reason.
+  test-derive:
+    name: stable / test rig-derive
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Rust stable
+        uses: ./.github/actions/rust-setup
+
+      - name: Test rig-derive
+        run: cargo test --locked -p rig-derive
+
   # `cargo nextest` (used by the `test` job) does NOT run doctests, and the
   # `doc` job only builds documentation — so without this job nothing executes
   # the `///` code examples and a broken doctest can sail through CI.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,13 @@ members = [
 # opt-in.
 # rig-derive is deliberately absent: a proc-macro crate's test binary links
 # libstd dynamically, which breaks under toolchains installed without the
-# dylib component; its macro suite runs via the dedicated
-# `cargo test -p rig-core --test macro_hygiene` CI step and rig-derive's own
-# trybuild tests.
+# dylib component. Absent from the default set is not absent from CI — its
+# own suite (trybuild cases and the dependency-rename fixtures) runs in the
+# `stable / test rig-derive` job, which names `-p rig-derive` explicitly, and
+# the macro-hygiene consumer runs in the `test guards` job's
+# `cargo test -p rig-core --test macro_hygiene` step. Both are required for
+# this exclusion to stay honest: until the first existed, every test in
+# rig-derive ran nowhere.
 default-members = [
     ".",
     "crates/rig-core",


### PR DESCRIPTION
`rig-derive`'s entire test suite — **43 tests across 12 binaries**, including 20 trybuild cases and the dependency-rename fixtures — executes in **no CI job**.

`rig-derive` sits outside `default-members`, so the `test` job's sweep never selects it, and grepping the workflows finds no step naming `-p rig-derive`. Nothing runs it.

## Why this is invisible rather than merely missing

The rename fixtures under `crates/rig-derive/tests/fixtures/` are **separate cargo projects** (each has its own `[workspace]`) that are only compiled when the test executes and shells out to `cargo check`. So a fixture that does not compile is untouched by the workspace build *and* by `clippy --all-features --all-targets`. A PR carrying a broken one shows a fully green gate.

That is not hypothetical — it is how this gap was found. A PR in review had substituted the fixture's sentinel line to `Option<agent_runtime::core::Vec<u8>>`, which cannot resolve (`Vec` reaches you through the std prelude, which injects it into lexical scope, not into a module's item namespace, so a qualified path through a glob re-export fails with E0425). `dependency_rename::generated_paths_follow_cargo_dependency_renames` would fail on it. CI was green.

## The manifest claimed this was covered

The root `Cargo.toml` justifies the `default-members` exclusion by saying the macro suite runs "via the dedicated `cargo test -p rig-core --test macro_hygiene` CI step **and rig-derive's own trybuild tests**." The first half is true. The second described something that ran nowhere. The comment is corrected to state what actually runs, and that both steps are load-bearing for the exclusion to stay honest.

## Design notes

**A dedicated job, not a step in `test guards`.** That job documents at length why it deliberately needs no protoc, and these fixtures shell out to a nested `cargo check` over the rig-agent and facade dependency graphs — a different build shape that should not silently invalidate that reasoning. I verified the new job needs no protoc either: `cargo tree --edges normal` over the facade fixture finds no lance/prost/tonic.

**Zero wall-clock cost to the gate.** It runs in parallel and finishes inside the `test` job's critical path.

**`cargo test`, not nextest** — the suite is trybuild plus subprocess-driven fixture checks, matching the sibling `macro_hygiene` step. (The `default-members` exclusion itself is untouched; the reason given for it — proc-macro test binaries linking libstd dynamically — is unrelated to running the crate's tests via an explicit `-p`.)

## Verification

`cargo test -p rig-derive` on this base: **exit 0, 43 passing tests across 12 suites**. This adds coverage without adding red.

Deliberately scoped to the CI gap alone — no test or fixture content is changed, so it can merge independently of any in-flight work.