### PR TITLE
fix(agent): restore the hook-free AgentRun integration surface

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1389,6 +1389,52 @@ carried:
   "Persisted histories" bullet in the tool-call identity section above for
   what a legacy `call_id` key now means and how to migrate the JSON by hand.
 
+### The hook-free `AgentRun` integration surface is restored
+
+0.41 made every `Agent` field private and removed the raw
+`Completion`/`StreamingCompletion` implementations (see "[`AgentRunner` is the
+only execution path](#6-agentrunner-is-the-only-execution-path)"). That
+orphaned callers who hand-drive the public sans-IO `AgentRun` state machine:
+they could no longer use an already-built `Agent` as their manual loop's
+configuration and tool source. This release restores exactly that capability —
+`AgentRunner` remains the only batteries-included runtime, and no second
+coordinator exists.
+
+```text
+Normal configured execution:      agent.runner(prompt).max_turns(n).run().await
+Manual/custom AgentRun loop:      agent.new_run(...) + agent.prepare_completion_request(...)
+                                  + prepared_turn.model_turn(...) / .execute_call(...)
+After cross-process resume:       rebuilt_agent.tool_server_handle()
+Already-own-the-registry:         builder.tool_server_handle(handle) as today
+```
+
+- `Agent::new_run(prompt)` returns a plain `AgentRun` seeded with the agent's
+  durable run policy (default turn budget, tool choice, structured-output
+  validation), the same way `Agent::runner` seeds its internal run.
+- `Agent::prepare_completion_request(prompt, history, &mut run)` prepares one
+  fully configured provider request straight from an
+  `AgentRunStep::CallModel` step's fields. It validates impossible tool
+  choices before any provider IO, and keeps the run's structured-output-tool
+  expectation paired with what the request actually advertises.
+- The returned `PreparedAgentRequest` splits into the sendable request and a
+  `PreparedAgentTurn`, whose `model_turn(response)` supplies the exact
+  executable/allowed tool-name sets the request carried and whose
+  `execute_call(...)` dispatches through the exact implementation snapshot
+  whose definitions the provider saw. Both are in-process values for one
+  issued request — not serializable, no durability beyond the `AgentRun`.
+- `Agent::tool_server_handle()` returns an owned clone of the agent's live
+  registry handle — the capability to use after a cross-process resume, when
+  the agent is rebuilt and the prepared turn is gone.
+
+This entire surface is hook-free: no hooks, memory, telemetry, concurrency
+policy, or classic invalid-call policy runs — including passive dynamic
+context, which exists only as a hook. `AgentRun::new()` remains for
+intentionally custom runs; such callers own keeping run policy consistent with
+the requests they prepare. `DynamicTool` remains the replacement for
+`Box<dyn ToolDyn>`; `ToolDyn` is not restored. See
+`examples/agent_run_stepping` for a complete manual loop with a
+cross-process resume.
+
 ---
 
 ## 0.40 → 0.41

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -2,7 +2,9 @@ use super::hook::{HookStack, RequestPatch};
 use super::model::ModelHandle;
 use super::prompt_request::{self, PromptRequest};
 use super::run::{AgentRun, ModelTurn, OutputMode, PendingToolCall};
-use super::runner::AgentRunner;
+use super::runner::{
+    AgentRunner, DEFAULT_INVALID_TOOL_CALL_RETRIES, DEFAULT_MAX_TURNS, build_agent_run,
+};
 use crate::{
     agent::prompt_request::{streaming::StreamingPromptRequest, tool_result_output},
     completion::{
@@ -12,7 +14,7 @@ use crate::{
     json_utils,
     streaming::{StreamingChat, StreamingPrompt},
     tool::{
-        ToolContext, ToolDispatch,
+        ToolContext,
         server::{ToolRegistrySnapshot, ToolServerError, ToolServerHandle},
     },
 };
@@ -222,28 +224,58 @@ pub(crate) fn allowed_tool_names_for_choice(
     Ok(allowed)
 }
 
+/// Inputs to [`build_prepared_completion_request`], as named fields.
+///
+/// The parameter list carries several adjacent same-typed values (three
+/// `Option<&str>`, two `bool`s); positional passing would let a call site
+/// silently transpose them (e.g. `committed_output_tool` with
+/// `output_tool_description`, breaking Tool-mode pinning) with no compiler
+/// signal. Named fields make every call site self-checking.
+pub(crate) struct PreparedRequestInputs<'a> {
+    pub(crate) model: &'a ModelHandle,
+    pub(crate) prompt: Message,
+    pub(crate) chat_history: &'a [Message],
+    pub(crate) preamble: Option<&'a str>,
+    pub(crate) static_context: &'a [Document],
+    pub(crate) temperature: Option<f64>,
+    pub(crate) max_tokens: Option<u64>,
+    pub(crate) additional_params: Option<&'a serde_json::Value>,
+    pub(crate) record_telemetry_content: bool,
+    pub(crate) tool_choice: Option<&'a ToolChoice>,
+    pub(crate) tool_server_handle: &'a ToolServerHandle,
+    pub(crate) output_schema: Option<&'a schemars::Schema>,
+    pub(crate) output_mode: &'a OutputMode,
+    /// The run's already-committed Tool-mode output-tool name, if any (#1928).
+    pub(crate) committed_output_tool: Option<&'a str>,
+    pub(crate) output_tool_description: Option<&'a str>,
+    pub(crate) augment_output_preamble: bool,
+    pub(crate) request_patch: Option<&'a RequestPatch>,
+}
+
 /// Helper function to build a completion request from agent components while
 /// preserving the executable Rig tool names sent to the provider.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn build_prepared_completion_request(
-    model: &ModelHandle,
-    prompt: Message,
-    chat_history: &[Message],
-    preamble: Option<&str>,
-    static_context: &[Document],
-    temperature: Option<f64>,
-    max_tokens: Option<u64>,
-    additional_params: Option<&serde_json::Value>,
-    record_telemetry_content: bool,
-    tool_choice: Option<&ToolChoice>,
-    tool_server_handle: &ToolServerHandle,
-    output_schema: Option<&schemars::Schema>,
-    output_mode: &OutputMode,
-    committed_output_tool: Option<&str>,
-    output_tool_description: Option<&str>,
-    augment_output_preamble: bool,
-    request_patch: Option<&RequestPatch>,
+    inputs: PreparedRequestInputs<'_>,
 ) -> Result<PreparedCompletionRequest, CompletionError> {
+    let PreparedRequestInputs {
+        model,
+        prompt,
+        chat_history,
+        preamble,
+        static_context,
+        temperature,
+        max_tokens,
+        additional_params,
+        record_telemetry_content,
+        tool_choice,
+        tool_server_handle,
+        output_schema,
+        output_mode,
+        committed_output_tool,
+        output_tool_description,
+        augment_output_preamble,
+        request_patch,
+    } = inputs;
     // Apply a per-turn request patch (the merged patch from every `CompletionCall`
     // hook): each set field replaces the agent's configured value for this turn,
     // unset fields inherit it, `additional_params` is shallow-merged, and
@@ -647,21 +679,19 @@ impl PreparedAgentTurn {
         call: &PendingToolCall,
         context: &mut ToolContext,
     ) -> UserContent {
-        context.clear_dispatch_result();
         if let Some(result) = &call.preresolved_result {
+            // Same context hygiene as a real dispatch: stale result metadata
+            // from a previous dispatch must not survive a pre-resolved call.
+            context.clear_dispatch_result();
             return result.clone();
         }
 
         let tool_call = &call.tool_call;
         let args = json_utils::serialize_json_value(&tool_call.function.arguments);
-        let ToolDispatch {
-            result,
-            context: dispatch_context,
-        } = self
+        let result = self
             .tool_snapshot
-            .dispatch(&tool_call.function.name, &args, context)
+            .execute(&tool_call.function.name, &args, context)
             .await;
-        context.accept_dispatch_result(dispatch_context);
 
         tool_result_output(
             tool_call.id.clone(),
@@ -856,10 +886,19 @@ impl Agent {
     /// callers own keeping the run's policy (tool choice, output validation,
     /// output-tool name) consistent with the requests they prepare.
     pub fn new_run(&self, prompt: impl Into<Message>) -> AgentRun {
-        // Seed through the runner's own construction path so the two can never
-        // drift: `AgentRunner::from_agent` derives the policy defaults from the
-        // agent, and `build_run` is the single run-construction site.
-        AgentRunner::from_agent(self, prompt).build_run(None)
+        // Same policy defaults as `AgentRunner::from_agent` (shared constants,
+        // so the two cannot drift) and the same single construction site
+        // (`build_agent_run`) — without materializing a throwaway runner,
+        // which would deep-clone static context, preamble, and params only to
+        // discard them.
+        build_agent_run(
+            prompt.into(),
+            self.default_max_turns.unwrap_or(DEFAULT_MAX_TURNS),
+            DEFAULT_INVALID_TOOL_CALL_RETRIES,
+            self.output_schema.as_ref(),
+            None,
+            self.tool_choice.clone(),
+        )
     }
 
     /// Prepare one fully configured, hook-free provider request from this
@@ -901,25 +940,25 @@ impl Agent {
         run: &mut AgentRun,
     ) -> Result<PreparedAgentRequest, CompletionError> {
         let committed_output_tool = run.output_tool_name().map(str::to_owned);
-        let prepared = build_prepared_completion_request(
-            &self.model,
-            prompt.into(),
-            history,
-            self.preamble.as_deref(),
-            &self.static_context,
-            self.temperature,
-            self.max_tokens,
-            self.additional_params.as_ref(),
-            self.record_telemetry_content,
-            self.tool_choice.as_ref(),
-            &self.tool_server_handle,
-            self.output_schema.as_ref(),
-            &self.output_mode,
-            committed_output_tool.as_deref(),
-            None,
-            true,
-            None,
-        )
+        let prepared = build_prepared_completion_request(PreparedRequestInputs {
+            model: &self.model,
+            prompt: prompt.into(),
+            chat_history: history,
+            preamble: self.preamble.as_deref(),
+            static_context: &self.static_context,
+            temperature: self.temperature,
+            max_tokens: self.max_tokens,
+            additional_params: self.additional_params.as_ref(),
+            record_telemetry_content: self.record_telemetry_content,
+            tool_choice: self.tool_choice.as_ref(),
+            tool_server_handle: &self.tool_server_handle,
+            output_schema: self.output_schema.as_ref(),
+            output_mode: &self.output_mode,
+            committed_output_tool: committed_output_tool.as_deref(),
+            output_tool_description: None,
+            augment_output_preamble: true,
+            request_patch: None,
+        })
         .await?;
         run.set_output_tool_name(prepared.output_tool_name.clone());
 

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -1,19 +1,25 @@
 use super::hook::{HookStack, RequestPatch};
 use super::model::ModelHandle;
 use super::prompt_request::{self, PromptRequest};
-use super::run::OutputMode;
+use super::run::{AgentRun, ModelTurn, OutputMode, PendingToolCall};
 use super::runner::AgentRunner;
 use crate::{
-    agent::prompt_request::streaming::StreamingPromptRequest,
+    agent::prompt_request::{streaming::StreamingPromptRequest, tool_result_output},
     completion::{
-        Chat, CompletionError, CompletionModel, CompletionRequestBuilder, Document, Message,
-        Prompt, PromptError, ToolDefinition, TypedPrompt,
+        Chat, CompletionError, CompletionModel, CompletionRequestBuilder, CompletionResponse,
+        Document, Message, Prompt, PromptError, ToolDefinition, TypedPrompt,
     },
     json_utils,
     streaming::{StreamingChat, StreamingPrompt},
-    tool::server::{ToolRegistrySnapshot, ToolServerError, ToolServerHandle},
+    tool::{
+        ToolContext, ToolDispatch,
+        server::{ToolRegistrySnapshot, ToolServerError, ToolServerHandle},
+    },
 };
-use rig_core::{message::ToolChoice, wasm_compat::WasmCompatSend};
+use rig_core::{
+    message::{ToolChoice, UserContent},
+    wasm_compat::WasmCompatSend,
+};
 use std::{collections::BTreeSet, sync::Arc};
 
 use super::UNKNOWN_AGENT_NAME;
@@ -525,6 +531,147 @@ pub(crate) async fn build_prepared_completion_request(
     })
 }
 
+/// One fully configured, hook-free provider request prepared from an
+/// [`Agent`], paired with the exact turn metadata the request was built with.
+///
+/// Produced by [`Agent::prepare_completion_request`] for callers manually
+/// driving the sans-IO [`AgentRun`] state machine. Split it with
+/// [`into_parts`](Self::into_parts): the request half is sent (or built and
+/// sent through a custom transport), while the [`PreparedAgentTurn`] half must
+/// outlive the send so the response and the turn's tool calls can be paired
+/// with the metadata and implementations this exact request advertised.
+///
+/// The pair is in-process state for one issued request. It is deliberately not
+/// serializable and claims no durability: the durable state of a manual loop is
+/// the [`AgentRun`] itself. After a cross-process resume, rebuild the agent and
+/// dispatch pending calls through [`Agent::tool_server_handle`] instead.
+pub struct PreparedAgentRequest {
+    builder: CompletionRequestBuilder<ModelHandle>,
+    turn: PreparedAgentTurn,
+}
+
+impl std::fmt::Debug for PreparedAgentRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PreparedAgentRequest")
+            .field("turn", &self.turn)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PreparedAgentRequest {
+    /// Split into the sendable request builder and the turn pairing.
+    ///
+    /// A consuming split, because sending consumes the builder while the turn
+    /// must outlive the send. The returned builder is fully configured from the
+    /// agent's baseline; send it as-is with
+    /// [`send`](CompletionRequestBuilder::send) (or
+    /// [`build`](CompletionRequestBuilder::build) it for a custom transport).
+    /// Modifying it further is caller-owned risk: the paired
+    /// [`PreparedAgentTurn`] keeps describing the request *as prepared*.
+    pub fn into_parts(self) -> (CompletionRequestBuilder<ModelHandle>, PreparedAgentTurn) {
+        (self.builder, self.turn)
+    }
+}
+
+/// The turn-pairing half of a [`PreparedAgentRequest`]: the executable and
+/// allowed tool-name sets captured during preparation, plus the exact registry
+/// snapshot whose definitions were sent to the provider.
+///
+/// It owns exactly two operations — [`model_turn`](Self::model_turn) to convert
+/// the provider's response into a [`ModelTurn`] carrying the captured name
+/// sets, and [`execute_call`](Self::execute_call) to execute the resulting
+/// [`AgentRunStep::CallTools`](super::run::AgentRunStep::CallTools) calls
+/// through the pinned implementations. Tool registrations changed *after*
+/// preparation are invisible to this turn: a replaced implementation still
+/// dispatches to the one whose definition was sent, and a newly registered tool
+/// is rejected even though the live registry has it.
+///
+/// In-process only, for the one request it was prepared with. It is not
+/// serializable; after a cross-process resume use the rebuilt agent's live
+/// [`Agent::tool_server_handle`], which follows current registry state instead.
+pub struct PreparedAgentTurn {
+    /// Exact implementations behind this turn's provider definitions.
+    tool_snapshot: Arc<ToolRegistrySnapshot>,
+    executable_tool_names: BTreeSet<String>,
+    allowed_tool_names: BTreeSet<String>,
+}
+
+impl std::fmt::Debug for PreparedAgentTurn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PreparedAgentTurn")
+            .field("executable_tool_names", &self.executable_tool_names)
+            .field("allowed_tool_names", &self.allowed_tool_names)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PreparedAgentTurn {
+    /// Convert the provider's response into the [`ModelTurn`] to feed
+    /// [`AgentRun::model_response`], supplying the executable and allowed
+    /// tool-name sets captured when the request was prepared.
+    ///
+    /// This removes the manual driver's name-set hazard: the caller never
+    /// re-derives either set from the live registry or orders
+    /// [`ModelTurn::new`]'s two same-typed set arguments by hand.
+    pub fn model_turn(&self, response: CompletionResponse) -> ModelTurn {
+        ModelTurn::new(
+            response.message_id,
+            response.choice,
+            response.usage,
+            self.executable_tool_names.clone(),
+            self.allowed_tool_names.clone(),
+        )
+    }
+
+    /// Execute one pending tool call from this turn's
+    /// [`AgentRunStep::CallTools`](super::run::AgentRunStep::CallTools) step,
+    /// returning the correlated tool-result content for
+    /// [`AgentRun::tool_results`].
+    ///
+    /// A call carrying a
+    /// [`preresolved_result`](PendingToolCall::preresolved_result) (from
+    /// invalid tool-call recovery) is returned unchanged without executing or
+    /// invoking anything. Every other call dispatches through the registry
+    /// snapshot pinned at preparation, never the live registry: a name outside
+    /// the prepared turn's executable set — including a tool registered after
+    /// preparation — is rejected with a not-found tool result rather than
+    /// executed.
+    ///
+    /// Like every dispatch surface, this clears result metadata left in
+    /// `context` by a previous dispatch before resolving the call (including
+    /// on the pre-resolved path) and publishes the new dispatch's result
+    /// metadata back into it. It runs no hooks, applies no concurrency policy,
+    /// and records no telemetry.
+    pub async fn execute_call(
+        &self,
+        call: &PendingToolCall,
+        context: &mut ToolContext,
+    ) -> UserContent {
+        context.clear_dispatch_result();
+        if let Some(result) = &call.preresolved_result {
+            return result.clone();
+        }
+
+        let tool_call = &call.tool_call;
+        let args = json_utils::serialize_json_value(&tool_call.function.arguments);
+        let ToolDispatch {
+            result,
+            context: dispatch_context,
+        } = self
+            .tool_snapshot
+            .dispatch(&tool_call.function.name, &args, context)
+            .await;
+        context.accept_dispatch_result(dispatch_context);
+
+        tool_result_output(
+            tool_call.id.clone(),
+            tool_call.provider.clone(),
+            tool_call.function.name.clone(),
+            result.output().clone(),
+        )
+    }
+}
+
 /// Struct representing an LLM agent. An agent is an LLM model combined with a preamble
 /// (i.e.: system prompt) and a static set of context documents and tools.
 /// All context documents and tools are always provided to the agent when prompted.
@@ -667,6 +814,130 @@ impl Agent {
         prompt: Option<String>,
     ) -> Result<Vec<ToolDefinition>, ToolServerError> {
         self.tool_server_handle.get_tool_defs(prompt).await
+    }
+
+    /// Returns an owned clone of the live handle to the tool registry this
+    /// agent's tools (from `.tool()` / `.dynamic_tools()` / a shared
+    /// [`ToolServer`](crate::tool::server::ToolServer)) are registered in.
+    ///
+    /// Most callers want [`Agent::runner`], which executes tools with hooks,
+    /// memory, telemetry, and the classic concurrency and invalid-call
+    /// policies. Dispatching directly through this handle runs none of those.
+    ///
+    /// The handle is **live**: it observes registry changes made after this
+    /// call (registrations, replacements, removals). That makes it the
+    /// capability available after a cross-process resume — rebuild the agent
+    /// and dispatch an [`AgentRun`]'s pending tool calls through the rebuilt
+    /// registry under live-registry semantics. In contrast, the prepared turn
+    /// from [`Agent::prepare_completion_request`] **pins** the definitions and
+    /// implementations advertised for one issued request and never sees later
+    /// registry changes.
+    pub fn tool_server_handle(&self) -> ToolServerHandle {
+        self.tool_server_handle.clone()
+    }
+
+    /// Create a sans-IO [`AgentRun`] seeded with this agent's durable run
+    /// policy: the default turn budget, tool choice, and structured-output
+    /// validation schema, exactly as [`Agent::runner`] would seed its internal
+    /// run.
+    ///
+    /// This is construction, not execution: the returned run holds no model,
+    /// tools, hooks, memory, or telemetry, and the caller drives it by hand
+    /// (see the [`run`](super::run) module docs). Because it is a plain
+    /// [`AgentRun`], the run's builder methods keep working on it, e.g.
+    /// `agent.new_run(prompt).max_turns(10)`.
+    ///
+    /// Pair it with [`Agent::prepare_completion_request`], which prepares each
+    /// model call under the same policy and commits the run's structured-output
+    /// tool expectation. Overriding seeded policy afterwards (for example
+    /// [`AgentRun::with_tool_choice`]) desynchronizes the run from the
+    /// requests that method prepares, which always carry the agent's baseline.
+    /// [`AgentRun::new`] remains available for intentionally custom runs; such
+    /// callers own keeping the run's policy (tool choice, output validation,
+    /// output-tool name) consistent with the requests they prepare.
+    pub fn new_run(&self, prompt: impl Into<Message>) -> AgentRun {
+        // Seed through the runner's own construction path so the two can never
+        // drift: `AgentRunner::from_agent` derives the policy defaults from the
+        // agent, and `build_run` is the single run-construction site.
+        AgentRunner::from_agent(self, prompt).build_run(None)
+    }
+
+    /// Prepare one fully configured, hook-free provider request from this
+    /// agent's baseline configuration, for a caller manually driving an
+    /// [`AgentRun`].
+    ///
+    /// Feed it directly from an
+    /// [`AgentRunStep::CallModel`](super::run::AgentRunStep::CallModel) step:
+    /// pass that step's `prompt` and `history` unchanged, plus the run being
+    /// driven. The request carries the agent's preamble, static context,
+    /// sampling parameters, additional provider parameters, resolved tool
+    /// definitions, tool choice, and structured-output constraint. An
+    /// impossible tool choice ([`ToolChoice::Required`] with no advertised
+    /// tool, or [`ToolChoice::Specific`] naming an unknown tool) fails here,
+    /// before any provider IO.
+    ///
+    /// `run` keeps request preparation and run policy paired for structured
+    /// output: preparation reads the run's committed output-tool name so a run
+    /// that committed to Tool-mode output on an earlier turn cannot flip back
+    /// to native later, and commits the name this request advertises back onto
+    /// the run — exactly as the classic driver does — so the run's output-tool
+    /// interception matches what the model was told. Nothing else about the
+    /// run is read or advanced. The request always carries the agent's
+    /// *baseline* tool choice: overriding the seeded policy on the run (e.g.
+    /// [`AgentRun::with_tool_choice`]) makes the run classify calls under a
+    /// policy this request never advertised.
+    ///
+    /// **Hook-free means hook-free.** This runs no hooks, appends no memory,
+    /// opens no classic lifecycle or telemetry spans, and applies no tool
+    /// concurrency or invalid-call policy. Behavior that exists only as a hook
+    /// — including passive dynamic context from
+    /// [`AgentBuilder::dynamic_context`](crate::agent::AgentBuilder::dynamic_context)
+    /// — simply does not happen on this surface. It also does not send the
+    /// request, execute tools, or create or advance the run.
+    pub async fn prepare_completion_request(
+        &self,
+        prompt: impl Into<Message>,
+        history: &[Message],
+        run: &mut AgentRun,
+    ) -> Result<PreparedAgentRequest, CompletionError> {
+        let committed_output_tool = run.output_tool_name().map(str::to_owned);
+        let prepared = build_prepared_completion_request(
+            &self.model,
+            prompt.into(),
+            history,
+            self.preamble.as_deref(),
+            &self.static_context,
+            self.temperature,
+            self.max_tokens,
+            self.additional_params.as_ref(),
+            self.record_telemetry_content,
+            self.tool_choice.as_ref(),
+            &self.tool_server_handle,
+            self.output_schema.as_ref(),
+            &self.output_mode,
+            committed_output_tool.as_deref(),
+            None,
+            true,
+            None,
+        )
+        .await?;
+        run.set_output_tool_name(prepared.output_tool_name.clone());
+
+        let PreparedCompletionRequest {
+            builder,
+            tool_snapshot,
+            executable_tool_names,
+            allowed_tool_names,
+            output_tool_name: _,
+        } = prepared;
+        Ok(PreparedAgentRequest {
+            builder,
+            turn: PreparedAgentTurn {
+                tool_snapshot,
+                executable_tool_names,
+                allowed_tool_names,
+            },
+        })
     }
 }
 
@@ -1165,5 +1436,804 @@ mod tests {
 
         let executable = tool_names(&["final_result", "final_result_1"]);
         assert_eq!(pick_output_tool_name(&executable), "final_result_2");
+    }
+}
+
+/// Tests for the minimal configured-`AgentRun` integration surface:
+/// [`Agent::tool_server_handle`], [`Agent::new_run`],
+/// [`Agent::prepare_completion_request`], [`PreparedAgentRequest`], and
+/// [`PreparedAgentTurn`].
+#[cfg(test)]
+mod agent_run_surface_tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::{
+        agent::{
+            AgentBuilder,
+            hook::InvalidToolCallAction,
+            hook::{AgentHook, CompletionCall, CompletionCallAction, HookContext},
+            run::{AgentRunStep, ModelTurnOutcome},
+        },
+        test_utils::{MockAddTool, MockCompletionModel, MockSubtractTool, MockTurn},
+        tool::{DynamicTool, Tool, ToolExecutionError, ToolOutput},
+    };
+    use rig_core::message::{ToolCall, ToolFunction, ToolResultContent};
+
+    /// Concatenated literal text of a tool-result `UserContent`.
+    fn result_text(content: &UserContent) -> String {
+        let UserContent::ToolResult(result) = content else {
+            panic!("expected a tool result, got {content:?}");
+        };
+        result
+            .content
+            .iter()
+            .filter_map(ToolResultContent::as_text)
+            .collect()
+    }
+
+    /// Advance a fresh run to its first `CallModel` step.
+    fn first_call_model(run: &mut AgentRun) -> (Message, Vec<Message>) {
+        match run.next_step().expect("first step") {
+            AgentRunStep::CallModel {
+                prompt, history, ..
+            } => (prompt, history),
+            other => panic!("expected CallModel, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_server_handle_sees_and_executes_agent_built_tools() {
+        let agent = AgentBuilder::new(MockCompletionModel::text("done"))
+            .tool(MockAddTool)
+            .build();
+
+        let handle = agent.tool_server_handle();
+        let defs = handle.get_tool_defs(None).await.expect("tool definitions");
+        assert!(defs.iter().any(|def| def.name == "add"));
+
+        let mut context = ToolContext::new();
+        let result = handle
+            .execute("add", r#"{"x":2,"y":3}"#, &mut context)
+            .await;
+        assert_eq!(result.output().render(), "5");
+    }
+
+    #[tokio::test]
+    async fn tool_server_handle_sees_and_executes_dynamic_tools() {
+        let echo = DynamicTool::new(
+            "echo",
+            "Echoes its arguments",
+            json!({"type": "object", "properties": {}}),
+            |_context, args| Box::pin(async move { Ok(ToolOutput::json(args)) }),
+        );
+        let agent = AgentBuilder::new(MockCompletionModel::text("done"))
+            .dynamic_tools(vec![echo])
+            .build();
+
+        let handle = agent.tool_server_handle();
+        let defs = handle.get_tool_defs(None).await.expect("tool definitions");
+        assert!(defs.iter().any(|def| def.name == "echo"));
+
+        let mut context = ToolContext::new();
+        let result = handle
+            .execute("echo", r#"{"hello":"world"}"#, &mut context)
+            .await;
+        assert_eq!(result.output().render(), r#"{"hello":"world"}"#);
+    }
+
+    #[tokio::test]
+    async fn prepared_request_carries_the_agent_baseline() {
+        let agent = AgentBuilder::new(MockCompletionModel::text("unused"))
+            .preamble("You are the baseline preamble")
+            .context("baseline context document")
+            .temperature(0.3)
+            .max_tokens(77)
+            .additional_params(json!({"top_p": 0.5}))
+            .tool_choice(ToolChoice::Auto)
+            .tool(MockAddTool)
+            .build();
+
+        let mut run = agent.new_run("go");
+        let (prompt, history) = first_call_model(&mut run);
+        let (builder, _turn) = agent
+            .prepare_completion_request(prompt, &history, &mut run)
+            .await
+            .expect("preparation succeeds")
+            .into_parts();
+        let request = builder.build();
+
+        assert!(request.chat_history.iter().any(|message| matches!(
+            message,
+            Message::System { content } if content == "You are the baseline preamble"
+        )));
+        assert!(
+            request
+                .documents
+                .iter()
+                .any(|document| document.text == "baseline context document")
+        );
+        assert_eq!(request.temperature, Some(0.3));
+        assert_eq!(request.max_tokens, Some(77));
+        assert_eq!(request.additional_params, Some(json!({"top_p": 0.5})));
+        assert_eq!(request.tool_choice, Some(ToolChoice::Auto));
+        assert!(request.tools.iter().any(|tool| tool.name == "add"));
+    }
+
+    #[tokio::test]
+    async fn model_turn_hands_off_the_exact_name_sets() {
+        // Two executable tools plus a restrictive Specific tool choice. The
+        // test never reconstructs either name set by hand: the sets reach the
+        // run exclusively through `PreparedAgentTurn::model_turn`.
+        let build_agent = |model: MockCompletionModel| {
+            AgentBuilder::new(model)
+                .tool(MockAddTool)
+                .tool(MockSubtractTool)
+                .tool_choice(ToolChoice::Specific {
+                    function_names: vec!["add".to_string()],
+                })
+                .build()
+        };
+
+        // An allowed call ("add") is accepted and reaches CallTools.
+        let model = MockCompletionModel::from_turns([MockTurn::tool_call(
+            "call-1",
+            "add",
+            json!({"x": 1, "y": 2}),
+        )]);
+        let agent = build_agent(model);
+        let mut run = agent.new_run("go").max_turns(2);
+        let (prompt, history) = first_call_model(&mut run);
+        let (builder, turn) = agent
+            .prepare_completion_request(prompt, &history, &mut run)
+            .await
+            .expect("preparation succeeds")
+            .into_parts();
+        let response = builder.send().await.expect("mock send");
+        let outcome = run
+            .model_response(turn.model_turn(response))
+            .expect("model response accepted");
+        assert!(matches!(outcome, ModelTurnOutcome::Continue { .. }));
+        match run.next_step().expect("next step") {
+            AgentRunStep::CallTools { calls } => {
+                assert_eq!(calls.len(), 1);
+                assert_eq!(calls[0].tool_call.function.name, "add");
+            }
+            other => panic!("expected CallTools, got {other:?}"),
+        }
+
+        // A disallowed call ("subtract" — executable but outside the Specific
+        // allow-list) is flagged for resolution.
+        let model = MockCompletionModel::from_turns([MockTurn::tool_call(
+            "call-2",
+            "subtract",
+            json!({"x": 5, "y": 2}),
+        )]);
+        let agent = build_agent(model);
+        let mut run = agent.new_run("go").max_turns(2);
+        let (prompt, history) = first_call_model(&mut run);
+        let (builder, turn) = agent
+            .prepare_completion_request(prompt, &history, &mut run)
+            .await
+            .expect("preparation succeeds")
+            .into_parts();
+        let response = builder.send().await.expect("mock send");
+        let outcome = run
+            .model_response(turn.model_turn(response))
+            .expect("model response accepted");
+        match outcome {
+            ModelTurnOutcome::NeedsResolution(context) => {
+                assert_eq!(context.tool_name, "subtract");
+                assert!(context.available_tools.contains(&"subtract".to_string()));
+                assert!(!context.allowed_tools.contains(&"subtract".to_string()));
+            }
+            other => panic!("expected NeedsResolution, got {other:?}"),
+        }
+    }
+
+    #[derive(Clone)]
+    struct ProbeA;
+
+    impl Tool for ProbeA {
+        const NAME: &'static str = "probe";
+        type Error = ToolExecutionError;
+        type Args = serde_json::Value;
+        type Output = String;
+
+        fn description(&self) -> String {
+            "Implementation A".into()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            json!({"type": "object", "properties": {}})
+        }
+
+        async fn call(
+            &self,
+            _context: &mut ToolContext,
+            _args: Self::Args,
+        ) -> Result<Self::Output, Self::Error> {
+            Ok("A".to_string())
+        }
+    }
+
+    #[derive(Clone)]
+    struct ProbeB;
+
+    impl Tool for ProbeB {
+        const NAME: &'static str = "probe";
+        type Error = ToolExecutionError;
+        type Args = serde_json::Value;
+        type Output = String;
+
+        fn description(&self) -> String {
+            "Implementation B".into()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            json!({"type": "object", "properties": {}})
+        }
+
+        async fn call(
+            &self,
+            _context: &mut ToolContext,
+            _args: Self::Args,
+        ) -> Result<Self::Output, Self::Error> {
+            Ok("B".to_string())
+        }
+    }
+
+    #[derive(Clone)]
+    struct LateTool;
+
+    impl Tool for LateTool {
+        const NAME: &'static str = "late";
+        type Error = ToolExecutionError;
+        type Args = serde_json::Value;
+        type Output = String;
+
+        fn description(&self) -> String {
+            "Registered after preparation".into()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            json!({"type": "object", "properties": {}})
+        }
+
+        async fn call(
+            &self,
+            _context: &mut ToolContext,
+            _args: Self::Args,
+        ) -> Result<Self::Output, Self::Error> {
+            Ok("late".to_string())
+        }
+    }
+
+    #[tokio::test]
+    async fn prepared_turn_executes_through_the_pinned_snapshot() {
+        let model =
+            MockCompletionModel::from_turns([MockTurn::tool_call("call-1", "probe", json!({}))]);
+        let agent = AgentBuilder::new(model).tool(ProbeA).build();
+        let mut run = agent.new_run("go").max_turns(2);
+        let (prompt, history) = first_call_model(&mut run);
+        let (builder, turn) = agent
+            .prepare_completion_request(prompt, &history, &mut run)
+            .await
+            .expect("preparation succeeds")
+            .into_parts();
+        let response = builder.send().await.expect("mock send");
+        run.model_response(turn.model_turn(response))
+            .expect("model response accepted");
+        let AgentRunStep::CallTools { calls } = run.next_step().expect("next step") else {
+            panic!("expected CallTools");
+        };
+
+        // Mutate the live registry AFTER preparation: replace `probe` with
+        // implementation B and register a brand-new tool.
+        let handle = agent.tool_server_handle();
+        handle.add_tool(ProbeB).await;
+        handle.add_tool(LateTool).await;
+
+        // The prepared turn still executes implementation A...
+        let mut context = ToolContext::new();
+        let result = turn.execute_call(&calls[0], &mut context).await;
+        assert_eq!(result_text(&result), "A");
+
+        // ...while the live handle now dispatches implementation B.
+        let live = handle.execute("probe", "{}", &mut context).await;
+        assert_eq!(live.output().render(), "B");
+
+        // A tool registered after preparation is rejected by the prepared
+        // turn even though the live registry has it.
+        let late_call = PendingToolCall {
+            tool_call: ToolCall::from_wire("call-2", ToolFunction::new("late".into(), json!({}))),
+            preresolved_result: None,
+            internal_call_id: None,
+        };
+        let rejected = turn.execute_call(&late_call, &mut context).await;
+        assert!(
+            result_text(&rejected).contains("not found"),
+            "post-preparation registration must be rejected: {rejected:?}"
+        );
+    }
+
+    #[derive(serde::Deserialize, schemars::JsonSchema)]
+    #[allow(dead_code)]
+    struct Summary {
+        answer: String,
+    }
+
+    #[tokio::test]
+    async fn seeded_run_and_prepared_request_agree_on_output_policy() {
+        // Schema-configured agent with a real tool on a provider that does not
+        // compose native structured output with tools: output mode resolves to
+        // Tool. The run must intercept exactly the output tool the request
+        // advertises — proving `new_run` + `prepare_completion_request` agree.
+        let model = MockCompletionModel::from_turns([MockTurn::tool_call(
+            "call-1",
+            "final_result",
+            json!({"answer": "42"}),
+        )]);
+        let agent = AgentBuilder::new(model.clone())
+            .tool(MockAddTool)
+            .output_schema::<Summary>()
+            .build();
+
+        let mut run = agent.new_run("go").max_turns(2);
+        let (prompt, history) = first_call_model(&mut run);
+        let (builder, turn) = agent
+            .prepare_completion_request(prompt, &history, &mut run)
+            .await
+            .expect("preparation succeeds")
+            .into_parts();
+
+        // Preparation committed the output-tool expectation onto the run.
+        assert_eq!(run.output_tool_name(), Some("final_result"));
+
+        let response = builder.send().await.expect("mock send");
+        run.model_response(turn.model_turn(response))
+            .expect("model response accepted");
+
+        // The request advertised the synthetic output tool (Tool mode, no
+        // native constraint), and the run finalizes by intercepting its call.
+        let requests = model.requests();
+        let request = requests.first().expect("one request sent");
+        assert!(request.tools.iter().any(|tool| tool.name == "final_result"));
+        assert!(request.output_schema.is_none());
+        match run.next_step().expect("final step") {
+            AgentRunStep::Done(response) => {
+                assert_eq!(response.output, r#"{"answer":"42"}"#);
+            }
+            other => panic!("expected Done via output-tool interception, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn seeded_run_validates_output_against_the_agent_schema() {
+        // `new_run` seeds the run's output validation from the agent's schema:
+        // an output-tool call missing a required field is re-prompted (within
+        // the default output-retry budget) instead of finalized as-is.
+        let model = MockCompletionModel::from_turns([
+            MockTurn::tool_call("call-1", "final_result", json!({"wrong_field": true})),
+            MockTurn::tool_call("call-2", "final_result", json!({"answer": "42"})),
+        ]);
+        let agent = AgentBuilder::new(model.clone())
+            .tool(MockAddTool)
+            .output_schema::<Summary>()
+            .build();
+
+        let mut run = agent.new_run("go").max_turns(3);
+        loop {
+            match run.next_step().expect("step") {
+                AgentRunStep::CallModel {
+                    prompt, history, ..
+                } => {
+                    let (builder, turn) = agent
+                        .prepare_completion_request(prompt, &history, &mut run)
+                        .await
+                        .expect("preparation succeeds")
+                        .into_parts();
+                    let response = builder.send().await.expect("mock send");
+                    run.model_response(turn.model_turn(response))
+                        .expect("model response accepted");
+                }
+                AgentRunStep::CallTools { calls } => {
+                    panic!("output-tool calls must be intercepted, got {calls:?}")
+                }
+                AgentRunStep::Done(response) => {
+                    assert_eq!(response.output, r#"{"answer":"42"}"#);
+                    break;
+                }
+            }
+        }
+        assert_eq!(
+            model.request_count(),
+            2,
+            "the incomplete output must be re-prompted exactly once"
+        );
+    }
+
+    #[tokio::test]
+    async fn seeded_run_uses_agent_turn_budget_and_retry_budget() {
+        // `new_run` seeds the agent's `default_max_turns`: with a budget of 2,
+        // a third model call fails with MaxTurnsError { max_turns: 2 }.
+        let model = MockCompletionModel::from_turns([
+            MockTurn::tool_call("call-1", "add", json!({"x": 1, "y": 1})),
+            MockTurn::tool_call("call-2", "add", json!({"x": 2, "y": 2})),
+        ]);
+        let agent = AgentBuilder::new(model)
+            .tool(MockAddTool)
+            .default_max_turns(2)
+            .build();
+
+        let mut run = agent.new_run("go");
+        let error = loop {
+            match run.next_step() {
+                Ok(AgentRunStep::CallModel {
+                    prompt, history, ..
+                }) => {
+                    let (builder, turn) = agent
+                        .prepare_completion_request(prompt, &history, &mut run)
+                        .await
+                        .expect("preparation succeeds")
+                        .into_parts();
+                    let response = builder.send().await.expect("mock send");
+                    run.model_response(turn.model_turn(response))
+                        .expect("model response accepted");
+                }
+                Ok(AgentRunStep::CallTools { calls }) => {
+                    let mut results = Vec::with_capacity(calls.len());
+                    for call in &calls {
+                        // Execution source is irrelevant here; the budget is
+                        // the subject under test.
+                        results.push(UserContent::tool_result_for(
+                            call.tool_call.id.clone(),
+                            call.tool_call.provider.clone(),
+                            call.tool_call.function.name.clone(),
+                            vec![ToolResultContent::text("2")],
+                        ));
+                    }
+                    run.tool_results(results).expect("results accepted");
+                }
+                Ok(AgentRunStep::Done(response)) => {
+                    panic!("run must exhaust its turn budget, got {response:?}")
+                }
+                Err(error) => break error,
+            }
+        };
+        assert!(
+            matches!(error, PromptError::MaxTurnsError { max_turns: 2, .. }),
+            "expected the agent-seeded budget of 2, got {error:?}"
+        );
+
+        // `new_run` also seeds the runner's default invalid-call retry budget
+        // of zero: a Retry resolution is immediately rejected.
+        let model =
+            MockCompletionModel::from_turns([MockTurn::tool_call("call-1", "bogus", json!({}))]);
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+        let mut run = agent.new_run("go").max_turns(2);
+        let (prompt, history) = first_call_model(&mut run);
+        let (builder, turn) = agent
+            .prepare_completion_request(prompt, &history, &mut run)
+            .await
+            .expect("preparation succeeds")
+            .into_parts();
+        let response = builder.send().await.expect("mock send");
+        let ModelTurnOutcome::NeedsResolution(context) = run
+            .model_response(turn.model_turn(response))
+            .expect("model response accepted")
+        else {
+            panic!("an unknown tool call must need resolution");
+        };
+        assert_eq!(context.tool_name, "bogus");
+        let error = run
+            .resolve_invalid_tool_call(InvalidToolCallAction::retry("use a real tool"))
+            .expect_err("a zero retry budget must reject Retry");
+        assert!(matches!(error, PromptError::UnknownToolCall { .. }));
+    }
+
+    #[tokio::test]
+    async fn impossible_tool_choice_fails_before_provider_io() {
+        // Required with no tools at all.
+        let model = MockCompletionModel::text("unused");
+        let agent = AgentBuilder::new(model.clone())
+            .tool_choice(ToolChoice::Required)
+            .build();
+        let mut run = agent.new_run("go");
+        let (prompt, history) = first_call_model(&mut run);
+        let error = agent
+            .prepare_completion_request(prompt, &history, &mut run)
+            .await
+            .expect_err("Required with no tools must fail locally");
+        assert!(matches!(error, CompletionError::RequestError(_)));
+        assert_eq!(model.request_count(), 0, "no provider IO may happen");
+
+        // Specific naming an unknown tool.
+        let model = MockCompletionModel::text("unused");
+        let agent = AgentBuilder::new(model.clone())
+            .tool(MockAddTool)
+            .tool_choice(ToolChoice::Specific {
+                function_names: vec!["missing".to_string()],
+            })
+            .build();
+        let mut run = agent.new_run("go");
+        let (prompt, history) = first_call_model(&mut run);
+        let error = agent
+            .prepare_completion_request(prompt, &history, &mut run)
+            .await
+            .expect_err("Specific naming an unknown tool must fail locally");
+        assert!(matches!(error, CompletionError::RequestError(_)));
+        assert_eq!(model.request_count(), 0, "no provider IO may happen");
+    }
+
+    /// A completion-call hook that counts invocations and visibly patches the
+    /// request, to pin the hook-free boundary.
+    #[derive(Clone, Default)]
+    struct CountingPatchHook(Arc<AtomicUsize>);
+
+    impl AgentHook for CountingPatchHook {
+        async fn on_completion_call(
+            &self,
+            _ctx: &HookContext,
+            _event: CompletionCall<'_>,
+        ) -> CompletionCallAction {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            CompletionCallAction::Patch(RequestPatch {
+                preamble: Some("patched by hook".to_string()),
+                ..Default::default()
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn prepare_completion_request_runs_no_hooks() {
+        let hook = CountingPatchHook::default();
+        let model = MockCompletionModel::text("done");
+        let agent = AgentBuilder::new(model.clone())
+            .preamble("baseline preamble")
+            .add_hook(hook.clone())
+            .build();
+
+        let mut run = agent.new_run("go");
+        let (prompt, history) = first_call_model(&mut run);
+        let (builder, _turn) = agent
+            .prepare_completion_request(prompt, &history, &mut run)
+            .await
+            .expect("preparation succeeds")
+            .into_parts();
+        let request = builder.build();
+
+        assert_eq!(hook.0.load(Ordering::SeqCst), 0, "no hook may fire");
+        assert!(
+            request.chat_history.iter().any(|message| matches!(
+                message,
+                Message::System { content } if content == "baseline preamble"
+            )),
+            "the baseline preamble must be untouched by the hook patch"
+        );
+    }
+
+    /// Guard: the same hook still fires (and patches) under `AgentRunner`.
+    #[tokio::test]
+    async fn completion_call_hook_still_fires_under_the_runner() {
+        let hook = CountingPatchHook::default();
+        let model = MockCompletionModel::text("done");
+        let agent = AgentBuilder::new(model.clone())
+            .preamble("baseline preamble")
+            .add_hook(hook.clone())
+            .build();
+
+        agent.runner("go").run().await.expect("runner succeeds");
+
+        assert_eq!(hook.0.load(Ordering::SeqCst), 1, "the hook must fire once");
+        let requests = model.requests();
+        let request = requests.first().expect("one request");
+        assert!(
+            request.chat_history.iter().any(|message| matches!(
+                message,
+                Message::System { content } if content == "patched by hook"
+            )),
+            "the runner must apply the hook's patch"
+        );
+    }
+
+    #[tokio::test]
+    async fn full_manual_round_trip_through_the_new_surface() {
+        let model = MockCompletionModel::from_turns([
+            MockTurn::tool_call("call-1", "add", json!({"x": 2, "y": 5})),
+            MockTurn::text("7"),
+        ]);
+        let agent = AgentBuilder::new(model)
+            .preamble("You are a calculator")
+            .tool(MockAddTool)
+            .build();
+
+        let mut run = agent.new_run("What is 2 + 5?").max_turns(2);
+        let mut prepared_turn: Option<PreparedAgentTurn> = None;
+        let mut context = ToolContext::new();
+        loop {
+            match run.next_step().expect("step") {
+                AgentRunStep::CallModel {
+                    prompt, history, ..
+                } => {
+                    let (builder, turn) = agent
+                        .prepare_completion_request(prompt, &history, &mut run)
+                        .await
+                        .expect("preparation succeeds")
+                        .into_parts();
+                    let response = builder.send().await.expect("mock send");
+                    let outcome = run
+                        .model_response(turn.model_turn(response))
+                        .expect("model response accepted");
+                    assert!(matches!(outcome, ModelTurnOutcome::Continue { .. }));
+                    prepared_turn = Some(turn);
+                }
+                AgentRunStep::CallTools { calls } => {
+                    let turn = prepared_turn.as_ref().expect("turn retained across send");
+                    let mut results = Vec::with_capacity(calls.len());
+                    for call in &calls {
+                        results.push(turn.execute_call(call, &mut context).await);
+                    }
+                    run.tool_results(results).expect("results accepted");
+                }
+                AgentRunStep::Done(response) => {
+                    assert_eq!(response.output, "7");
+                    assert_eq!(response.completion_calls.len(), 2);
+                    break;
+                }
+            }
+        }
+    }
+
+    /// A tool named `add` that fails the test if its body ever runs.
+    #[derive(Clone, Default)]
+    struct MustNotRunTool(Arc<AtomicUsize>);
+
+    impl Tool for MustNotRunTool {
+        const NAME: &'static str = "add";
+        type Error = ToolExecutionError;
+        type Args = serde_json::Value;
+        type Output = String;
+
+        fn description(&self) -> String {
+            "Must not execute".into()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            json!({"type": "object", "properties": {}})
+        }
+
+        async fn call(
+            &self,
+            _context: &mut ToolContext,
+            _args: Self::Args,
+        ) -> Result<Self::Output, Self::Error> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Ok("executed".to_string())
+        }
+    }
+
+    #[tokio::test]
+    async fn preresolved_calls_execute_nothing_and_clear_stale_metadata() {
+        let executions = Arc::new(AtomicUsize::new(0));
+        let agent = AgentBuilder::new(MockCompletionModel::text("unused"))
+            .tool(MustNotRunTool(executions.clone()))
+            .build();
+        let mut run = agent.new_run("go");
+        let (prompt, history) = first_call_model(&mut run);
+        let (_builder, turn) = agent
+            .prepare_completion_request(prompt, &history, &mut run)
+            .await
+            .expect("preparation succeeds")
+            .into_parts();
+
+        let tool_call = ToolCall::from_wire("call-1", ToolFunction::new("add".into(), json!({})));
+        let preresolved = UserContent::tool_result_for(
+            tool_call.id.clone(),
+            tool_call.provider.clone(),
+            "add".to_string(),
+            vec![ToolResultContent::text("already handled")],
+        );
+        let call = PendingToolCall {
+            tool_call,
+            preresolved_result: Some(preresolved.clone()),
+            internal_call_id: None,
+        };
+
+        // Seed the context with stale metadata from a previous dispatch.
+        let mut context = ToolContext::new();
+        context.insert_result("stale".to_string());
+
+        let result = turn.execute_call(&call, &mut context).await;
+        assert_eq!(result_text(&result), "already handled");
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            0,
+            "a pre-resolved call must execute nothing"
+        );
+        assert!(
+            context.result::<String>().is_none(),
+            "stale dispatch metadata must be cleared on the pre-resolved path"
+        );
+    }
+
+    /// Guard: cross-process resume finishes pending calls through a rebuilt
+    /// agent's live `tool_server_handle()`, asserting only what the existing
+    /// API promises (no snapshot survival, no drift detection).
+    #[tokio::test]
+    async fn cross_process_resume_finishes_via_the_live_handle() {
+        // "Process one": drive to CallTools, then suspend.
+        let model = MockCompletionModel::from_turns([MockTurn::tool_call(
+            "call-1",
+            "add",
+            json!({"x": 2, "y": 5}),
+        )]);
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+        let mut run = agent.new_run("What is 2 + 5?").max_turns(2);
+        let (prompt, history) = first_call_model(&mut run);
+        let (builder, turn) = agent
+            .prepare_completion_request(prompt, &history, &mut run)
+            .await
+            .expect("preparation succeeds")
+            .into_parts();
+        let response = builder.send().await.expect("mock send");
+        run.model_response(turn.model_turn(response))
+            .expect("model response accepted");
+        let AgentRunStep::CallTools { .. } = run.next_step().expect("next step") else {
+            panic!("expected CallTools");
+        };
+        let suspended = serde_json::to_string(&run).expect("run serializes");
+
+        // "Process two": rebuild an equivalent agent, deserialize the run, and
+        // finish through the live handle. The prepared turn did not survive.
+        let model = MockCompletionModel::from_turns([MockTurn::text("7")]);
+        let rebuilt = AgentBuilder::new(model).tool(MockAddTool).build();
+        let mut resumed: AgentRun = serde_json::from_str(&suspended).expect("run deserializes");
+
+        let AgentRunStep::CallTools { calls } = resumed.next_step().expect("re-emitted step")
+        else {
+            panic!("resumed run must re-emit the pending tool calls");
+        };
+        let handle = rebuilt.tool_server_handle();
+        let mut context = ToolContext::new();
+        let mut results = Vec::with_capacity(calls.len());
+        for call in &calls {
+            let args = json_utils::serialize_json_value(&call.tool_call.function.arguments);
+            let result = handle
+                .execute(&call.tool_call.function.name, &args, &mut context)
+                .await;
+            results.push(UserContent::tool_result_for(
+                call.tool_call.id.clone(),
+                call.tool_call.provider.clone(),
+                call.tool_call.function.name.clone(),
+                result.output().clone().into_content(),
+            ));
+        }
+        resumed.tool_results(results).expect("results accepted");
+
+        let (prompt, history) = match resumed.next_step().expect("follow-up step") {
+            AgentRunStep::CallModel {
+                prompt, history, ..
+            } => (prompt, history),
+            other => panic!("expected CallModel, got {other:?}"),
+        };
+        let (builder, turn) = rebuilt
+            .prepare_completion_request(prompt, &history, &mut resumed)
+            .await
+            .expect("preparation succeeds")
+            .into_parts();
+        let response = builder.send().await.expect("mock send");
+        resumed
+            .model_response(turn.model_turn(response))
+            .expect("model response accepted");
+        match resumed.next_step().expect("final step") {
+            AgentRunStep::Done(response) => assert_eq!(response.output, "7"),
+            other => panic!("expected Done, got {other:?}"),
+        }
     }
 }

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -6,7 +6,7 @@ use super::runner::{
     AgentRunner, DEFAULT_INVALID_TOOL_CALL_RETRIES, DEFAULT_MAX_TURNS, build_agent_run,
 };
 use crate::{
-    agent::prompt_request::{streaming::StreamingPromptRequest, tool_result_output},
+    agent::prompt_request::streaming::StreamingPromptRequest,
     completion::{
         Chat, CompletionError, CompletionModel, CompletionRequestBuilder, CompletionResponse,
         Document, Message, Prompt, PromptError, ToolDefinition, TypedPrompt,
@@ -22,7 +22,7 @@ use rig_core::{
     message::{ToolChoice, UserContent},
     wasm_compat::WasmCompatSend,
 };
-use std::{collections::BTreeSet, sync::Arc};
+use std::{borrow::Cow, collections::BTreeSet, sync::Arc};
 
 use super::UNKNOWN_AGENT_NAME;
 
@@ -234,7 +234,10 @@ pub(crate) fn allowed_tool_names_for_choice(
 pub(crate) struct PreparedRequestInputs<'a> {
     pub(crate) model: &'a ModelHandle,
     pub(crate) prompt: Message,
-    pub(crate) chat_history: &'a [Message],
+    /// Borrowed for per-turn drivers that keep their history; owned for the
+    /// manual surface, whose `CallModel` step hands the driver a fresh `Vec`
+    /// that would otherwise be cloned and dropped.
+    pub(crate) chat_history: Cow<'a, [Message]>,
     pub(crate) preamble: Option<&'a str>,
     pub(crate) static_context: &'a [Document],
     pub(crate) temperature: Option<f64>,
@@ -245,17 +248,38 @@ pub(crate) struct PreparedRequestInputs<'a> {
     pub(crate) tool_server_handle: &'a ToolServerHandle,
     pub(crate) output_schema: Option<&'a schemars::Schema>,
     pub(crate) output_mode: &'a OutputMode,
-    /// The run's already-committed Tool-mode output-tool name, if any (#1928).
-    pub(crate) committed_output_tool: Option<&'a str>,
     pub(crate) output_tool_description: Option<&'a str>,
     pub(crate) augment_output_preamble: bool,
     pub(crate) request_patch: Option<&'a RequestPatch>,
 }
 
+/// Build a prepared request under `run`'s committed output-tool policy.
+///
+/// The single home for the #1928 read/commit pairing shared by the classic
+/// driver and [`Agent::prepare_completion_request`] — the only two callers of
+/// [`build_prepared_completion_request`]: the run's committed Tool-mode
+/// output-tool name feeds preparation (so a committed run cannot flip back to
+/// native on a later turn), and the name the prepared request actually
+/// advertises is committed back onto the run before it is returned.
+pub(crate) async fn build_prepared_completion_request_for_run(
+    run: &mut AgentRun,
+    inputs: PreparedRequestInputs<'_>,
+) -> Result<PreparedCompletionRequest, CompletionError> {
+    let committed_output_tool = run.output_tool_name();
+    let prepared = build_prepared_completion_request(inputs, committed_output_tool).await?;
+    run.set_output_tool_name(prepared.output_tool_name.clone());
+    Ok(prepared)
+}
+
 /// Helper function to build a completion request from agent components while
 /// preserving the executable Rig tool names sent to the provider.
+/// `committed_output_tool` is the run's already-committed Tool-mode
+/// output-tool name, if any (#1928); call through
+/// [`build_prepared_completion_request_for_run`] so the read/commit pairing
+/// stays in one place.
 pub(crate) async fn build_prepared_completion_request(
     inputs: PreparedRequestInputs<'_>,
+    committed_output_tool: Option<&str>,
 ) -> Result<PreparedCompletionRequest, CompletionError> {
     let PreparedRequestInputs {
         model,
@@ -271,7 +295,6 @@ pub(crate) async fn build_prepared_completion_request(
         tool_server_handle,
         output_schema,
         output_mode,
-        committed_output_tool,
         output_tool_description,
         augment_output_preamble,
         request_patch,
@@ -479,16 +502,17 @@ pub(crate) async fn build_prepared_completion_request(
     // *this turn only* (context-window compaction / summarization). The RAG query
     // text above deliberately still derives from the original `chat_history`, so
     // this changes only what is sent, never what is retrieved or persisted.
-    let messages_history: &[Message] = request_patch
-        .and_then(|o| o.history.as_deref())
-        .unwrap_or(chat_history);
-    let chat_history: Vec<Message> = if let Some(preamble) = &effective_preamble {
-        std::iter::once(Message::system(preamble.clone()))
-            .chain(messages_history.iter().cloned())
-            .collect()
-    } else {
-        messages_history.to_vec()
-    };
+    // `into_owned` moves an already-owned history (the manual surface) and
+    // clones a borrowed one (the classic driver, or a patched history).
+    let messages_history: Cow<'_, [Message]> =
+        match request_patch.and_then(|o| o.history.as_deref()) {
+            Some(patched) => Cow::Borrowed(patched),
+            None => chat_history,
+        };
+    let mut chat_history: Vec<Message> = messages_history.into_owned();
+    if let Some(preamble) = &effective_preamble {
+        chat_history.insert(0, Message::system(preamble.clone()));
+    }
 
     // In Tool mode, advertise the synthetic output tool to the provider (its name
     // is added to `allowed_tool_names` below but never to `executable_tool_names`,
@@ -690,15 +714,9 @@ impl PreparedAgentTurn {
         let args = json_utils::serialize_json_value(&tool_call.function.arguments);
         let result = self
             .tool_snapshot
-            .execute(&tool_call.function.name, &args, context)
+            .execute(&tool_call.function.name, args, context)
             .await;
-
-        tool_result_output(
-            tool_call.id.clone(),
-            tool_call.provider.clone(),
-            tool_call.function.name.clone(),
-            result.output().clone(),
-        )
+        call.result_content(result.output().clone())
     }
 }
 
@@ -878,13 +896,12 @@ impl Agent {
     /// `agent.new_run(prompt).max_turns(10)`.
     ///
     /// Pair it with [`Agent::prepare_completion_request`], which prepares each
-    /// model call under the same policy and commits the run's structured-output
-    /// tool expectation. Overriding seeded policy afterwards (for example
-    /// [`AgentRun::with_tool_choice`]) desynchronizes the run from the
-    /// requests that method prepares, which always carry the agent's baseline.
-    /// [`AgentRun::new`] remains available for intentionally custom runs; such
-    /// callers own keeping the run's policy (tool choice, output validation,
-    /// output-tool name) consistent with the requests they prepare.
+    /// model call under the **run's** policy — including a later
+    /// [`AgentRun::with_tool_choice`] override — and commits the run's
+    /// structured-output tool expectation. [`AgentRun::new`] remains available
+    /// for intentionally custom runs; such callers own keeping the run's
+    /// policy (tool choice, output validation, output-tool name) consistent
+    /// with the requests they prepare.
     pub fn new_run(&self, prompt: impl Into<Message>) -> AgentRun {
         // Same policy defaults as `AgentRunner::from_agent` (shared constants,
         // so the two cannot drift) and the same single construction site
@@ -915,16 +932,16 @@ impl Agent {
     /// tool, or [`ToolChoice::Specific`] naming an unknown tool) fails here,
     /// before any provider IO.
     ///
-    /// `run` keeps request preparation and run policy paired for structured
-    /// output: preparation reads the run's committed output-tool name so a run
+    /// `run` keeps request preparation and run policy paired. For structured
+    /// output, preparation reads the run's committed output-tool name so a run
     /// that committed to Tool-mode output on an earlier turn cannot flip back
     /// to native later, and commits the name this request advertises back onto
     /// the run — exactly as the classic driver does — so the run's output-tool
-    /// interception matches what the model was told. Nothing else about the
-    /// run is read or advanced. The request always carries the agent's
-    /// *baseline* tool choice: overriding the seeded policy on the run (e.g.
-    /// [`AgentRun::with_tool_choice`]) makes the run classify calls under a
-    /// policy this request never advertised.
+    /// interception matches what the model was told. The advertised tool
+    /// choice is likewise the **run's** (seeded from the agent by
+    /// [`Agent::new_run`], and following an [`AgentRun::with_tool_choice`]
+    /// override), so the run always classifies calls under the policy the
+    /// provider actually saw. Nothing else about the run is read or advanced.
     ///
     /// **Hook-free means hook-free.** This runs no hooks, appends no memory,
     /// opens no classic lifecycle or telemetry spans, and applies no tool
@@ -936,31 +953,37 @@ impl Agent {
     pub async fn prepare_completion_request(
         &self,
         prompt: impl Into<Message>,
-        history: &[Message],
+        history: Vec<Message>,
         run: &mut AgentRun,
     ) -> Result<PreparedAgentRequest, CompletionError> {
-        let committed_output_tool = run.output_tool_name().map(str::to_owned);
-        let prepared = build_prepared_completion_request(PreparedRequestInputs {
-            model: &self.model,
-            prompt: prompt.into(),
-            chat_history: history,
-            preamble: self.preamble.as_deref(),
-            static_context: &self.static_context,
-            temperature: self.temperature,
-            max_tokens: self.max_tokens,
-            additional_params: self.additional_params.as_ref(),
-            record_telemetry_content: self.record_telemetry_content,
-            tool_choice: self.tool_choice.as_ref(),
-            tool_server_handle: &self.tool_server_handle,
-            output_schema: self.output_schema.as_ref(),
-            output_mode: &self.output_mode,
-            committed_output_tool: committed_output_tool.as_deref(),
-            output_tool_description: None,
-            augment_output_preamble: true,
-            request_patch: None,
-        })
+        // The run's tool choice — not the agent baseline — so a
+        // `with_tool_choice` override on the run reaches the provider and the
+        // run never classifies calls under a policy the request didn't carry.
+        // Cloned up front because the inputs below cannot borrow `run` while
+        // the wrapper holds it mutably.
+        let tool_choice = run.tool_choice().cloned();
+        let prepared = build_prepared_completion_request_for_run(
+            run,
+            PreparedRequestInputs {
+                model: &self.model,
+                prompt: prompt.into(),
+                chat_history: Cow::Owned(history),
+                preamble: self.preamble.as_deref(),
+                static_context: &self.static_context,
+                temperature: self.temperature,
+                max_tokens: self.max_tokens,
+                additional_params: self.additional_params.as_ref(),
+                record_telemetry_content: self.record_telemetry_content,
+                tool_choice: tool_choice.as_ref(),
+                tool_server_handle: &self.tool_server_handle,
+                output_schema: self.output_schema.as_ref(),
+                output_mode: &self.output_mode,
+                output_tool_description: None,
+                augment_output_preamble: true,
+                request_patch: None,
+            },
+        )
         .await?;
-        run.set_output_tool_name(prepared.output_tool_name.clone());
 
         let PreparedCompletionRequest {
             builder,
@@ -1581,7 +1604,7 @@ mod agent_run_surface_tests {
         let mut run = agent.new_run("go");
         let (prompt, history) = first_call_model(&mut run);
         let (builder, _turn) = agent
-            .prepare_completion_request(prompt, &history, &mut run)
+            .prepare_completion_request(prompt, history, &mut run)
             .await
             .expect("preparation succeeds")
             .into_parts();
@@ -1629,7 +1652,7 @@ mod agent_run_surface_tests {
         let mut run = agent.new_run("go").max_turns(2);
         let (prompt, history) = first_call_model(&mut run);
         let (builder, turn) = agent
-            .prepare_completion_request(prompt, &history, &mut run)
+            .prepare_completion_request(prompt, history, &mut run)
             .await
             .expect("preparation succeeds")
             .into_parts();
@@ -1657,7 +1680,7 @@ mod agent_run_surface_tests {
         let mut run = agent.new_run("go").max_turns(2);
         let (prompt, history) = first_call_model(&mut run);
         let (builder, turn) = agent
-            .prepare_completion_request(prompt, &history, &mut run)
+            .prepare_completion_request(prompt, history, &mut run)
             .await
             .expect("preparation succeeds")
             .into_parts();
@@ -1761,7 +1784,7 @@ mod agent_run_surface_tests {
         let mut run = agent.new_run("go").max_turns(2);
         let (prompt, history) = first_call_model(&mut run);
         let (builder, turn) = agent
-            .prepare_completion_request(prompt, &history, &mut run)
+            .prepare_completion_request(prompt, history, &mut run)
             .await
             .expect("preparation succeeds")
             .into_parts();
@@ -1826,7 +1849,7 @@ mod agent_run_surface_tests {
         let mut run = agent.new_run("go").max_turns(2);
         let (prompt, history) = first_call_model(&mut run);
         let (builder, turn) = agent
-            .prepare_completion_request(prompt, &history, &mut run)
+            .prepare_completion_request(prompt, history, &mut run)
             .await
             .expect("preparation succeeds")
             .into_parts();
@@ -1853,6 +1876,74 @@ mod agent_run_surface_tests {
     }
 
     #[tokio::test]
+    async fn run_tool_choice_override_reaches_the_prepared_request() {
+        // The run — not the agent baseline — is the source of truth for tool
+        // choice: an `AgentRun::with_tool_choice` override after `new_run`
+        // must reach the provider request and the run's allowed set alike.
+        let model = MockCompletionModel::from_turns([MockTurn::tool_call(
+            "call-1",
+            "subtract",
+            json!({"x": 5, "y": 2}),
+        )]);
+        let agent = AgentBuilder::new(model.clone())
+            .tool(MockAddTool)
+            .tool(MockSubtractTool)
+            .tool_choice(ToolChoice::Auto)
+            .build();
+
+        let mut run = agent
+            .new_run("go")
+            .max_turns(2)
+            .with_tool_choice(ToolChoice::Specific {
+                function_names: vec!["add".to_string()],
+            });
+        let (prompt, history) = first_call_model(&mut run);
+        let (builder, turn) = agent
+            .prepare_completion_request(prompt, history, &mut run)
+            .await
+            .expect("preparation succeeds")
+            .into_parts();
+        let response = builder.send().await.expect("mock send");
+
+        // The provider saw the override, not the agent's Auto baseline...
+        let requests = model.requests();
+        let request = requests.first().expect("one request");
+        assert_eq!(
+            request.tool_choice,
+            Some(ToolChoice::Specific {
+                function_names: vec!["add".to_string()],
+            })
+        );
+
+        // ...and the run classifies under that same policy: the executable
+        // `subtract` call is disallowed by the overridden choice.
+        match run
+            .model_response(turn.model_turn(response))
+            .expect("model response accepted")
+        {
+            ModelTurnOutcome::NeedsResolution(context) => {
+                assert_eq!(context.tool_name, "subtract");
+            }
+            other => panic!("expected NeedsResolution under the override, got {other:?}"),
+        }
+
+        // An override that is impossible against the agent's tools still
+        // fails before provider IO.
+        let model = MockCompletionModel::text("unused");
+        let agent = AgentBuilder::new(model.clone()).tool(MockAddTool).build();
+        let mut run = agent.new_run("go").with_tool_choice(ToolChoice::Specific {
+            function_names: vec!["missing".to_string()],
+        });
+        let (prompt, history) = first_call_model(&mut run);
+        let error = agent
+            .prepare_completion_request(prompt, history, &mut run)
+            .await
+            .expect_err("an impossible override must fail locally");
+        assert!(matches!(error, CompletionError::RequestError(_)));
+        assert_eq!(model.request_count(), 0, "no provider IO may happen");
+    }
+
+    #[tokio::test]
     async fn seeded_run_validates_output_against_the_agent_schema() {
         // `new_run` seeds the run's output validation from the agent's schema:
         // an output-tool call missing a required field is re-prompted (within
@@ -1873,7 +1964,7 @@ mod agent_run_surface_tests {
                     prompt, history, ..
                 } => {
                     let (builder, turn) = agent
-                        .prepare_completion_request(prompt, &history, &mut run)
+                        .prepare_completion_request(prompt, history, &mut run)
                         .await
                         .expect("preparation succeeds")
                         .into_parts();
@@ -1917,7 +2008,7 @@ mod agent_run_surface_tests {
                     prompt, history, ..
                 }) => {
                     let (builder, turn) = agent
-                        .prepare_completion_request(prompt, &history, &mut run)
+                        .prepare_completion_request(prompt, history, &mut run)
                         .await
                         .expect("preparation succeeds")
                         .into_parts();
@@ -1958,7 +2049,7 @@ mod agent_run_surface_tests {
         let mut run = agent.new_run("go").max_turns(2);
         let (prompt, history) = first_call_model(&mut run);
         let (builder, turn) = agent
-            .prepare_completion_request(prompt, &history, &mut run)
+            .prepare_completion_request(prompt, history, &mut run)
             .await
             .expect("preparation succeeds")
             .into_parts();
@@ -1986,7 +2077,7 @@ mod agent_run_surface_tests {
         let mut run = agent.new_run("go");
         let (prompt, history) = first_call_model(&mut run);
         let error = agent
-            .prepare_completion_request(prompt, &history, &mut run)
+            .prepare_completion_request(prompt, history, &mut run)
             .await
             .expect_err("Required with no tools must fail locally");
         assert!(matches!(error, CompletionError::RequestError(_)));
@@ -2003,7 +2094,7 @@ mod agent_run_surface_tests {
         let mut run = agent.new_run("go");
         let (prompt, history) = first_call_model(&mut run);
         let error = agent
-            .prepare_completion_request(prompt, &history, &mut run)
+            .prepare_completion_request(prompt, history, &mut run)
             .await
             .expect_err("Specific naming an unknown tool must fail locally");
         assert!(matches!(error, CompletionError::RequestError(_)));
@@ -2041,7 +2132,7 @@ mod agent_run_surface_tests {
         let mut run = agent.new_run("go");
         let (prompt, history) = first_call_model(&mut run);
         let (builder, _turn) = agent
-            .prepare_completion_request(prompt, &history, &mut run)
+            .prepare_completion_request(prompt, history, &mut run)
             .await
             .expect("preparation succeeds")
             .into_parts();
@@ -2101,7 +2192,7 @@ mod agent_run_surface_tests {
                     prompt, history, ..
                 } => {
                     let (builder, turn) = agent
-                        .prepare_completion_request(prompt, &history, &mut run)
+                        .prepare_completion_request(prompt, history, &mut run)
                         .await
                         .expect("preparation succeeds")
                         .into_parts();
@@ -2166,7 +2257,7 @@ mod agent_run_surface_tests {
         let mut run = agent.new_run("go");
         let (prompt, history) = first_call_model(&mut run);
         let (_builder, turn) = agent
-            .prepare_completion_request(prompt, &history, &mut run)
+            .prepare_completion_request(prompt, history, &mut run)
             .await
             .expect("preparation succeeds")
             .into_parts();
@@ -2216,7 +2307,7 @@ mod agent_run_surface_tests {
         let mut run = agent.new_run("What is 2 + 5?").max_turns(2);
         let (prompt, history) = first_call_model(&mut run);
         let (builder, turn) = agent
-            .prepare_completion_request(prompt, &history, &mut run)
+            .prepare_completion_request(prompt, history, &mut run)
             .await
             .expect("preparation succeeds")
             .into_parts();
@@ -2246,12 +2337,9 @@ mod agent_run_surface_tests {
             let result = handle
                 .execute(&call.tool_call.function.name, &args, &mut context)
                 .await;
-            results.push(UserContent::tool_result_for(
-                call.tool_call.id.clone(),
-                call.tool_call.provider.clone(),
-                call.tool_call.function.name.clone(),
-                result.output().clone().into_content(),
-            ));
+            // `result_content` applies the id/provider/name correlation so
+            // the resume path never copies those fields by hand.
+            results.push(call.result_content(result.output().clone()));
         }
         resumed.tool_results(results).expect("results accepted");
 
@@ -2262,7 +2350,7 @@ mod agent_run_surface_tests {
             other => panic!("expected CallModel, got {other:?}"),
         };
         let (builder, turn) = rebuilt
-            .prepare_completion_request(prompt, &history, &mut resumed)
+            .prepare_completion_request(prompt, history, &mut resumed)
             .await
             .expect("preparation succeeds")
             .into_parts();

--- a/crates/rig-agent/src/agent/mod.rs
+++ b/crates/rig-agent/src/agent/mod.rs
@@ -113,7 +113,7 @@ mod tool;
 pub(crate) const UNKNOWN_AGENT_NAME: &str = "Unnamed Agent";
 
 pub use builder::{AgentBuilder, NoToolConfig, WithBuilderTools, WithToolServerHandle};
-pub use completion::Agent;
+pub use completion::{Agent, PreparedAgentRequest, PreparedAgentTurn};
 pub use hook::CompletionCall as CompletionCallEvent;
 pub use hook::{
     AgentHook, CompletionCallAction, CompletionResponse as CompletionResponseEvent, HookContext,

--- a/crates/rig-agent/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-agent/src/agent/prompt_request/streaming.rs
@@ -4,7 +4,9 @@ use rig_core::{
 };
 
 use crate::{
-    agent::completion::{PreparedCompletionRequest, build_prepared_completion_request},
+    agent::completion::{
+        PreparedCompletionRequest, PreparedRequestInputs, build_prepared_completion_request,
+    },
     agent::hook::{
         AgentHook, HookContext, HookStack, InvalidToolCallAction, ModelSelection,
         ModelSelectionAction, ModelTurnFinished, ReasoningDelta, StepEventKind,
@@ -558,25 +560,25 @@ where
                     // Pin Tool output mode once committed so later turns stay
                     // consistent even if the per-turn tool set changes (#1928).
                     let committed_output_tool = run.output_tool_name().map(str::to_owned);
-                    let mut prepared = match build_prepared_completion_request(
-                        &selected_model,
-                        prompt.clone(),
-                        &history,
-                        runner.preamble.as_deref(),
-                        &runner.static_context,
-                        runner.temperature,
-                        runner.max_tokens,
-                        runner.additional_params.as_ref(),
-                        runner.record_telemetry_content,
-                        runner.tool_choice.as_ref(),
-                        &runner.tool_server_handle,
-                        runner.output_schema.as_ref(),
-                        &runner.output_mode,
-                        committed_output_tool.as_deref(),
-                        runner.output_tool_description.as_deref(),
-                        runner.augment_output_preamble,
-                        request_patch.as_ref(),
-                    )
+                    let mut prepared = match build_prepared_completion_request(PreparedRequestInputs {
+                        model: &selected_model,
+                        prompt: prompt.clone(),
+                        chat_history: &history,
+                        preamble: runner.preamble.as_deref(),
+                        static_context: &runner.static_context,
+                        temperature: runner.temperature,
+                        max_tokens: runner.max_tokens,
+                        additional_params: runner.additional_params.as_ref(),
+                        record_telemetry_content: runner.record_telemetry_content,
+                        tool_choice: runner.tool_choice.as_ref(),
+                        tool_server_handle: &runner.tool_server_handle,
+                        output_schema: runner.output_schema.as_ref(),
+                        output_mode: &runner.output_mode,
+                        committed_output_tool: committed_output_tool.as_deref(),
+                        output_tool_description: runner.output_tool_description.as_deref(),
+                        augment_output_preamble: runner.augment_output_preamble,
+                        request_patch: request_patch.as_ref(),
+                    })
                     .await
                     {
                         Ok(prepared) => prepared,

--- a/crates/rig-agent/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-agent/src/agent/prompt_request/streaming.rs
@@ -5,7 +5,7 @@ use rig_core::{
 
 use crate::{
     agent::completion::{
-        PreparedCompletionRequest, PreparedRequestInputs, build_prepared_completion_request,
+        PreparedCompletionRequest, PreparedRequestInputs, build_prepared_completion_request_for_run,
     },
     agent::hook::{
         AgentHook, HookContext, HookStack, InvalidToolCallAction, ModelSelection,
@@ -557,28 +557,30 @@ where
 
                     let chat_span = source.open_chat_span(&runner, effective_preamble);
 
-                    // Pin Tool output mode once committed so later turns stay
+                    // `build_prepared_completion_request_for_run` pins Tool
+                    // output mode once committed, so later turns stay
                     // consistent even if the per-turn tool set changes (#1928).
-                    let committed_output_tool = run.output_tool_name().map(str::to_owned);
-                    let mut prepared = match build_prepared_completion_request(PreparedRequestInputs {
-                        model: &selected_model,
-                        prompt: prompt.clone(),
-                        chat_history: &history,
-                        preamble: runner.preamble.as_deref(),
-                        static_context: &runner.static_context,
-                        temperature: runner.temperature,
-                        max_tokens: runner.max_tokens,
-                        additional_params: runner.additional_params.as_ref(),
-                        record_telemetry_content: runner.record_telemetry_content,
-                        tool_choice: runner.tool_choice.as_ref(),
-                        tool_server_handle: &runner.tool_server_handle,
-                        output_schema: runner.output_schema.as_ref(),
-                        output_mode: &runner.output_mode,
-                        committed_output_tool: committed_output_tool.as_deref(),
-                        output_tool_description: runner.output_tool_description.as_deref(),
-                        augment_output_preamble: runner.augment_output_preamble,
-                        request_patch: request_patch.as_ref(),
-                    })
+                    let mut prepared = match build_prepared_completion_request_for_run(
+                        &mut run,
+                        PreparedRequestInputs {
+                            model: &selected_model,
+                            prompt: prompt.clone(),
+                            chat_history: std::borrow::Cow::Borrowed(&history),
+                            preamble: runner.preamble.as_deref(),
+                            static_context: &runner.static_context,
+                            temperature: runner.temperature,
+                            max_tokens: runner.max_tokens,
+                            additional_params: runner.additional_params.as_ref(),
+                            record_telemetry_content: runner.record_telemetry_content,
+                            tool_choice: runner.tool_choice.as_ref(),
+                            tool_server_handle: &runner.tool_server_handle,
+                            output_schema: runner.output_schema.as_ref(),
+                            output_mode: &runner.output_mode,
+                            output_tool_description: runner.output_tool_description.as_deref(),
+                            augment_output_preamble: runner.augment_output_preamble,
+                            request_patch: request_patch.as_ref(),
+                        },
+                    )
                     .await
                     {
                         Ok(prepared) => prepared,
@@ -588,7 +590,6 @@ where
                             break 'outer;
                         }
                     };
-                    run.set_output_tool_name(prepared.output_tool_name.clone());
                     let turn_tool_snapshot = prepared.tool_snapshot.clone();
                     if runner.record_telemetry_content {
                         let input_messages = prepared.builder.messages_for_telemetry();

--- a/crates/rig-agent/src/agent/run/mod.rs
+++ b/crates/rig-agent/src/agent/run/mod.rs
@@ -207,6 +207,28 @@ pub struct PendingToolCall {
     pub internal_call_id: Option<String>,
 }
 
+impl PendingToolCall {
+    /// Correlate an executed tool's output with this call, producing the
+    /// tool-result content [`AgentRun::tool_results`] expects.
+    ///
+    /// This applies the same correlation every built-in dispatch surface
+    /// does — the result carries this call's id, provider call id, and
+    /// executed tool name — so a manual driver (for example one finishing a
+    /// resumed run through
+    /// [`Agent::tool_server_handle`](crate::agent::Agent::tool_server_handle))
+    /// never copies those fields by hand. It does not consult
+    /// [`preresolved_result`](Self::preresolved_result); return that content
+    /// directly instead of executing anything when it is set.
+    pub fn result_content(&self, output: crate::tool::ToolOutput) -> UserContent {
+        UserContent::tool_result_for(
+            self.tool_call.id.clone(),
+            self.tool_call.provider.clone(),
+            self.tool_call.function.name.clone(),
+            output.into_content(),
+        )
+    }
+}
+
 /// A completed model turn fed back to [`AgentRun::model_response`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -489,6 +511,15 @@ impl AgentRun {
     pub fn with_tool_choice(mut self, tool_choice: ToolChoice) -> Self {
         self.tool_choice = Some(tool_choice);
         self
+    }
+
+    /// The tool choice active for this run, if any. Request preparation for a
+    /// manually driven run reads this — never the agent baseline directly —
+    /// so the policy advertised to the provider always matches the policy the
+    /// run enforces, even after [`Self::with_tool_choice`] overrides the
+    /// seeded value.
+    pub(crate) fn tool_choice(&self) -> Option<&ToolChoice> {
+        self.tool_choice.as_ref()
     }
 
     /// Set the synthetic output-tool name for Tool output mode (see #1928).

--- a/crates/rig-agent/src/agent/run/mod.rs
+++ b/crates/rig-agent/src/agent/run/mod.rs
@@ -29,6 +29,55 @@
 //! [`Agent::runner`](crate::agent::Agent::runner); constructing an `AgentRun`
 //! directly is not an alternate way to execute an `Agent`.
 //!
+//! # Driving a run with a configured `Agent`
+//!
+//! A manual driver can still use an already-built `Agent` as its configuration
+//! and tool source without duplicating either:
+//!
+//! - [`Agent::new_run`](crate::agent::Agent::new_run) seeds a run with the
+//!   agent's durable run policy;
+//! - [`Agent::prepare_completion_request`](crate::agent::Agent::prepare_completion_request)
+//!   prepares one fully configured, hook-free provider request straight from a
+//!   [`AgentRunStep::CallModel`] step, returning a
+//!   [`PreparedAgentRequest`](crate::agent::PreparedAgentRequest) whose
+//!   [`PreparedAgentTurn`](crate::agent::PreparedAgentTurn) half pairs the
+//!   response and the turn's tool calls with the exact name-set metadata and
+//!   implementation snapshot that request carried;
+//! - after a cross-process resume, the rebuilt agent's live
+//!   [`Agent::tool_server_handle`](crate::agent::Agent::tool_server_handle)
+//!   dispatches the pending calls under live-registry semantics.
+//!
+//! ```text
+//! Agent
+//!   | new_run(prompt)
+//!   +-------------------------------> AgentRun            (durable policy)
+//!   |
+//!   | prepare_completion_request(prompt, history, &mut run)
+//!   v
+//! PreparedAgentRequest
+//!   | into_parts()
+//!   +----> request                    caller sends through its transport
+//!   `----> PreparedAgentTurn          (in-process, one issued turn)
+//!           | model_turn(response)    exact name-set metadata
+//!           ` execute_call(...)       exact pinned implementation snapshot
+//!
+//! After cross-process resume only:
+//! rebuilt Agent::tool_server_handle() live dispatch, live-registry semantics
+//! ```
+//!
+//! This surface is hook-free by design: no hooks fire, no memory is appended,
+//! no classic lifecycle or telemetry spans open, and no tool concurrency or
+//! approval policy applies — behavior that exists only as a hook (including
+//! passive dynamic context) simply does not happen here. Manual driving makes
+//! the caller own: provider IO and transport behavior, retry bounds and replay
+//! safety, result conversion and correlation, persistence timing, registry
+//! consistency across deploys, any approval/hook policy, and memory/telemetry.
+//! No durability exists beyond what `AgentRun` already provides: the prepared
+//! request and turn are in-process values for one issued request, while the
+//! serializable `AgentRun` remains the only durable state.
+//! [`AgentRunner`](crate::agent::AgentRunner) remains the only
+//! batteries-included runtime.
+//!
 //! [`crate::completion::Prompt::prompt`] and
 //! [`Agent::runner`](crate::agent::Agent::runner) drive this machine internally;
 //! the same machine can be driven by hand for custom provider control flow:

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -225,6 +225,16 @@ pub struct AgentRunner {
     pub(crate) error_usage: Option<Arc<Mutex<Usage>>>,
 }
 
+/// Default total model-call budget when the agent does not configure one.
+/// Shared by [`AgentRunner::from_agent`] and
+/// [`Agent::new_run`](crate::agent::Agent::new_run) so the runner and the
+/// manual-driver surface seed identical run policy.
+pub(crate) const DEFAULT_MAX_TURNS: usize = 1;
+
+/// Default budget for invalid tool-call retries. Shared like
+/// [`DEFAULT_MAX_TURNS`].
+pub(crate) const DEFAULT_INVALID_TOOL_CALL_RETRIES: usize = 0;
+
 impl AgentRunner {
     /// Build a runner from an agent, seeding it with the agent's default hook
     /// stack. Prefer [`Agent::runner`].
@@ -232,8 +242,8 @@ impl AgentRunner {
         Self {
             prompt: prompt.into(),
             chat_history: None,
-            max_turns: agent.default_max_turns.unwrap_or(1),
-            max_invalid_tool_call_retries: 0,
+            max_turns: agent.default_max_turns.unwrap_or(DEFAULT_MAX_TURNS),
+            max_invalid_tool_call_retries: DEFAULT_INVALID_TOOL_CALL_RETRIES,
             model: agent.model.clone(),
             agent_name: agent.name.clone(),
             preamble: agent.preamble.clone(),

--- a/crates/rig-agent/src/tool/mod.rs
+++ b/crates/rig-agent/src/tool/mod.rs
@@ -570,6 +570,26 @@ pub(crate) struct ToolDispatch {
     pub(crate) context: ToolContext,
 }
 
+impl ToolDispatch {
+    /// Publish this dispatch's outcome to the caller-owned context and return
+    /// its result: the dispatch's result metadata is adopted, while the
+    /// caller's inbound values are untouched.
+    ///
+    /// The shared completion half of the context-hygiene contract used by
+    /// every `execute` surface
+    /// ([`ToolServerHandle::execute`](crate::tool::server::ToolServerHandle::execute),
+    /// [`ToolSet::execute`], and the registry-snapshot execute behind
+    /// [`PreparedAgentTurn::execute_call`](crate::agent::PreparedAgentTurn::execute_call)).
+    /// Callers must run [`ToolContext::clear_dispatch_result`] **before**
+    /// starting the dispatch — not here — so a dispatch future that is
+    /// cancelled mid-flight cannot leave the previous dispatch's stale
+    /// metadata behind (pinned by the cancelled-dispatch hygiene tests).
+    pub(crate) fn publish(self, context: &mut ToolContext) -> ToolResult {
+        context.accept_dispatch_result(self.context);
+        self.result
+    }
+}
+
 /// Execute a resolved registry entry through the single dispatch boundary.
 ///
 /// Every surface enters here with its caller-owned context. The helper clones
@@ -724,14 +744,12 @@ impl ToolSet {
         args: impl Into<String>,
         context: &mut ToolContext,
     ) -> ToolResult {
+        // Clear BEFORE dispatching (not in `publish`): a cancelled dispatch
+        // must not leave the previous dispatch's stale metadata behind.
         context.clear_dispatch_result();
         let tool = self.get(name).cloned();
-        let ToolDispatch {
-            result,
-            context: dispatch_context,
-        } = dispatch_tool(name, args.into(), tool, context).await;
-        context.accept_dispatch_result(dispatch_context);
-        result
+        let dispatch = dispatch_tool(name, args.into(), tool, context).await;
+        dispatch.publish(context)
     }
 
     /// Documents describing all registered tools.

--- a/crates/rig-agent/src/tool/server.rs
+++ b/crates/rig-agent/src/tool/server.rs
@@ -53,35 +53,34 @@ impl ToolRegistrySnapshot {
     }
 
     /// Dispatch through the exact implementation advertised for this turn.
+    /// Takes owned args so a caller that already built the serialized payload
+    /// moves it instead of re-copying it.
     pub(crate) async fn dispatch(
         &self,
         tool_name: &str,
-        args: &str,
+        args: impl Into<String>,
         context: &ToolContext,
     ) -> ToolDispatch {
         let tool = self.tools.get(tool_name).cloned();
-        dispatch_tool(tool_name, args.to_string(), tool, context).await
+        dispatch_tool(tool_name, args.into(), tool, context).await
     }
 
     /// Execute a pinned tool through the canonical structured path.
     ///
     /// Mirrors [`ToolServerHandle::execute`] against this snapshot's pinned
-    /// handles: clears result metadata from the previous dispatch, runs one
-    /// isolated dispatch, and publishes the new dispatch's result metadata
-    /// back to `context`.
+    /// handles; [`ToolDispatch::publish`] owns the shared completion half of
+    /// the context-hygiene contract.
     pub(crate) async fn execute(
         &self,
         tool_name: &str,
-        args: &str,
+        args: impl Into<String>,
         context: &mut ToolContext,
     ) -> ToolResult {
+        // Clear BEFORE dispatching (not in `publish`): a cancelled dispatch
+        // must not leave the previous dispatch's stale metadata behind.
         context.clear_dispatch_result();
-        let ToolDispatch {
-            result,
-            context: dispatch_context,
-        } = self.dispatch(tool_name, args, context).await;
-        context.accept_dispatch_result(dispatch_context);
-        result
+        let dispatch = self.dispatch(tool_name, args, context).await;
+        dispatch.publish(context)
     }
 }
 
@@ -447,13 +446,11 @@ impl ToolServerHandle {
         args: &str,
         context: &mut ToolContext,
     ) -> ToolResult {
+        // Clear BEFORE dispatching (not in `publish`): a cancelled dispatch
+        // must not leave the previous dispatch's stale metadata behind.
         context.clear_dispatch_result();
-        let ToolDispatch {
-            result,
-            context: dispatch_context,
-        } = self.dispatch(tool_name, args, context).await;
-        context.accept_dispatch_result(dispatch_context);
-        result
+        let dispatch = self.dispatch(tool_name, args, context).await;
+        dispatch.publish(context)
     }
 
     /// Run one isolated dispatch and retain its full context for agent hooks.

--- a/crates/rig-agent/src/tool/server.rs
+++ b/crates/rig-agent/src/tool/server.rs
@@ -62,6 +62,27 @@ impl ToolRegistrySnapshot {
         let tool = self.tools.get(tool_name).cloned();
         dispatch_tool(tool_name, args.to_string(), tool, context).await
     }
+
+    /// Execute a pinned tool through the canonical structured path.
+    ///
+    /// Mirrors [`ToolServerHandle::execute`] against this snapshot's pinned
+    /// handles: clears result metadata from the previous dispatch, runs one
+    /// isolated dispatch, and publishes the new dispatch's result metadata
+    /// back to `context`.
+    pub(crate) async fn execute(
+        &self,
+        tool_name: &str,
+        args: &str,
+        context: &mut ToolContext,
+    ) -> ToolResult {
+        context.clear_dispatch_result();
+        let ToolDispatch {
+            result,
+            context: dispatch_context,
+        } = self.dispatch(tool_name, args, context).await;
+        context.accept_dispatch_result(dispatch_context);
+        result
+    }
 }
 
 /// Shared state behind a `ToolServerHandle`.

--- a/examples/agent_run_stepping/src/main.rs
+++ b/examples/agent_run_stepping/src/main.rs
@@ -272,11 +272,12 @@ async fn main() -> Result<()> {
     let agent = build_agent(model);
     let mut run: AgentRun = serde_json::from_str(&suspended)?;
     let handle = agent.tool_server_handle();
+    // As in Part 1: one tool context for the whole (resumed) run.
+    let mut context = ToolContext::new();
 
     loop {
         match run.next_step()? {
             AgentRunStep::CallTools { calls } => {
-                let mut context = ToolContext::new();
                 let mut results = Vec::with_capacity(calls.len());
                 for call in calls {
                     // Tool calls suppressed by invalid tool-call recovery come

--- a/examples/agent_run_stepping/src/main.rs
+++ b/examples/agent_run_stepping/src/main.rs
@@ -1,34 +1,67 @@
-//! Two complementary ways to drive the agent loop.
+//! Three complementary ways to drive the agent loop.
 //!
-//! ## Part 1 — hand-driven [`AgentRun`] state machine
+//! ## Part 1 — hand-driven [`AgentRun`] fed by a configured [`rig::agent::Agent`]
 //!
 //! `agent.prompt(...)` runs this machine internally; stepping it yourself lets
-//! you inspect every model call, execute tools with your own policy, and —
-//! because the machine is fully serializable between steps — pause a run while
-//! tool calls are pending and resume it later (even in another process).
+//! you inspect every model call and execute tools with your own policy. The
+//! agent stays the single source of configuration and tools:
+//! `agent.new_run(...)` seeds the run with the agent's durable policy, and
+//! `agent.prepare_completion_request(...)` builds each hook-free provider
+//! request straight from the `CallModel` step. The returned
+//! [`rig::agent::PreparedAgentTurn`] pairs the response and the turn's tool
+//! calls with the exact tool-name sets and implementation snapshot the request
+//! advertised.
 //!
-//! ## Part 2 — high-level [`rig::agent::AgentRunner`] with hooks
+//! The relationship:
+//!
+//! ```text
+//! Agent
+//!   | new_run(prompt)
+//!   +-------------------------------> AgentRun            (durable policy)
+//!   |
+//!   | prepare_completion_request(prompt, history, &mut run)
+//!   v
+//! PreparedAgentRequest
+//!   | into_parts()
+//!   +----> request                    caller sends through its transport
+//!   `----> PreparedAgentTurn          (in-process, one issued turn)
+//!           | model_turn(response)    exact name-set metadata
+//!           ` execute_call(...)       exact pinned implementation snapshot
+//!
+//! After cross-process resume only:
+//! rebuilt Agent::tool_server_handle() live dispatch, live-registry semantics
+//! ```
+//!
+//! This surface runs no hooks, memory, telemetry, or concurrency policy: the
+//! manual driver owns provider IO, retry bounds, result correlation,
+//! persistence timing, and any approval policy.
+//!
+//! ## Part 2 — cross-process resume
+//!
+//! The run state is fully serializable while tool calls are pending. A
+//! restarted process rebuilds the agent, deserializes the run, and finishes
+//! the pending calls through the rebuilt agent's live
+//! `tool_server_handle()` — the prepared turn is in-process state for one
+//! issued request and deliberately does not survive.
+//!
+//! ## Part 3 — high-level [`rig::agent::AgentRunner`] with hooks
 //!
 //! For the common case you don't need that level of control: attach an
 //! [`AgentHook`] to observe tool calls (and every other event) without
 //! hand-driving the loop. Use `agent.runner(prompt).add_hook(h).run().await`.
 //!
-//! Both approaches are demonstrated in `main` below.
-//!
 //! Requires `OPENAI_API_KEY`.
 
-use std::collections::BTreeSet;
-
 use anyhow::Result;
-use rig::agent::run::{AgentRun, AgentRunStep, ModelTurn, ModelTurnOutcome};
+use rig::agent::run::{AgentRun, AgentRunStep, ModelTurnOutcome};
 use rig::agent::{
-    AgentHook, HookContext, InvalidToolCallAction, ToolCall as ToolCallEvent, ToolCallAction,
+    Agent, AgentHook, HookContext, InvalidToolCallAction, ToolCall as ToolCallEvent, ToolCallAction,
 };
 use rig::completion::CompletionModel;
 use rig::message::UserContent;
 use rig::prelude::*;
 use rig::providers::openai;
-use rig::tool::{Tool, ToolSet};
+use rig::tool::{Tool, ToolContext};
 use serde::Deserialize;
 use serde_json::json;
 
@@ -67,16 +100,25 @@ impl Tool for Add {
 
     async fn call(
         &self,
-        _context: &mut rig::tool::ToolContext,
+        _context: &mut ToolContext,
         args: Self::Args,
     ) -> Result<Self::Output, Self::Error> {
         Ok(args.x + args.y)
     }
 }
 
+/// Build the calculator agent. Part 2 calls this twice to simulate a process
+/// restart: the "restarted process" reconstructs an equivalent agent.
+fn build_agent(model: impl CompletionModel + 'static) -> Agent {
+    rig::agent::AgentBuilder::new(model)
+        .preamble("You are a calculator. Always use the provided tools to compute results.")
+        .tool(Add)
+        .build()
+}
+
 // ---------------------------------------------------------------------------
 // A minimal AgentHook that logs every tool call routed through the runner.
-// Used in Part 2 below to show the high-level hook-based path.
+// Used in Part 3 below to show the high-level hook-based path.
 // ---------------------------------------------------------------------------
 
 struct ToolLoggerHook;
@@ -92,16 +134,27 @@ impl AgentHook for ToolLoggerHook {
 async fn main() -> Result<()> {
     let openai = openai::Client::from_env()?;
     let model = openai.completion_model(openai::GPT_4O);
-    let agent = rig::agent::AgentBuilder::new(model.clone())
-        .preamble("You are a calculator. Always use the provided tools to compute results.")
-        .tool(Add)
-        .build();
-    let local_tools = ToolSet::builder().static_tool(Add).build();
-    let tool_definitions = local_tools.get_tool_definitions();
+    let agent = build_agent(model.clone());
 
-    let mut run = AgentRun::new("What is 2 + 5?").max_turns(2);
+    // -----------------------------------------------------------------------
+    // Part 1 — manual loop over the agent-seeded run.
+    // -----------------------------------------------------------------------
+
+    // Seed the run with the agent's durable policy (tool choice, output
+    // validation, default turn budget); `AgentRun`'s builder methods still
+    // apply on top.
+    let mut run = agent.new_run("What is 2 + 5?").max_turns(2);
+    // The prepared turn from the latest model call, retained across the send
+    // so the following `CallTools` step dispatches through the same pinned
+    // implementation snapshot whose definitions the provider saw.
+    let mut prepared_turn = None;
+    // One tool context for the whole run, like the classic runner: result
+    // metadata from each dispatch is published back into it.
+    let mut context = ToolContext::new();
 
     loop {
+        // Both `AgentRunStep` and `ModelTurnOutcome` are deliberately
+        // exhaustive: a driver must handle every variant.
         match run.next_step()? {
             AgentRunStep::CallModel {
                 prompt,
@@ -109,75 +162,54 @@ async fn main() -> Result<()> {
                 turn,
             } => {
                 println!("→ model call #{turn}");
-                // A hand-driven `AgentRun` is a sans-IO protocol primitive, not
-                // execution of the configured `Agent`. Its transport is an
-                // explicit raw model request and therefore has no agent hooks.
-                let response = model
-                    .completion_request(prompt)
-                    .messages(history)
-                    .preamble(
-                        "You are a calculator. Always use the provided tools to compute results."
-                            .to_string(),
-                    )
-                    .tools(tool_definitions.clone())
-                    .send()
-                    .await?;
-
-                // The tools advertised to the provider for this turn. With
-                // static tools these are the agent's registered tools; agents
-                // with dynamic (RAG) tools would resolve them per turn.
-                let tool_names: BTreeSet<String> = tool_definitions
-                    .iter()
-                    .map(|def| def.name.clone())
-                    .collect();
-
-                let mut outcome = run.model_response(ModelTurn::new(
-                    response.message_id.clone(),
-                    response.choice.clone(),
-                    response.usage,
-                    tool_names.clone(),
-                    tool_names,
-                ))?;
-                while let ModelTurnOutcome::NeedsResolution(context) = outcome {
-                    eprintln!("model called unknown tool `{}`", context.tool_name);
-                    // Preserve the agent loop's default fail-fast behavior; a
-                    // driver could instead retry, repair, or skip here.
-                    outcome = run.resolve_invalid_tool_call(InvalidToolCallAction::fail())?;
+                // Prepare a hook-free request directly from the step's fields.
+                // The agent supplies preamble, context, sampling parameters,
+                // tool definitions, and tool choice; impossible tool choices
+                // fail here, before any provider IO.
+                let (request, turn_pairing) = agent
+                    .prepare_completion_request(prompt, &history, &mut run)
+                    .await?
+                    .into_parts();
+                // The caller owns the send (its transport, retries, and
+                // errors). `model_turn` then supplies the exact executable and
+                // allowed tool-name sets the request advertised — nothing is
+                // re-derived from the live registry.
+                let response = request.send().await?;
+                let mut outcome = run.model_response(turn_pairing.model_turn(response))?;
+                prepared_turn = Some(turn_pairing);
+                loop {
+                    match outcome {
+                        ModelTurnOutcome::Continue { .. } => break,
+                        ModelTurnOutcome::TurnRetried => break,
+                        ModelTurnOutcome::NeedsResolution(context) => {
+                            eprintln!("model called unknown tool `{}`", context.tool_name);
+                            // Preserve the agent loop's default fail-fast
+                            // behavior; a driver could instead retry, repair,
+                            // or skip here.
+                            outcome =
+                                run.resolve_invalid_tool_call(InvalidToolCallAction::fail())?;
+                        }
+                    }
                 }
             }
-            AgentRunStep::CallTools { .. } => {
-                // The whole run is serializable while tool calls are pending:
-                // persist it here to pause for approval and resume later —
-                // even in a process that never saw this step. The resumed run
-                // re-emits the pending tool calls from its own state.
-                let suspended = serde_json::to_string(&run)?;
-                let mut run_resumed: AgentRun = serde_json::from_str(&suspended)?;
-                let AgentRunStep::CallTools { calls } = run_resumed.next_step()? else {
-                    anyhow::bail!("resumed run must re-emit the pending tool calls");
+            AgentRunStep::CallTools { calls } => {
+                let Some(turn_pairing) = prepared_turn.as_ref() else {
+                    anyhow::bail!("CallTools always follows a prepared model call");
                 };
-
-                let mut results = Vec::new();
-                for call in calls {
-                    // Tool calls suppressed by invalid tool-call recovery come
-                    // with a pre-resolved result and must not be executed.
-                    if let Some(result) = call.preresolved_result {
-                        results.push(result);
-                        continue;
-                    }
-                    let name = &call.tool_call.function.name;
-                    let args = call.tool_call.function.arguments.to_string();
-                    println!("→ executing {name}({args})");
-                    let mut context = rig::tool::ToolContext::new();
-                    let result = local_tools.execute(name, args, &mut context).await;
-                    results.push(UserContent::tool_result_for(
-                        call.tool_call.id.clone(),
-                        call.tool_call.provider.clone(),
-                        name.clone(),
-                        result.output().clone().into_content(),
-                    ));
+                let mut results = Vec::with_capacity(calls.len());
+                for call in &calls {
+                    println!(
+                        "→ executing {}({})",
+                        call.tool_call.function.name, call.tool_call.function.arguments
+                    );
+                    // `execute_call` honors pre-resolved results (from invalid
+                    // tool-call recovery) and dispatches everything else
+                    // through the snapshot pinned at preparation — a tool
+                    // re-registered since then cannot be reached, and a tool
+                    // registered since then is rejected.
+                    results.push(turn_pairing.execute_call(call, &mut context).await);
                 }
-                run_resumed.tool_results(results)?;
-                run = run_resumed;
+                run.tool_results(results)?;
             }
             AgentRunStep::Done(response) => {
                 println!("✓ {}", response.output);
@@ -192,7 +224,104 @@ async fn main() -> Result<()> {
     }
 
     // -----------------------------------------------------------------------
-    // Part 2 — high-level AgentRunner path with hooks
+    // Part 2 — cross-process resume.
+    //
+    // Drive a fresh run up to its first pending tool calls, serialize it, and
+    // "restart": rebuild the agent and finish through its live handle.
+    // -----------------------------------------------------------------------
+
+    println!("\n--- Part 2: suspend with pending tool calls, resume after a restart ---");
+
+    let mut run = agent.new_run("What is 3 + 4?").max_turns(2);
+    let suspended = loop {
+        match run.next_step()? {
+            AgentRunStep::CallModel {
+                prompt, history, ..
+            } => {
+                let (request, turn_pairing) = agent
+                    .prepare_completion_request(prompt, &history, &mut run)
+                    .await?
+                    .into_parts();
+                let response = request.send().await?;
+                match run.model_response(turn_pairing.model_turn(response))? {
+                    ModelTurnOutcome::Continue { .. } | ModelTurnOutcome::TurnRetried => {}
+                    ModelTurnOutcome::NeedsResolution(context) => {
+                        anyhow::bail!("unexpected unknown tool `{}`", context.tool_name);
+                    }
+                }
+            }
+            // Suspend while tool calls are pending: the serialized run is
+            // self-contained and re-emits them on resume.
+            AgentRunStep::CallTools { .. } => break serde_json::to_string(&run)?,
+            AgentRunStep::Done(response) => {
+                anyhow::bail!(
+                    "expected a tool call before completion, got: {}",
+                    response.output
+                )
+            }
+        }
+    };
+    drop(run);
+    drop(agent);
+
+    // "Restarted process": rebuild an equivalent agent and deserialize the
+    // run. The `PreparedAgentTurn` did not survive — it pins an in-process
+    // implementation snapshot for one issued request and is deliberately not
+    // serializable — so pending calls dispatch through the rebuilt agent's
+    // live tool_server_handle(), under live-registry semantics.
+    let agent = build_agent(model);
+    let mut run: AgentRun = serde_json::from_str(&suspended)?;
+    let handle = agent.tool_server_handle();
+
+    loop {
+        match run.next_step()? {
+            AgentRunStep::CallTools { calls } => {
+                let mut context = ToolContext::new();
+                let mut results = Vec::with_capacity(calls.len());
+                for call in calls {
+                    // Tool calls suppressed by invalid tool-call recovery come
+                    // with a pre-resolved result and must not be executed.
+                    if let Some(result) = call.preresolved_result {
+                        results.push(result);
+                        continue;
+                    }
+                    let name = &call.tool_call.function.name;
+                    let args = call.tool_call.function.arguments.to_string();
+                    println!("→ executing {name}({args}) via the live handle");
+                    let result = handle.execute(name, &args, &mut context).await;
+                    results.push(UserContent::tool_result_for(
+                        call.tool_call.id.clone(),
+                        call.tool_call.provider.clone(),
+                        name.clone(),
+                        result.output().clone().into_content(),
+                    ));
+                }
+                run.tool_results(results)?;
+            }
+            AgentRunStep::CallModel {
+                prompt, history, ..
+            } => {
+                let (request, turn_pairing) = agent
+                    .prepare_completion_request(prompt, &history, &mut run)
+                    .await?
+                    .into_parts();
+                let response = request.send().await?;
+                match run.model_response(turn_pairing.model_turn(response))? {
+                    ModelTurnOutcome::Continue { .. } | ModelTurnOutcome::TurnRetried => {}
+                    ModelTurnOutcome::NeedsResolution(context) => {
+                        anyhow::bail!("unexpected unknown tool `{}`", context.tool_name);
+                    }
+                }
+            }
+            AgentRunStep::Done(response) => {
+                println!("✓ resumed run finished: {}", response.output);
+                break;
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Part 3 — high-level AgentRunner path with hooks
     //
     // Most use-cases don't need the manual stepping above. `agent.runner(…)`
     // returns an `AgentRunner` that drives the same machine internally while
@@ -200,7 +329,7 @@ async fn main() -> Result<()> {
     // `.add_hook(h)`; each call appends another hook to the stack.
     // -----------------------------------------------------------------------
 
-    println!("\n--- Part 2: AgentRunner with ToolLoggerHook ---");
+    println!("\n--- Part 3: AgentRunner with ToolLoggerHook ---");
 
     let resp = agent
         .runner("What is 2 + 5?")

--- a/examples/agent_run_stepping/src/main.rs
+++ b/examples/agent_run_stepping/src/main.rs
@@ -58,7 +58,6 @@ use rig::agent::{
     Agent, AgentHook, HookContext, InvalidToolCallAction, ToolCall as ToolCallEvent, ToolCallAction,
 };
 use rig::completion::CompletionModel;
-use rig::message::UserContent;
 use rig::prelude::*;
 use rig::providers::openai;
 use rig::tool::{Tool, ToolContext};
@@ -167,7 +166,7 @@ async fn main() -> Result<()> {
                 // tool definitions, and tool choice; impossible tool choices
                 // fail here, before any provider IO.
                 let (request, turn_pairing) = agent
-                    .prepare_completion_request(prompt, &history, &mut run)
+                    .prepare_completion_request(prompt, history, &mut run)
                     .await?
                     .into_parts();
                 // The caller owns the send (its transport, retries, and
@@ -239,7 +238,7 @@ async fn main() -> Result<()> {
                 prompt, history, ..
             } => {
                 let (request, turn_pairing) = agent
-                    .prepare_completion_request(prompt, &history, &mut run)
+                    .prepare_completion_request(prompt, history, &mut run)
                     .await?
                     .into_parts();
                 let response = request.send().await?;
@@ -279,23 +278,21 @@ async fn main() -> Result<()> {
         match run.next_step()? {
             AgentRunStep::CallTools { calls } => {
                 let mut results = Vec::with_capacity(calls.len());
-                for call in calls {
+                for call in &calls {
                     // Tool calls suppressed by invalid tool-call recovery come
                     // with a pre-resolved result and must not be executed.
-                    if let Some(result) = call.preresolved_result {
-                        results.push(result);
+                    if let Some(result) = &call.preresolved_result {
+                        results.push(result.clone());
                         continue;
                     }
                     let name = &call.tool_call.function.name;
                     let args = call.tool_call.function.arguments.to_string();
                     println!("→ executing {name}({args}) via the live handle");
                     let result = handle.execute(name, &args, &mut context).await;
-                    results.push(UserContent::tool_result_for(
-                        call.tool_call.id.clone(),
-                        call.tool_call.provider.clone(),
-                        name.clone(),
-                        result.output().clone().into_content(),
-                    ));
+                    // `result_content` correlates the executed tool's output
+                    // with this call (id, provider call id, tool name), so
+                    // none of those fields are copied by hand.
+                    results.push(call.result_content(result.output().clone()));
                 }
                 run.tool_results(results)?;
             }
@@ -303,7 +300,7 @@ async fn main() -> Result<()> {
                 prompt, history, ..
             } => {
                 let (request, turn_pairing) = agent
-                    .prepare_completion_request(prompt, &history, &mut run)
+                    .prepare_completion_request(prompt, history, &mut run)
                     .await?
                     .into_parts();
                 let response = request.send().await?;


### PR DESCRIPTION
Restore the focused low-level capabilities lost when Agent fields and raw
completion construction became private: callers manually driving AgentRun can
seed a run from durable agent policy, prepare one configured hook-free
request, pair its response and tool calls with the exact turn
metadata/implementation snapshot, and clone the agent's live ToolServerHandle
when rebuilding after a resume. AgentRunner remains the only
batteries-included runtime; this PR adds no second coordinator.

## What's restored

In v0.40 a manual `AgentRun` driver could use an already-built `Agent` as the
configuration and tool source for its loop; v0.41 removed that when `Agent`
fields went private and the raw `Completion`/`StreamingCompletion` impls were
deleted. This PR restores exactly that capability, additively:

- `Agent::tool_server_handle()` — owned clone of the **live** registry handle
  (the capability to use after a cross-process resume; observes later registry
  changes).
- `Agent::new_run(prompt)` — a plain `AgentRun` seeded with the agent's
  durable run policy, constructed through the same `build_agent_run` path the
  runner uses, so the two cannot drift.
- `Agent::prepare_completion_request(prompt, history, &mut run)` — one fully
  configured, hook-free provider request, fed directly from
  `AgentRunStep::CallModel`'s fields. Reads the run's committed output-tool
  name and commits the freshly resolved name back (exactly as the classic
  driver does), so multi-turn Tool-mode pinning and run/request output policy
  stay paired. Impossible tool choices fail before any provider IO.
- `PreparedAgentRequest::into_parts()` → the sendable request builder plus an
  opaque `PreparedAgentTurn` owning exactly two operations:
  - `model_turn(response)` supplies the exact executable/allowed tool-name
    sets captured at preparation (no more hand-ordering two same-typed sets);
  - `execute_call(call, &mut context)` honors `preresolved_result`, applies
    the standard clear→dispatch→accept context hygiene, and executes only
    through the registry snapshot **pinned at preparation** — a tool
    re-registered afterwards is unreachable, a tool registered afterwards is
    rejected.

The prepared pair is in-process state for one issued request — not
serializable, no durability claims. Durable state remains the `AgentRun`.
Hook-free means hook-free: no hooks, memory, telemetry spans, concurrency
policy, or passive dynamic context run on this surface, and the docs say so.

## Docs and tests

- `examples/agent_run_stepping` rewritten around the new surface, including a
  cross-process resume that finishes pending calls via the rebuilt agent's
  `tool_server_handle()`.
- `run` module docs gained the Agent ⇄ AgentRun ⇄ PreparedAgentRequest/Turn
  relationship diagram and the list of what manual driving makes the caller
  own; MIGRATING.md gained a matching "0.41 → next" section (`DynamicTool`
  remains the replacement for `Box<dyn ToolDyn>`).
- 14 in-crate tests cover: agent-built tool access, configured preparation,
  exact name-set handoff, snapshot fidelity, seeded-run policy agreement
  (output mode/tool name, output validation, turn and retry budgets, pre-IO
  tool-choice validation), the hook-free boundary (plus a guard that the same
  hook still fires under `AgentRunner`), a full manual round trip,
  pre-resolved hygiene, and a cross-process resume guard.

Verified: `cargo fmt`, full `rig-agent` suite, `clippy --all-targets
--all-features -D warnings` (rig-agent + example), rustdoc with warnings
denied, `git diff --check`.

Supersedes the direction of #2278 for fixing this regression (analysis:
https://gist.github.com/gold-silver-copper/5bdcbc6afbab072cdb93fb614b719fc5);
no `AgentDriver`/`DriveStep`/`TurnTools` and no second coordinator.
(`on_reasoning_delta` was already fixed by #2282.)
