### PR TITLE
Fix Neo4j rustdoc link warning

### DIFF
--- a/crates/rig-neo4j/src/vector_index.rs
+++ b/crates/rig-neo4j/src/vector_index.rs
@@ -299,7 +299,7 @@ where
     /// Inserts one node per embedding, flattening the document's JSON fields
     /// onto the node alongside the embedding (`embedding_property`) and its
     /// source text (`embedded_text`). Nodes are written under the index's
-    /// `node_label`, defaulting to [`DEFAULT_NODE_LABEL`].
+    /// `node_label`, defaulting to the `Document` label.
     async fn insert_documents<Doc: Serialize + Embed + Send>(
         &self,
         documents: Vec<(Doc, Vec<Embedding>)>,


### PR DESCRIPTION
## Summary

- replace the public rustdoc link to the private `DEFAULT_NODE_LABEL` constant with the user-visible `Document` default
- eliminate the `rustdoc::private_intra_doc_links` warning from `rig-neo4j` and workspace documentation builds

## Root cause

The public `InsertDocuments::insert_documents` implementation documentation linked to a private module constant. Rustdoc warns because the link cannot resolve in public documentation unless private items are included.

## Impact

Documentation now states the same default label directly. There is no public API or runtime behavior change.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo doc -p rig-neo4j --no-deps`
- `cargo clippy -p rig-neo4j --all-targets --all-features`
- `cargo test -p rig-neo4j`
- `cargo clippy --all-targets --all-features`
- `cargo test`
- `cargo doc --workspace --no-deps`

A separate complete-diff review found no remaining correctness, regression, security, or missing-test issues.