### PR TITLE
Consolidate provider and agent boilerplate

### DIFF
--- a/crates/rig-agent/src/agent/run/mod.rs
+++ b/crates/rig-agent/src/agent/run/mod.rs
@@ -108,6 +108,38 @@ fn unknown_tool_call_error(
     }
 }
 
+struct InvalidToolCallDiagnostic<'a> {
+    tool_call: &'a ToolCall,
+    executable_tool_names: &'a BTreeSet<String>,
+    allowed_tool_names: &'a BTreeSet<String>,
+    history: &'a [Message],
+}
+
+impl InvalidToolCallDiagnostic<'_> {
+    fn unknown(&self, tool_name: String) -> PromptError {
+        unknown_tool_call_error(
+            tool_name,
+            self.executable_tool_names.iter().cloned().collect(),
+            self.allowed_tool_names.iter().cloned().collect(),
+            self.history.to_vec(),
+        )
+    }
+
+    fn unknown_current(&self) -> PromptError {
+        self.unknown(self.tool_call.function.name.clone())
+    }
+
+    fn cancelled(&self, reason: String) -> PromptError {
+        PromptError::prompt_cancelled(self.history.to_vec(), reason)
+    }
+}
+
+enum ValidatedInvalidToolCallAction {
+    Retry { feedback: String },
+    Repair { tool_name: String },
+    Skip { reason: String },
+}
+
 /// Default number of times Tool output mode re-prompts the model for valid
 /// structured output before finalizing best-effort (see #1928). Mirrors
 /// pydantic-ai's default output-retry budget of 1.
@@ -924,6 +956,48 @@ impl AgentRun {
         }));
     }
 
+    /// Validate the recovery policy shared by buffered and streamed turns.
+    /// Medium-specific rollback, repair, and skip effects remain at the call
+    /// sites; rejection, retry budgeting, and tool-choice checks live here so
+    /// the two surfaces cannot drift.
+    fn validate_invalid_tool_call_action(
+        &mut self,
+        action: InvalidToolCallAction,
+        diagnostic: InvalidToolCallDiagnostic<'_>,
+    ) -> Result<ValidatedInvalidToolCallAction, PromptError> {
+        let result = match action {
+            InvalidToolCallAction::Fail => Err(diagnostic.unknown_current()),
+            InvalidToolCallAction::Retry { feedback } => {
+                if self.invalid_tool_call_retries >= self.max_invalid_tool_call_retries {
+                    Err(diagnostic.unknown_current())
+                } else {
+                    self.invalid_tool_call_retries += 1;
+                    Ok(ValidatedInvalidToolCallAction::Retry { feedback })
+                }
+            }
+            InvalidToolCallAction::Repair { tool_name } => {
+                if diagnostic.allowed_tool_names.contains(&tool_name) {
+                    Ok(ValidatedInvalidToolCallAction::Repair { tool_name })
+                } else {
+                    Err(diagnostic.unknown(tool_name))
+                }
+            }
+            InvalidToolCallAction::Stop { reason } => Err(diagnostic.cancelled(reason)),
+            InvalidToolCallAction::Skip { reason } => {
+                if matches!(self.tool_choice, Some(ToolChoice::None)) {
+                    Err(diagnostic.unknown_current())
+                } else {
+                    Ok(ValidatedInvalidToolCallAction::Skip { reason })
+                }
+            }
+        };
+
+        if result.is_err() {
+            self.state = RunState::Failed;
+        }
+        result
+    }
+
     /// Answer a pending [`ModelTurnOutcome::NeedsResolution`].
     ///
     /// Applies the agent loop's recovery semantics:
@@ -971,29 +1045,18 @@ impl AgentRun {
         };
 
         let diagnostic_history = self.diagnostic_history(&resolving);
