### PR TITLE
refactor: consolidate provider scaffolding and agent-runner plumbing (−227 LOC)

### DIFF
--- a/crates/rig-agent/src/agent/builder.rs
+++ b/crates/rig-agent/src/agent/builder.rs
@@ -441,6 +441,16 @@ impl AgentBuilder<NoToolConfig> {
         self.with_tool_state(WithToolServerHandle { handle })
     }
 
+    /// Transition into the `WithBuilderTools` state with no tools yet; every
+    /// tool-adding method below is the `WithBuilderTools` method after this
+    /// one-way step.
+    fn into_tool_builder(self) -> AgentBuilder<WithBuilderTools> {
+        self.with_tool_state(WithBuilderTools {
+            tools: ToolSet::default(),
+            retrieval_indexes: vec![],
+        })
+    }
+
     /// Add a static tool to the agent.
     ///
     /// This transitions the builder to the `WithBuilderTools` state, where
@@ -449,17 +459,12 @@ impl AgentBuilder<NoToolConfig> {
     where
         T: Tool + 'static,
     {
-        let mut tools = ToolSet::default();
-        tools.add_tool(tool);
-        self.with_tool_state(WithBuilderTools {
-            tools,
-            retrieval_indexes: vec![],
-        })
+        self.into_tool_builder().tool(tool)
     }
 
     /// Add one runtime-defined tool to the agent.
     pub fn dynamic_tool(self, tool: DynamicTool) -> AgentBuilder<WithBuilderTools> {
-        self.dynamic_tools(vec![tool])
+        self.into_tool_builder().dynamic_tool(tool)
     }
 
     /// Add one context-free dynamic tool through the classic registry adapter.
@@ -467,7 +472,7 @@ impl AgentBuilder<NoToolConfig> {
         self,
         tool: PortableDynamicTool,
     ) -> AgentBuilder<WithBuilderTools> {
-        self.dynamic_tool(DynamicTool::from_portable(tool))
+        self.into_tool_builder().portable_dynamic_tool(tool)
     }
 
     /// Add runtime-defined tools to the agent.
@@ -475,11 +480,7 @@ impl AgentBuilder<NoToolConfig> {
     /// This is useful when tool definitions and callbacks are constructed at runtime.
     /// Transitions the builder to the `WithBuilderTools` state.
     pub fn dynamic_tools(self, tools: Vec<DynamicTool>) -> AgentBuilder<WithBuilderTools> {
-        let tools = ToolSet::from_dynamic_tools(tools);
-        self.with_tool_state(WithBuilderTools {
-            tools,
-            retrieval_indexes: vec![],
-        })
+        self.into_tool_builder().dynamic_tools(tools)
     }
 
     /// Add an MCP tool (from `rmcp`) to the agent, bounded by
@@ -512,7 +513,7 @@ impl AgentBuilder<NoToolConfig> {
         client: rmcp::service::ServerSink,
         timeout: impl Into<Option<std::time::Duration>>,
     ) -> AgentBuilder<WithBuilderTools> {
-        self.with_rmcp_toolset(build_rmcp_tools(vec![tool], client, timeout.into()))
+        self.rmcp_tools_with_timeout(vec![tool], client, timeout)
     }
 
     /// Add an array of MCP tools (from `rmcp`) to the agent, each bounded by

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -216,28 +216,31 @@ pub(crate) fn allowed_tool_names_for_choice(
     Ok(allowed)
 }
 
-/// Helper function to build a completion request from agent components while
-/// preserving the executable Rig tool names sent to the provider.
-#[allow(clippy::too_many_arguments)]
+/// Helper function to build a completion request from the runner's configured
+/// baseline while preserving the executable Rig tool names sent to the
+/// provider. Only the per-turn inputs — the selected model, prompt, history,
+/// committed output tool, and hook patch — arrive as parameters; everything
+/// else is read off the runner.
 pub(crate) async fn build_prepared_completion_request(
+    runner: &crate::agent::AgentRunner,
     model: &ModelHandle,
     prompt: Message,
     chat_history: &[Message],
-    preamble: Option<&str>,
-    static_context: &[Document],
-    temperature: Option<f64>,
-    max_tokens: Option<u64>,
-    additional_params: Option<&serde_json::Value>,
-    record_telemetry_content: bool,
-    tool_choice: Option<&ToolChoice>,
-    tool_server_handle: &ToolServerHandle,
-    output_schema: Option<&schemars::Schema>,
-    output_mode: &OutputMode,
     committed_output_tool: Option<&str>,
-    output_tool_description: Option<&str>,
-    augment_output_preamble: bool,
     request_patch: Option<&RequestPatch>,
 ) -> Result<PreparedCompletionRequest, CompletionError> {
+    let preamble = runner.preamble.as_deref();
+    let static_context = &runner.static_context;
+    let temperature = runner.temperature;
+    let max_tokens = runner.max_tokens;
+    let additional_params = runner.additional_params.as_ref();
+    let record_telemetry_content = runner.record_telemetry_content;
+    let tool_choice = runner.tool_choice.as_ref();
+    let tool_server_handle = &runner.tool_server_handle;
+    let output_schema = runner.output_schema.as_ref();
+    let output_mode = &runner.output_mode;
+    let output_tool_description = runner.output_tool_description.as_deref();
+    let augment_output_preamble = runner.augment_output_preamble;
     // Apply a per-turn request patch (the merged patch from every `CompletionCall`
     // hook): each set field replaces the agent's configured value for this turn,
     // unset fields inherit it, `additional_params` is shallow-merged, and

--- a/crates/rig-agent/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-agent/src/agent/prompt_request/streaming.rs
@@ -559,22 +559,11 @@ where
                     // consistent even if the per-turn tool set changes (#1928).
                     let committed_output_tool = run.output_tool_name().map(str::to_owned);
                     let mut prepared = match build_prepared_completion_request(
+                        &runner,
                         &selected_model,
                         prompt.clone(),
                         &history,
-                        runner.preamble.as_deref(),
-                        &runner.static_context,
-                        runner.temperature,
-                        runner.max_tokens,
-                        runner.additional_params.as_ref(),
-                        runner.record_telemetry_content,
-                        runner.tool_choice.as_ref(),
-                        &runner.tool_server_handle,
-                        runner.output_schema.as_ref(),
-                        &runner.output_mode,
                         committed_output_tool.as_deref(),
-                        runner.output_tool_description.as_deref(),
-                        runner.augment_output_preamble,
                         request_patch.as_ref(),
                     )
                     .await
@@ -1043,6 +1032,22 @@ impl StreamingTurnSource {
             has_hooks: !hooks.is_empty(),
         }
     }
+
+    /// Record a completed model turn's canonical output onto the agent and
+    /// chat spans. Only self-created agent spans receive `gen_ai.completion`,
+    /// so neither surface pollutes a caller-supplied span.
+    fn record_turn_telemetry(
+        &self,
+        agent_span: &tracing::Span,
+        chat_span: &tracing::Span,
+        choice: &[AssistantContent],
+        record_content: bool,
+    ) {
+        if self.created_agent_span && self.record_telemetry_content {
+            agent_span.record("gen_ai.completion", assistant_text_from_choice(choice));
+        }
+        rig_core::telemetry::record_model_output(chat_span, choice, record_content);
+    }
 }
 
 impl TurnSource for StreamingTurnSource {
@@ -1444,13 +1449,8 @@ impl TurnSource for StreamingTurnSource {
                         // final and content telemetry were visible before the
                         // cancellation. Preserve that behavior while Retry
                         // alone suppresses the provisional final.
-                        if self.created_agent_span && self.record_telemetry_content {
-                            agent_span.record(
-                                "gen_ai.completion",
-                                assistant_text_from_choice(&canonical_choice),
-                            );
-                        }
-                        rig_core::telemetry::record_model_output(
+                        self.record_turn_telemetry(
+                            agent_span,
                             &chat_span,
                             &canonical_choice,
                             runner.record_telemetry_content,
@@ -1470,13 +1470,8 @@ impl TurnSource for StreamingTurnSource {
 
             // Only hook-accepted canonical output belongs in content telemetry.
             // Keep caller-owned spans untouched, matching the blocking source.
-            if self.created_agent_span && self.record_telemetry_content {
-                agent_span.record(
-                    "gen_ai.completion",
-                    assistant_text_from_choice(&canonical_choice),
-                );
-            }
-            rig_core::telemetry::record_model_output(
+            self.record_turn_telemetry(
+                agent_span,
                 &chat_span,
                 &canonical_choice,
                 runner.record_telemetry_content,

--- a/crates/rig-agent/src/agent/run/mod.rs
+++ b/crates/rig-agent/src/agent/run/mod.rs
@@ -278,6 +278,27 @@ struct ResolvingState {
     has_tool_calls: bool,
 }
 
+/// The invalid tool call resolution is currently parked on, if any: the item
+/// at `next_index` when it is a tool call outside the allowed set.
+fn pending_invalid_call(resolving: &ResolvingState) -> Option<&ToolCall> {
+    match resolving.items.get(resolving.next_index) {
+        Some(AssistantContent::ToolCall(tool_call))
+            if !resolving
+                .allowed_tool_names
+                .contains(&tool_call.function.name) =>
+        {
+            Some(tool_call)
+        }
+        _ => None,
+    }
+}
+
+fn has_tool_calls(items: &[AssistantContent]) -> bool {
+    items
+        .iter()
+        .any(|item| matches!(item, AssistantContent::ToolCall(_)))
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct TurnState {
     message_id: Option<String>,
@@ -901,9 +922,7 @@ impl AgentRun {
         self.record_completion_call(turn.usage);
 
         let items: Vec<AssistantContent> = turn.choice.clone();
-        let has_tool_calls = items
-            .iter()
-            .any(|item| matches!(item, AssistantContent::ToolCall(_)));
+        let has_tool_calls = has_tool_calls(&items);
 
         self.state = RunState::ResolvingToolCalls(Box::new(ResolvingState {
             message_id: turn.message_id,
@@ -1017,31 +1036,14 @@ impl AgentRun {
         &mut self,
         action: InvalidToolCallAction,
     ) -> Result<ModelTurnOutcome, PromptError> {
-        // Take the resolving state; rejection paths below restore it so an
-        // out-of-protocol call does not corrupt a drivable run.
-        let mut resolving = match std::mem::replace(&mut self.state, RunState::Failed) {
-            RunState::ResolvingToolCalls(resolving) => resolving,
-            other => {
-                self.state = other;
-                return Err(self.protocol_violation(
-                    "resolve_invalid_tool_call called without a pending invalid tool call",
-                ));
-            }
-        };
-        let tool_call = match resolving.items.get(resolving.next_index) {
-            Some(AssistantContent::ToolCall(tool_call))
-                if !resolving
-                    .allowed_tool_names
-                    .contains(&tool_call.function.name) =>
-            {
-                tool_call.clone()
-            }
-            _ => {
-                self.state = RunState::ResolvingToolCalls(resolving);
-                return Err(self.protocol_violation(
-                    "resolve_invalid_tool_call called without a pending invalid tool call",
-                ));
-            }
+        let mut resolving = self.take_resolving(
+            "resolve_invalid_tool_call called without a pending invalid tool call",
+        )?;
+        let Some(tool_call) = pending_invalid_call(&resolving).cloned() else {
+            self.state = RunState::ResolvingToolCalls(resolving);
+            return Err(self.protocol_violation(
+                "resolve_invalid_tool_call called without a pending invalid tool call",
+            ));
         };
 
         let diagnostic_history = self.diagnostic_history(&resolving);
@@ -1114,34 +1116,19 @@ impl AgentRun {
     /// disappear, a sibling output call can still finalize the turn, and
     /// response observers still receive the canonical response fields.
     pub(crate) fn ignore_invalid_tool_call(&mut self) -> Result<ModelTurnOutcome, PromptError> {
-        let mut resolving = match std::mem::replace(&mut self.state, RunState::Failed) {
-            RunState::ResolvingToolCalls(resolving) => resolving,
-            other => {
-                self.state = other;
-                return Err(self.protocol_violation(
-                    "ignore_invalid_tool_call called without a pending invalid tool call",
-                ));
-            }
-        };
+        let mut resolving = self.take_resolving(
+            "ignore_invalid_tool_call called without a pending invalid tool call",
+        )?;
 
-        match resolving.items.get(resolving.next_index) {
-            Some(AssistantContent::ToolCall(tool_call))
-                if !resolving
-                    .allowed_tool_names
-                    .contains(&tool_call.function.name) => {}
-            _ => {
-                self.state = RunState::ResolvingToolCalls(resolving);
-                return Err(self.protocol_violation(
-                    "ignore_invalid_tool_call called without a pending invalid tool call",
-                ));
-            }
+        if pending_invalid_call(&resolving).is_none() {
+            self.state = RunState::ResolvingToolCalls(resolving);
+            return Err(self.protocol_violation(
+                "ignore_invalid_tool_call called without a pending invalid tool call",
+            ));
         }
 
         resolving.items.remove(resolving.next_index);
-        resolving.has_tool_calls = resolving
-            .items
-            .iter()
-            .any(|item| matches!(item, AssistantContent::ToolCall(_)));
+        resolving.has_tool_calls = has_tool_calls(&resolving.items);
         // Dropping the last item leaves the turn empty, which is now
         // representable. This used to push a fabricated empty-text part so the
         // content type stayed satisfied; `is_empty_assistant_turn` keeps such a
@@ -1205,18 +1192,24 @@ impl AgentRun {
         Ok(())
     }
 
+    /// Take the resolving state out of `self.state`, leaving `Failed` behind;
+    /// callers restore it on their rejection paths so an out-of-protocol call
+    /// does not corrupt a drivable run.
+    fn take_resolving(&mut self, violation: &str) -> Result<Box<ResolvingState>, PromptError> {
+        match std::mem::replace(&mut self.state, RunState::Failed) {
+            RunState::ResolvingToolCalls(resolving) => Ok(resolving),
+            other => {
+                self.state = other;
+                Err(self.protocol_violation(violation))
+            }
+        }
+    }
+
     /// Scan forward for the next invalid tool call; finish the turn when the
     /// scan completes.
     fn advance_resolution(&mut self) -> Result<ModelTurnOutcome, PromptError> {
-        let mut resolving = match std::mem::replace(&mut self.state, RunState::Failed) {
-            RunState::ResolvingToolCalls(resolving) => resolving,
-            other => {
-                self.state = other;
-                return Err(self.protocol_violation(
-                    "internal: advance_resolution outside of tool-call resolution",
-                ));
-            }
-        };
+        let mut resolving =
+            self.take_resolving("internal: advance_resolution outside of tool-call resolution")?;
         while let Some(item) = resolving.items.get(resolving.next_index) {
             match item {
                 AssistantContent::ToolCall(tool_call)
@@ -1360,24 +1353,14 @@ impl AgentRun {
         )?;
 
         match action {
-            ValidatedInvalidToolCallAction::Retry { feedback } => {
-                let Some((assistant_message, user_message)) =
-                    partial.rollback_messages(invalid.tool_call.clone(), feedback)
-                else {
-                    self.state = RunState::Failed;
-                    return Err(PromptError::prompt_cancelled(
-                        diagnostic_history,
-                        "invalid tool call retry produced no retry messages",
-                    ));
-                };
-                self.new_messages.push(assistant_message);
-                self.new_messages.push(user_message);
-                self.rollback_pending = true;
-                self.state = RunState::PreparingRequest;
-                Ok(StreamedResolution::TurnAbandoned {
-                    skipped_tool_result: None,
-                })
-            }
+            ValidatedInvalidToolCallAction::Retry { feedback } => self.abandon_streamed_turn(
+                partial,
+                invalid,
+                feedback,
+                diagnostic_history,
+                "invalid tool call retry produced no retry messages",
+                None,
+            ),
             ValidatedInvalidToolCallAction::Repair { tool_name } => {
                 Ok(StreamedResolution::Repaired { tool_name })
             }
@@ -1391,24 +1374,46 @@ impl AgentRun {
                     name: invalid.tool_call.function.name.clone(),
                     content: vec![ToolResultContent::text(reason.clone())],
                 };
-                let Some((assistant_message, user_message)) =
-                    partial.rollback_messages(invalid.tool_call.clone(), reason)
-                else {
-                    self.state = RunState::Failed;
-                    return Err(PromptError::prompt_cancelled(
-                        diagnostic_history,
-                        "invalid tool call skip produced no recovery messages",
-                    ));
-                };
-                self.new_messages.push(assistant_message);
-                self.new_messages.push(user_message);
-                self.rollback_pending = true;
-                self.state = RunState::PreparingRequest;
-                Ok(StreamedResolution::TurnAbandoned {
-                    skipped_tool_result: Some(Box::new(skipped_tool_result)),
-                })
+                self.abandon_streamed_turn(
+                    partial,
+                    invalid,
+                    reason,
+                    diagnostic_history,
+                    "invalid tool call skip produced no recovery messages",
+                    Some(Box::new(skipped_tool_result)),
+                )
             }
         }
+    }
+
+    /// Shared rollback for the streamed Retry and Skip resolutions: push the
+    /// partial turn's rollback messages and abandon the turn, or fail the run
+    /// when the partial turn yields no rollback messages.
+    fn abandon_streamed_turn(
+        &mut self,
+        partial: &PartialStreamedTurn,
+        invalid: &StreamedInvalidToolCall,
+        feedback: String,
+        diagnostic_history: Vec<Message>,
+        no_messages_reason: &str,
+        skipped_tool_result: Option<Box<ToolResult>>,
+    ) -> Result<StreamedResolution, PromptError> {
+        let Some((assistant_message, user_message)) =
+            partial.rollback_messages(invalid.tool_call.clone(), feedback)
+        else {
+            self.state = RunState::Failed;
+            return Err(PromptError::prompt_cancelled(
+                diagnostic_history,
+                no_messages_reason,
+            ));
+        };
+        self.new_messages.push(assistant_message);
+        self.new_messages.push(user_message);
+        self.rollback_pending = true;
+        self.state = RunState::PreparingRequest;
+        Ok(StreamedResolution::TurnAbandoned {
+            skipped_tool_result,
+        })
     }
 
     /// Feed the assembled streamed turn for the pending
@@ -1435,10 +1440,7 @@ impl AgentRun {
             self.streamed_completion_call_recorded = true;
         }
 
-        let has_tool_calls = turn
-            .choice
-            .iter()
-            .any(|item| matches!(item, AssistantContent::ToolCall(_)));
+        let has_tool_calls = has_tool_calls(&turn.choice);
 
         for item in &turn.choice {
             let AssistantContent::ToolCall(tool_call) = item else {

--- a/crates/rig-agent/src/extractor.rs
+++ b/crates/rig-agent/src/extractor.rs
@@ -93,7 +93,7 @@ where
     T: JsonSchema + for<'de> Deserialize<'de> + WasmCompatSend + WasmCompatSync,
 {
     extractor: &'a Extractor<T>,
-    model: ModelHandle,
+    model: Option<ModelHandle>,
 }
 
 impl<T> Extractor<T>
@@ -113,7 +113,15 @@ where
     pub fn using_model(&self, model: ModelHandle) -> ExtractorRun<'_, T> {
         ExtractorRun {
             extractor: self,
-            model,
+            model: Some(model),
+        }
+    }
+
+    /// A run with no model override: the extractor's own default model.
+    fn default_run(&self) -> ExtractorRun<'_, T> {
+        ExtractorRun {
+            extractor: self,
+            model: None,
         }
     }
 
@@ -135,8 +143,7 @@ where
         &self,
         text: impl Into<Message> + WasmCompatSend,
     ) -> Result<T, ExtractionError> {
-        let (data, _usage) = self.retry_extract(text.into(), vec![], None).await?;
-        Ok(data)
+        self.default_run().extract(text).await
     }
 
     /// Attempts to extract data from the given text with a number of retries.
@@ -150,8 +157,9 @@ where
         text: impl Into<Message> + WasmCompatSend,
         chat_history: Vec<Message>,
     ) -> Result<T, ExtractionError> {
-        let (data, _usage) = self.retry_extract(text.into(), chat_history, None).await?;
-        Ok(data)
+        self.default_run()
+            .extract_with_chat_history(text, chat_history)
+            .await
     }
 
     /// Attempts to extract data from the given text with a number of retries,
@@ -171,8 +179,7 @@ where
         &self,
         text: impl Into<Message> + WasmCompatSend,
     ) -> Result<ExtractionResponse<T>, ExtractionError> {
-        let (data, usage) = self.retry_extract(text.into(), vec![], None).await?;
-        Ok(ExtractionResponse { data, usage })
+        self.default_run().extract_with_usage(text).await
     }
 
     /// Attempts to extract data from the given text with a number of retries,
@@ -194,8 +201,9 @@ where
         text: impl Into<Message> + WasmCompatSend,
         chat_history: Vec<Message>,
     ) -> Result<ExtractionResponse<T>, ExtractionError> {
-        let (data, usage) = self.retry_extract(text.into(), chat_history, None).await?;
-        Ok(ExtractionResponse { data, usage })
+        self.default_run()
+            .extract_with_chat_history_with_usage(text, chat_history)
+            .await
     }
 
     /// Runs the extraction with the retry semantics shared by all public
@@ -304,11 +312,7 @@ where
         &self,
         text: impl Into<Message> + WasmCompatSend,
     ) -> Result<T, ExtractionError> {
-        let (data, _usage) = self
-            .extractor
-            .retry_extract(text.into(), vec![], Some(&self.model))
-            .await?;
-        Ok(data)
+        Ok(self.extract_with_usage(text).await?.data)
     }
 
     /// Extract structured data with chat history and the run-local model.
@@ -317,11 +321,10 @@ where
         text: impl Into<Message> + WasmCompatSend,
         chat_history: Vec<Message>,
     ) -> Result<T, ExtractionError> {
-        let (data, _usage) = self
-            .extractor
-            .retry_extract(text.into(), chat_history, Some(&self.model))
-            .await?;
-        Ok(data)
+        Ok(self
+            .extract_with_chat_history_with_usage(text, chat_history)
+            .await?
+            .data)
     }
 
     /// Extract structured data and usage with the run-local model.
@@ -329,11 +332,8 @@ where
         &self,
         text: impl Into<Message> + WasmCompatSend,
     ) -> Result<ExtractionResponse<T>, ExtractionError> {
-        let (data, usage) = self
-            .extractor
-            .retry_extract(text.into(), vec![], Some(&self.model))
-            .await?;
-        Ok(ExtractionResponse { data, usage })
+        self.extract_with_chat_history_with_usage(text, vec![])
+            .await
     }
 
     /// Extract structured data with chat history and usage using the run-local model.
@@ -344,7 +344,7 @@ where
     ) -> Result<ExtractionResponse<T>, ExtractionError> {
         let (data, usage) = self
             .extractor
-            .retry_extract(text.into(), chat_history, Some(&self.model))
+            .retry_extract(text.into(), chat_history, self.model.as_ref())
             .await?;
         Ok(ExtractionResponse { data, usage })
     }

--- a/crates/rig-core/src/client/mod.rs
+++ b/crates/rig-core/src/client/mod.rs
@@ -368,6 +368,39 @@ macro_rules! impl_default_provider_builder {
 }
 pub(crate) use impl_default_provider_builder;
 
+// A provider's Capabilities impl is a pure associated-type table where every
+// slot a provider does not support is `Nothing`. The named optional slots
+// keep each provider's invocation down to what it actually supports, and the
+// macro owns the feature gating on the image/audio slots.
+macro_rules! impl_capabilities {
+    (
+        $ext:ty
+        $(, completion = $completion:ty)?
+        $(, embeddings = $embeddings:ty)?
+        $(, transcription = $transcription:ty)?
+        $(, model_listing = $model_listing:ty)?
+        $(, image_generation = $image_generation:ty)?
+        $(, audio_generation = $audio_generation:ty)?
+        $(, rerank = $rerank:ty)?
+        $(,)?
+    ) => {
+        impl<H> $crate::client::Capabilities<H> for $ext {
+            type Completion = $crate::client::impl_capabilities!(@slot $($completion)?);
+            type Embeddings = $crate::client::impl_capabilities!(@slot $($embeddings)?);
+            type Transcription = $crate::client::impl_capabilities!(@slot $($transcription)?);
+            type ModelListing = $crate::client::impl_capabilities!(@slot $($model_listing)?);
+            #[cfg(feature = "image")]
+            type ImageGeneration = $crate::client::impl_capabilities!(@slot $($image_generation)?);
+            #[cfg(feature = "audio")]
+            type AudioGeneration = $crate::client::impl_capabilities!(@slot $($audio_generation)?);
+            type Rerank = $crate::client::impl_capabilities!(@slot $($rerank)?);
+        }
+    };
+    (@slot $model:ty) => { $crate::client::Capable<$model> };
+    (@slot) => { $crate::client::Nothing };
+}
+pub(crate) use impl_capabilities;
+
 // ProviderClient is implemented for concrete client aliases, which likewise
 // cannot be factored into a function. The optional base-URL form captures the
 // only common construction variation without hiding provider-specific auth.

--- a/crates/rig-core/src/providers/anthropic/client.rs
+++ b/crates/rig-core/src/providers/anthropic/client.rs
@@ -3,7 +3,7 @@ use http::{HeaderName, HeaderValue};
 
 use super::completion::{ANTHROPIC_VERSION_LATEST, CompletionModel};
 use crate::{
-    client::{self, ApiKey, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder},
+    client::{self, ApiKey, DebugExt, Provider, ProviderBuilder},
     http_client::{self, HttpClientExt},
     providers::anthropic::model_listing::AnthropicModelLister,
 };
@@ -19,18 +19,11 @@ impl Provider for AnthropicExt {
     const VERIFY_PATH: &'static str = "/v1/models";
 }
 
-impl<H> Capabilities<H> for AnthropicExt {
-    type Completion = Capable<CompletionModel<H>>;
-
-    type Embeddings = Nothing;
-    type Transcription = Nothing;
-    type ModelListing = Capable<AnthropicModelLister<H>>;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    AnthropicExt,
+    completion = CompletionModel<H>,
+    model_listing = AnthropicModelLister<H>,
+);
 
 #[derive(Debug, Clone)]
 pub struct AnthropicBuilder {

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -24,10 +24,7 @@
 
 use std::fmt::Debug;
 
-use crate::client::{
-    self, ApiKey, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-    ProviderClient,
-};
+use crate::client::{self, ApiKey, DebugExt, Provider, ProviderBuilder, ProviderClient};
 use crate::http_client::{self, HttpClientExt, bearer_auth_header};
 use crate::providers::internal::transcription::OpenAiTranscriptionClient;
 use crate::{
@@ -87,17 +84,13 @@ impl Provider for AzureExt {
     const VERIFY_PATH: &'static str = "";
 }
 
-impl<H> Capabilities<H> for AzureExt {
-    type Completion = Capable<CompletionModel<H>>;
-    type Embeddings = Capable<EmbeddingModel<H>>;
-    type Transcription = Capable<TranscriptionModel<H>>;
-    type ModelListing = Nothing;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Capable<AudioGenerationModel<H>>;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    AzureExt,
+    completion = CompletionModel<H>,
+    embeddings = EmbeddingModel<H>,
+    transcription = TranscriptionModel<H>,
+    audio_generation = AudioGenerationModel<H>,
+);
 
 impl ProviderBuilder for AzureExtBuilder {
     type Extension<H>

--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -18,10 +18,7 @@
 
 mod auth;
 
-use crate::client::{
-    self, ApiKey, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-    ProviderClient, Transport,
-};
+use crate::client::{self, ApiKey, DebugExt, Provider, ProviderBuilder, ProviderClient, Transport};
 use crate::completion::{self, CompletionError, NormalizeCompletionResponse};
 use crate::http_client::{self, HttpClientExt};
 use crate::providers::openai::responses_api::{
@@ -169,17 +166,7 @@ impl responses_api::ResponsesProviderExt for ChatGPTExt {
     }
 }
 
-impl<H> Capabilities<H> for ChatGPTExt {
-    type Completion = Capable<ResponsesCompletionModel<H>>;
-    type Embeddings = Nothing;
-    type Transcription = Nothing;
-    type ModelListing = Nothing;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(ChatGPTExt, completion = ResponsesCompletionModel<H>);
 
 impl DebugExt for ChatGPTExt {}
 

--- a/crates/rig-core/src/providers/cohere/client.rs
+++ b/crates/rig-core/src/providers/cohere/client.rs
@@ -1,6 +1,6 @@
 use crate::{
     Embed,
-    client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider},
+    client::{self, BearerAuth, DebugExt, Provider},
     embeddings::EmbeddingsBuilder,
     http_client::HttpClientExt,
     wasm_compat::*,
@@ -30,18 +30,11 @@ impl Provider for CohereExt {
     const VERIFY_PATH: &'static str = "/models";
 }
 
-impl<H> Capabilities<H> for CohereExt {
-    type Completion = Capable<CompletionModel<H>>;
-    type Embeddings = Capable<EmbeddingModel<H>>;
-    type Transcription = Nothing;
-    type ModelListing = Nothing;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    CohereExt,
+    completion = CompletionModel<H>,
+    embeddings = EmbeddingModel<H>,
+);
 
 impl DebugExt for CohereExt {}
 

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -23,8 +23,7 @@
 mod auth;
 
 use crate::client::{
-    self, ApiKey, Capabilities, Capable, DebugExt, ModelLister, Nothing, Provider, ProviderBuilder,
-    ProviderClient, Transport,
+    self, ApiKey, DebugExt, ModelLister, Provider, ProviderBuilder, ProviderClient, Transport,
 };
 use crate::completion::NormalizeCompletionResponse;
 use crate::completion::{self, CompletionError};
@@ -190,17 +189,12 @@ impl Provider for CopilotExt {
     const VERIFY_PATH: &'static str = "";
 }
 
-impl<H> Capabilities<H> for CopilotExt {
-    type Completion = Capable<CompletionModel<H>>;
-    type Embeddings = Capable<EmbeddingModel<H>>;
-    type Transcription = Nothing;
-    type ModelListing = Capable<CopilotModelLister<H>>;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    CopilotExt,
+    completion = CompletionModel<H>,
+    embeddings = EmbeddingModel<H>,
+    model_listing = CopilotModelLister<H>,
+);
 
 impl DebugExt for CopilotExt {}
 

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -14,12 +14,9 @@
 
 use serde_json::Value;
 
-use crate::client::{
-    self, BearerAuth, Capabilities, Capable, DebugExt, ModelLister, Nothing, Provider,
-    ProviderClient,
-};
+use crate::client::{self, BearerAuth, DebugExt, ModelLister, Provider, ProviderClient};
 use crate::http_client::HttpClientExt;
-use crate::model::{Model, ModelList, ModelListingError};
+use crate::model::{ModelList, ModelListingError};
 use crate::providers::internal::openai_chat_completions_compatible::map_openai_finish_reason;
 use crate::providers::openai;
 use crate::telemetry::ProviderResponseExt;
@@ -117,17 +114,11 @@ impl openai::completion::OpenAICompatibleProvider for DeepSeekExt {
     }
 }
 
-impl<H> Capabilities<H> for DeepSeekExt {
-    type Completion = Capable<CompletionModel<H>>;
-    type Embeddings = Nothing;
-    type Transcription = Nothing;
-    type ModelListing = Capable<DeepSeekModelLister<H>>;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    DeepSeekExt,
+    completion = CompletionModel<H>,
+    model_listing = DeepSeekModelLister<H>,
+);
 
 impl DebugExt for DeepSeekExt {}
 
@@ -406,20 +397,6 @@ impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
     }
 }
 
-#[derive(Debug, Deserialize)]
-struct ListModelEntry {
-    id: String,
-    owned_by: String,
-}
-
-impl From<ListModelEntry> for Model {
-    fn from(value: ListModelEntry) -> Self {
-        let mut model = Model::from_id(value.id);
-        model.owned_by = Some(value.owned_by);
-        model
-    }
-}
-
 /// [`ModelLister`] implementation for the DeepSeek API (`GET /models`).
 #[derive(Clone)]
 pub struct DeepSeekModelLister<H = reqwest::Client> {
@@ -437,11 +414,11 @@ where
     }
 
     async fn list_all(&self) -> Result<ModelList, ModelListingError> {
-        crate::providers::internal::model_listing::list_models::<ListModelEntry, _, _>(
-            &self.client,
-            "DeepSeek",
-            "/models",
-        )
+        crate::providers::internal::model_listing::list_models::<
+            crate::providers::internal::model_listing::ListModelEntry,
+            _,
+            _,
+        >(&self.client, "DeepSeek", "/models")
         .await
     }
 }
@@ -910,11 +887,12 @@ mod tests {
             ]
         }"#;
 
-        let response: crate::providers::internal::model_listing::DataEnvelope<ListModelEntry> =
-            serde_json::from_str(data).expect("list models response should deserialize");
+        let response: crate::providers::internal::model_listing::DataEnvelope<
+            crate::providers::internal::model_listing::ListModelEntry,
+        > = serde_json::from_str(data).expect("list models response should deserialize");
         assert_eq!(response.data.len(), 2);
         assert_eq!(response.data[0].id, "deepseek-chat");
-        assert_eq!(response.data[0].owned_by, "deepseek");
+        assert_eq!(response.data[0].owned_by.as_deref(), Some("deepseek"));
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/doubleword/client.rs
+++ b/crates/rig-core/src/providers/doubleword/client.rs
@@ -1,4 +1,4 @@
-use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
+use crate::client::{self, BearerAuth, DebugExt, Provider};
 
 // ================================================================
 // Doubleword Client
@@ -32,18 +32,11 @@ impl crate::providers::openai::completion::OpenAICompatibleProvider for Doublewo
     type Response = crate::providers::openai::CompletionResponse;
 }
 
-impl<H> Capabilities<H> for DoublewordExt {
-    type Completion = Capable<super::completion::CompletionModel<H>>;
-    type Embeddings = Capable<super::EmbeddingModel<H>>;
-
-    type Transcription = Nothing;
-    type ModelListing = Nothing;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    DoublewordExt,
+    completion = super::completion::CompletionModel<H>,
+    embeddings = super::EmbeddingModel<H>,
+);
 
 client::impl_default_provider_builder!(
     DoublewordExtBuilder => DoublewordExt,

--- a/crates/rig-core/src/providers/gemini/client.rs
+++ b/crates/rig-core/src/providers/gemini/client.rs
@@ -1,6 +1,4 @@
-use crate::client::{
-    self, ApiKey, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder, Transport,
-};
+use crate::client::{self, ApiKey, DebugExt, Provider, ProviderBuilder, Transport};
 use crate::http_client::{self};
 use crate::providers::gemini::model_listing::{GeminiInteractionsModelLister, GeminiModelLister};
 use serde::Deserialize;
@@ -108,31 +106,22 @@ impl Provider for GeminiInteractionsExt {
     }
 }
 
-impl<H> Capabilities<H> for GeminiExt {
-    type Completion = Capable<super::completion::CompletionModel<H>>;
-    type Embeddings = Capable<super::embedding::EmbeddingModel<H>>;
-    type Transcription = Capable<super::transcription::TranscriptionModel<H>>;
-    type ModelListing = Capable<GeminiModelLister<H>>;
+client::impl_capabilities!(
+    GeminiExt,
+    completion = super::completion::CompletionModel<H>,
+    embeddings = super::embedding::EmbeddingModel<H>,
+    transcription = super::transcription::TranscriptionModel<H>,
+    model_listing = GeminiModelLister<H>,
+    image_generation = super::image_generation::ImageGenerationModel<H>,
+);
 
-    #[cfg(feature = "image")]
-    type ImageGeneration = Capable<super::image_generation::ImageGenerationModel<H>>;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
-
-impl<H> Capabilities<H> for GeminiInteractionsExt {
-    type Completion = Capable<super::interactions_api::InteractionsCompletionModel<H>>;
-    type Embeddings = Capable<super::embedding::EmbeddingModel<H>>;
-    type Transcription = Capable<super::transcription::TranscriptionModel<H>>;
-    type ModelListing = Capable<GeminiInteractionsModelLister<H>>;
-
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    GeminiInteractionsExt,
+    completion = super::interactions_api::InteractionsCompletionModel<H>,
+    embeddings = super::embedding::EmbeddingModel<H>,
+    transcription = super::transcription::TranscriptionModel<H>,
+    model_listing = GeminiInteractionsModelLister<H>,
+);
 
 impl ProviderBuilder for GeminiBuilder {
     type Extension<H>

--- a/crates/rig-core/src/providers/gemini/transcription.rs
+++ b/crates/rig-core/src/providers/gemini/transcription.rs
@@ -18,21 +18,11 @@ use super::{Client, completion::gemini_api_types::GenerateContentResponse};
 const TRANSCRIPTION_PREAMBLE: &str =
     "Translate the provided audio exactly. Do not add additional information.";
 
-#[derive(Clone)]
-pub struct TranscriptionModel<T = reqwest::Client> {
-    client: Client<T>,
-    /// Name of the model (e.g.: gemini-1.5-flash)
-    pub model: String,
-}
-
-impl<T> TranscriptionModel<T> {
-    pub fn new(client: Client<T>, model: impl Into<String>) -> Self {
-        Self {
-            client,
-            model: model.into(),
-        }
-    }
-}
+pub type TranscriptionModel<T = reqwest::Client> =
+    crate::providers::internal::transcription::GenericTranscriptionModel<
+        crate::providers::gemini::client::GeminiExt,
+        T,
+    >;
 
 impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
 where

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 use super::openai;
-use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
+use crate::client::{self, BearerAuth, DebugExt, Provider};
 use crate::completion::CompletionError;
 use crate::http_client::HttpClientExt;
 use crate::providers::internal::transcription::OpenAiTranscriptionClient;
@@ -75,18 +75,11 @@ impl openai::completion::OpenAICompatibleProvider for GroqExt {
     }
 }
 
-impl<H> Capabilities<H> for GroqExt {
-    type Completion = Capable<CompletionModel<H>>;
-    type Embeddings = Nothing;
-    type Transcription = Capable<TranscriptionModel<H>>;
-    type ModelListing = Nothing;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    GroqExt,
+    completion = CompletionModel<H>,
+    transcription = TranscriptionModel<H>,
+);
 
 impl DebugExt for GroqExt {}
 

--- a/crates/rig-core/src/providers/huggingface/client.rs
+++ b/crates/rig-core/src/providers/huggingface/client.rs
@@ -1,6 +1,4 @@
-use crate::client::{
-    self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-};
+use crate::client::{self, BearerAuth, DebugExt, Provider, ProviderBuilder};
 use crate::http_client;
 #[cfg(feature = "image")]
 use crate::image_generation::ImageGenerationError;
@@ -160,18 +158,12 @@ impl crate::providers::openai::completion::OpenAICompatibleProvider for HuggingF
     }
 }
 
-impl<H> Capabilities<H> for HuggingFaceExt {
-    type Completion = Capable<super::completion::CompletionModel<H>>;
-    type Embeddings = Nothing;
-    type Transcription = Capable<super::transcription::TranscriptionModel<H>>;
-    type ModelListing = Nothing;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Capable<super::image_generation::ImageGenerationModel<H>>;
-
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    HuggingFaceExt,
+    completion = super::completion::CompletionModel<H>,
+    transcription = super::transcription::TranscriptionModel<H>,
+    image_generation = super::image_generation::ImageGenerationModel<H>,
+);
 
 impl DebugExt for HuggingFaceExt {
     fn fields(&self) -> impl Iterator<Item = (&'static str, &dyn Debug)> {

--- a/crates/rig-core/src/providers/huggingface/transcription.rs
+++ b/crates/rig-core/src/providers/huggingface/transcription.rs
@@ -6,7 +6,6 @@ use crate::transcription::TranscriptionError;
 use crate::wasm_compat::WasmCompatSync;
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
-use serde::Deserialize;
 use serde_json::json;
 
 pub const WHISPER_LARGE_V3: &str = "openai/whisper-large-v3";
@@ -14,39 +13,14 @@ pub const WHISPER_LARGE_V3_TURBO: &str = "openai/whisper-large-v3-turbo";
 
 pub const WHISPER_SMALL: &str = "openai/whisper-small";
 
-#[derive(Debug, Deserialize)]
-pub struct TranscriptionResponse {
-    pub text: String,
-}
+pub use crate::providers::openai::TranscriptionResponse;
 
-impl TryFrom<TranscriptionResponse>
-    for transcription::TranscriptionResponse<TranscriptionResponse>
-{
-    type Error = TranscriptionError;
+pub type TranscriptionModel<T = reqwest::Client> =
+    crate::providers::internal::transcription::GenericTranscriptionModel<
+        crate::providers::huggingface::client::HuggingFaceExt,
+        T,
+    >;
 
-    fn try_from(value: TranscriptionResponse) -> Result<Self, Self::Error> {
-        Ok(transcription::TranscriptionResponse {
-            text: value.text.clone(),
-            response: value,
-        })
-    }
-}
-
-#[derive(Clone)]
-pub struct TranscriptionModel<T = reqwest::Client> {
-    client: Client<T>,
-    /// Name of the model (e.g.: gpt-3.5-turbo-1106)
-    pub model: String,
-}
-
-impl<T> TranscriptionModel<T> {
-    pub fn new(client: Client<T>, model: impl Into<String>) -> Self {
-        Self {
-            client,
-            model: model.into(),
-        }
-    }
-}
 impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
 where
     T: HttpClientExt + Clone + WasmCompatSync + 'static,

--- a/crates/rig-core/src/providers/hyperbolic.rs
+++ b/crates/rig-core/src/providers/hyperbolic.rs
@@ -13,7 +13,7 @@
 //! ```
 
 use crate::client::BearerAuth;
-use crate::client::{self, Capabilities, Capable, DebugExt, Nothing, Provider};
+use crate::client::{self, DebugExt, Provider};
 
 // ================================================================
 // Main Hyperbolic Client
@@ -33,17 +33,12 @@ impl Provider for HyperbolicExt {
     const VERIFY_PATH: &'static str = "/models";
 }
 
-impl<H> Capabilities<H> for HyperbolicExt {
-    type Completion = Capable<CompletionModel<H>>;
-    type Embeddings = Nothing;
-    type Transcription = Nothing;
-    type ModelListing = Nothing;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Capable<ImageGenerationModel<H>>;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Capable<AudioGenerationModel<H>>;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    HyperbolicExt,
+    completion = CompletionModel<H>,
+    image_generation = ImageGenerationModel<H>,
+    audio_generation = AudioGenerationModel<H>,
+);
 
 impl DebugExt for HyperbolicExt {}
 

--- a/crates/rig-core/src/providers/internal/model_listing.rs
+++ b/crates/rig-core/src/providers/internal/model_listing.rs
@@ -21,6 +21,28 @@ pub(crate) struct DataEnvelope<Entry> {
     pub(crate) data: Vec<Entry>,
 }
 
+/// The standard OpenAI-style listing entry (OpenAI, Mistral, DeepSeek,
+/// Xiaomi MiMo). `id` is the one field every listing carries; the rest are
+/// optional so providers that omit them still decode. Providers whose
+/// entries genuinely diverge keep their own DTO.
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct ListModelEntry {
+    pub(crate) id: String,
+    pub(crate) name: Option<String>,
+    pub(crate) created: Option<u64>,
+    pub(crate) owned_by: Option<String>,
+}
+
+impl From<ListModelEntry> for Model {
+    fn from(value: ListModelEntry) -> Self {
+        let mut model = Model::from_id(value.id);
+        model.name = value.name;
+        model.created_at = value.created;
+        model.owned_by = value.owned_by;
+        model
+    }
+}
+
 /// Map a transport-level send error into listing-flavored context: an
 /// [`http_client::Error::InvalidStatusCodeWithMessage`] (backends that reject
 /// non-2xx before handing back a response) keeps the provider label, path,
@@ -102,4 +124,24 @@ where
     let envelope: DataEnvelope<Entry> = get_json(client, provider_name, path).await?;
     let models = envelope.data.into_iter().map(Into::into).collect();
     Ok(ModelList::new(models))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ListModelEntry;
+    use crate::model::Model;
+
+    /// `id` is the one required field: an entry that carries nothing else
+    /// (some OpenAI-compatible gateways omit `created`/`owned_by`) still
+    /// decodes, mapping the absent fields to `None` on the `Model`.
+    #[test]
+    fn minimal_entry_decodes_with_id_alone() {
+        let entry: ListModelEntry =
+            serde_json::from_str(r#"{"id":"gpt-test"}"#).expect("minimal entry should decode");
+        let model = Model::from(entry);
+        assert_eq!(model.id, "gpt-test");
+        assert_eq!(model.name, None);
+        assert_eq!(model.created_at, None);
+        assert_eq!(model.owned_by, None);
+    }
 }

--- a/crates/rig-core/src/providers/internal/transcription.rs
+++ b/crates/rig-core/src/providers/internal/transcription.rs
@@ -11,6 +11,7 @@ use bytes::Bytes;
 use serde::de::DeserializeOwned;
 
 use super::envelope::ProviderEnvelope;
+use crate::client::Client;
 use crate::http_client::multipart::Part;
 use crate::http_client::{self, HttpClientExt, MultipartForm};
 use crate::transcription::{self, TranscriptionError, TranscriptionRequest};
@@ -77,6 +78,27 @@ where
             form,
         )
         .await
+    }
+}
+
+/// The client-plus-model wrapper behind each provider's public
+/// `TranscriptionModel` alias. Only the transcription conversation itself is
+/// provider-specific, so the storage and constructor live here once; each
+/// provider keeps its own [`TranscriptionModel`](transcription::TranscriptionModel)
+/// impl on its alias.
+#[derive(Clone)]
+pub struct GenericTranscriptionModel<Ext, H = reqwest::Client> {
+    pub(crate) client: Client<Ext, H>,
+    /// Name of the model (e.g.: `whisper-1`)
+    pub model: String,
+}
+
+impl<Ext, H> GenericTranscriptionModel<Ext, H> {
+    pub fn new(client: Client<Ext, H>, model: impl Into<String>) -> Self {
+        Self {
+            client,
+            model: model.into(),
+        }
     }
 }
 

--- a/crates/rig-core/src/providers/llamafile.rs
+++ b/crates/rig-core/src/providers/llamafile.rs
@@ -28,9 +28,7 @@
 //! # }
 //! ```
 
-use crate::client::{
-    self, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderClient, Transport,
-};
+use crate::client::{self, DebugExt, Nothing, Provider, ProviderClient, Transport};
 use crate::providers::openai;
 
 // ================================================================
@@ -75,17 +73,11 @@ impl openai::embedding::OpenAIEmbeddingsCompatible for LlamafileExt {
     const PROVIDER_NAME: &'static str = "llamafile";
 }
 
-impl<H> Capabilities<H> for LlamafileExt {
-    type Completion = Capable<openai::completion::GenericCompletionModel<LlamafileExt, H>>;
-    type Embeddings = Capable<openai::embedding::GenericEmbeddingModel<LlamafileExt, H>>;
-    type Transcription = Nothing;
-    type ModelListing = Nothing;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    LlamafileExt,
+    completion = openai::completion::GenericCompletionModel<LlamafileExt, H>,
+    embeddings = openai::embedding::GenericEmbeddingModel<LlamafileExt, H>,
+);
 
 impl DebugExt for LlamafileExt {}
 

--- a/crates/rig-core/src/providers/minimax.rs
+++ b/crates/rig-core/src/providers/minimax.rs
@@ -21,7 +21,7 @@
 //! let model = client.completion_model(minimax::MINIMAX_M2);
 //! ```
 
-use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
+use crate::client::{self, BearerAuth, DebugExt, Provider};
 use crate::providers::anthropic::client::{
     AnthropicBuilder as AnthropicCompatBuilder, AnthropicKey, impl_anthropic_compatible_builder,
 };
@@ -87,30 +87,15 @@ impl Provider for MiniMaxAnthropicExt {
     const VERIFY_PATH: &'static str = "/v1/models";
 }
 
-impl<H> Capabilities<H> for MiniMaxExt {
-    type Completion = Capable<super::openai::completion::GenericCompletionModel<MiniMaxExt, H>>;
-    type Embeddings = Nothing;
-    type Transcription = Nothing;
-    type ModelListing = Nothing;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    MiniMaxExt,
+    completion = super::openai::completion::GenericCompletionModel<MiniMaxExt, H>,
+);
 
-impl<H> Capabilities<H> for MiniMaxAnthropicExt {
-    type Completion =
-        Capable<super::anthropic::completion::GenericCompletionModel<MiniMaxAnthropicExt, H>>;
-    type Embeddings = Nothing;
-    type Transcription = Nothing;
-    type ModelListing = Nothing;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    MiniMaxAnthropicExt,
+    completion = super::anthropic::completion::GenericCompletionModel<MiniMaxAnthropicExt, H>,
+);
 
 impl DebugExt for MiniMaxExt {}
 impl DebugExt for MiniMaxAnthropicExt {}

--- a/crates/rig-core/src/providers/mira.rs
+++ b/crates/rig-core/src/providers/mira.rs
@@ -7,7 +7,7 @@
 //! let client = mira::Client::new("YOUR_API_KEY");
 //!
 //! ```
-use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
+use crate::client::{self, BearerAuth, DebugExt, Provider};
 use crate::http_client::{self, HttpClientExt};
 use crate::providers::internal::openai_chat_completions_compatible::map_openai_finish_reason;
 use crate::{
@@ -32,19 +32,7 @@ impl Provider for MiraExt {
     const VERIFY_PATH: &'static str = "/user-credits";
 }
 
-impl<H> Capabilities<H> for MiraExt {
-    type Completion = Capable<CompletionModel<H>>;
-    type Embeddings = Nothing;
-    type Transcription = Nothing;
-    type ModelListing = Nothing;
-
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(MiraExt, completion = CompletionModel<H>);
 
 impl DebugExt for MiraExt {}
 

--- a/crates/rig-core/src/providers/mistral/client.rs
+++ b/crates/rig-core/src/providers/mistral/client.rs
@@ -1,5 +1,5 @@
 use crate::{
-    client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider},
+    client::{self, BearerAuth, DebugExt, Provider},
     providers::mistral::MistralModelLister,
 };
 use serde::{Deserialize, Serialize};
@@ -97,19 +97,13 @@ impl crate::providers::openai::completion::OpenAICompatibleProvider for MistralE
     }
 }
 
-impl<H> Capabilities<H> for MistralExt {
-    type Completion = Capable<super::CompletionModel<H>>;
-    type Embeddings = Capable<super::EmbeddingModel<H>>;
-
-    type Transcription = Capable<super::TranscriptionModel<H>>;
-    type ModelListing = Capable<MistralModelLister<H>>;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    MistralExt,
+    completion = super::CompletionModel<H>,
+    embeddings = super::EmbeddingModel<H>,
+    transcription = super::TranscriptionModel<H>,
+    model_listing = MistralModelLister<H>,
+);
 
 impl DebugExt for MistralExt {}
 

--- a/crates/rig-core/src/providers/mistral/model_listing.rs
+++ b/crates/rig-core/src/providers/mistral/model_listing.rs
@@ -1,29 +1,10 @@
 use crate::{
     client::ModelLister,
     http_client::HttpClientExt,
-    model::{Model, ModelList, ModelListingError},
-    providers::{internal, mistral::Client},
+    model::{ModelList, ModelListingError},
+    providers::{internal, internal::model_listing::ListModelEntry, mistral::Client},
     wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
-use serde::Deserialize;
-
-#[derive(Debug, Deserialize)]
-struct ListModelEntry {
-    id: String,
-    name: Option<String>,
-    created: u64,
-    owned_by: String,
-}
-
-impl From<ListModelEntry> for Model {
-    fn from(value: ListModelEntry) -> Self {
-        let mut model = Model::from_id(value.id);
-        model.name = value.name;
-        model.created_at = Some(value.created);
-        model.owned_by = Some(value.owned_by);
-        model
-    }
-}
 
 /// [`ModelLister`] implementation for the Mistral API (`GET /v1/models`).
 #[derive(Clone)]

--- a/crates/rig-core/src/providers/mistral/transcription.rs
+++ b/crates/rig-core/src/providers/mistral/transcription.rs
@@ -90,11 +90,11 @@ impl TryFrom<MistralTranscriptionResponse>
     }
 }
 
-#[derive(Clone)]
-pub struct TranscriptionModel<T = reqwest::Client> {
-    client: Client<T>,
-    pub model: String,
-}
+pub type TranscriptionModel<T = reqwest::Client> =
+    crate::providers::internal::transcription::GenericTranscriptionModel<
+        crate::providers::mistral::client::MistralExt,
+        T,
+    >;
 
 impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
 where
@@ -164,15 +164,6 @@ where
                 status,
                 String::from_utf8_lossy(&response_bytes),
             ))
-        }
-    }
-}
-
-impl<T> TranscriptionModel<T> {
-    pub fn new(client: Client<T>, model: impl Into<String>) -> Self {
-        Self {
-            client,
-            model: model.into(),
         }
     }
 }

--- a/crates/rig-core/src/providers/moonshot.rs
+++ b/crates/rig-core/src/providers/moonshot.rs
@@ -22,7 +22,7 @@
 //!     .build()
 //!     .expect("Failed to build Moonshot client");
 //! ```
-use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
+use crate::client::{self, BearerAuth, DebugExt, Provider};
 use crate::providers::anthropic::client::{
     AnthropicBuilder as AnthropicCompatBuilder, AnthropicKey, impl_anthropic_compatible_builder,
 };
@@ -77,30 +77,12 @@ impl_anthropic_compatible_builder!(
     base_url = ANTHROPIC_API_BASE_URL,
 );
 
-impl<H> Capabilities<H> for MoonshotExt {
-    type Completion = Capable<CompletionModel<H>>;
-    type Embeddings = Nothing;
-    type Transcription = Nothing;
-    type ModelListing = Nothing;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(MoonshotExt, completion = CompletionModel<H>);
 
-impl<H> Capabilities<H> for MoonshotAnthropicExt {
-    type Completion =
-        Capable<super::anthropic::completion::GenericCompletionModel<MoonshotAnthropicExt, H>>;
-    type Embeddings = Nothing;
-    type Transcription = Nothing;
-    type ModelListing = Nothing;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    MoonshotAnthropicExt,
+    completion = super::anthropic::completion::GenericCompletionModel<MoonshotAnthropicExt, H>,
+);
 
 pub type Client<H = reqwest::Client> = client::Client<MoonshotExt, H>;
 pub type ClientBuilder<H = crate::markers::Missing> =

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -38,9 +38,7 @@
 //! # Ok(())
 //! # }
 //! ```
-use crate::client::{
-    self, ApiKey, Capabilities, Capable, DebugExt, ModelLister, Nothing, Provider, ProviderClient,
-};
+use crate::client::{self, ApiKey, DebugExt, ModelLister, Nothing, Provider, ProviderClient};
 use crate::completion::Usage;
 use crate::http_client::{self, HttpClientExt};
 use crate::message::DocumentSourceKind;
@@ -121,18 +119,12 @@ impl Provider for OllamaExt {
     const VERIFY_PATH: &'static str = "api/tags";
 }
 
-impl<H> Capabilities<H> for OllamaExt {
-    type Completion = Capable<CompletionModel<H>>;
-    type Transcription = Nothing;
-    type Embeddings = Capable<EmbeddingModel<H>>;
-    type ModelListing = Capable<OllamaModelLister<H>>;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    OllamaExt,
+    completion = CompletionModel<H>,
+    embeddings = EmbeddingModel<H>,
+    model_listing = OllamaModelLister<H>,
+);
 
 impl DebugExt for OllamaExt {}
 

--- a/crates/rig-core/src/providers/openai/client.rs
+++ b/crates/rig-core/src/providers/openai/client.rs
@@ -1,6 +1,6 @@
 use super::responses_api::{ResponsesProviderExt, SystemInstructionsPlacement};
 use crate::{
-    client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider},
+    client::{self, BearerAuth, DebugExt, Provider},
     http_client::HttpClientExt,
     wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
@@ -68,29 +68,25 @@ impl Provider for OpenAICompletionsExt {
     const VERIFY_PATH: &'static str = "/models";
 }
 
-impl<H> Capabilities<H> for OpenAIResponsesExt {
-    type Completion = Capable<super::responses_api::ResponsesCompletionModel<H>>;
-    type Embeddings = Capable<super::EmbeddingModel<H>>;
-    type Transcription = Capable<super::TranscriptionModel<H>>;
-    type ModelListing = Capable<super::OpenAIModelLister<H>>;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Capable<super::ImageGenerationModel<H>>;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Capable<super::audio_generation::AudioGenerationModel<H>>;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    OpenAIResponsesExt,
+    completion = super::responses_api::ResponsesCompletionModel<H>,
+    embeddings = super::EmbeddingModel<H>,
+    transcription = super::TranscriptionModel<H>,
+    model_listing = super::OpenAIModelLister<H>,
+    image_generation = super::ImageGenerationModel<H>,
+    audio_generation = super::audio_generation::AudioGenerationModel<H>,
+);
 
-impl<H> Capabilities<H> for OpenAICompletionsExt {
-    type Completion = Capable<super::completion::CompletionModel<H>>;
-    type Embeddings = Capable<super::GenericEmbeddingModel<OpenAICompletionsExt, H>>;
-    type Transcription = Capable<super::TranscriptionModel<H>>;
-    type ModelListing = Capable<super::OpenAIModelLister<H>>;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Capable<super::ImageGenerationModel<H>>;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Capable<super::audio_generation::AudioGenerationModel<H>>;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    OpenAICompletionsExt,
+    completion = super::completion::CompletionModel<H>,
+    embeddings = super::GenericEmbeddingModel<OpenAICompletionsExt, H>,
+    transcription = super::TranscriptionModel<H>,
+    model_listing = super::OpenAIModelLister<H>,
+    image_generation = super::ImageGenerationModel<H>,
+    audio_generation = super::audio_generation::AudioGenerationModel<H>,
+);
 
 impl DebugExt for OpenAIResponsesExt {}
 

--- a/crates/rig-core/src/providers/openai/model_listing.rs
+++ b/crates/rig-core/src/providers/openai/model_listing.rs
@@ -1,27 +1,10 @@
 use crate::{
     client::ModelLister,
     http_client::HttpClientExt,
-    model::{Model, ModelList, ModelListingError},
-    providers::{internal, openai::Client},
+    model::{ModelList, ModelListingError},
+    providers::{internal, internal::model_listing::ListModelEntry, openai::Client},
     wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
-use serde::Deserialize;
-
-#[derive(Debug, Deserialize)]
-struct ListModelEntry {
-    id: String,
-    created: u64,
-    owned_by: String,
-}
-
-impl From<ListModelEntry> for Model {
-    fn from(value: ListModelEntry) -> Self {
-        let mut model = Model::from_id(value.id);
-        model.created_at = Some(value.created);
-        model.owned_by = Some(value.owned_by);
-        model
-    }
-}
 
 /// [`ModelLister`] implementation for the OpenAI API (`GET /models`).
 #[derive(Clone)]

--- a/crates/rig-core/src/providers/openrouter/client.rs
+++ b/crates/rig-core/src/providers/openrouter/client.rs
@@ -1,4 +1,4 @@
-use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
+use crate::client::{self, BearerAuth, DebugExt, Provider};
 use http::HeaderValue;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -25,18 +25,14 @@ impl Provider for OpenRouterExt {
     const VERIFY_PATH: &'static str = "/key";
 }
 
-impl<H> Capabilities<H> for OpenRouterExt {
-    type Completion = Capable<super::CompletionModel<H>>;
-    type Embeddings = Capable<super::EmbeddingModel<H>>;
-    type Transcription = Capable<super::transcription::TranscriptionModel<H>>;
-    type ModelListing = Capable<super::OpenRouterModelLister<H>>;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Capable<super::audio_generation::AudioGenerationModel<H>>;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    OpenRouterExt,
+    completion = super::CompletionModel<H>,
+    embeddings = super::EmbeddingModel<H>,
+    transcription = super::transcription::TranscriptionModel<H>,
+    model_listing = super::OpenRouterModelLister<H>,
+    audio_generation = super::audio_generation::AudioGenerationModel<H>,
+);
 
 impl DebugExt for OpenRouterExt {}
 

--- a/crates/rig-core/src/providers/openrouter/transcription.rs
+++ b/crates/rig-core/src/providers/openrouter/transcription.rs
@@ -85,20 +85,11 @@ impl TryFrom<TranscriptionResponse>
 // Model
 // ================================================================
 
-#[derive(Clone)]
-pub struct TranscriptionModel<T = reqwest::Client> {
-    client: Client<T>,
-    pub model: String,
-}
-
-impl<T> TranscriptionModel<T> {
-    pub fn new(client: Client<T>, model: impl Into<String>) -> Self {
-        Self {
-            client,
-            model: model.into(),
-        }
-    }
-}
+pub type TranscriptionModel<T = reqwest::Client> =
+    crate::providers::internal::transcription::GenericTranscriptionModel<
+        crate::providers::openrouter::client::OpenRouterExt,
+        T,
+    >;
 
 fn infer_format_from_filename(filename: &str) -> String {
     std::path::Path::new(filename)

--- a/crates/rig-core/src/providers/perplexity.rs
+++ b/crates/rig-core/src/providers/perplexity.rs
@@ -12,7 +12,7 @@
 //! # }
 //! ```
 use crate::client::BearerAuth;
-use crate::client::{self, Capabilities, Capable, DebugExt, Nothing, Provider};
+use crate::client::{self, DebugExt, Provider};
 use crate::completion::CompletionError;
 use crate::providers::openai;
 
@@ -78,18 +78,7 @@ impl openai::completion::OpenAICompatibleProvider for PerplexityExt {
     }
 }
 
-impl<H> Capabilities<H> for PerplexityExt {
-    type Completion = Capable<CompletionModel<H>>;
-    type Transcription = Nothing;
-    type Embeddings = Nothing;
-    type ModelListing = Nothing;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(PerplexityExt, completion = CompletionModel<H>);
 
 impl DebugExt for PerplexityExt {}
 

--- a/crates/rig-core/src/providers/together/client.rs
+++ b/crates/rig-core/src/providers/together/client.rs
@@ -1,4 +1,4 @@
-use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
+use crate::client::{self, BearerAuth, DebugExt, Provider};
 
 // ================================================================
 // Together AI Client
@@ -41,18 +41,11 @@ impl crate::providers::openai::completion::OpenAICompatibleProvider for Together
     }
 }
 
-impl<H> Capabilities<H> for TogetherExt {
-    type Completion = Capable<super::CompletionModel<H>>;
-    type Embeddings = Capable<super::EmbeddingModel<H>>;
-
-    type Transcription = Nothing;
-    type ModelListing = Nothing;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    TogetherExt,
+    completion = super::CompletionModel<H>,
+    embeddings = super::EmbeddingModel<H>,
+);
 
 client::impl_default_provider_builder!(
     TogetherExtBuilder => TogetherExt,

--- a/crates/rig-core/src/providers/voyageai.rs
+++ b/crates/rig-core/src/providers/voyageai.rs
@@ -1,4 +1,4 @@
-use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
+use crate::client::{self, BearerAuth, DebugExt, Provider};
 use crate::embeddings;
 use crate::embeddings::EmbeddingError;
 use crate::http_client::HttpClientExt;
@@ -28,18 +28,11 @@ impl Provider for VoyageExt {
     const VERIFY_PATH: &'static str = "";
 }
 
-impl<H> Capabilities<H> for VoyageExt {
-    type Completion = Nothing;
-    type Embeddings = Capable<EmbeddingModel<H>>;
-    type Rerank = Capable<RerankModel<H>>;
-    type Transcription = Nothing;
-    type ModelListing = Nothing;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-}
+client::impl_capabilities!(
+    VoyageExt,
+    embeddings = EmbeddingModel<H>,
+    rerank = RerankModel<H>,
+);
 
 impl DebugExt for VoyageExt {}
 

--- a/crates/rig-core/src/providers/xai/client.rs
+++ b/crates/rig-core/src/providers/xai/client.rs
@@ -1,4 +1,4 @@
-use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
+use crate::client::{self, BearerAuth, DebugExt, Provider};
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct XAiExt;
@@ -19,18 +19,12 @@ impl Provider for XAiExt {
     const VERIFY_PATH: &'static str = "/v1/api-key";
 }
 
-impl<H> Capabilities<H> for XAiExt {
-    type Completion = Capable<super::completion::CompletionModel<H>>;
-
-    type Embeddings = Nothing;
-    type Transcription = Nothing;
-    type ModelListing = Nothing;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Capable<super::image_generation::ImageGenerationModel<H>>;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Capable<super::audio_generation::AudioGenerationModel<H>>;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    XAiExt,
+    completion = super::completion::CompletionModel<H>,
+    image_generation = super::image_generation::ImageGenerationModel<H>,
+    audio_generation = super::audio_generation::AudioGenerationModel<H>,
+);
 
 impl DebugExt for XAiExt {}
 

--- a/crates/rig-core/src/providers/xiaomimimo.rs
+++ b/crates/rig-core/src/providers/xiaomimimo.rs
@@ -21,9 +21,7 @@
 //! let model = client.completion_model(xiaomimimo::MIMO_V2_5_PRO);
 //! ```
 
-use crate::client::{
-    self, BearerAuth, Capabilities, Capable, DebugExt, ModelLister, Nothing, Provider,
-};
+use crate::client::{self, BearerAuth, DebugExt, ModelLister, Provider};
 use crate::http_client::HttpClientExt;
 use crate::model::{Model, ModelList, ModelListingError};
 use crate::providers::anthropic::client::{
@@ -84,30 +82,16 @@ impl Provider for XiaomiMimoAnthropicExt {
     const VERIFY_PATH: &'static str = "/v1/models";
 }
 
-impl<H> Capabilities<H> for XiaomiMimoExt {
-    type Completion = Capable<super::openai::completion::GenericCompletionModel<XiaomiMimoExt, H>>;
-    type Embeddings = Nothing;
-    type Transcription = Nothing;
-    type ModelListing = Capable<XiaomiMimoModelLister<H>>;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    XiaomiMimoExt,
+    completion = super::openai::completion::GenericCompletionModel<XiaomiMimoExt, H>,
+    model_listing = XiaomiMimoModelLister<H>,
+);
 
-impl<H> Capabilities<H> for XiaomiMimoAnthropicExt {
-    type Completion =
-        Capable<super::anthropic::completion::GenericCompletionModel<XiaomiMimoAnthropicExt, H>>;
-    type Embeddings = Nothing;
-    type Transcription = Nothing;
-    type ModelListing = Nothing;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    XiaomiMimoAnthropicExt,
+    completion = super::anthropic::completion::GenericCompletionModel<XiaomiMimoAnthropicExt, H>,
+);
 
 impl DebugExt for XiaomiMimoExt {}
 impl DebugExt for XiaomiMimoAnthropicExt {}

--- a/crates/rig-core/src/providers/zai.rs
+++ b/crates/rig-core/src/providers/zai.rs
@@ -22,7 +22,7 @@
 //! let glm_4_6 = client.completion_model(zai::GLM_4_6);
 //! ```
 
-use crate::client::{self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider};
+use crate::client::{self, BearerAuth, DebugExt, Provider};
 use crate::providers::anthropic::client::{
     AnthropicBuilder as AnthropicCompatBuilder, AnthropicKey, impl_anthropic_compatible_builder,
 };
@@ -86,30 +86,15 @@ impl Provider for ZAiAnthropicExt {
     const VERIFY_PATH: &'static str = "/v1/models";
 }
 
-impl<H> Capabilities<H> for ZAiExt {
-    type Completion = Capable<super::openai::completion::GenericCompletionModel<ZAiExt, H>>;
-    type Embeddings = Nothing;
-    type Transcription = Nothing;
-    type ModelListing = Nothing;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    ZAiExt,
+    completion = super::openai::completion::GenericCompletionModel<ZAiExt, H>,
+);
 
-impl<H> Capabilities<H> for ZAiAnthropicExt {
-    type Completion =
-        Capable<super::anthropic::completion::GenericCompletionModel<ZAiAnthropicExt, H>>;
-    type Embeddings = Nothing;
-    type Transcription = Nothing;
-    type ModelListing = Nothing;
-    #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
-    #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
-    type Rerank = Nothing;
-}
+client::impl_capabilities!(
+    ZAiAnthropicExt,
+    completion = super::anthropic::completion::GenericCompletionModel<ZAiAnthropicExt, H>,
+);
 
 impl DebugExt for ZAiExt {}
 impl DebugExt for ZAiAnthropicExt {}


### PR DESCRIPTION
## Summary

Consolidation pass over `rig-core` and `rig-agent`, rebased on #2288 (which independently landed the Anthropic-sibling base-URL scaffold, the OpenAI/Groq/Azure transcription model, and the decision-enum removal — those overlaps were resolved in favor of main). What remains here: **39 files, +496/−723 (net −227 lines)**.

### rig-core
- **`impl_capabilities!` macro** replaces ~31 hand-written `Capabilities` impls (all-`Nothing`-except-the-real-slots), emitting the `image`/`audio` feature gates itself. Applied across every provider, including the dual-ext Anthropic siblings on top of #2288's structure.
- **`GenericTranscriptionModel<Ext, H>`** removes the identical `TranscriptionModel` wrapper structs for huggingface / openrouter / mistral / gemini (public names preserved via type aliases); complements #2288's `OpenAiTranscriptionModel`, which covers openai/groq/azure. huggingface's byte-identical `TranscriptionResponse` re-exports openai's.
- **Shared `ListModelEntry`** replaces 4 near-identical model-listing DTOs (openai, mistral, deepseek, xiaomimimo).

### rig-agent
- `AgentBuilder<NoToolConfig>` tool methods delegate through one `into_tool_builder()` transition.
- `Extractor`'s 4 `extract*` methods delegate to `ExtractorRun` (run-local model is now `Option<ModelHandle>`), collapsing 8 near-identical bodies into one core.
- `build_prepared_completion_request` takes `&AgentRunner` instead of 17 positional parameters.
- `AgentRun`: new `take_resolving` / `pending_invalid_call` / `has_tool_calls` / `abandon_streamed_turn` helpers deduplicate the state-machine guards and the streamed Retry/Skip rollback.
- `StreamingTurnSource::record_turn_telemetry` unifies the two accepted-turn telemetry blocks.

## Behavioral notes
- `ListModelEntry` deliberately relaxes `created`/`owned_by` to optional: a gateway omitting them now lists instead of failing deserialization (covered by a new test).
- `huggingface::transcription::TranscriptionResponse` is now a re-export of openai's identical struct — same shape/semantics, but no longer a distinct type (semver-relevant for downstream impls keyed on it).

## Deliberately rejected
- Macro-izing the `stream!` error/cancel yield paths: `async_stream` can't transform a `yield` inside a nested macro expansion.
- The six one-line `HookStack` forwarders and `optional_setters!`-style macros: would trade rustdoc/readability for ~20 lines.
- Folding `DebugExt` into `impl_capabilities!`: azure's custom `fields` would become a hidden exception.

## Testing (re-run after the rebase)
- `cargo fmt` — clean
- `cargo clippy --workspace --all-targets --all-features` — 0 warnings
- `cargo test --workspace --all-features` — all green
- `cargo doc --workspace --no-deps` — clean
- `cargo check --target wasm32-unknown-unknown` (rig-core) — passes
- Adversarial full-diff review (deleted-vs-added comparison, cfg-gate audit, serde field audit) — findings fixed or noted above