### PR TITLE
ci: pin sccache and make its install best-effort

### DIFF
--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -93,14 +93,45 @@ runs:
     # unchanged workspace members stop recompiling too. Opt-in per job: it
     # only pays off where workspace crates compile (it cannot cache
     # clippy-driver or rustdoc, which is why the clippy/doc jobs skip it).
+    #
+    # `version` is pinned deliberately. Left empty, the action resolves the
+    # release through an authenticated `repos.getLatestRelease` API call on
+    # every run of every sccache-enabled job — a network round-trip that has
+    # nothing to do with building rig and that took down a whole `main` run
+    # when a runner's egress proxy served a self-signed certificate
+    # (`HttpError: self-signed certificate`, run 31576834062). A pinned tag
+    # skips the call entirely and goes straight to the release asset, so the
+    # only remaining network dependency is the download itself.
+    #
+    # `disable_annotations` makes the action's post step return before it
+    # shells out to `sccache --show-stats`. That post step is not optional
+    # and runs even when the install failed, where `$SCCACHE_PATH` is unset
+    # and it dies with `Unable to locate executable file: undefined` — a
+    # second, independent job failure from the same root cause. Silencing it
+    # costs only the per-job cache-hit annotation.
+    #
+    # Together with `continue-on-error`, sccache is now strictly best-effort:
+    # if the download fails the job compiles without it (slower, still
+    # correct) instead of failing. The wrapper is exported only on success,
+    # because pointing RUSTC_WRAPPER at a binary that was never installed
+    # would break every subsequent cargo invocation.
     - name: Run sccache
+      id: sccache
       if: inputs.sccache == 'true'
+      continue-on-error: true
       uses: mozilla/sccache-action@v0.0.11
+      with:
+        version: v0.17.0
+        disable_annotations: "true"
 
     - name: Enable sccache as the rustc wrapper
       if: inputs.sccache == 'true'
       shell: bash
       run: |
+        if [ "${{ steps.sccache.outcome }}" != "success" ]; then
+          echo "::warning::sccache install failed; building without it"
+          exit 0
+        fi
         {
           echo "SCCACHE_GHA_ENABLED=true"
           echo "RUSTC_WRAPPER=sccache"


### PR DESCRIPTION
## What broke

[Run 31576834062](https://github.com/0xPlaygrounds/rig/actions/runs/31576834062) on `main` went red on `stable / test guards` after 35s, before a single crate compiled. Two errors, both from `mozilla/sccache-action@v0.0.11`:

```
##[error]HttpError: self-signed certificate; if the root CA is installed locally, try running Node.js with --use-system-ca   # Run sccache
##[error]Unable to locate executable file: undefined                                                                        # Post Install Rust stable
```

Nothing in the commit under test is implicated — the other 12 jobs on the same commit passed, and `test guards` passes on adjacent branches.

**First error.** With no `version` input the action resolves the release at runtime:

```ts
if (version.length === 0) {
  const release = await octokit.rest.repos.getLatestRelease({owner: 'mozilla', repo: 'sccache'});
```

That API call is made on every run of every sccache-enabled job. This runner's egress proxy served a self-signed certificate, octokit threw, the step failed, and the job was over.

**Second error.** The action's post step is not optional and runs regardless, shelling out to `` `${process.env.SCCACHE_PATH}` --show-stats ``. The install never completed, so `SCCACHE_PATH` was unset and it failed on `undefined` — a second job failure from the same root cause, and one that `continue-on-error` on the install step alone would not have suppressed.

## The fix

- **`version: v0.17.0`** — removes the API call; the action goes straight to the release asset. v0.17.0 is what the unpinned lookup was already installing, so this is not a version change, and CI stops silently tracking whatever sccache ships next.
- **`disable_annotations: "true"`** — the post step returns before touching `SCCACHE_PATH`, so it can no longer fail. Costs the per-job cache-hit annotation.
- **`continue-on-error: true` + gated wrapper export** — sccache is now strictly best-effort. A failed download costs a slower compile and a `::warning::`, not a red run. `RUSTC_WRAPPER` is exported only when the install succeeded, so it never points at a missing binary.

Only `.github/actions/rust-setup/action.yml` changes; `sccache: "true"` is set by `stable / test` and `stable / test guards`, both of which run on this PR.