### PR TITLE
refactor: reduce provider and agent duplication

### DIFF
--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -62,7 +62,7 @@ use crate::{
     completion::{CompletionError, CompletionModel, Document, Message, PromptError, Usage},
     json_utils,
     tool::{
-        ToolContext, ToolDispatch, ToolOutput, ToolResult,
+        ToolContext, ToolDispatch, ToolResult,
         server::{ToolRegistrySnapshot, ToolServerHandle},
     },
 };
@@ -137,50 +137,6 @@ pub(crate) fn resolve_model_turn_action(
             Ok(ModelTurnDecision::Retried)
         }
         ModelTurnAction::Stop(reason) => Ok(ModelTurnDecision::Terminate(reason)),
-    }
-}
-
-pub(crate) enum ToolCallDecision {
-    Proceed,
-    ProceedWith(serde_json::Value),
-    Skip(String),
-    Terminate(String),
-}
-
-pub(crate) fn tool_call_decision(action: ToolCallAction) -> ToolCallDecision {
-    match action {
-        ToolCallAction::Run => ToolCallDecision::Proceed,
-        ToolCallAction::Rewrite(args) => ToolCallDecision::ProceedWith(args),
-        ToolCallAction::Skip(reason) => ToolCallDecision::Skip(reason),
-        ToolCallAction::Stop(reason) => ToolCallDecision::Terminate(reason),
-    }
-}
-
-pub(crate) enum ToolResultDecision {
-    Keep,
-    Replace(ToolOutput),
-    Terminate(String),
-}
-
-pub(crate) fn tool_result_decision(action: ToolResultAction) -> ToolResultDecision {
-    match action {
-        ToolResultAction::Keep => ToolResultDecision::Keep,
-        ToolResultAction::Rewrite(result) => ToolResultDecision::Replace(result),
-        ToolResultAction::Stop(reason) => ToolResultDecision::Terminate(reason),
-    }
-}
-
-pub(crate) enum CompletionCallDecision {
-    Proceed,
-    Patch(RequestPatch),
-    Terminate(String),
-}
-
-pub(crate) fn completion_call_decision(action: CompletionCallAction) -> CompletionCallDecision {
-    match action {
-        CompletionCallAction::Continue => CompletionCallDecision::Proceed,
-        CompletionCallAction::Patch(patch) => CompletionCallDecision::Patch(patch),
-        CompletionCallAction::Stop(reason) => CompletionCallDecision::Terminate(reason),
     }
 }
 