-        let executable_tool_names: Vec<String> =
-            resolving.executable_tool_names.iter().cloned().collect();
-        let allowed_tool_names: Vec<String> =
-            resolving.allowed_tool_names.iter().cloned().collect();
+        let action = self.validate_invalid_tool_call_action(
+            action,
+            InvalidToolCallDiagnostic {
+                tool_call: &tool_call,
+                executable_tool_names: &resolving.executable_tool_names,
+                allowed_tool_names: &resolving.allowed_tool_names,
+                history: &diagnostic_history,
+            },
+        )?;
 
         match action {
-            InvalidToolCallAction::Fail => Err(unknown_tool_call_error(
-                tool_call.function.name,
-                executable_tool_names,
-                allowed_tool_names,
-                diagnostic_history,
-            )),
-            InvalidToolCallAction::Retry { feedback } => {
-                if self.invalid_tool_call_retries >= self.max_invalid_tool_call_retries {
-                    return Err(unknown_tool_call_error(
-                        tool_call.function.name,
-                        executable_tool_names,
-                        allowed_tool_names,
-                        diagnostic_history,
-                    ));
-                }
-                self.invalid_tool_call_retries += 1;
-
+            ValidatedInvalidToolCallAction::Retry { feedback } => {
                 self.new_messages.push(Message::Assistant {
                     id: resolving.message_id.clone(),
                     content: resolving.original_choice.clone(),
@@ -1012,15 +1075,7 @@ impl AgentRun {
                 self.state = RunState::PreparingRequest;
                 Ok(ModelTurnOutcome::TurnRetried)
             }
-            InvalidToolCallAction::Repair { tool_name } => {
-                if !allowed_tool_names.contains(&tool_name) {
-                    return Err(unknown_tool_call_error(
-                        tool_name,
-                        executable_tool_names,
-                        allowed_tool_names,
-                        diagnostic_history,
-                    ));
-                }
+            ValidatedInvalidToolCallAction::Repair { tool_name } => {
                 if let Some(AssistantContent::ToolCall(tool_call)) =
                     resolving.items.get_mut(resolving.next_index)
                 {
@@ -1030,19 +1085,7 @@ impl AgentRun {
                 self.state = RunState::ResolvingToolCalls(resolving);
                 self.advance_resolution()
             }
-            InvalidToolCallAction::Stop { reason } => {
-                self.state = RunState::Failed;
-                Err(PromptError::prompt_cancelled(diagnostic_history, reason))
-            }
-            InvalidToolCallAction::Skip { reason } => {
-                if matches!(self.tool_choice, Some(ToolChoice::None)) {
-                    return Err(unknown_tool_call_error(
-                        tool_call.function.name,
-                        executable_tool_names,
-                        allowed_tool_names,
-                        diagnostic_history,
-                    ));
-                }
+            ValidatedInvalidToolCallAction::Skip { reason } => {
                 let user_content = UserContent::tool_result_for(
                     tool_call.id.clone(),
                     tool_call.provider.clone(),
@@ -1306,32 +1349,18 @@ impl AgentRun {
 
         let diagnostic_history =
             self.streamed_diagnostic_history(partial, Some(invalid.tool_call.clone()));
-        let executable_tool_names: Vec<String> =
-            invalid.executable_tool_names.iter().cloned().collect();
-        let allowed_tool_names: Vec<String> = invalid.allowed_tool_names.iter().cloned().collect();
+        let action = self.validate_invalid_tool_call_action(
+            action,
+            InvalidToolCallDiagnostic {
+                tool_call: &invalid.tool_call,
+                executable_tool_names: &invalid.executable_tool_names,
+                allowed_tool_names: &invalid.allowed_tool_names,
+                history: &diagnostic_history,
+            },
+        )?;
 
         match action {
-            InvalidToolCallAction::Fail => {
-                self.state = RunState::Failed;
-                Err(unknown_tool_call_error(
-                    invalid.tool_call.function.name.clone(),
-                    executable_tool_names,
-                    allowed_tool_names,
-                    diagnostic_history,
-                ))
-            }
-            InvalidToolCallAction::Retry { feedback } => {
-                if self.invalid_tool_call_retries >= self.max_invalid_tool_call_retries {
-                    self.state = RunState::Failed;
-                    return Err(unknown_tool_call_error(
-                        invalid.tool_call.function.name.clone(),
-                        executable_tool_names,
-                        allowed_tool_names,
-                        diagnostic_history,
-                    ));
-                }
-                self.invalid_tool_call_retries += 1;
-
+            ValidatedInvalidToolCallAction::Retry { feedback } => {
                 let Some((assistant_message, user_message)) =
                     partial.rollback_messages(invalid.tool_call.clone(), feedback)
                 else {
@@ -1349,33 +1378,10 @@ impl AgentRun {
                     skipped_tool_result: None,
                 })
             }
-            InvalidToolCallAction::Repair { tool_name } => {
-                if !invalid.allowed_tool_names.contains(&tool_name) {
-                    self.state = RunState::Failed;
-                    return Err(unknown_tool_call_error(
-                        tool_name,
-                        executable_tool_names,
-                        allowed_tool_names,
-                        diagnostic_history,
-                    ));
-                }
+            ValidatedInvalidToolCallAction::Repair { tool_name } => {
                 Ok(StreamedResolution::Repaired { tool_name })
             }
-            InvalidToolCallAction::Stop { reason } => {
-                self.state = RunState::Failed;
-                Err(PromptError::prompt_cancelled(diagnostic_history, reason))
-            }
-            InvalidToolCallAction::Skip { reason } => {
-                if matches!(self.tool_choice, Some(ToolChoice::None)) {
-                    self.state = RunState::Failed;
-                    return Err(unknown_tool_call_error(
-                        invalid.tool_call.function.name.clone(),
-                        executable_tool_names,
-                        allowed_tool_names,
-                        diagnostic_history,
-                    ));
-                }
-
+            ValidatedInvalidToolCallAction::Skip { reason } => {
                 // Synthetic skip reason: emit verbatim text, matching the
                 // non-streamed `resolve_invalid_tool_call` skip path (parity) and
                 // avoiding re-parsing a rejection message as structured output.

--- a/crates/rig-core/src/client/mod.rs
+++ b/crates/rig-core/src/client/mod.rs
@@ -324,6 +324,152 @@ pub trait ProviderBuilder: Sized + Default + Clone {
     }
 }
 
+// These implementations are declarations of associated types and constants,
+// so ordinary helper functions cannot express the repeated structure. Keeping
+// the variation points in one invocation makes each provider's configuration
+// visible without duplicating the generic builder plumbing.
+macro_rules! impl_default_provider_builder {
+    (
+        $builder:ty => $extension:ty,
+        api_key = $api_key:ty,
+        base_url = $base_url:expr
+        $(, finish = $finish:path, state = $state:ident)? $(,)?
+    ) => {
+        impl $crate::client::ProviderBuilder for $builder {
+            type Extension<H>
+                = $extension
+            where
+                H: $crate::http_client::HttpClientExt;
+            type ApiKey = $api_key;
+
+            const BASE_URL: &'static str = $base_url;
+
+            fn build<H>(
+                _builder: &$crate::client::ClientBuilder<Self, Self::ApiKey, H>,
+            ) -> $crate::http_client::Result<Self::Extension<H>>
+            where
+                H: $crate::http_client::HttpClientExt,
+            {
+                Ok(<$extension>::default())
+            }
+
+            $(
+                fn finish<H>(
+                    &self,
+                    builder: $crate::client::ClientBuilder<Self, Self::ApiKey, H>,
+                ) -> $crate::http_client::Result<
+                    $crate::client::ClientBuilder<Self, Self::ApiKey, H>,
+                > {
+                    $finish(&self.$state, builder)
+                }
+            )?
+        }
+    };
+}
+pub(crate) use impl_default_provider_builder;
+
+// ProviderClient is implemented for concrete client aliases, which likewise
+// cannot be factored into a function. The optional base-URL form captures the
+// only common construction variation without hiding provider-specific auth.
+macro_rules! impl_provider_client {
+    (
+        $client:ty,
+        input = $input:ty,
+        api_key_env = $api_key_env:literal,
+        base_url_env_first = $base_url_env:literal $(,)?
+    ) => {
+        $crate::client::impl_provider_client!(@with_base
+            $client,
+            input = $input,
+            api_key_env = $api_key_env,
+            configuration = {
+                let base_url = $crate::client::optional_env_var($base_url_env)?;
+                let api_key = $crate::client::required_env_var($api_key_env)?;
+                (api_key, base_url)
+            }
+        );
+    };
+    (
+        $client:ty,
+        input = $input:ty,
+        api_key_env = $api_key_env:literal,
+        base_url_env = $base_url_env:literal $(,)?
+    ) => {
+        $crate::client::impl_provider_client!(@with_base
+            $client,
+            input = $input,
+            api_key_env = $api_key_env,
+            configuration = {
+                let api_key = $crate::client::required_env_var($api_key_env)?;
+                let base_url = $crate::client::optional_env_var($base_url_env)?;
+                (api_key, base_url)
+            }
+        );
+    };
+    (
+        $client:ty,
+        input = $input:ty,
+        api_key_env = $api_key_env:literal,
+        base_url = $base_url:expr $(,)?
+    ) => {
+        $crate::client::impl_provider_client!(@with_base
+            $client,
+            input = $input,
+            api_key_env = $api_key_env,
+            configuration = {
+                let api_key = $crate::client::required_env_var($api_key_env)?;
+                (api_key, $base_url)
+            }
+        );
+    };
+    (@with_base
+        $client:ty,
+        input = $input:ty,
+        api_key_env = $api_key_env:literal,
+        configuration = $configuration:block
+    ) => {
+        impl $crate::client::ProviderClient for $client {
+            type Input = $input;
+            type Error = $crate::client::ProviderClientError;
+
+            #[doc = concat!("Create this provider client from the `", $api_key_env, "` environment variable.")]
+            fn from_env() -> Result<Self, Self::Error> {
+                let (api_key, base_url) = $configuration;
+                let mut builder = Self::builder().api_key(api_key);
+                if let Some(base_url) = base_url {
+                    builder = builder.base_url(base_url);
+                }
+                builder.build().map_err(Into::into)
+            }
+
+            fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
+                Self::new(input).map_err(Into::into)
+            }
+        }
+    };
+    (
+        $client:ty,
+        input = $input:ty,
+        api_key_env = $api_key_env:literal $(,)?
+    ) => {
+        impl $crate::client::ProviderClient for $client {
+            type Input = $input;
+            type Error = $crate::client::ProviderClientError;
+
+            #[doc = concat!("Create this provider client from the `", $api_key_env, "` environment variable.")]
+            fn from_env() -> Result<Self, Self::Error> {
+                let api_key = $crate::client::required_env_var($api_key_env)?;
+                Self::new(api_key).map_err(Into::into)
+            }
+
+            fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
+                Self::new(input).map_err(Into::into)
+            }
+        }
+    };
+}
+pub(crate) use impl_provider_client;
+
 /// `new` is pinned to `H = reqwest::Client` so the call site infers without an explicit `H`
 /// annotation. Callers who want a different backend should go through [`Client::builder`] and
 /// chain [`ClientBuilder::http_client`] before [`ClientBuilder::build`].

--- a/crates/rig-core/src/providers/anthropic/client.rs
+++ b/crates/rig-core/src/providers/anthropic/client.rs
@@ -3,10 +3,7 @@ use http::{HeaderName, HeaderValue};
 
 use super::completion::{ANTHROPIC_VERSION_LATEST, CompletionModel};
 use crate::{
-    client::{
-        self, ApiKey, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-        ProviderClient,
-    },
+    client::{self, ApiKey, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder},
     http_client::{self, HttpClientExt},
     providers::anthropic::model_listing::AnthropicModelLister,
 };
@@ -104,33 +101,12 @@ impl ProviderBuilder for AnthropicBuilder {
 
 impl DebugExt for AnthropicExt {}
 
-impl ProviderClient for Client {
-    type Input = String;
-    type Error = crate::client::ProviderClientError;
-
-    fn from_env() -> Result<Self, Self::Error>
-    where
-        Self: Sized,
-    {
-        let base_url = crate::client::optional_env_var("ANTHROPIC_BASE_URL")?;
-        let key = crate::client::required_env_var("ANTHROPIC_API_KEY")?;
-
-        let mut builder = Self::builder().api_key(key);
-
-        if let Some(base) = base_url {
-            builder = builder.base_url(&base);
-        }
-
-        builder.build().map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error>
-    where
-        Self: Sized,
-    {
-        Self::builder().api_key(input).build().map_err(Into::into)
-    }
-}
+client::impl_provider_client!(
+    Client,
+    input = String,
+    api_key_env = "ANTHROPIC_API_KEY",
+    base_url_env_first = "ANTHROPIC_BASE_URL",
+);
 
 /// Create a new anthropic client using the builder
 ///

--- a/crates/rig-core/src/providers/cohere/client.rs
+++ b/crates/rig-core/src/providers/cohere/client.rs
@@ -1,11 +1,8 @@
 use crate::{
     Embed,
-    client::{
-        self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-        ProviderClient,
-    },
+    client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider},
     embeddings::EmbeddingsBuilder,
-    http_client::{self, HttpClientExt},
+    http_client::HttpClientExt,
     wasm_compat::*,
 };
 
@@ -48,44 +45,13 @@ impl<H> Capabilities<H> for CohereExt {
 
 impl DebugExt for CohereExt {}
 
-impl ProviderBuilder for CohereBuilder {
-    type Extension<H>
-        = CohereExt
-    where
-        H: HttpClientExt;
-    type ApiKey = CohereApiKey;
+client::impl_default_provider_builder!(
+    CohereBuilder => CohereExt,
+    api_key = CohereApiKey,
+    base_url = "https://api.cohere.ai",
+);
 
-    const BASE_URL: &'static str = "https://api.cohere.ai";
-
-    fn build<H>(
-        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: HttpClientExt,
-    {
-        Ok(CohereExt)
-    }
-}
-
-impl ProviderClient for Client {
-    type Input = CohereApiKey;
-    type Error = crate::client::ProviderClientError;
-
-    fn from_env() -> Result<Self, Self::Error>
-    where
-        Self: Sized,
-    {
-        let key = crate::client::required_env_var("COHERE_API_KEY")?;
-        Self::new(key).map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error>
-    where
-        Self: Sized,
-    {
-        Self::new(input).map_err(Into::into)
-    }
-}
+client::impl_provider_client!(Client, input = CohereApiKey, api_key_env = "COHERE_API_KEY",);
 
 #[derive(Debug)]
 pub struct ApiErrorResponse {

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -16,9 +16,9 @@ use serde_json::Value;
 
 use crate::client::{
     self, BearerAuth, Capabilities, Capable, DebugExt, ModelLister, Nothing, Provider,
-    ProviderBuilder, ProviderClient,
+    ProviderClient,
 };
-use crate::http_client::{self, HttpClientExt};
+use crate::http_client::HttpClientExt;
 use crate::model::{Model, ModelList, ModelListingError};
 use crate::providers::internal::openai_chat_completions_compatible::map_openai_finish_reason;
 use crate::providers::openai;
@@ -131,24 +131,11 @@ impl<H> Capabilities<H> for DeepSeekExt {
 
 impl DebugExt for DeepSeekExt {}
 
-impl ProviderBuilder for DeepSeekExtBuilder {
-    type Extension<H>
-        = DeepSeekExt
-    where
-        H: HttpClientExt;
-    type ApiKey = DeepSeekApiKey;
-
-    const BASE_URL: &'static str = DEEPSEEK_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: HttpClientExt,
-    {
-        Ok(DeepSeekExt)
-    }
-}
+client::impl_default_provider_builder!(
+    DeepSeekExtBuilder => DeepSeekExt,
+    api_key = DeepSeekApiKey,
+    base_url = DEEPSEEK_API_BASE_URL,
+);
 
 pub type Client<H = reqwest::Client> = client::Client<DeepSeekExt, H>;
 pub type ClientBuilder<H = crate::markers::Missing> =

--- a/crates/rig-core/src/providers/doubleword/client.rs
+++ b/crates/rig-core/src/providers/doubleword/client.rs
@@ -1,10 +1,4 @@
-use crate::{
-    client::{
-        self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-        ProviderClient,
-    },
-    http_client,
-};
+use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
 
 // ================================================================
 // Doubleword Client
@@ -51,49 +45,18 @@ impl<H> Capabilities<H> for DoublewordExt {
     type Rerank = Nothing;
 }
 
-impl ProviderBuilder for DoublewordExtBuilder {
-    type Extension<H>
-        = DoublewordExt
-    where
-        H: http_client::HttpClientExt;
-    type ApiKey = DoublewordApiKey;
+client::impl_default_provider_builder!(
+    DoublewordExtBuilder => DoublewordExt,
+    api_key = DoublewordApiKey,
+    base_url = DOUBLEWORD_API_BASE_URL,
+);
 
-    const BASE_URL: &'static str = DOUBLEWORD_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: http_client::HttpClientExt,
-    {
-        Ok(DoublewordExt)
-    }
-}
-
-impl ProviderClient for Client {
-    type Input = String;
-    type Error = crate::client::ProviderClientError;
-
-    /// Create a new Doubleword client from the `DOUBLEWORD_API_KEY` environment
-    /// variable. The base URL can optionally be overridden with
-    /// `DOUBLEWORD_BASE_URL` (defaults to `https://api.doubleword.ai/v1`).
-    fn from_env() -> Result<Self, Self::Error> {
-        let base_url = crate::client::optional_env_var("DOUBLEWORD_BASE_URL")?;
-        let api_key = crate::client::required_env_var("DOUBLEWORD_API_KEY")?;
-
-        let mut builder = Client::builder().api_key(&api_key);
-
-        if let Some(base) = base_url {
-            builder = builder.base_url(&base);
-        }
-
-        builder.build().map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::new(&input).map_err(Into::into)
-    }
-}
+client::impl_provider_client!(
+    Client,
+    input = String,
+    api_key_env = "DOUBLEWORD_API_KEY",
+    base_url_env_first = "DOUBLEWORD_BASE_URL",
+);
 
 pub mod doubleword_api_types {
     use serde::Deserialize;

--- a/crates/rig-core/src/providers/gemini/client.rs
+++ b/crates/rig-core/src/providers/gemini/client.rs
@@ -1,6 +1,5 @@
 use crate::client::{
-    self, ApiKey, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-    ProviderClient, Transport,
+    self, ApiKey, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder, Transport,
 };
 use crate::http_client::{self};
 use crate::providers::gemini::model_listing::{GeminiInteractionsModelLister, GeminiModelLister};
@@ -177,35 +176,12 @@ impl ProviderBuilder for GeminiInteractionsBuilder {
     }
 }
 
-impl ProviderClient for Client {
-    type Input = GeminiApiKey;
-    type Error = crate::client::ProviderClientError;
-
-    /// Create a new Google Gemini client from the `GEMINI_API_KEY` environment variable.
-    fn from_env() -> Result<Self, Self::Error> {
-        let api_key = crate::client::required_env_var("GEMINI_API_KEY")?;
-        Self::new(api_key).map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::new(input).map_err(Into::into)
-    }
-}
-
-impl ProviderClient for InteractionsClient {
-    type Input = GeminiApiKey;
-    type Error = crate::client::ProviderClientError;
-
-    /// Create a new Google Gemini interactions client from the `GEMINI_API_KEY` environment variable.
-    fn from_env() -> Result<Self, Self::Error> {
-        let api_key = crate::client::required_env_var("GEMINI_API_KEY")?;
-        Self::new(api_key).map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::new(input).map_err(Into::into)
-    }
-}
+client::impl_provider_client!(Client, input = GeminiApiKey, api_key_env = "GEMINI_API_KEY",);
+client::impl_provider_client!(
+    InteractionsClient,
+    input = GeminiApiKey,
+    api_key_env = "GEMINI_API_KEY",
+);
 
 impl<H> Client<H> {
     /// Create an Interactions API client from this GenerateContent client.

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -15,12 +15,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 use super::openai::{self, TranscriptionResponse};
-use crate::client::{
-    self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-    ProviderClient,
-};
+use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
 use crate::completion::CompletionError;
-use crate::http_client::{self, HttpClientExt};
+use crate::http_client::HttpClientExt;
 use crate::transcription::{self};
 
 // ================================================================
@@ -93,24 +90,11 @@ impl<H> Capabilities<H> for GroqExt {
 
 impl DebugExt for GroqExt {}
 
-impl ProviderBuilder for GroqBuilder {
-    type Extension<H>
-        = GroqExt
-    where
-        H: HttpClientExt;
-    type ApiKey = GroqApiKey;
-
-    const BASE_URL: &'static str = GROQ_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: HttpClientExt,
-    {
-        Ok(GroqExt)
-    }
-}
+client::impl_default_provider_builder!(
+    GroqBuilder => GroqExt,
+    api_key = GroqApiKey,
+    base_url = GROQ_API_BASE_URL,
+);
 
 pub type Client<H = reqwest::Client> = client::Client<GroqExt, H>;
 pub type ClientBuilder<H = crate::markers::Missing> =
@@ -125,20 +109,7 @@ pub type CompletionModel<H = reqwest::Client> =
 /// with the OpenAI Chat Completions path, usage payload included.
 pub type StreamingCompletionResponse = openai::StreamingCompletionResponse;
 
-impl ProviderClient for Client {
-    type Input = String;
-    type Error = crate::client::ProviderClientError;
-
-    /// Create a new Groq client from the `GROQ_API_KEY` environment variable.
-    fn from_env() -> Result<Self, Self::Error> {
-        let api_key = crate::client::required_env_var("GROQ_API_KEY")?;
-        Self::new(&api_key).map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::new(&input).map_err(Into::into)
-    }
-}
+client::impl_provider_client!(Client, input = String, api_key_env = "GROQ_API_KEY");
 
 use crate::providers::openai::client::ApiResponse;
 

--- a/crates/rig-core/src/providers/huggingface/client.rs
+++ b/crates/rig-core/src/providers/huggingface/client.rs
@@ -1,6 +1,5 @@
 use crate::client::{
     self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-    ProviderClient,
 };
 use crate::http_client;
 #[cfg(feature = "image")]
@@ -201,21 +200,7 @@ impl ProviderBuilder for HuggingFaceBuilder {
     }
 }
 
-impl ProviderClient for Client {
-    type Input = String;
-    type Error = crate::client::ProviderClientError;
-
-    /// Create a new Huggingface client from the `HUGGINGFACE_API_KEY` environment variable.
-    fn from_env() -> Result<Self, Self::Error> {
-        let api_key = crate::client::required_env_var("HUGGINGFACE_API_KEY")?;
-
-        Self::new(&api_key).map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::new(&input).map_err(Into::into)
-    }
-}
+client::impl_provider_client!(Client, input = String, api_key_env = "HUGGINGFACE_API_KEY",);
 
 impl<H> ClientBuilder<H> {
     pub fn subprovider(mut self, subprovider: SubProvider) -> Self {

--- a/crates/rig-core/src/providers/hyperbolic.rs
+++ b/crates/rig-core/src/providers/hyperbolic.rs
@@ -12,9 +12,8 @@
 //! # }
 //! ```
 
-use crate::client::{self, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder};
-use crate::client::{BearerAuth, ProviderClient};
-use crate::http_client::{self, HttpClientExt};
+use crate::client::BearerAuth;
+use crate::client::{self, Capabilities, Capable, DebugExt, Nothing, Provider};
 
 // ================================================================
 // Main Hyperbolic Client
@@ -88,43 +87,21 @@ impl crate::providers::openai::completion::OpenAICompatibleProvider for Hyperbol
     }
 }
 
-impl ProviderBuilder for HyperbolicBuilder {
-    type Extension<H>
-        = HyperbolicExt
-    where
-        H: HttpClientExt;
-    type ApiKey = HyperbolicApiKey;
-
-    const BASE_URL: &'static str = HYPERBOLIC_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &crate::client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: HttpClientExt,
-    {
-        Ok(HyperbolicExt)
-    }
-}
+client::impl_default_provider_builder!(
+    HyperbolicBuilder => HyperbolicExt,
+    api_key = HyperbolicApiKey,
+    base_url = HYPERBOLIC_API_BASE_URL,
+);
 
 pub type Client<H = reqwest::Client> = client::Client<HyperbolicExt, H>;
 pub type ClientBuilder<H = crate::markers::Missing> =
     client::ClientBuilder<HyperbolicBuilder, HyperbolicApiKey, H>;
 
-impl ProviderClient for Client {
-    type Input = HyperbolicApiKey;
-    type Error = crate::client::ProviderClientError;
-
-    /// Create a new Hyperbolic client from the `HYPERBOLIC_API_KEY` environment variable.
-    fn from_env() -> Result<Self, Self::Error> {
-        let api_key = crate::client::required_env_var("HYPERBOLIC_API_KEY")?;
-        Self::new(&api_key).map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::new(input).map_err(Into::into)
-    }
-}
+client::impl_provider_client!(
+    Client,
+    input = HyperbolicApiKey,
+    api_key_env = "HYPERBOLIC_API_KEY",
+);
 
 #[cfg(any(feature = "image", feature = "audio"))]
 use crate::providers::openai::client::ApiResponse;

--- a/crates/rig-core/src/providers/llamafile.rs
+++ b/crates/rig-core/src/providers/llamafile.rs
@@ -29,10 +29,8 @@
 //! ```
 
 use crate::client::{
-    self, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder, ProviderClient,
-    Transport,
+    self, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderClient, Transport,
 };
-use crate::http_client::{self, HttpClientExt};
 use crate::providers::openai;
 
 // ================================================================
@@ -91,24 +89,11 @@ impl<H> Capabilities<H> for LlamafileExt {
 
 impl DebugExt for LlamafileExt {}
 
-impl ProviderBuilder for LlamafileBuilder {
-    type Extension<H>
-        = LlamafileExt
-    where
-        H: HttpClientExt;
-    type ApiKey = Nothing;
-
-    const BASE_URL: &'static str = LLAMAFILE_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: HttpClientExt,
-    {
-        Ok(LlamafileExt)
-    }
-}
+client::impl_default_provider_builder!(
+    LlamafileBuilder => LlamafileExt,
+    api_key = Nothing,
+    base_url = LLAMAFILE_API_BASE_URL,
+);
 
 pub type Client<H = reqwest::Client> = client::Client<LlamafileExt, H>;
 pub type ClientBuilder<H = crate::markers::Missing> =

--- a/crates/rig-core/src/providers/minimax.rs
+++ b/crates/rig-core/src/providers/minimax.rs
@@ -21,11 +21,7 @@
 //! let model = client.completion_model(minimax::MINIMAX_M2);
 //! ```
 
-use crate::client::{
-    self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-    ProviderClient,
-};
-use crate::http_client::{self, HttpClientExt};
+use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
 use crate::providers::anthropic::client::{
     AnthropicBuilder as AnthropicCompatBuilder, AnthropicKey, finish_anthropic_builder,
 };
@@ -126,50 +122,18 @@ impl super::openai::completion::OpenAICompatibleProvider for MiniMaxExt {
     type Response = super::openai::CompletionResponse;
 }
 
-impl ProviderBuilder for MiniMaxBuilder {
-    type Extension<H>
-        = MiniMaxExt
-    where
-        H: HttpClientExt;
-    type ApiKey = MiniMaxApiKey;
-
-    const BASE_URL: &'static str = GLOBAL_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: HttpClientExt,
-    {
-        Ok(MiniMaxExt)
-    }
-}
-
-impl ProviderBuilder for MiniMaxAnthropicBuilder {
-    type Extension<H>
-        = MiniMaxAnthropicExt
-    where
-        H: HttpClientExt;
-    type ApiKey = AnthropicKey;
-
-    const BASE_URL: &'static str = GLOBAL_ANTHROPIC_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: HttpClientExt,
-    {
-        Ok(MiniMaxAnthropicExt)
-    }
-
-    fn finish<H>(
-        &self,
-        builder: client::ClientBuilder<Self, AnthropicKey, H>,
-    ) -> http_client::Result<client::ClientBuilder<Self, AnthropicKey, H>> {
-        finish_anthropic_builder(&self.anthropic, builder)
-    }
-}
+client::impl_default_provider_builder!(
+    MiniMaxBuilder => MiniMaxExt,
+    api_key = MiniMaxApiKey,
+    base_url = GLOBAL_API_BASE_URL,
+);
+client::impl_default_provider_builder!(
+    MiniMaxAnthropicBuilder => MiniMaxAnthropicExt,
+    api_key = AnthropicKey,
+    base_url = GLOBAL_ANTHROPIC_API_BASE_URL,
+    finish = finish_anthropic_builder,
+    state = anthropic,
+);
 
 impl super::anthropic::completion::AnthropicCompatibleProvider for MiniMaxAnthropicExt {
     const PROVIDER_NAME: &'static str = "minimax";
@@ -179,47 +143,19 @@ impl super::anthropic::completion::AnthropicCompatibleProvider for MiniMaxAnthro
     }
 }
 
-impl ProviderClient for Client {
-    type Input = MiniMaxApiKey;
-    type Error = crate::client::ProviderClientError;
+client::impl_provider_client!(
+    Client,
+    input = MiniMaxApiKey,
+    api_key_env = "MINIMAX_API_KEY",
+    base_url_env = "MINIMAX_API_BASE",
+);
 
-    fn from_env() -> Result<Self, Self::Error> {
-        let api_key = crate::client::required_env_var("MINIMAX_API_KEY")?;
-        let mut builder = Self::builder().api_key(api_key);
-
-        if let Some(base_url) = crate::client::optional_env_var("MINIMAX_API_BASE")? {
-            builder = builder.base_url(base_url);
-        }
-
-        builder.build().map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::new(input).map_err(Into::into)
-    }
-}
-
-impl ProviderClient for AnthropicClient {
-    type Input = String;
-    type Error = crate::client::ProviderClientError;
-
-    fn from_env() -> Result<Self, Self::Error> {
-        let api_key = crate::client::required_env_var("MINIMAX_API_KEY")?;
-        let mut builder = Self::builder().api_key(api_key);
-
-        if let Some(base_url) =
-            anthropic_base_override("MINIMAX_ANTHROPIC_API_BASE", "MINIMAX_API_BASE")?
-        {
-            builder = builder.base_url(base_url);
-        }
-
-        builder.build().map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::builder().api_key(input).build().map_err(Into::into)
-    }
-}
+client::impl_provider_client!(
+    AnthropicClient,
+    input = String,
+    api_key_env = "MINIMAX_API_KEY",
+    base_url = anthropic_base_override("MINIMAX_ANTHROPIC_API_BASE", "MINIMAX_API_BASE")?,
+);
 
 fn anthropic_base_override(
     primary_env: &'static str,

--- a/crates/rig-core/src/providers/mira.rs
+++ b/crates/rig-core/src/providers/mira.rs
@@ -7,10 +7,7 @@
 //! let client = mira::Client::new("YOUR_API_KEY");
 //!
 //! ```
-use crate::client::{
-    self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-    ProviderClient,
-};
+use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
 use crate::http_client::{self, HttpClientExt};
 use crate::providers::internal::openai_chat_completions_compatible::map_openai_finish_reason;
 use crate::{
@@ -109,24 +106,11 @@ impl crate::providers::openai::completion::OpenAICompatibleProvider for MiraExt 
     }
 }
 
-impl ProviderBuilder for MiraBuilder {
-    type Extension<H>
-        = MiraExt
-    where
-        H: HttpClientExt;
-    type ApiKey = MiraApiKey;
-
-    const BASE_URL: &'static str = MIRA_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &crate::client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: HttpClientExt,
-    {
-        Ok(MiraExt)
-    }
-}
+client::impl_default_provider_builder!(
+    MiraBuilder => MiraExt,
+    api_key = MiraApiKey,
+    base_url = MIRA_API_BASE_URL,
+);
 
 pub type Client<H = reqwest::Client> = client::Client<MiraExt, H>;
 pub type ClientBuilder<H = crate::markers::Missing> =
@@ -244,20 +228,7 @@ where
     }
 }
 
-impl ProviderClient for Client {
-    type Input = String;
-    type Error = crate::client::ProviderClientError;
-
-    /// Create a new Mira client from the `MIRA_API_KEY` environment variable.
-    fn from_env() -> Result<Self, Self::Error> {
-        let api_key = crate::client::required_env_var("MIRA_API_KEY")?;
-        Self::new(&api_key).map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::new(&input).map_err(Into::into)
-    }
-}
+client::impl_provider_client!(Client, input = String, api_key_env = "MIRA_API_KEY");
 
 /// Mira completion model, driven by the shared OpenAI Chat Completions path.
 pub type CompletionModel<H = reqwest::Client> =

--- a/crates/rig-core/src/providers/mistral/client.rs
+++ b/crates/rig-core/src/providers/mistral/client.rs
@@ -1,9 +1,5 @@
 use crate::{
-    client::{
-        self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-        ProviderClient,
-    },
-    http_client,
+    client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider},
     providers::mistral::MistralModelLister,
 };
 use serde::{Deserialize, Serialize};
@@ -117,42 +113,13 @@ impl<H> Capabilities<H> for MistralExt {
 
 impl DebugExt for MistralExt {}
 
-impl ProviderBuilder for MistralBuilder {
-    type Extension<H>
-        = MistralExt
-    where
-        H: http_client::HttpClientExt;
-    type ApiKey = MistralApiKey;
+client::impl_default_provider_builder!(
+    MistralBuilder => MistralExt,
+    api_key = MistralApiKey,
+    base_url = MISTRAL_API_BASE_URL,
+);
 
-    const BASE_URL: &'static str = MISTRAL_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: http_client::HttpClientExt,
-    {
-        Ok(MistralExt)
-    }
-}
-
-impl ProviderClient for Client {
-    type Input = String;
-    type Error = crate::client::ProviderClientError;
-
-    /// Create a new Mistral client from the `MISTRAL_API_KEY` environment variable.
-    fn from_env() -> Result<Self, Self::Error>
-    where
-        Self: Sized,
-    {
-        let api_key = crate::client::required_env_var("MISTRAL_API_KEY")?;
-        Self::new(&api_key).map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::new(&input).map_err(Into::into)
-    }
-}
+client::impl_provider_client!(Client, input = String, api_key_env = "MISTRAL_API_KEY");
 
 /// In-depth details on prompt tokens.
 ///

--- a/crates/rig-core/src/providers/moonshot.rs
+++ b/crates/rig-core/src/providers/moonshot.rs
@@ -22,12 +22,7 @@
 //!     .build()
 //!     .expect("Failed to build Moonshot client");
 //! ```
-use crate::client::{
-    self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-    ProviderClient,
-};
-use crate::http_client;
-use crate::http_client::HttpClientExt;
+use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
 use crate::providers::anthropic::client::{
     AnthropicBuilder as AnthropicCompatBuilder, AnthropicKey, finish_anthropic_builder,
 };
@@ -71,50 +66,18 @@ impl Provider for MoonshotAnthropicExt {
 impl DebugExt for MoonshotExt {}
 impl DebugExt for MoonshotAnthropicExt {}
 
-impl ProviderBuilder for MoonshotBuilder {
-    type Extension<H>
-        = MoonshotExt
-    where
-        H: HttpClientExt;
-    type ApiKey = MoonshotApiKey;
-
-    const BASE_URL: &'static str = GLOBAL_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &crate::client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: HttpClientExt,
-    {
-        Ok(MoonshotExt)
-    }
-}
-
-impl ProviderBuilder for MoonshotAnthropicBuilder {
-    type Extension<H>
-        = MoonshotAnthropicExt
-    where
-        H: HttpClientExt;
-    type ApiKey = AnthropicKey;
-
-    const BASE_URL: &'static str = ANTHROPIC_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &crate::client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: HttpClientExt,
-    {
-        Ok(MoonshotAnthropicExt)
-    }
-
-    fn finish<H>(
-        &self,
-        builder: client::ClientBuilder<Self, AnthropicKey, H>,
-    ) -> http_client::Result<client::ClientBuilder<Self, AnthropicKey, H>> {
-        finish_anthropic_builder(&self.anthropic, builder)
-    }
-}
+client::impl_default_provider_builder!(
+    MoonshotBuilder => MoonshotExt,
+    api_key = MoonshotApiKey,
+    base_url = GLOBAL_API_BASE_URL,
+);
+client::impl_default_provider_builder!(
+    MoonshotAnthropicBuilder => MoonshotAnthropicExt,
+    api_key = AnthropicKey,
+    base_url = ANTHROPIC_API_BASE_URL,
+    finish = finish_anthropic_builder,
+    state = anthropic,
+);
 
 impl<H> Capabilities<H> for MoonshotExt {
     type Completion = Capable<CompletionModel<H>>;
@@ -148,44 +111,19 @@ pub type AnthropicClient<H = reqwest::Client> = client::Client<MoonshotAnthropic
 pub type AnthropicClientBuilder<H = crate::markers::Missing> =
     client::ClientBuilder<MoonshotAnthropicBuilder, AnthropicKey, H>;
 
-impl ProviderClient for Client {
-    type Input = String;
-    type Error = crate::client::ProviderClientError;
+client::impl_provider_client!(
+    Client,
+    input = String,
+    api_key_env = "MOONSHOT_API_KEY",
+    base_url_env = "MOONSHOT_API_BASE",
+);
 
-    /// Create a new Moonshot client from the `MOONSHOT_API_KEY` environment variable.
-    fn from_env() -> Result<Self, Self::Error> {
-        let api_key = crate::client::required_env_var("MOONSHOT_API_KEY")?;
-        let mut builder = Self::builder().api_key(&api_key);
-        if let Some(base_url) = crate::client::optional_env_var("MOONSHOT_API_BASE")? {
-            builder = builder.base_url(base_url);
-        }
-        builder.build().map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::new(&input).map_err(Into::into)
-    }
-}
-
-impl ProviderClient for AnthropicClient {
-    type Input = String;
-    type Error = crate::client::ProviderClientError;
-
-    fn from_env() -> Result<Self, Self::Error> {
-        let api_key = crate::client::required_env_var("MOONSHOT_API_KEY")?;
-        let mut builder = Self::builder().api_key(api_key);
-        if let Some(base_url) =
-            anthropic_base_override("MOONSHOT_ANTHROPIC_API_BASE", "MOONSHOT_API_BASE")?
-        {
-            builder = builder.base_url(base_url);
-        }
-        builder.build().map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::builder().api_key(input).build().map_err(Into::into)
-    }
-}
+client::impl_provider_client!(
+    AnthropicClient,
+    input = String,
+    api_key_env = "MOONSHOT_API_KEY",
+    base_url = anthropic_base_override("MOONSHOT_ANTHROPIC_API_BASE", "MOONSHOT_API_BASE")?,
+);
 
 impl<H> ClientBuilder<H> {
     pub fn global(self) -> Self {

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -39,8 +39,7 @@
 //! # }
 //! ```
 use crate::client::{
-    self, ApiKey, Capabilities, Capable, DebugExt, ModelLister, Nothing, Provider, ProviderBuilder,
-    ProviderClient,
+    self, ApiKey, Capabilities, Capable, DebugExt, ModelLister, Nothing, Provider, ProviderClient,
 };
 use crate::completion::Usage;
 use crate::http_client::{self, HttpClientExt};
@@ -137,24 +136,11 @@ impl<H> Capabilities<H> for OllamaExt {
 
 impl DebugExt for OllamaExt {}
 
-impl ProviderBuilder for OllamaBuilder {
-    type Extension<H>
-        = OllamaExt
-    where
-        H: HttpClientExt;
-    type ApiKey = OllamaApiKey;
-
-    const BASE_URL: &'static str = OLLAMA_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: HttpClientExt,
-    {
-        Ok(OllamaExt)
-    }
-}
+client::impl_default_provider_builder!(
+    OllamaBuilder => OllamaExt,
+    api_key = OllamaApiKey,
+    base_url = OLLAMA_API_BASE_URL,
+);
 
 pub type Client<H = reqwest::Client> = client::Client<OllamaExt, H>;
 pub type ClientBuilder<H = crate::markers::Missing> =

--- a/crates/rig-core/src/providers/openai/client.rs
+++ b/crates/rig-core/src/providers/openai/client.rs
@@ -1,10 +1,7 @@
 use super::responses_api::{ResponsesProviderExt, SystemInstructionsPlacement};
 use crate::{
-    client::{
-        self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-        ProviderClient,
-    },
-    http_client::{self, HttpClientExt},
+    client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider},
+    http_client::HttpClientExt,
     wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
 use serde::Deserialize;
@@ -99,43 +96,16 @@ impl DebugExt for OpenAIResponsesExt {}
 
 impl DebugExt for OpenAICompletionsExt {}
 
-impl ProviderBuilder for OpenAIResponsesExtBuilder {
-    type Extension<H>
-        = OpenAIResponsesExt
-    where
-        H: HttpClientExt;
-    type ApiKey = OpenAIApiKey;
-
-    const BASE_URL: &'static str = OPENAI_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: HttpClientExt,
-    {
-        Ok(OpenAIResponsesExt::default())
-    }
-}
-
-impl ProviderBuilder for OpenAICompletionsExtBuilder {
-    type Extension<H>
-        = OpenAICompletionsExt
-    where
-        H: HttpClientExt;
-    type ApiKey = OpenAIApiKey;
-
-    const BASE_URL: &'static str = OPENAI_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: HttpClientExt,
-    {
-        Ok(OpenAICompletionsExt::default())
-    }
-}
+client::impl_default_provider_builder!(
+    OpenAIResponsesExtBuilder => OpenAIResponsesExt,
+    api_key = OpenAIApiKey,
+    base_url = OPENAI_API_BASE_URL,
+);
+client::impl_default_provider_builder!(
+    OpenAICompletionsExtBuilder => OpenAICompletionsExt,
+    api_key = OpenAIApiKey,
+    base_url = OPENAI_API_BASE_URL,
+);
 
 impl<H> Client<H>
 where
@@ -229,51 +199,18 @@ where
     }
 }
 
-impl ProviderClient for Client {
-    type Input = OpenAIApiKey;
-    type Error = crate::client::ProviderClientError;
-
-    /// Create a new OpenAI Responses API client from the `OPENAI_API_KEY` environment variable.
-    fn from_env() -> Result<Self, Self::Error> {
-        let base_url = crate::client::optional_env_var("OPENAI_BASE_URL")?;
-        let api_key = crate::client::required_env_var("OPENAI_API_KEY")?;
-
-        let mut builder = Client::builder().api_key(&api_key);
-
-        if let Some(base) = base_url {
-            builder = builder.base_url(&base);
-        }
-
-        builder.build().map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::new(input).map_err(Into::into)
-    }
-}
-
-impl ProviderClient for CompletionsClient {
-    type Input = OpenAIApiKey;
-    type Error = crate::client::ProviderClientError;
-
-    /// Create a new OpenAI Completions API client from the `OPENAI_API_KEY` environment variable.
-    fn from_env() -> Result<Self, Self::Error> {
-        let base_url = crate::client::optional_env_var("OPENAI_BASE_URL")?;
-        let api_key = crate::client::required_env_var("OPENAI_API_KEY")?;
-
-        let mut builder = CompletionsClient::builder().api_key(&api_key);
-
-        if let Some(base) = base_url {
-            builder = builder.base_url(&base);
-        }
-
-        builder.build().map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::new(input).map_err(Into::into)
-    }
-}
+client::impl_provider_client!(
+    Client,
+    input = OpenAIApiKey,
+    api_key_env = "OPENAI_API_KEY",
+    base_url_env_first = "OPENAI_BASE_URL",
+);
+client::impl_provider_client!(
+    CompletionsClient,
+    input = OpenAIApiKey,
+    api_key_env = "OPENAI_API_KEY",
+    base_url_env_first = "OPENAI_BASE_URL",
+);
 
 /// Error envelope returned by OpenAI-compatible providers alongside 2xx
 /// statuses. Providers spell the message field differently (`message`,

--- a/crates/rig-core/src/providers/openrouter/client.rs
+++ b/crates/rig-core/src/providers/openrouter/client.rs
@@ -1,10 +1,4 @@
-use crate::{
-    client::{
-        self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-        ProviderClient,
-    },
-    http_client,
-};
+use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
 use http::HeaderValue;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -46,40 +40,17 @@ impl<H> Capabilities<H> for OpenRouterExt {
 
 impl DebugExt for OpenRouterExt {}
 
-impl ProviderBuilder for OpenRouterExtBuilder {
-    type Extension<H>
-        = OpenRouterExt
-    where
-        H: http_client::HttpClientExt;
-    type ApiKey = OpenRouterApiKey;
+client::impl_default_provider_builder!(
+    OpenRouterExtBuilder => OpenRouterExt,
+    api_key = OpenRouterApiKey,
+    base_url = OPENROUTER_API_BASE_URL,
+);
 
-    const BASE_URL: &'static str = OPENROUTER_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &crate::client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: http_client::HttpClientExt,
-    {
-        Ok(OpenRouterExt)
-    }
-}
-
-impl ProviderClient for Client {
-    type Input = OpenRouterApiKey;
-    type Error = crate::client::ProviderClientError;
-
-    /// Create a new openrouter client from the `OPENROUTER_API_KEY` environment variable.
-    fn from_env() -> Result<Self, Self::Error> {
-        let api_key = crate::client::required_env_var("OPENROUTER_API_KEY")?;
-
-        Self::new(&api_key).map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::new(input).map_err(Into::into)
-    }
-}
+client::impl_provider_client!(
+    Client,
+    input = OpenRouterApiKey,
+    api_key_env = "OPENROUTER_API_KEY",
+);
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Usage {

--- a/crates/rig-core/src/providers/perplexity.rs
+++ b/crates/rig-core/src/providers/perplexity.rs
@@ -12,14 +12,9 @@
 //! # }
 //! ```
 use crate::client::BearerAuth;
+use crate::client::{self, Capabilities, Capable, DebugExt, Nothing, Provider};
 use crate::completion::CompletionError;
 use crate::providers::openai;
-use crate::{
-    client::{
-        self, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder, ProviderClient,
-    },
-    http_client::{self, HttpClientExt},
-};
 
 // ================================================================
 // Main Perplexity Client
@@ -98,24 +93,11 @@ impl<H> Capabilities<H> for PerplexityExt {
 
 impl DebugExt for PerplexityExt {}
 
-impl ProviderBuilder for PerplexityBuilder {
-    type Extension<H>
-        = PerplexityExt
-    where
-        H: HttpClientExt;
-    type ApiKey = PerplexityApiKey;
-
-    const BASE_URL: &'static str = PERPLEXITY_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &crate::client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: HttpClientExt,
-    {
-        Ok(PerplexityExt)
-    }
-}
+client::impl_default_provider_builder!(
+    PerplexityBuilder => PerplexityExt,
+    api_key = PerplexityApiKey,
+    base_url = PERPLEXITY_API_BASE_URL,
+);
 
 pub type Client<H = reqwest::Client> = client::Client<PerplexityExt, H>;
 pub type ClientBuilder<H = crate::markers::Missing> =
@@ -128,20 +110,7 @@ pub type CompletionModel<H = reqwest::Client> =
 /// Raw completion payload, shared with the OpenAI Chat Completions path.
 pub type CompletionResponse = openai::CompletionResponse;
 
-impl ProviderClient for Client {
-    type Input = String;
-    type Error = crate::client::ProviderClientError;
-
-    /// Create a new Perplexity client from the `PERPLEXITY_API_KEY` environment variable.
-    fn from_env() -> Result<Self, Self::Error> {
-        let api_key = crate::client::required_env_var("PERPLEXITY_API_KEY")?;
-        Self::new(&api_key).map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::new(&input).map_err(Into::into)
-    }
-}
+client::impl_provider_client!(Client, input = String, api_key_env = "PERPLEXITY_API_KEY");
 
 // ================================================================
 // Perplexity Completion API

--- a/crates/rig-core/src/providers/together/client.rs
+++ b/crates/rig-core/src/providers/together/client.rs
@@ -1,10 +1,4 @@
-use crate::{
-    client::{
-        self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-        ProviderClient,
-    },
-    http_client,
-};
+use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
 
 // ================================================================
 // Together AI Client
@@ -60,39 +54,13 @@ impl<H> Capabilities<H> for TogetherExt {
     type Rerank = Nothing;
 }
 
-impl ProviderBuilder for TogetherExtBuilder {
-    type Extension<H>
-        = TogetherExt
-    where
-        H: http_client::HttpClientExt;
-    type ApiKey = TogetherApiKey;
+client::impl_default_provider_builder!(
+    TogetherExtBuilder => TogetherExt,
+    api_key = TogetherApiKey,
+    base_url = TOGETHER_AI_BASE_URL,
+);
 
-    const BASE_URL: &'static str = TOGETHER_AI_BASE_URL;
-
-    fn build<H>(
-        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: http_client::HttpClientExt,
-    {
-        Ok(TogetherExt)
-    }
-}
-
-impl ProviderClient for Client {
-    type Input = String;
-    type Error = crate::client::ProviderClientError;
-
-    /// Create a new Together AI client from the `TOGETHER_API_KEY` environment variable.
-    fn from_env() -> Result<Self, Self::Error> {
-        let api_key = crate::client::required_env_var("TOGETHER_API_KEY")?;
-        Self::new(&api_key).map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::new(&input).map_err(Into::into)
-    }
-}
+client::impl_provider_client!(Client, input = String, api_key_env = "TOGETHER_API_KEY");
 
 #[cfg(test)]
 mod tests {

--- a/crates/rig-core/src/providers/voyageai.rs
+++ b/crates/rig-core/src/providers/voyageai.rs
@@ -1,10 +1,7 @@
-use crate::client::{
-    self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-    ProviderClient,
-};
+use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
 use crate::embeddings;
 use crate::embeddings::EmbeddingError;
-use crate::http_client::{self, HttpClientExt};
+use crate::http_client::HttpClientExt;
 use crate::rerank;
 use crate::rerank::RerankError;
 use bytes::Bytes;
@@ -46,43 +43,17 @@ impl<H> Capabilities<H> for VoyageExt {
 
 impl DebugExt for VoyageExt {}
 
-impl ProviderBuilder for VoyageBuilder {
-    type Extension<H>
-        = VoyageExt
-    where
-        H: HttpClientExt;
-    type ApiKey = VoyageApiKey;
-
-    const BASE_URL: &'static str = VOYAGEAI_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &crate::client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: HttpClientExt,
-    {
-        Ok(VoyageExt)
-    }
-}
+client::impl_default_provider_builder!(
+    VoyageBuilder => VoyageExt,
+    api_key = VoyageApiKey,
+    base_url = VOYAGEAI_API_BASE_URL,
+);
 
 pub type Client<H = reqwest::Client> = client::Client<VoyageExt, H>;
 pub type ClientBuilder<H = crate::markers::Missing> =
     client::ClientBuilder<VoyageBuilder, VoyageApiKey, H>;
 
-impl ProviderClient for Client {
-    type Input = String;
-    type Error = crate::client::ProviderClientError;
-
-    /// Create a new OpenAI client from the `OPENAI_API_KEY` environment variable.
-    fn from_env() -> Result<Self, Self::Error> {
-        let api_key = crate::client::required_env_var("VOYAGE_API_KEY")?;
-        Self::new(&api_key).map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::new(&input).map_err(Into::into)
-    }
-}
+client::impl_provider_client!(Client, input = String, api_key_env = "VOYAGE_API_KEY");
 
 impl<T> EmbeddingModel<T> {
     pub fn new(client: Client<T>, model: impl Into<String>, ndims: usize) -> Self {

--- a/crates/rig-core/src/providers/xai/client.rs
+++ b/crates/rig-core/src/providers/xai/client.rs
@@ -1,10 +1,4 @@
-use crate::{
-    client::{
-        self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-        ProviderClient,
-    },
-    http_client,
-};
+use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct XAiExt;
@@ -40,39 +34,13 @@ impl<H> Capabilities<H> for XAiExt {
 
 impl DebugExt for XAiExt {}
 
-impl ProviderBuilder for XAiExtBuilder {
-    type Extension<H>
-        = XAiExt
-    where
-        H: http_client::HttpClientExt;
-    type ApiKey = XAiApiKey;
+client::impl_default_provider_builder!(
+    XAiExtBuilder => XAiExt,
+    api_key = XAiApiKey,
+    base_url = XAI_BASE_URL,
+);
 
-    const BASE_URL: &'static str = XAI_BASE_URL;
-
-    fn build<H>(
-        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: http_client::HttpClientExt,
-    {
-        Ok(XAiExt)
-    }
-}
-
-impl ProviderClient for Client {
-    type Input = String;
-    type Error = crate::client::ProviderClientError;
-
-    /// Create a new xAI client from the `XAI_API_KEY` environment variable.
-    fn from_env() -> Result<Self, Self::Error> {
-        let api_key = crate::client::required_env_var("XAI_API_KEY")?;
-        Self::new(&api_key).map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::new(&input).map_err(Into::into)
-    }
-}
+client::impl_provider_client!(Client, input = String, api_key_env = "XAI_API_KEY");
 #[cfg(test)]
 mod tests {
     #[test]

--- a/crates/rig-core/src/providers/xiaomimimo.rs
+++ b/crates/rig-core/src/providers/xiaomimimo.rs
@@ -23,9 +23,8 @@
 
 use crate::client::{
     self, BearerAuth, Capabilities, Capable, DebugExt, ModelLister, Nothing, Provider,
-    ProviderBuilder, ProviderClient,
 };
-use crate::http_client::{self, HttpClientExt};
+use crate::http_client::HttpClientExt;
 use crate::model::{Model, ModelList, ModelListingError};
 use crate::providers::anthropic::client::{
     AnthropicBuilder as AnthropicCompatBuilder, AnthropicKey, finish_anthropic_builder,
@@ -120,50 +119,18 @@ impl super::openai::completion::OpenAICompatibleProvider for XiaomiMimoExt {
     type Response = super::openai::CompletionResponse;
 }
 
-impl ProviderBuilder for XiaomiMimoBuilder {
-    type Extension<H>
-        = XiaomiMimoExt
-    where
-        H: HttpClientExt;
-    type ApiKey = XiaomiMimoApiKey;
-
-    const BASE_URL: &'static str = API_BASE_URL;
-
-    fn build<H>(
-        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: HttpClientExt,
-    {
-        Ok(XiaomiMimoExt)
-    }
-}
-
-impl ProviderBuilder for XiaomiMimoAnthropicBuilder {
-    type Extension<H>
-        = XiaomiMimoAnthropicExt
-    where
-        H: HttpClientExt;
-    type ApiKey = AnthropicKey;
-
-    const BASE_URL: &'static str = ANTHROPIC_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: HttpClientExt,
-    {
-        Ok(XiaomiMimoAnthropicExt)
-    }
-
-    fn finish<H>(
-        &self,
-        builder: client::ClientBuilder<Self, AnthropicKey, H>,
-    ) -> http_client::Result<client::ClientBuilder<Self, AnthropicKey, H>> {
-        finish_anthropic_builder(&self.anthropic, builder)
-    }
-}
+client::impl_default_provider_builder!(
+    XiaomiMimoBuilder => XiaomiMimoExt,
+    api_key = XiaomiMimoApiKey,
+    base_url = API_BASE_URL,
+);
+client::impl_default_provider_builder!(
+    XiaomiMimoAnthropicBuilder => XiaomiMimoAnthropicExt,
+    api_key = AnthropicKey,
+    base_url = ANTHROPIC_API_BASE_URL,
+    finish = finish_anthropic_builder,
+    state = anthropic,
+);
 
 impl super::anthropic::completion::AnthropicCompatibleProvider for XiaomiMimoAnthropicExt {
     const PROVIDER_NAME: &'static str = "xiaomimimo";
@@ -173,47 +140,19 @@ impl super::anthropic::completion::AnthropicCompatibleProvider for XiaomiMimoAnt
     }
 }
 
-impl ProviderClient for Client {
-    type Input = XiaomiMimoApiKey;
-    type Error = crate::client::ProviderClientError;
+client::impl_provider_client!(
+    Client,
+    input = XiaomiMimoApiKey,
+    api_key_env = "XIAOMI_MIMO_API_KEY",
+    base_url_env = "XIAOMI_MIMO_API_BASE",
+);
 
-    fn from_env() -> Result<Self, Self::Error> {
-        let api_key = crate::client::required_env_var("XIAOMI_MIMO_API_KEY")?;
-        let mut builder = Self::builder().api_key(api_key);
-
-        if let Some(base_url) = crate::client::optional_env_var("XIAOMI_MIMO_API_BASE")? {
-            builder = builder.base_url(base_url);
-        }
-
-        builder.build().map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::new(input).map_err(Into::into)
-    }
-}
-
-impl ProviderClient for AnthropicClient {
-    type Input = String;
-    type Error = crate::client::ProviderClientError;
-
-    fn from_env() -> Result<Self, Self::Error> {
-        let api_key = crate::client::required_env_var("XIAOMI_MIMO_API_KEY")?;
-        let mut builder = Self::builder().api_key(api_key);
-
-        if let Some(base_url) =
-            anthropic_base_override("XIAOMI_MIMO_ANTHROPIC_API_BASE", "XIAOMI_MIMO_API_BASE")?
-        {
-            builder = builder.base_url(base_url);
-        }
-
-        builder.build().map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::builder().api_key(input).build().map_err(Into::into)
-    }
-}
+client::impl_provider_client!(
+    AnthropicClient,
+    input = String,
+    api_key_env = "XIAOMI_MIMO_API_KEY",
+    base_url = anthropic_base_override("XIAOMI_MIMO_ANTHROPIC_API_BASE", "XIAOMI_MIMO_API_BASE",)?,
+);
 
 fn anthropic_base_override(
     primary_env: &'static str,

--- a/crates/rig-core/src/providers/zai.rs
+++ b/crates/rig-core/src/providers/zai.rs
@@ -22,11 +22,7 @@
 //! let glm_4_6 = client.completion_model(zai::GLM_4_6);
 //! ```
 
-use crate::client::{
-    self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-    ProviderClient,
-};
-use crate::http_client::{self, HttpClientExt};
+use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
 use crate::providers::anthropic::client::{
     AnthropicBuilder as AnthropicCompatBuilder, AnthropicKey, finish_anthropic_builder,
 };
@@ -125,50 +121,18 @@ impl super::openai::completion::OpenAICompatibleProvider for ZAiExt {
     type Response = super::openai::CompletionResponse;
 }
 
-impl ProviderBuilder for ZAiBuilder {
-    type Extension<H>
-        = ZAiExt
-    where
-        H: HttpClientExt;
-    type ApiKey = ZAiApiKey;
-
-    const BASE_URL: &'static str = GENERAL_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: HttpClientExt,
-    {
-        Ok(ZAiExt)
-    }
-}
-
-impl ProviderBuilder for ZAiAnthropicBuilder {
-    type Extension<H>
-        = ZAiAnthropicExt
-    where
-        H: HttpClientExt;
-    type ApiKey = AnthropicKey;
-
-    const BASE_URL: &'static str = ANTHROPIC_API_BASE_URL;
-
-    fn build<H>(
-        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
-    ) -> http_client::Result<Self::Extension<H>>
-    where
-        H: HttpClientExt,
-    {
-        Ok(ZAiAnthropicExt)
-    }
-
-    fn finish<H>(
-        &self,
-        builder: client::ClientBuilder<Self, AnthropicKey, H>,
-    ) -> http_client::Result<client::ClientBuilder<Self, AnthropicKey, H>> {
-        finish_anthropic_builder(&self.anthropic, builder)
-    }
-}
+client::impl_default_provider_builder!(
+    ZAiBuilder => ZAiExt,
+    api_key = ZAiApiKey,
+    base_url = GENERAL_API_BASE_URL,
+);
+client::impl_default_provider_builder!(
+    ZAiAnthropicBuilder => ZAiAnthropicExt,
+    api_key = AnthropicKey,
+    base_url = ANTHROPIC_API_BASE_URL,
+    finish = finish_anthropic_builder,
+    state = anthropic,
+);
 
 impl super::anthropic::completion::AnthropicCompatibleProvider for ZAiAnthropicExt {
     const PROVIDER_NAME: &'static str = "z.ai";
@@ -178,45 +142,19 @@ impl super::anthropic::completion::AnthropicCompatibleProvider for ZAiAnthropicE
     }
 }
 
-impl ProviderClient for Client {
-    type Input = ZAiApiKey;
-    type Error = crate::client::ProviderClientError;
+client::impl_provider_client!(
+    Client,
+    input = ZAiApiKey,
+    api_key_env = "ZAI_API_KEY",
+    base_url_env = "ZAI_API_BASE",
+);
 
-    fn from_env() -> Result<Self, Self::Error> {
-        let api_key = crate::client::required_env_var("ZAI_API_KEY")?;
-        let mut builder = Self::builder().api_key(api_key);
-
-        if let Some(base_url) = crate::client::optional_env_var("ZAI_API_BASE")? {
-            builder = builder.base_url(base_url);
-        }
-
-        builder.build().map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::new(input).map_err(Into::into)
-    }
-}
-
-impl ProviderClient for AnthropicClient {
-    type Input = String;
-    type Error = crate::client::ProviderClientError;
-
-    fn from_env() -> Result<Self, Self::Error> {
-        let api_key = crate::client::required_env_var("ZAI_API_KEY")?;
-        let mut builder = Self::builder().api_key(api_key);
-
-        if let Some(base_url) = anthropic_base_override("ZAI_ANTHROPIC_API_BASE", "ZAI_API_BASE")? {
-            builder = builder.base_url(base_url);
-        }
-
-        builder.build().map_err(Into::into)
-    }
-
-    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
-        Self::builder().api_key(input).build().map_err(Into::into)
-    }
-}
+client::impl_provider_client!(
+    AnthropicClient,
+    input = String,
+    api_key_env = "ZAI_API_KEY",
+    base_url = anthropic_base_override("ZAI_ANTHROPIC_API_BASE", "ZAI_API_BASE")?,
+);
 
 fn anthropic_base_override(
     primary_env: &'static str,


### PR DESCRIPTION
## Summary

- consolidate 24 repeated provider builder implementations behind a private declaration macro
- consolidate 25 repeated provider client constructors while preserving provider-specific API-key types, base URLs, environment lookup order, and Anthropic-compatible finish hooks
- share typed invalid-tool-call validation between buffered and streamed agent runs

## Motivation

Provider integrations repeated the same associated-type and constructor plumbing across many modules, while buffered and streamed invalid-tool recovery duplicated validation behavior. Keeping those paths separate increased the chance that new fields, error behavior, or streaming semantics would drift.

This refactor removes 603 net lines across 24 production Rust files without exposing new public APIs or intentionally changing provider wire behavior.

## Rebase note

Rebased onto `main` at `c046bd8e6`, which includes #2286. The former `AgentBuilder` consolidation was dropped during conflict resolution because #2286 already replaced that boilerplate with the shared `with_tool_state` and `build_agent` paths.

## Impact

- provider-specific authentication, capabilities, error preservation, and request/response conversions remain in their existing modules
- base-URL environment error precedence is preserved, including the base-URL-first behavior of Anthropic, Doubleword, and OpenAI
- streamed and non-streamed invalid-tool-call recovery now share one validation core while retaining their medium-specific rollback effects
- no tests or examples were changed because existing regression and parity coverage exercises the migrated behavior

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo test`
- `cargo test -p rig-core -p rig-agent --all-features`
- `cargo check -p rig-core -p rig-agent --target wasm32-unknown-unknown --no-default-features`
- `cargo doc --workspace --no-deps`
- `git diff --check`

A separate final full-diff review covered all 24 changed files and found no remaining correctness, regression, security, unsafe-edge-case, or missing-test issues. Verification found and removed three PR-introduced unused imports. Workspace docs retain one pre-existing warning in unchanged `rig-neo4j` documentation.