@@ -607,21 +563,20 @@ pub(crate) async fn resolve_completion_call(
     history: &[Message],
     turn: usize,
 ) -> CompletionCallOutcome {
-    match completion_call_decision(
-        hooks
-            .on_completion_call(
-                ctx,
-                CompletionCall {
-                    prompt,
-                    history,
-                    turn,
-                },
-            )
-            .await,
-    ) {
-        CompletionCallDecision::Terminate(reason) => CompletionCallOutcome::Terminate(reason),
-        CompletionCallDecision::Patch(patch) => CompletionCallOutcome::Proceed(Some(patch)),
-        CompletionCallDecision::Proceed => CompletionCallOutcome::Proceed(None),
+    match hooks
+        .on_completion_call(
+            ctx,
+            CompletionCall {
+                prompt,
+                history,
+                turn,
+            },
+        )
+        .await
+    {
+        CompletionCallAction::Stop(reason) => CompletionCallOutcome::Terminate(reason),
+        CompletionCallAction::Patch(patch) => CompletionCallOutcome::Proceed(Some(patch)),
+        CompletionCallAction::Continue => CompletionCallOutcome::Proceed(None),
     }
 }
 
@@ -702,8 +657,8 @@ pub(crate) async fn run_single_tool(
     }
 
     // Resolve the `ToolCall` hook chain. A proceeding chain carries any
-    // `ToolCallAction::Rewrite` in the action itself (→ `ProceedWith`); a chain that a
-    // later hook short-circuits with `Skip`/`Terminate` salvages the accumulated
+    // `ToolCallAction::Rewrite` in the action itself; a chain that a later hook
+    // short-circuits with `Skip`/`Stop` salvages the accumulated
     // rewrite into `salvaged_rewrite` so it is *not* lost — the rewritten args
     // must still be reported on the skipped `ToolResult` and in tracing rather
     // than leaking the model's original args (see [`HookStack::resolve_tool_call`]).
@@ -738,14 +693,14 @@ pub(crate) async fn run_single_tool(
     // `ToolCallAction::Rewrite` replacement, or a salvaged rewrite) — surfaced in the
     // execution-commit event so a redaction rewrite does not leak. Unused for a skip.
     let mut skipped: Option<ToolResult> = None;
-    let effective_args: serde_json::Value = match tool_call_decision(action) {
-        ToolCallDecision::Terminate(reason) => {
+    let effective_args: serde_json::Value = match action {
+        ToolCallAction::Stop(reason) => {
             return Err(PromptError::prompt_cancelled(
                 error_history.to_vec(),
                 reason,
             ));
         }
-        ToolCallDecision::Skip(reason) => {
+        ToolCallAction::Skip(reason) => {
             tracing::info!(tool_name = tool_name, reason = reason, "Tool call rejected");
             // Synthetic rejection: `Skipped` outcome, message delivered verbatim.
             // Still fires the `ToolResult` hook so a policy observes the skip.
@@ -754,7 +709,7 @@ pub(crate) async fn run_single_tool(
             // (if any) so tracing/history stay consistent, though they go unused.
             salvaged_rewrite.unwrap_or_else(|| tool_call.function.arguments.clone())
         }
-        ToolCallDecision::ProceedWith(replacement) => {
+        ToolCallAction::Rewrite(replacement) => {
             // Proceeding rewrite: re-record the span so the trace, and the
             // downstream `ToolResult` event, reflect what the tool actually
             // received rather than what the model emitted.
@@ -768,7 +723,7 @@ pub(crate) async fn run_single_tool(
             );
             replacement
         }
-        ToolCallDecision::Proceed => tool_call.function.arguments.clone(),
+        ToolCallAction::Run => tool_call.function.arguments.clone(),
     };
 
     // Resolve the structured execution result and how the call surfaced. A skip
@@ -792,33 +747,31 @@ pub(crate) async fn run_single_tool(
     };
     // Presentation rewrites happen after execution. The raw structured result
     // and per-dispatch context remain unchanged for every hook.
-    let result_decision = tool_result_decision(
-        hooks
-            .on_tool_result(
-                ctx,
-                ToolResultEvent {
-                    tool_name,
-                    tool_call_id: Some(tool_call.id.as_str()),
-                    internal_call_id,
-                    args: &args,
-                    presentation: exec.output(),
-                    raw_result: &exec,
-                    tool_context: &dispatch_context,
-                },
-            )
-            .await,
-    );
+    let result_action = hooks
+        .on_tool_result(
+            ctx,
+            ToolResultEvent {
+                tool_name,
+                tool_call_id: Some(tool_call.id.as_str()),
+                internal_call_id,
+                args: &args,
+                presentation: exec.output(),
+                raw_result: &exec,
+                tool_context: &dispatch_context,
+            },
+        )
+        .await;
     // Outcome metadata describes the execution itself, while result content
     // follows the same presentation policy as the model. This keeps redaction
     // and stop hooks from leaking raw tool output through telemetry.
     record_tool_result(&tool_span, &exec);
 
-    match result_decision {
-        ToolResultDecision::Terminate(reason) => Err(PromptError::prompt_cancelled(
+    match result_action {
+        ToolResultAction::Stop(reason) => Err(PromptError::prompt_cancelled(
             error_history.to_vec(),
             reason,
         )),
-        ToolResultDecision::Replace(replacement) => {
+        ToolResultAction::Rewrite(replacement) => {
             if record_content {
                 tool_span.record("gen_ai.tool.call.result", replacement.render());
             }
@@ -832,7 +785,7 @@ pub(crate) async fn run_single_tool(
                 execution,
             })
         }
-        ToolResultDecision::Keep => {
+        ToolResultAction::Keep => {
             if record_content {
                 tool_span.record("gen_ai.tool.call.result", exec.output().render());
             }
@@ -6947,23 +6900,6 @@ mod migrated_tests {
         let _other_agent = AgentBuilder::new(other_model).add_hook(hook).build();
     }
 
-    /// `ToolCallAction::Rewrite` resolves to a `ProceedWith` tool-call decision that
-    /// carries the replacement arguments, and is named for fail-closed
-    /// diagnostics.
-    #[test]
-    fn rewrite_args_resolves_to_proceed_with_for_tool_call() {
-        let args = json!({"x": 1, "y": 2});
-        match super::tool_call_decision(ToolCallAction::rewrite(args.clone())) {
-            super::ToolCallDecision::ProceedWith(replacement) => assert_eq!(replacement, args),
-            _ => panic!("ToolCallAction::Rewrite should resolve to ProceedWith"),
-        }
-        // The typed convenience builds the same variant as the value constructor.
-        assert_eq!(
-            ToolCallAction::try_rewrite(&json!({"x": 1, "y": 2})).expect("serializes"),
-            ToolCallAction::rewrite(json!({"x": 1, "y": 2})),
-        );
-    }
-
     /// A hook that rewrites a *valid* tool call's arguments (`ToolCallAction::Rewrite`
     /// on `ToolCall`) is honored identically under `run()` and `stream()`: the
     /// tool executes with the replacement, so both drivers observe the same
@@ -7256,18 +7192,6 @@ mod migrated_tests {
         }
     }
 
-    /// `ToolResultAction::Rewrite` resolves to a `Replace` tool-result decision carrying
-    /// the replacement, and is named for fail-closed diagnostics.
-    #[test]
-    fn rewrite_result_resolves_to_replace_for_tool_result() {
-        match super::tool_result_decision(ToolResultAction::rewrite("redacted")) {
-            super::ToolResultDecision::Replace(result) => {
-                assert_eq!(result.as_text(), Some("redacted"))
-            }
-            _ => panic!("ToolResultAction::Rewrite should resolve to Replace"),
-        }
-    }
-
     /// A hook that rewrites a tool's result (`ToolResultAction::Rewrite` on
     /// `ToolResult`) is honored identically under `run()` and `stream()`: the
     /// model-visible history carries the replacement while the `ToolResult` event
@@ -7413,19 +7337,6 @@ mod migrated_tests {
 
     const OVERRIDE_PREAMBLE: &str = "overridden: critical-step instructions";
     const OVERRIDE_MAX_TOKENS: u64 = 512;
-
-    /// `CompletionCallAction::Patch` resolves to a `Patch` completion-call decision
-    /// carrying the patch, and is named for fail-closed diagnostics.
-    #[test]
-    fn patch_request_resolves_to_patch_for_completion_call() {
-        let patch = RequestPatch::new()
-            .temperature(0.25)
-            .tool_choice(ToolChoice::Required);
-        match super::completion_call_decision(CompletionCallAction::patch(patch.clone())) {
-            super::CompletionCallDecision::Patch(got) => assert_eq!(got, patch),
-            _ => panic!("PatchRequest should resolve to Patch for a completion call"),
-        }
-    }
 
     /// A `CompletionCallAction::Patch` hook patches the request for the turn identically
     /// under `run()` and `stream()`: the captured completion request shows the

--- a/crates/rig-core/src/providers/anthropic/client.rs
+++ b/crates/rig-core/src/providers/anthropic/client.rs
@@ -189,6 +189,55 @@ where
 
     Ok(builder)
 }
+
+// The remaining compatible-client repetition is inherent builder methods and
+// a ProviderBuilder implementation, neither of which ordinary functions can
+// generate. Keep the actual header behavior in `finish_anthropic_builder` and
+// generate only this type-level plumbing.
+macro_rules! impl_anthropic_compatible_builder {
+    ($builder:ty => $extension:ty, base_url = $base_url:expr $(,)?) => {
+        $crate::client::impl_default_provider_builder!(
+            $builder => $extension,
+            api_key = $crate::providers::anthropic::client::AnthropicKey,
+            base_url = $base_url,
+            finish = $crate::providers::anthropic::client::finish_anthropic_builder,
+            state = anthropic,
+        );
+
+        impl<H>
+            $crate::client::ClientBuilder<
+                $builder,
+                $crate::providers::anthropic::client::AnthropicKey,
+                H,
+            >
+        {
+            pub fn anthropic_version(self, anthropic_version: &str) -> Self {
+                self.over_ext(|mut ext| {
+                    ext.anthropic.anthropic_version = anthropic_version.into();
+                    ext
+                })
+            }
+
+            pub fn anthropic_betas(self, anthropic_betas: &[&str]) -> Self {
+                self.over_ext(|mut ext| {
+                    ext.anthropic
+                        .anthropic_betas
+                        .extend(anthropic_betas.iter().copied().map(String::from));
+                    ext
+                })
+            }
+
+            pub fn anthropic_beta(self, anthropic_beta: &str) -> Self {
+                self.over_ext(|mut ext| {
+                    ext.anthropic.anthropic_betas.push(anthropic_beta.into());
+                    ext
+                })
+            }
+        }
+    };
+}
+pub(crate) use impl_anthropic_compatible_builder;
+
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -24,16 +24,15 @@
 
 use std::fmt::Debug;
 
-use super::openai::TranscriptionResponse;
 use crate::client::{
     self, ApiKey, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
     ProviderClient,
 };
 use crate::http_client::{self, HttpClientExt, bearer_auth_header};
+use crate::providers::internal::transcription::OpenAiTranscriptionClient;
 use crate::{
     embeddings::{self, EmbeddingError},
     providers::openai,
-    transcription::{self},
 };
 use serde::Deserialize;
 // ================================================================
@@ -306,6 +305,7 @@ impl ProviderClient for Client {
     }
 }
 
+#[cfg(feature = "image")]
 use crate::providers::openai::client::ApiResponse;
 
 // ================================================================
@@ -522,57 +522,21 @@ impl openai::completion::OpenAICompatibleProvider for AzureExt {
 // Azure OpenAI Transcription API
 // ================================================================
 
-#[derive(Clone)]
-pub struct TranscriptionModel<T = reqwest::Client> {
-    client: Client<T>,
-    /// Name of the model (e.g.: gpt-3.5-turbo-1106)
-    pub model: String,
-}
+/// Azure OpenAI transcription model; `model` identifies the Azure deployment.
+pub type TranscriptionModel<T = reqwest::Client> =
+    crate::providers::internal::transcription::OpenAiTranscriptionModel<Client<T>>;
 
-impl<T> TranscriptionModel<T> {
-    pub fn new(client: Client<T>, model: impl Into<String>) -> Self {
-        Self {
-            client,
-            model: model.into(),
-        }
-    }
-}
-
-impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
+impl<T> OpenAiTranscriptionClient for Client<T>
 where
     T: HttpClientExt + Clone + 'static,
 {
-    type Response = TranscriptionResponse;
-    type Client = Client<T>;
+    const MODEL_IN_FORM: bool = false;
 
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
-
-    async fn transcription(
+    fn transcription_request(
         &self,
-        request: transcription::TranscriptionRequest,
-    ) -> Result<
-        transcription::TranscriptionResponse<Self::Response>,
-        transcription::TranscriptionError,
-    > {
-        // Azure addresses the deployment through the URL, so no `model` form
-        // field is sent. `language` IS sent when set — the endpoint accepts
-        // it, and the old hand-rolled request dropping it was a bug.
-        let form = crate::providers::internal::transcription::transcription_form(
-            request,
-            crate::providers::internal::transcription::TranscriptionFields { model: None },
-        )?;
-
-        crate::providers::internal::transcription::send_transcription::<
-            _,
-            ApiResponse<TranscriptionResponse>,
-        >(
-            &self.client,
-            self.client.post_transcription(&self.model)?,
-            form,
-        )
-        .await
+        model: &str,
+    ) -> crate::http_client::Result<crate::http_client::Builder> {
+        self.post_transcription(model)
     }
 }
 
@@ -822,6 +786,46 @@ mod azure_tests {
             Some(http::StatusCode::BAD_REQUEST)
         );
         assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn transcription_routes_deployment_in_url_not_multipart_body() {
+        use crate::test_utils::RecordingHttpClient;
+        use crate::transcription::TranscriptionModel as _;
+
+        let http_client = RecordingHttpClient::new(r#"{"text":"transcribed"}"#);
+        let client = Client::builder()
+            .api_key("test-key")
+            .azure_endpoint("https://example.openai.azure.com".to_owned())
+            .http_client(http_client.clone())
+            .build()
+            .expect("build client");
+        let model = TranscriptionModel::new(client, "whisper-deployment");
+
+        let response = model
+            .transcription_request()
+            .data(vec![1, 2, 3])
+            .filename(Some("audio.mp3".to_owned()))
+            .send()
+            .await
+            .expect("transcription should succeed");
+
+        assert_eq!(response.text, "transcribed");
+        let request = http_client
+            .requests()
+            .into_iter()
+            .next()
+            .expect("request should be captured");
+        assert_eq!(
+            request.uri,
+            "https://example.openai.azure.com/openai/deployments/whisper-deployment/audio/translations?api-version=2024-10-21"
+        );
+        let body = String::from_utf8_lossy(&request.body);
+        assert!(!body.contains("name=\"model\""), "{body}");
+        assert!(
+            body.contains("name=\"file\"; filename=\"audio.mp3\""),
+            "{body}"
+        );
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -14,11 +14,11 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
-use super::openai::{self, TranscriptionResponse};
+use super::openai;
 use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
 use crate::completion::CompletionError;
 use crate::http_client::HttpClientExt;
-use crate::transcription::{self};
+use crate::providers::internal::transcription::OpenAiTranscriptionClient;
 
 // ================================================================
 // Main Groq Client
@@ -111,6 +111,7 @@ pub type StreamingCompletionResponse = openai::StreamingCompletionResponse;
 
 client::impl_provider_client!(Client, input = String, api_key_env = "GROQ_API_KEY");
 
+#[cfg(test)]
 use crate::providers::openai::client::ApiResponse;
 
 fn apply_native_tools_to_additional_params(
@@ -225,56 +226,21 @@ pub const WHISPER_LARGE_V3: &str = "whisper-large-v3";
 pub const WHISPER_LARGE_V3_TURBO: &str = "whisper-large-v3-turbo";
 pub const DISTIL_WHISPER_LARGE_V3_EN: &str = "distil-whisper-large-v3-en";
 
-#[derive(Clone)]
-pub struct TranscriptionModel<T> {
-    client: Client<T>,
-    /// Name of the model (e.g.: whisper-large-v3)
-    pub model: String,
-}
+/// Groq transcription model using the shared OpenAI-style implementation.
+pub type TranscriptionModel<T = reqwest::Client> =
+    crate::providers::internal::transcription::OpenAiTranscriptionModel<Client<T>>;
 
-impl<T> TranscriptionModel<T> {
-    pub fn new(client: Client<T>, model: impl Into<String>) -> Self {
-        Self {
-            client,
-            model: model.into(),
-        }
-    }
-}
-impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
+impl<T> OpenAiTranscriptionClient for Client<T>
 where
-    T: HttpClientExt + Clone + Send + std::fmt::Debug + Default + 'static,
+    T: HttpClientExt + Clone + 'static,
 {
-    type Response = TranscriptionResponse;
+    const MODEL_IN_FORM: bool = true;
 
-    type Client = Client<T>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
-
-    async fn transcription(
+    fn transcription_request(
         &self,
-        request: transcription::TranscriptionRequest,
-    ) -> Result<
-        transcription::TranscriptionResponse<Self::Response>,
-        transcription::TranscriptionError,
-    > {
-        let form = crate::providers::internal::transcription::transcription_form(
-            request,
-            crate::providers::internal::transcription::TranscriptionFields {
-                model: Some(&self.model),
-            },
-        )?;
-
-        crate::providers::internal::transcription::send_transcription::<
-            _,
-            ApiResponse<TranscriptionResponse>,
-        >(
-            &self.client,
-            self.client.post("/audio/transcriptions")?,
-            form,
-        )
-        .await
+        _model: &str,
+    ) -> crate::http_client::Result<crate::http_client::Builder> {
+        self.post("/audio/transcriptions")
     }
 }
 
@@ -364,6 +330,49 @@ mod tests {
         let json = serde_json::to_value(no_tools_request).expect("request should serialize");
         assert_eq!(json["response_format"]["type"], "json_schema");
         assert_eq!(json["response_format"]["json_schema"]["strict"], true);
+    }
+
+    #[tokio::test]
+    async fn transcription_routes_model_in_multipart_body() {
+        use crate::client::transcription::TranscriptionClient;
+        use crate::test_utils::RecordingHttpClient;
+        use crate::transcription::TranscriptionModel as _;
+
+        let http_client = RecordingHttpClient::new(r#"{"text":"transcribed"}"#);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client.clone())
+            .build()
+            .expect("build client");
+        let model = client.transcription_model(super::WHISPER_LARGE_V3);
+
+        let response = model
+            .transcription_request()
+            .data(vec![1, 2, 3])
+            .filename(Some("audio.mp3".to_owned()))
+            .send()
+            .await
+            .expect("transcription should succeed");
+
+        assert_eq!(response.text, "transcribed");
+        let request = http_client
+            .requests()
+            .into_iter()
+            .next()
+            .expect("request should be captured");
+        assert_eq!(
+            request.uri,
+            "https://api.groq.com/openai/v1/audio/transcriptions"
+        );
+        let body = String::from_utf8_lossy(&request.body);
+        assert!(
+            body.contains("name=\"model\"\r\n\r\nwhisper-large-v3\r\n"),
+            "{body}"
+        );
+        assert!(
+            body.contains("name=\"file\"; filename=\"audio.mp3\""),
+            "{body}"
+        );
     }
 
     #[test]

--- a/crates/rig-core/src/providers/internal/anthropic_compatible.rs
+++ b/crates/rig-core/src/providers/internal/anthropic_compatible.rs
@@ -1,0 +1,115 @@
+//! Shared base-URL resolution for providers exposing both OpenAI- and
+//! Anthropic-compatible endpoints.
+
+/// Describes how one provider maps its OpenAI-compatible endpoint onto its
+/// Anthropic-compatible endpoint.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct AnthropicBaseUrl {
+    known_bases: &'static [(&'static str, &'static str)],
+    openai_paths: &'static [&'static str],
+    anthropic_path: &'static str,
+}
+
+impl AnthropicBaseUrl {
+    pub(crate) const fn new(
+        known_bases: &'static [(&'static str, &'static str)],
+        openai_paths: &'static [&'static str],
+        anthropic_path: &'static str,
+    ) -> Self {
+        Self {
+            known_bases,
+            openai_paths,
+            anthropic_path,
+        }
+    }
+
+    /// Read the dedicated Anthropic override first, falling back to the
+    /// provider's general base URL only when it can be mapped safely.
+    pub(crate) fn resolve_from_env(
+        self,
+        primary_env: &'static str,
+        fallback_env: &'static str,
+    ) -> crate::client::ProviderClientResult<Option<String>> {
+        let primary = crate::client::optional_env_var(primary_env)?;
+        let fallback = crate::client::optional_env_var(fallback_env)?;
+
+        Ok(self.resolve(primary.as_deref(), fallback.as_deref()))
+    }
+
+    pub(crate) fn resolve(self, primary: Option<&str>, fallback: Option<&str>) -> Option<String> {
+        primary
+            .map(str::to_owned)
+            .or_else(|| fallback.and_then(|base_url| self.normalize(base_url)))
+    }
+
+    /// Preserve an explicitly Anthropic-shaped URL, map canonical provider
+    /// endpoints exactly, or rewrite a recognized OpenAI-compatible path on a
+    /// custom host. Unknown paths are not guessed.
+    pub(crate) fn normalize(self, base_url: &str) -> Option<String> {
+        if base_url.contains("/anthropic") {
+            return Some(base_url.to_owned());
+        }
+
+        let trimmed = base_url.trim_end_matches('/');
+        if let Some((_, anthropic_base)) = self
+            .known_bases
+            .iter()
+            .find(|(openai_base, _)| *openai_base == trimmed)
+        {
+            return Some((*anthropic_base).to_owned());
+        }
+
+        let mut url = url::Url::parse(base_url).ok()?;
+        if !self.openai_path(url.path()) {
+            return None;
+        }
+        url.set_path(self.anthropic_path);
+        Some(url.to_string())
+    }
+
+    fn openai_path(self, path: &str) -> bool {
+        self.openai_paths.contains(&path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AnthropicBaseUrl;
+
+    const RULE: AnthropicBaseUrl = AnthropicBaseUrl::new(
+        &[(
+            "https://api.example.com/v1",
+            "https://api.example.com/anthropic",
+        )],
+        &["/v1", "/v1/"],
+        "/anthropic",
+    );
+
+    #[test]
+    fn maps_known_and_custom_openai_bases() {
+        assert_eq!(
+            RULE.normalize("https://api.example.com/v1/").as_deref(),
+            Some("https://api.example.com/anthropic")
+        );
+        assert_eq!(
+            RULE.normalize("https://proxy.example.com/v1").as_deref(),
+            Some("https://proxy.example.com/anthropic")
+        );
+    }
+
+    #[test]
+    fn primary_wins_and_unknown_fallback_paths_are_ignored() {
+        assert_eq!(
+            RULE.resolve(
+                Some("https://primary.example.com/anthropic"),
+                Some("https://proxy.example.com/v1")
+            )
+            .as_deref(),
+            Some("https://primary.example.com/anthropic")
+        );
+        assert_eq!(
+            RULE.resolve(None, Some("https://proxy.example.com/api")),
+            None
+        );
+    }
+}

--- a/crates/rig-core/src/providers/internal/mod.rs
+++ b/crates/rig-core/src/providers/internal/mod.rs
@@ -8,6 +8,7 @@
 //! crate-private.
 
 pub mod adapter;
+pub(crate) mod anthropic_compatible;
 #[cfg(feature = "audio")]
 pub(crate) mod audio_generation;
 pub(crate) mod auth;

--- a/crates/rig-core/src/providers/internal/transcription.rs
+++ b/crates/rig-core/src/providers/internal/transcription.rs
@@ -3,10 +3,9 @@
 //! OpenAI, Groq and Azure OpenAI all accept the same multipart body — the
 //! audio as a `file` part plus optional `language`, `prompt` and `temperature`
 //! fields and a flattened `additional_params` object — and answer with the
-//! same `{ text }` payload or error envelope. The per-provider differences are
-//! carried as data ([`TranscriptionFields`]) and as the provider's own
-//! envelope type (via [`ProviderEnvelope`]), so each provider keeps its exact
-//! wire behavior.
+//! same `{ text }` payload and OpenAI-style error envelope. The per-provider
+//! differences are limited to request routing and whether the model is sent as
+//! a form field.
 
 use bytes::Bytes;
 use serde::de::DeserializeOwned;
@@ -15,6 +14,71 @@ use super::envelope::ProviderEnvelope;
 use crate::http_client::multipart::Part;
 use crate::http_client::{self, HttpClientExt, MultipartForm};
 use crate::transcription::{self, TranscriptionError, TranscriptionRequest};
+
+/// Provider-specific request routing for the shared OpenAI-style model.
+pub(crate) trait OpenAiTranscriptionClient: HttpClientExt + Clone {
+    /// Whether the model is a multipart form field. Azure addresses the model
+    /// as a deployment in the request URL instead.
+    const MODEL_IN_FORM: bool;
+
+    fn transcription_request(&self, model: &str) -> http_client::Result<http_client::Builder>;
+}
+
+/// The common model shell for OpenAI, Groq, and Azure OpenAI transcription.
+/// Their response and multipart wire formats are identical; the client trait
+/// above retains the only variation, request routing.
+#[derive(Clone)]
+pub struct OpenAiTranscriptionModel<C> {
+    client: C,
+    /// Name of the transcription model or, for Azure OpenAI, deployment.
+    pub model: String,
+}
+
+impl<C> OpenAiTranscriptionModel<C> {
+    /// Create a transcription model backed by `client`.
+    pub fn new(client: C, model: impl Into<String>) -> Self {
+        Self {
+            client,
+            model: model.into(),
+        }
+    }
+}
+
+impl<C> transcription::TranscriptionModel for OpenAiTranscriptionModel<C>
+where
+    C: OpenAiTranscriptionClient + 'static,
+{
+    type Response = crate::providers::openai::TranscriptionResponse;
+    type Client = C;
+
+    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
+        Self::new(client.clone(), model)
+    }
+
+    async fn transcription(
+        &self,
+        request: TranscriptionRequest,
+    ) -> Result<transcription::TranscriptionResponse<Self::Response>, TranscriptionError> {
+        let form = transcription_form(
+            request,
+            TranscriptionFields {
+                model: C::MODEL_IN_FORM.then_some(self.model.as_str()),
+            },
+        )?;
+
+        send_transcription::<
+            _,
+            crate::providers::openai::client::ApiResponse<
+                crate::providers::openai::TranscriptionResponse,
+            >,
+        >(
+            &self.client,
+            self.client.transcription_request(&self.model)?,
+            form,
+        )
+        .await
+    }
+}
 
 /// The per-provider parts of an OpenAI-style transcription request.
 #[derive(Debug, Clone, Copy)]

--- a/crates/rig-core/src/providers/minimax.rs
+++ b/crates/rig-core/src/providers/minimax.rs
@@ -23,8 +23,9 @@
 
 use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
 use crate::providers::anthropic::client::{
-    AnthropicBuilder as AnthropicCompatBuilder, AnthropicKey, finish_anthropic_builder,
+    AnthropicBuilder as AnthropicCompatBuilder, AnthropicKey, impl_anthropic_compatible_builder,
 };
+use crate::providers::internal::anthropic_compatible::AnthropicBaseUrl;
 
 /// Global OpenAI-compatible base URL.
 pub const GLOBAL_API_BASE_URL: &str = "https://api.minimax.io/v1";
@@ -127,12 +128,9 @@ client::impl_default_provider_builder!(
     api_key = MiniMaxApiKey,
     base_url = GLOBAL_API_BASE_URL,
 );
-client::impl_default_provider_builder!(
+impl_anthropic_compatible_builder!(
     MiniMaxAnthropicBuilder => MiniMaxAnthropicExt,
-    api_key = AnthropicKey,
     base_url = GLOBAL_ANTHROPIC_API_BASE_URL,
-    finish = finish_anthropic_builder,
-    state = anthropic,
 );
 
 impl super::anthropic::completion::AnthropicCompatibleProvider for MiniMaxAnthropicExt {
@@ -154,49 +152,18 @@ client::impl_provider_client!(
     AnthropicClient,
     input = String,
     api_key_env = "MINIMAX_API_KEY",
-    base_url = anthropic_base_override("MINIMAX_ANTHROPIC_API_BASE", "MINIMAX_API_BASE")?,
+    base_url =
+        ANTHROPIC_BASE_URLS.resolve_from_env("MINIMAX_ANTHROPIC_API_BASE", "MINIMAX_API_BASE")?,
 );
 
-fn anthropic_base_override(
-    primary_env: &'static str,
-    fallback_env: &'static str,
-) -> crate::client::ProviderClientResult<Option<String>> {
-    let primary = crate::client::optional_env_var(primary_env)?;
-    let fallback = crate::client::optional_env_var(fallback_env)?;
-
-    Ok(resolve_anthropic_base_override(
-        primary.as_deref(),
-        fallback.as_deref(),
-    ))
-}
-
-fn resolve_anthropic_base_override(
-    primary: Option<&str>,
-    fallback: Option<&str>,
-) -> Option<String> {
-    primary
-        .map(str::to_owned)
-        .or_else(|| fallback.and_then(normalize_anthropic_base_url))
-}
-
-fn normalize_anthropic_base_url(base_url: &str) -> Option<String> {
-    if base_url.contains("/anthropic") {
-        return Some(base_url.to_owned());
-    }
-
-    match base_url.trim_end_matches('/') {
-        GLOBAL_API_BASE_URL => Some(GLOBAL_ANTHROPIC_API_BASE_URL.to_owned()),
-        CHINA_API_BASE_URL => Some(CHINA_ANTHROPIC_API_BASE_URL.to_owned()),
-        _ => {
-            let mut url = url::Url::parse(base_url).ok()?;
-            if !matches!(url.path(), "/v1" | "/v1/") {
-                return None;
-            }
-            url.set_path("/anthropic");
-            Some(url.to_string())
-        }
-    }
-}
+const ANTHROPIC_BASE_URLS: AnthropicBaseUrl = AnthropicBaseUrl::new(
+    &[
+        (GLOBAL_API_BASE_URL, GLOBAL_ANTHROPIC_API_BASE_URL),
+        (CHINA_API_BASE_URL, CHINA_ANTHROPIC_API_BASE_URL),
+    ],
+    &["/v1", "/v1/"],
+    "/anthropic",
+);
 
 impl<H> ClientBuilder<H> {
     pub fn global(self) -> Self {
@@ -216,36 +183,13 @@ impl<H> AnthropicClientBuilder<H> {
     pub fn china(self) -> Self {
         self.base_url(CHINA_ANTHROPIC_API_BASE_URL)
     }
-
-    pub fn anthropic_version(self, anthropic_version: &str) -> Self {
-        self.over_ext(|mut ext| {
-            ext.anthropic.anthropic_version = anthropic_version.into();
-            ext
-        })
-    }
-
-    pub fn anthropic_betas(self, anthropic_betas: &[&str]) -> Self {
-        self.over_ext(|mut ext| {
-            ext.anthropic
-                .anthropic_betas
-                .extend(anthropic_betas.iter().copied().map(String::from));
-            ext
-        })
-    }
-
-    pub fn anthropic_beta(self, anthropic_beta: &str) -> Self {
-        self.over_ext(|mut ext| {
-            ext.anthropic.anthropic_betas.push(anthropic_beta.into());
-            ext
-        })
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        CHINA_ANTHROPIC_API_BASE_URL, CHINA_API_BASE_URL, GLOBAL_ANTHROPIC_API_BASE_URL,
-        GLOBAL_API_BASE_URL, normalize_anthropic_base_url, resolve_anthropic_base_override,
+        ANTHROPIC_BASE_URLS, CHINA_ANTHROPIC_API_BASE_URL, CHINA_API_BASE_URL,
+        GLOBAL_ANTHROPIC_API_BASE_URL, GLOBAL_API_BASE_URL,
     };
 
     #[test]
@@ -266,15 +210,19 @@ mod tests {
     #[test]
     fn normalize_openai_bases_to_anthropic_bases() {
         assert_eq!(
-            normalize_anthropic_base_url(GLOBAL_API_BASE_URL).as_deref(),
+            ANTHROPIC_BASE_URLS
+                .normalize(GLOBAL_API_BASE_URL)
+                .as_deref(),
             Some(GLOBAL_ANTHROPIC_API_BASE_URL)
         );
         assert_eq!(
-            normalize_anthropic_base_url(CHINA_API_BASE_URL).as_deref(),
+            ANTHROPIC_BASE_URLS.normalize(CHINA_API_BASE_URL).as_deref(),
             Some(CHINA_ANTHROPIC_API_BASE_URL)
         );
         assert_eq!(
-            normalize_anthropic_base_url("https://proxy.example.com/v1").as_deref(),
+            ANTHROPIC_BASE_URLS
+                .normalize("https://proxy.example.com/v1")
+                .as_deref(),
             Some("https://proxy.example.com/anthropic")
         );
     }
@@ -282,14 +230,16 @@ mod tests {
     #[test]
     fn normalize_preserves_existing_anthropic_base() {
         assert_eq!(
-            normalize_anthropic_base_url(CHINA_ANTHROPIC_API_BASE_URL).as_deref(),
+            ANTHROPIC_BASE_URLS
+                .normalize(CHINA_ANTHROPIC_API_BASE_URL)
+                .as_deref(),
             Some(CHINA_ANTHROPIC_API_BASE_URL)
         );
     }
 
     #[test]
     fn anthropic_primary_override_wins() {
-        let override_url = resolve_anthropic_base_override(
+        let override_url = ANTHROPIC_BASE_URLS.resolve(
             Some("https://primary.example.com/anthropic"),
             Some(CHINA_API_BASE_URL),
         );

--- a/crates/rig-core/src/providers/moonshot.rs
+++ b/crates/rig-core/src/providers/moonshot.rs
@@ -24,8 +24,9 @@
 //! ```
 use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
 use crate::providers::anthropic::client::{
-    AnthropicBuilder as AnthropicCompatBuilder, AnthropicKey, finish_anthropic_builder,
+    AnthropicBuilder as AnthropicCompatBuilder, AnthropicKey, impl_anthropic_compatible_builder,
 };
+use crate::providers::internal::anthropic_compatible::AnthropicBaseUrl;
 use crate::{completion::CompletionError, providers::openai};
 
 // ================================================================
@@ -71,12 +72,9 @@ client::impl_default_provider_builder!(
     api_key = MoonshotApiKey,
     base_url = GLOBAL_API_BASE_URL,
 );
-client::impl_default_provider_builder!(
+impl_anthropic_compatible_builder!(
     MoonshotAnthropicBuilder => MoonshotAnthropicExt,
-    api_key = AnthropicKey,
     base_url = ANTHROPIC_API_BASE_URL,
-    finish = finish_anthropic_builder,
-    state = anthropic,
 );
 
 impl<H> Capabilities<H> for MoonshotExt {
@@ -122,7 +120,8 @@ client::impl_provider_client!(
     AnthropicClient,
     input = String,
     api_key_env = "MOONSHOT_API_KEY",
-    base_url = anthropic_base_override("MOONSHOT_ANTHROPIC_API_BASE", "MOONSHOT_API_BASE")?,
+    base_url =
+        ANTHROPIC_BASE_URLS.resolve_from_env("MOONSHOT_ANTHROPIC_API_BASE", "MOONSHOT_API_BASE")?,
 );
 
 impl<H> ClientBuilder<H> {
@@ -139,29 +138,6 @@ impl<H> AnthropicClientBuilder<H> {
     pub fn global(self) -> Self {
         self.base_url(ANTHROPIC_API_BASE_URL)
     }
-
-    pub fn anthropic_version(self, anthropic_version: &str) -> Self {
-        self.over_ext(|mut ext| {
-            ext.anthropic.anthropic_version = anthropic_version.into();
-            ext
-        })
-    }
-
-    pub fn anthropic_betas(self, anthropic_betas: &[&str]) -> Self {
-        self.over_ext(|mut ext| {
-            ext.anthropic
-                .anthropic_betas
-                .extend(anthropic_betas.iter().copied().map(String::from));
-            ext
-        })
-    }
-
-    pub fn anthropic_beta(self, anthropic_beta: &str) -> Self {
-        self.over_ext(|mut ext| {
-            ext.anthropic.anthropic_betas.push(anthropic_beta.into());
-            ext
-        })
-    }
 }
 
 impl super::anthropic::completion::AnthropicCompatibleProvider for MoonshotAnthropicExt {
@@ -172,40 +148,14 @@ impl super::anthropic::completion::AnthropicCompatibleProvider for MoonshotAnthr
     }
 }
 
-fn anthropic_base_override(
-    primary_env: &'static str,
-    fallback_env: &'static str,
-) -> crate::client::ProviderClientResult<Option<String>> {
-    let primary = crate::client::optional_env_var(primary_env)?;
-    let fallback = crate::client::optional_env_var(fallback_env)?;
-
-    Ok(resolve_anthropic_base_override(
-        primary.as_deref(),
-        fallback.as_deref(),
-    ))
-}
-
-fn resolve_anthropic_base_override(
-    primary: Option<&str>,
-    fallback: Option<&str>,
-) -> Option<String> {
-    primary
-        .map(str::to_owned)
-        .or_else(|| fallback.and_then(normalize_anthropic_base_url))
-}
-
-fn normalize_anthropic_base_url(base_url: &str) -> Option<String> {
-    if base_url.contains("/anthropic") {
-        return Some(base_url.to_owned());
-    }
-
-    let mut url = url::Url::parse(base_url).ok()?;
-    if !matches!(url.path(), "/v1" | "/v1/") {
-        return None;
-    }
-    url.set_path("/anthropic");
-    Some(url.to_string())
-}
+const ANTHROPIC_BASE_URLS: AnthropicBaseUrl = AnthropicBaseUrl::new(
+    &[
+        (GLOBAL_API_BASE_URL, ANTHROPIC_API_BASE_URL),
+        (CHINA_API_BASE_URL, "https://api.moonshot.cn/anthropic"),
+    ],
+    &["/v1", "/v1/"],
+    "/anthropic",
+);
 
 // ================================================================
 // Moonshot Completion API
@@ -277,7 +227,7 @@ impl openai::completion::OpenAICompatibleProvider for MoonshotExt {
 
 #[cfg(test)]
 mod tests {
-    use super::{MoonshotExt, normalize_anthropic_base_url, resolve_anthropic_base_override};
+    use super::{ANTHROPIC_BASE_URLS, MoonshotExt};
     use crate::completion::CompletionRequest;
     use crate::message::{
         AssistantContent, Message, Reasoning, ToolCall, ToolChoice, ToolFunction,
@@ -454,15 +404,21 @@ mod tests {
     #[test]
     fn normalize_openai_style_base_to_anthropic_base() {
         assert_eq!(
-            normalize_anthropic_base_url("https://api.moonshot.ai/v1").as_deref(),
+            ANTHROPIC_BASE_URLS
+                .normalize("https://api.moonshot.ai/v1")
+                .as_deref(),
             Some("https://api.moonshot.ai/anthropic")
         );
         assert_eq!(
-            normalize_anthropic_base_url("https://api.moonshot.cn/v1").as_deref(),
+            ANTHROPIC_BASE_URLS
+                .normalize("https://api.moonshot.cn/v1")
+                .as_deref(),
             Some("https://api.moonshot.cn/anthropic")
         );
         assert_eq!(
-            normalize_anthropic_base_url("https://proxy.example.com/v1").as_deref(),
+            ANTHROPIC_BASE_URLS
+                .normalize("https://proxy.example.com/v1")
+                .as_deref(),
             Some("https://proxy.example.com/anthropic")
         );
     }
@@ -470,14 +426,16 @@ mod tests {
     #[test]
     fn normalize_preserves_existing_anthropic_base() {
         assert_eq!(
-            normalize_anthropic_base_url("https://proxy.example.com/anthropic").as_deref(),
+            ANTHROPIC_BASE_URLS
+                .normalize("https://proxy.example.com/anthropic")
+                .as_deref(),
             Some("https://proxy.example.com/anthropic")
         );
     }
 
     #[test]
     fn anthropic_primary_override_wins() {
-        let override_url = resolve_anthropic_base_override(
+        let override_url = ANTHROPIC_BASE_URLS.resolve(
             Some("https://primary.example.com/anthropic"),
             Some("https://api.moonshot.cn/v1"),
         );

--- a/crates/rig-core/src/providers/openai/transcription.rs
+++ b/crates/rig-core/src/providers/openai/transcription.rs
@@ -1,8 +1,6 @@
 use crate::http_client::HttpClientExt;
-use crate::providers::internal::transcription::{
-    TranscriptionFields, send_transcription, transcription_form,
-};
-use crate::providers::openai::{Client, client::ApiResponse};
+use crate::providers::internal::transcription::OpenAiTranscriptionClient;
+use crate::providers::openai::Client;
 use crate::transcription;
 use crate::transcription::TranscriptionError;
 use serde::Deserialize;
@@ -31,53 +29,21 @@ impl TryFrom<TranscriptionResponse>
     }
 }
 
-#[derive(Clone)]
-pub struct TranscriptionModel<T = reqwest::Client> {
-    client: Client<T>,
-    pub model: String,
-}
+/// OpenAI transcription model using the shared OpenAI-style implementation.
+pub type TranscriptionModel<T = reqwest::Client> =
+    crate::providers::internal::transcription::OpenAiTranscriptionModel<Client<T>>;
 
-impl<T> TranscriptionModel<T> {
-    pub fn new(client: Client<T>, model: impl Into<String>) -> Self {
-        Self {
-            client,
-            model: model.into(),
-        }
-    }
-}
-
-impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
+impl<T> OpenAiTranscriptionClient for Client<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + Send + 'static,
+    T: HttpClientExt + Clone + 'static,
 {
-    type Response = TranscriptionResponse;
+    const MODEL_IN_FORM: bool = true;
 
-    type Client = Client<T>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
-
-    async fn transcription(
+    fn transcription_request(
         &self,
-        request: transcription::TranscriptionRequest,
-    ) -> Result<
-        transcription::TranscriptionResponse<Self::Response>,
-        transcription::TranscriptionError,
-    > {
-        let form = transcription_form(
-            request,
-            TranscriptionFields {
-                model: Some(&self.model),
-            },
-        )?;
-
-        send_transcription::<_, ApiResponse<TranscriptionResponse>>(
-            &self.client,
-            self.client.post("/audio/transcriptions")?,
-            form,
-        )
-        .await
+        _model: &str,
+    ) -> crate::http_client::Result<crate::http_client::Builder> {
+        self.post("/audio/transcriptions")
     }
 }
 
@@ -87,6 +53,45 @@ mod tests {
     use crate::client::transcription::TranscriptionClient;
     use crate::test_utils::RecordingHttpClient;
     use crate::transcription::TranscriptionModel as _;
+
+    #[tokio::test]
+    async fn transcription_routes_model_in_multipart_body() {
+        let http_client = RecordingHttpClient::new(r#"{"text":"transcribed"}"#);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client.clone())
+            .build()
+            .expect("build client");
+        let model = client.transcription_model(WHISPER_1);
+
+        let response = model
+            .transcription_request()
+            .data(vec![1, 2, 3])
+            .filename(Some("audio.mp3".to_owned()))
+            .send()
+            .await
+            .expect("transcription should succeed");
+
+        assert_eq!(response.text, "transcribed");
+        let request = http_client
+            .requests()
+            .into_iter()
+            .next()
+            .expect("request should be captured");
+        assert_eq!(
+            request.uri,
+            "https://api.openai.com/v1/audio/transcriptions"
+        );
+        let body = String::from_utf8_lossy(&request.body);
+        assert!(
+            body.contains("name=\"model\"\r\n\r\nwhisper-1\r\n"),
+            "{body}"
+        );
+        assert!(
+            body.contains("name=\"file\"; filename=\"audio.mp3\""),
+            "{body}"
+        );
+    }
 
     #[tokio::test]
     async fn transcription_http_non_success_preserves_status_and_body() {

--- a/crates/rig-core/src/providers/xiaomimimo.rs
+++ b/crates/rig-core/src/providers/xiaomimimo.rs
@@ -27,8 +27,9 @@ use crate::client::{
 use crate::http_client::HttpClientExt;
 use crate::model::{Model, ModelList, ModelListingError};
 use crate::providers::anthropic::client::{
-    AnthropicBuilder as AnthropicCompatBuilder, AnthropicKey, finish_anthropic_builder,
+    AnthropicBuilder as AnthropicCompatBuilder, AnthropicKey, impl_anthropic_compatible_builder,
 };
+use crate::providers::internal::anthropic_compatible::AnthropicBaseUrl;
 use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
 
 /// OpenAI-compatible base URL.
@@ -124,12 +125,9 @@ client::impl_default_provider_builder!(
     api_key = XiaomiMimoApiKey,
     base_url = API_BASE_URL,
 );
-client::impl_default_provider_builder!(
+impl_anthropic_compatible_builder!(
     XiaomiMimoAnthropicBuilder => XiaomiMimoAnthropicExt,
-    api_key = AnthropicKey,
     base_url = ANTHROPIC_API_BASE_URL,
-    finish = finish_anthropic_builder,
-    state = anthropic,
 );
 
 impl super::anthropic::completion::AnthropicCompatibleProvider for XiaomiMimoAnthropicExt {
@@ -151,72 +149,15 @@ client::impl_provider_client!(
     AnthropicClient,
     input = String,
     api_key_env = "XIAOMI_MIMO_API_KEY",
-    base_url = anthropic_base_override("XIAOMI_MIMO_ANTHROPIC_API_BASE", "XIAOMI_MIMO_API_BASE",)?,
+    base_url = ANTHROPIC_BASE_URLS
+        .resolve_from_env("XIAOMI_MIMO_ANTHROPIC_API_BASE", "XIAOMI_MIMO_API_BASE")?,
 );
 
-fn anthropic_base_override(
-    primary_env: &'static str,
-    fallback_env: &'static str,
-) -> crate::client::ProviderClientResult<Option<String>> {
-    let primary = crate::client::optional_env_var(primary_env)?;
-    let fallback = crate::client::optional_env_var(fallback_env)?;
-
-    Ok(resolve_anthropic_base_override(
-        primary.as_deref(),
-        fallback.as_deref(),
-    ))
-}
-
-fn resolve_anthropic_base_override(
-    primary: Option<&str>,
-    fallback: Option<&str>,
-) -> Option<String> {
-    primary
-        .map(str::to_owned)
-        .or_else(|| fallback.and_then(normalize_anthropic_base_url))
-}
-
-fn normalize_anthropic_base_url(base_url: &str) -> Option<String> {
-    if base_url.contains("/anthropic") {
-        return Some(base_url.to_owned());
-    }
-
-    if base_url.trim_end_matches('/') == API_BASE_URL {
-        return Some(ANTHROPIC_API_BASE_URL.to_owned());
-    }
-
-    let mut url = url::Url::parse(base_url).ok()?;
-    if !matches!(url.path(), "/v1" | "/v1/") {
-        return None;
-    }
-    url.set_path("/anthropic/v1");
-    Some(url.to_string())
-}
-
-impl<H> AnthropicClientBuilder<H> {
-    pub fn anthropic_version(self, anthropic_version: &str) -> Self {
-        self.over_ext(|mut ext| {
-            ext.anthropic.anthropic_version = anthropic_version.into();
-            ext
-        })
-    }
-
-    pub fn anthropic_betas(self, anthropic_betas: &[&str]) -> Self {
-        self.over_ext(|mut ext| {
-            ext.anthropic
-                .anthropic_betas
-                .extend(anthropic_betas.iter().copied().map(String::from));
-            ext
-        })
-    }
-
-    pub fn anthropic_beta(self, anthropic_beta: &str) -> Self {
-        self.over_ext(|mut ext| {
-            ext.anthropic.anthropic_betas.push(anthropic_beta.into());
-            ext
-        })
-    }
-}
+const ANTHROPIC_BASE_URLS: AnthropicBaseUrl = AnthropicBaseUrl::new(
+    &[(API_BASE_URL, ANTHROPIC_API_BASE_URL)],
+    &["/v1", "/v1/"],
+    "/anthropic/v1",
+);
 
 #[derive(Debug, serde::Deserialize)]
 struct ListModelEntry {
@@ -260,10 +201,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        ANTHROPIC_API_BASE_URL, API_BASE_URL, normalize_anthropic_base_url,
-        resolve_anthropic_base_override,
-    };
+    use super::{ANTHROPIC_API_BASE_URL, ANTHROPIC_BASE_URLS, API_BASE_URL};
 
     #[test]
     fn test_client_initialization() {
@@ -285,11 +223,13 @@ mod tests {
     #[test]
     fn normalize_openai_bases_to_anthropic_bases() {
         assert_eq!(
-            normalize_anthropic_base_url(API_BASE_URL).as_deref(),
+            ANTHROPIC_BASE_URLS.normalize(API_BASE_URL).as_deref(),
             Some(ANTHROPIC_API_BASE_URL)
         );
         assert_eq!(
-            normalize_anthropic_base_url("https://proxy.example.com/v1").as_deref(),
+            ANTHROPIC_BASE_URLS
+                .normalize("https://proxy.example.com/v1")
+                .as_deref(),
             Some("https://proxy.example.com/anthropic/v1")
         );
     }
@@ -297,14 +237,16 @@ mod tests {
     #[test]
     fn normalize_preserves_existing_anthropic_base() {
         assert_eq!(
-            normalize_anthropic_base_url(ANTHROPIC_API_BASE_URL).as_deref(),
+            ANTHROPIC_BASE_URLS
+                .normalize(ANTHROPIC_API_BASE_URL)
+                .as_deref(),
             Some(ANTHROPIC_API_BASE_URL)
         );
     }
 
     #[test]
     fn anthropic_primary_override_wins() {
-        let override_url = resolve_anthropic_base_override(
+        let override_url = ANTHROPIC_BASE_URLS.resolve(
             Some("https://primary.example.com/anthropic/v1"),
             Some(API_BASE_URL),
         );

--- a/crates/rig-core/src/providers/zai.rs
+++ b/crates/rig-core/src/providers/zai.rs
@@ -24,8 +24,9 @@
 
 use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
 use crate::providers::anthropic::client::{
-    AnthropicBuilder as AnthropicCompatBuilder, AnthropicKey, finish_anthropic_builder,
+    AnthropicBuilder as AnthropicCompatBuilder, AnthropicKey, impl_anthropic_compatible_builder,
 };
+use crate::providers::internal::anthropic_compatible::AnthropicBaseUrl;
 
 /// General-purpose OpenAI-compatible base URL.
 pub const GENERAL_API_BASE_URL: &str = "https://api.z.ai/api/paas/v4";
@@ -126,12 +127,9 @@ client::impl_default_provider_builder!(
     api_key = ZAiApiKey,
     base_url = GENERAL_API_BASE_URL,
 );
-client::impl_default_provider_builder!(
+impl_anthropic_compatible_builder!(
     ZAiAnthropicBuilder => ZAiAnthropicExt,
-    api_key = AnthropicKey,
     base_url = ANTHROPIC_API_BASE_URL,
-    finish = finish_anthropic_builder,
-    state = anthropic,
 );
 
 impl super::anthropic::completion::AnthropicCompatibleProvider for ZAiAnthropicExt {
@@ -153,51 +151,22 @@ client::impl_provider_client!(
     AnthropicClient,
     input = String,
     api_key_env = "ZAI_API_KEY",
-    base_url = anthropic_base_override("ZAI_ANTHROPIC_API_BASE", "ZAI_API_BASE")?,
+    base_url = ANTHROPIC_BASE_URLS.resolve_from_env("ZAI_ANTHROPIC_API_BASE", "ZAI_API_BASE")?,
 );
 
-fn anthropic_base_override(
-    primary_env: &'static str,
-    fallback_env: &'static str,
-) -> crate::client::ProviderClientResult<Option<String>> {
-    let primary = crate::client::optional_env_var(primary_env)?;
-    let fallback = crate::client::optional_env_var(fallback_env)?;
-
-    Ok(resolve_anthropic_base_override(
-        primary.as_deref(),
-        fallback.as_deref(),
-    ))
-}
-
-fn resolve_anthropic_base_override(
-    primary: Option<&str>,
-    fallback: Option<&str>,
-) -> Option<String> {
-    primary
-        .map(str::to_owned)
-        .or_else(|| fallback.and_then(normalize_anthropic_base_url))
-}
-
-fn normalize_anthropic_base_url(base_url: &str) -> Option<String> {
-    if base_url.contains("/anthropic") {
-        return Some(base_url.to_owned());
-    }
-
-    match base_url.trim_end_matches('/') {
-        GENERAL_API_BASE_URL | CODING_API_BASE_URL => Some(ANTHROPIC_API_BASE_URL.to_owned()),
-        _ => {
-            let mut url = url::Url::parse(base_url).ok()?;
-            if !matches!(
-                url.path(),
-                "/api/paas/v4" | "/api/paas/v4/" | "/api/coding/paas/v4" | "/api/coding/paas/v4/"
-            ) {
-                return None;
-            }
-            url.set_path("/api/anthropic");
-            Some(url.to_string())
-        }
-    }
-}
+const ANTHROPIC_BASE_URLS: AnthropicBaseUrl = AnthropicBaseUrl::new(
+    &[
+        (GENERAL_API_BASE_URL, ANTHROPIC_API_BASE_URL),
+        (CODING_API_BASE_URL, ANTHROPIC_API_BASE_URL),
+    ],
+    &[
+        "/api/paas/v4",
+        "/api/paas/v4/",
+        "/api/coding/paas/v4",
+        "/api/coding/paas/v4/",
+    ],
+    "/api/anthropic",
+);
 
 impl<H> ClientBuilder<H> {
     pub fn general(self) -> Self {
@@ -213,36 +182,12 @@ impl<H> AnthropicClientBuilder<H> {
     pub fn general(self) -> Self {
         self.base_url(ANTHROPIC_API_BASE_URL)
     }
-
-    pub fn anthropic_version(self, anthropic_version: &str) -> Self {
-        self.over_ext(|mut ext| {
-            ext.anthropic.anthropic_version = anthropic_version.into();
-            ext
-        })
-    }
-
-    pub fn anthropic_betas(self, anthropic_betas: &[&str]) -> Self {
-        self.over_ext(|mut ext| {
-            ext.anthropic
-                .anthropic_betas
-                .extend(anthropic_betas.iter().copied().map(String::from));
-            ext
-        })
-    }
-
-    pub fn anthropic_beta(self, anthropic_beta: &str) -> Self {
-        self.over_ext(|mut ext| {
-            ext.anthropic.anthropic_betas.push(anthropic_beta.into());
-            ext
-        })
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        ANTHROPIC_API_BASE_URL, CODING_API_BASE_URL, GENERAL_API_BASE_URL,
-        normalize_anthropic_base_url, resolve_anthropic_base_override,
+        ANTHROPIC_API_BASE_URL, ANTHROPIC_BASE_URLS, CODING_API_BASE_URL, GENERAL_API_BASE_URL,
     };
 
     #[test]
@@ -263,19 +208,27 @@ mod tests {
     #[test]
     fn normalize_openai_style_bases_to_anthropic_base() {
         assert_eq!(
-            normalize_anthropic_base_url(GENERAL_API_BASE_URL).as_deref(),
+            ANTHROPIC_BASE_URLS
+                .normalize(GENERAL_API_BASE_URL)
+                .as_deref(),
             Some(ANTHROPIC_API_BASE_URL)
         );
         assert_eq!(
-            normalize_anthropic_base_url(CODING_API_BASE_URL).as_deref(),
+            ANTHROPIC_BASE_URLS
+                .normalize(CODING_API_BASE_URL)
+                .as_deref(),
             Some(ANTHROPIC_API_BASE_URL)
         );
         assert_eq!(
-            normalize_anthropic_base_url("https://proxy.example.com/api/paas/v4").as_deref(),
+            ANTHROPIC_BASE_URLS
+                .normalize("https://proxy.example.com/api/paas/v4")
+                .as_deref(),
             Some("https://proxy.example.com/api/anthropic")
         );
         assert_eq!(
-            normalize_anthropic_base_url("https://proxy.example.com/api/coding/paas/v4").as_deref(),
+            ANTHROPIC_BASE_URLS
+                .normalize("https://proxy.example.com/api/coding/paas/v4")
+                .as_deref(),
             Some("https://proxy.example.com/api/anthropic")
         );
     }
@@ -283,14 +236,16 @@ mod tests {
     #[test]
     fn normalize_preserves_existing_anthropic_base() {
         assert_eq!(
-            normalize_anthropic_base_url("https://proxy.example.com/api/anthropic").as_deref(),
+            ANTHROPIC_BASE_URLS
+                .normalize("https://proxy.example.com/api/anthropic")
+                .as_deref(),
             Some("https://proxy.example.com/api/anthropic")
         );
     }
 
     #[test]
     fn anthropic_primary_override_wins() {
-        let override_url = resolve_anthropic_base_override(
+        let override_url = ANTHROPIC_BASE_URLS.resolve(
             Some("https://primary.example.com/api/anthropic"),
             Some(GENERAL_API_BASE_URL),
         );

--- a/crates/rig-core/src/test_utils/http.rs
+++ b/crates/rig-core/src/test_utils/http.rs
@@ -169,8 +169,9 @@ impl HttpClientExt for RecordingHttpClient {
         U: From<Bytes> + WasmCompatSend + 'static,
     {
         let response = self.response_guard().clone();
-        let (parts, _body) = req.into_parts();
-        self.record_request(parts.uri.to_string(), parts.headers, Bytes::new());
+        let (parts, body) = req.into_parts();
+        let (_, body) = body.boundary("recording-http-client").encode();
+        self.record_request(parts.uri.to_string(), parts.headers, body);
 
         async move { Self::build_unary_response(response) }
     }


### PR DESCRIPTION
## Summary

This broad refactor reduces repeated production plumbing in both `rig-core` and `rig-agent` while preserving provider wire behavior and agent hook semantics.

- Share Anthropic-compatible URL/env resolution across MiniMax, Moonshot, Xiaomi MiMo, and Z.AI.
- Generate the four providers' otherwise-unexpressible Anthropic builder/trait plumbing while keeping header behavior in the existing ordinary function.
- Share the OpenAI-style transcription model shell across OpenAI, Groq, and Azure, with provider-specific request routing and model placement.
- Match public hook action enums directly in the agent runner instead of translating them through three private identity enums.

## Production LOC

Counted with a Rust-aware source counter that excludes blank/comment-only lines, inline `#[cfg(test)]` modules, test support, integration tests, and examples.

| Crate | Baseline (`618edf07`) | Final | Change |
| --- | ---: | ---: | ---: |
| `rig-core` | 38,632 | 38,493 | -139 |
| `rig-agent` | 8,875 | 8,834 | -41 |
| **Total** | **47,507** | **47,327** | **-180** |

## Consolidated patterns

- `AnthropicBaseUrl` makes canonical base mappings, recognized OpenAI paths, Anthropic paths, dedicated-env precedence, and safe fallback behavior data-driven.
- `impl_anthropic_compatible_builder!` owns only inherent-method and trait-impl generation; `finish_anthropic_builder` remains the single behavioral implementation.
- `OpenAiTranscriptionModel<C>` owns multipart construction and response/error decoding; a private client strategy selects the request URL and whether `model` belongs in the form.
- The agent runner now consumes `ToolCallAction`, `ToolResultAction`, and `CompletionCallAction` directly.

The provider-facing transcription structs are intentionally simplified to public aliases of the shared implementation. Constructors, the public `model` field, response type, and behavioral APIs remain, but raw concrete type identity changes; semver compatibility was explicitly out of scope.

## Tests and verification

Targeted checks:

- `cargo test -p rig-core --all-features providers::internal::anthropic_compatible -- --nocapture`
- `cargo test -p rig-core --all-features transcription_routes -- --nocapture`
- `cargo test -p rig-core --all-features transcription -- --nocapture`
- `cargo test -p rig-agent --all-features parity_across_run_and_stream -- --nocapture`
- `cargo test -p rig-agent --all-features completion_call -- --nocapture`

Full gates:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --package rig-core --target wasm32-unknown-unknown`
- `cargo check --package rig-agent --target wasm32-unknown-unknown`
- `cargo test -p rig-core -p rig-agent --all-features`
- `cargo test`
- `cargo test -p rig-core --doc --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --all-features`
- `cargo public-api -p rig-core -sss --all-features diff 618edf07..4d0f8bab`
- `git diff --check 618edf07..4d0f8bab`

All passed.

## Review

Two independent full-diff reviews were completed. The first found no P0/P1 issues and identified:

- missing provider-level transcription URI/multipart assertions;
- stale/incomplete shared transcription and runner documentation.

Both were fixed. OpenAI and Groq now assert model-in-form routing, while Azure asserts deployment-in-URL and no model form field. The final independent review of the committed diff found no remaining issues.

## Rejected refactors

- A universal agent configuration object: it would move strongly typed fields and generics without removing meaningful behavior.
- A cross-capability JSON request/response model: provider wire differences would become less explicit and easier to regress.
- Guessing unknown Anthropic fallback URL paths: the shared resolver deliberately returns no override for unrecognized paths.

## Remaining risk

The principal intentional risk is the raw transcription model type-identity change described above. Provider behavior is covered by request-shape, error-preservation, native all-feature, doctest, and browser-WASM checks. No cassette fixtures or dependencies changed.