### PR TITLE
fix(openai): merge additional_params tools into chat completions tool list; record error-envelope coverage

### DIFF
--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -1860,7 +1860,7 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
 
         let history_has_tool_result = history_contains_tool_result(&full_history);
 
-        let (tools, tool_choice) = if supports_tools {
+        let (mut tools, tool_choice) = if supports_tools {
             let tool_choice = tool_choice.map(ToolChoice::try_from).transpose()?;
             let tools: Vec<ToolDefinition> = tools
                 .into_iter()
@@ -1879,6 +1879,55 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
             }
             (Vec::new(), None)
         };
+
+        // `additional_params` is flattened into the serialized request, so a raw
+        // `tools` array left in it would silently replace the typed `tools`
+        // field (the body is built via `serde_json::to_value`, where the
+        // flattened key wins). Merge its function tools into the typed list
+        // instead, mirroring the Responses API path (issue #1890). Entries that
+        // are not function tools stay behind for the provider's
+        // `prepare_request` hook — Groq, for one, folds its native tools
+        // (`{"type": "browser_search"}`, ...) into `compound_custom` from there.
+        let mut additional_params = additional_params;
+        if supports_tools
+            && let Some(map) = additional_params
+                .as_mut()
+                .and_then(serde_json::Value::as_object_mut)
+            && let Some(raw_tools) = map.remove("tools")
+        {
+            let raw_tools =
+                serde_json::from_value::<Vec<serde_json::Value>>(raw_tools).map_err(|err| {
+                    CompletionError::RequestError(
+                        format!(
+                            "Invalid OpenAI Chat Completions `additional_params.tools` payload: {err}"
+                        )
+                        .into(),
+                    )
+                })?;
+            let mut remaining = Vec::new();
+            for raw_tool in raw_tools {
+                let is_function_tool =
+                    raw_tool.get("type").and_then(serde_json::Value::as_str) == Some("function");
+                if is_function_tool {
+                    let tool =
+                        serde_json::from_value::<ToolDefinition>(raw_tool).map_err(|err| {
+                            CompletionError::RequestError(
+                                format!(
+                                    "Invalid function tool in OpenAI Chat Completions \
+                                 `additional_params.tools`: {err}"
+                                )
+                                .into(),
+                            )
+                        })?;
+                    tools.push(tool);
+                } else {
+                    remaining.push(raw_tool);
+                }
+            }
+            if !remaining.is_empty() {
+                map.insert("tools".to_string(), serde_json::Value::Array(remaining));
+            }
+        }
 
         if output_schema.is_some() && !supports_response_format {
             tracing::warn!(
@@ -2849,6 +2898,67 @@ mod tests {
             serde_json::to_value(openai_request).expect("serialization should succeed");
 
         assert!(serialized.get("max_tokens").is_none());
+    }
+
+    /// A mixed `additional_params.tools` array splits by shape: function tools
+    /// merge into the typed `tools` field (issue #1890 — left in the flattened
+    /// params they replace the typed field at serialization), while
+    /// non-function entries stay behind for the provider's `prepare_request`
+    /// hook (Groq folds its native tools into `compound_custom` from there).
+    /// Not a cassette test: OpenAI proper rejects non-function chat tools, so
+    /// the retained-entry half cannot be recorded against the live API.
+    #[test]
+    fn additional_params_function_tools_merge_and_native_tools_stay() {
+        let request = CoreCompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: vec!["Hello".into()],
+            documents: vec![],
+            tools: vec![crate::completion::ToolDefinition {
+                name: "builder_tool".to_string(),
+                description: "from the builder".to_string(),
+                parameters: serde_json::json!({"type": "object", "properties": {}}),
+            }],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: Some(serde_json::json!({
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "params_tool",
+                            "description": "from additional_params",
+                            "parameters": {"type": "object", "properties": {}}
+                        }
+                    },
+                    {"type": "browser_search"}
+                ]
+            })),
+            output_schema: None,
+            record_telemetry_content: false,
+        };
+
+        let openai_request = CompletionRequest::try_from(OpenAIRequestParams {
+            model: "gpt-4o-mini".to_string(),
+            request,
+            strict_tools: false,
+            tool_result_array_content: false,
+            supports_response_format: true,
+            supports_tools: true,
+        })
+        .expect("request conversion should succeed");
+
+        let names: Vec<&str> = openai_request
+            .tools
+            .iter()
+            .map(|tool| tool.function.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["builder_tool", "params_tool"]);
+        assert_eq!(
+            openai_request.additional_params,
+            Some(serde_json::json!({"tools": [{"type": "browser_search"}]}))
+        );
     }
 
     #[test]

--- a/tests/cassettes/anthropic/error_envelope/nonexistent_model_error_preserves_status_and_body.yaml
+++ b/tests/cassettes/anthropic/error_envelope/nonexistent_model_error_preserves_status_and_body.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":16,"messages":[{"content":[{"text":"Say hi.","type":"text"}],"role":"user"}],"model":"claude-nonexistent-rig-test"}'
+then:
+  status: 404
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"error":{"message":"model: claude-nonexistent-rig-test","type":"not_found_error"},"request_id":"req_REDACTED_1","type":"error"}'

--- a/tests/cassettes/anthropic/error_envelope/nonexistent_model_streaming_error_preserves_status_and_body.yaml
+++ b/tests/cassettes/anthropic/error_envelope/nonexistent_model_streaming_error_preserves_status_and_body.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":16,"messages":[{"content":[{"text":"Say hi.","type":"text"}],"role":"user"}],"model":"claude-nonexistent-rig-test","stream":true}'
+then:
+  status: 404
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"error":{"message":"model: claude-nonexistent-rig-test","type":"not_found_error"},"request_id":"req_REDACTED_1","type":"error"}'

--- a/tests/cassettes/gemini/error_envelope/nonexistent_model_error_preserves_status_and_body.yaml
+++ b/tests/cassettes/gemini/error_envelope/nonexistent_model_error_preserves_status_and_body.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1beta/models/gemini-nonexistent-rig-test:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Say hi.","thought":false}],"role":"user"}],"generationConfig":{"maxOutputTokens":16},"safetySettings":null,"systemInstruction":null,"toolConfig":null}'
+then:
+  status: 404
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"error":{"code":404,"message":"models/gemini-nonexistent-rig-test is not found for API version v1beta, or is not supported for generateContent. Call ModelService.ListModels to see the list of available models and their supported methods.","status":"NOT_FOUND"}}'

--- a/tests/cassettes/gemini/error_envelope/nonexistent_model_streaming_error_preserves_status_and_body.yaml
+++ b/tests/cassettes/gemini/error_envelope/nonexistent_model_streaming_error_preserves_status_and_body.yaml
@@ -1,0 +1,20 @@
+when:
+  path: /v1beta/models/gemini-nonexistent-rig-test:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Say hi.","thought":false}],"role":"user"}],"generationConfig":{"maxOutputTokens":16},"safetySettings":null,"systemInstruction":null,"toolConfig":null}'
+then:
+  status: 404
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: '{"error":{"code":404,"message":"models/gemini-nonexistent-rig-test is not found for API version v1beta, or is not supported for generateContent. Call ModelService.ListModels to see the list of available models and their supported methods.","status":"NOT_FOUND"}}'

--- a/tests/cassettes/openai/additional_params_tools/builder_tools_survive_additional_params_tools.yaml
+++ b/tests/cassettes/openai/additional_params_tools/builder_tools_survive_additional_params_tools.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/chat/completions
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"messages":[{"content":"Call the lookup_alpha tool now. Do not call any other tool.","role":"user"}],"model":"gpt-4o-mini","tool_choice":"required","tools":[{"function":{"description":"A zero-argument tool named lookup_alpha.","name":"lookup_alpha","parameters":{"properties":{},"required":[],"type":"object"}},"type":"function"},{"function":{"description":"Returns the beta signal. Only call when explicitly asked for beta.","name":"lookup_beta","parameters":{"additionalProperties":false,"properties":{},"type":"object"}},"type":"function"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"choices":[{"finish_reason":"tool_calls","index":0,"logprobs":null,"message":{"annotations":[],"content":null,"refusal":null,"role":"assistant","tool_calls":[{"function":{"arguments":"{}","name":"lookup_alpha"},"id":"call_REDACTED_1","type":"function"}]}}],"created":0,"id":"chatcmpl-REDACTED_1","model":"gpt-4o-mini-2024-07-18","object":"chat.completion","service_tier":"default","system_fingerprint":"fp_REDACTED_1","usage":{"completion_tokens":10,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":0,"rejected_prediction_tokens":0},"prompt_tokens":75,"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0},"total_tokens":85}}'

--- a/tests/cassettes/openai/error_envelope/nonexistent_model_error_preserves_status_and_body.yaml
+++ b/tests/cassettes/openai/error_envelope/nonexistent_model_error_preserves_status_and_body.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"input":[{"content":[{"text":"Say hi.","type":"input_text"}],"role":"user","type":"message"}],"max_output_tokens":16,"model":"gpt-4o-mini-nonexistent-rig-test"}'
+then:
+  status: 400
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"error":{"code":"model_not_found","message":"The requested model ''gpt-4o-mini-nonexistent-rig-test'' does not exist.","param":"model","type":"invalid_request_error"}}'

--- a/tests/cassettes/openai/error_envelope/nonexistent_model_streaming_error_preserves_status_and_body.yaml
+++ b/tests/cassettes/openai/error_envelope/nonexistent_model_streaming_error_preserves_status_and_body.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"input":[{"content":[{"text":"Say hi.","type":"input_text"}],"role":"user","type":"message"}],"max_output_tokens":16,"model":"gpt-4o-mini-nonexistent-rig-test","stream":true}'
+then:
+  status: 400
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"error":{"code":"model_not_found","message":"The requested model ''gpt-4o-mini-nonexistent-rig-test'' does not exist.","param":"model","type":"invalid_request_error"}}'

--- a/tests/providers/anthropic/cassette/error_envelope.rs
+++ b/tests/providers/anthropic/cassette/error_envelope.rs
@@ -1,0 +1,79 @@
+//! Anthropic error-envelope preservation, recorded from the real API.
+//!
+//! Locks down that a non-2xx provider response keeps its status and raw
+//! error body recoverable through `provider_response_status()` /
+//! `provider_response_body()`, for both the unary Messages path and the
+//! streaming path.
+//!
+//! Run cassette tests in replay mode by default, or set
+//! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
+use futures::StreamExt;
+use rig::completion::CompletionModel;
+use rig::prelude::*;
+
+use super::super::support::with_anthropic_cassette;
+
+#[tokio::test]
+async fn nonexistent_model_error_preserves_status_and_body() {
+    with_anthropic_cassette(
+        "error_envelope/nonexistent_model_error_preserves_status_and_body",
+        |client| async move {
+            let model = client.completion_model("claude-nonexistent-rig-test");
+            let request = model.completion_request("Say hi.").max_tokens(16).build();
+
+            let error = model
+                .completion(request)
+                .await
+                .expect_err("a nonexistent model should be a provider error");
+
+            let status = error
+                .provider_response_status()
+                .expect("provider status should be preserved");
+            assert_eq!(status.as_u16(), 404, "unexpected status: {status}");
+
+            let body = error
+                .provider_response_json()
+                .expect("provider error body should be JSON")
+                .expect("provider error body should be present");
+            assert_eq!(body["type"], "error");
+            assert_eq!(body["error"]["type"], "not_found_error");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn nonexistent_model_streaming_error_preserves_status_and_body() {
+    with_anthropic_cassette(
+        "error_envelope/nonexistent_model_streaming_error_preserves_status_and_body",
+        |client| async move {
+            let model = client.completion_model("claude-nonexistent-rig-test");
+            let request = model.completion_request("Say hi.").max_tokens(16).build();
+
+            // The SSE connection opens lazily, so the HTTP error may surface
+            // either from `stream()` itself or as the first stream item.
+            let error = match model.stream(request).await {
+                Err(error) => error,
+                Ok(mut stream) => match stream.next().await {
+                    Some(Err(error)) => error,
+                    Some(Ok(item)) => {
+                        panic!("expected a provider error, got stream item: {item:?}")
+                    }
+                    None => panic!("stream ended without surfacing the provider error"),
+                },
+            };
+
+            let status = error
+                .provider_response_status()
+                .expect("provider status should be preserved");
+            assert_eq!(status.as_u16(), 404, "unexpected status: {status}");
+
+            let body = error
+                .provider_response_json()
+                .expect("provider error body should be JSON")
+                .expect("provider error body should be present");
+            assert_eq!(body["error"]["type"], "not_found_error");
+        },
+    )
+    .await;
+}

--- a/tests/providers/anthropic/mod.rs
+++ b/tests/providers/anthropic/mod.rs
@@ -5,6 +5,7 @@ mod cassette {
     mod default_max_turns;
     mod document_file_id;
     mod empty_end_turn;
+    mod error_envelope;
     mod image;
     mod messages_behaviors;
     mod messages_sessions;

--- a/tests/providers/gemini/cassette/error_envelope.rs
+++ b/tests/providers/gemini/cassette/error_envelope.rs
@@ -1,0 +1,78 @@
+//! Gemini error-envelope preservation, recorded from the real API.
+//!
+//! Locks down that a non-2xx provider response keeps its status and raw
+//! error body recoverable through `provider_response_status()` /
+//! `provider_response_body()`, for both the unary generateContent path and
+//! the streaming path.
+//!
+//! Run cassette tests in replay mode by default, or set
+//! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
+use futures::StreamExt;
+use rig::completion::CompletionModel;
+use rig::prelude::*;
+
+use super::super::support::with_gemini_cassette;
+
+#[tokio::test]
+async fn nonexistent_model_error_preserves_status_and_body() {
+    with_gemini_cassette(
+        "error_envelope/nonexistent_model_error_preserves_status_and_body",
+        |client| async move {
+            let model = client.completion_model("gemini-nonexistent-rig-test");
+            let request = model.completion_request("Say hi.").max_tokens(16).build();
+
+            let error = model
+                .completion(request)
+                .await
+                .expect_err("a nonexistent model should be a provider error");
+
+            let status = error
+                .provider_response_status()
+                .expect("provider status should be preserved");
+            assert_eq!(status.as_u16(), 404, "unexpected status: {status}");
+
+            let body = error
+                .provider_response_json()
+                .expect("provider error body should be JSON")
+                .expect("provider error body should be present");
+            assert_eq!(body["error"]["status"], "NOT_FOUND");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn nonexistent_model_streaming_error_preserves_status_and_body() {
+    with_gemini_cassette(
+        "error_envelope/nonexistent_model_streaming_error_preserves_status_and_body",
+        |client| async move {
+            let model = client.completion_model("gemini-nonexistent-rig-test");
+            let request = model.completion_request("Say hi.").max_tokens(16).build();
+
+            // The SSE connection opens lazily, so the HTTP error may surface
+            // either from `stream()` itself or as the first stream item.
+            let error = match model.stream(request).await {
+                Err(error) => error,
+                Ok(mut stream) => match stream.next().await {
+                    Some(Err(error)) => error,
+                    Some(Ok(item)) => {
+                        panic!("expected a provider error, got stream item: {item:?}")
+                    }
+                    None => panic!("stream ended without surfacing the provider error"),
+                },
+            };
+
+            let status = error
+                .provider_response_status()
+                .expect("provider status should be preserved");
+            assert_eq!(status.as_u16(), 404, "unexpected status: {status}");
+
+            let body = error
+                .provider_response_json()
+                .expect("provider error body should be JSON")
+                .expect("provider error body should be present");
+            assert_eq!(body["error"]["status"], "NOT_FOUND");
+        },
+    )
+    .await;
+}

--- a/tests/providers/gemini/mod.rs
+++ b/tests/providers/gemini/mod.rs
@@ -14,6 +14,7 @@ mod cassette {
     mod document_ordering;
     mod dynamic_tools;
     mod embeddings;
+    mod error_envelope;
     mod extractor;
     mod generate_behaviors;
     mod generate_sessions;

--- a/tests/providers/openai/cassette/additional_params_tools.rs
+++ b/tests/providers/openai/cassette/additional_params_tools.rs
@@ -1,0 +1,68 @@
+//! Chat Completions: builder tools must survive `additional_params` that also
+//! carries a `tools` key (issue #1890).
+//!
+//! The chat request body flattens `additional_params` into the serialized
+//! struct, so a raw `tools` array supplied there used to silently *replace*
+//! the builder's function tools (the body is built via `serde_json::to_value`,
+//! where the flattened key wins last). The intended contract — matching the
+//! Responses API path, which merges `additional_params["tools"]` into the
+//! typed tool list — is that both sets reach the wire.
+//!
+//! Run cassette tests in replay mode by default, or set
+//! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
+use rig::completion::CompletionModel;
+use rig::message::{AssistantContent, ToolChoice};
+use rig::prelude::*;
+
+use super::super::support::with_openai_completions_cassette;
+use crate::support::zero_arg_tool_definition;
+
+#[tokio::test]
+async fn builder_tools_survive_additional_params_tools() {
+    with_openai_completions_cassette(
+        "additional_params_tools/builder_tools_survive_additional_params_tools",
+        |client| async move {
+            let model = client.completion_model("gpt-4o-mini");
+            let request = model
+                .completion_request(
+                    "Call the lookup_alpha tool now. Do not call any other tool.",
+                )
+                .tool(zero_arg_tool_definition("lookup_alpha"))
+                .tool_choice(ToolChoice::Required)
+                .additional_params(serde_json::json!({
+                    "tools": [{
+                        "type": "function",
+                        "function": {
+                            "name": "lookup_beta",
+                            "description": "Returns the beta signal. Only call when explicitly asked for beta.",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": false
+                            }
+                        }
+                    }]
+                }))
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("completion should succeed");
+
+            let called: Vec<&str> = response
+                .choice
+                .iter()
+                .filter_map(|content| match content {
+                    AssistantContent::ToolCall(call) => Some(call.function.name.as_str()),
+                    _ => None,
+                })
+                .collect();
+            assert!(
+                called.contains(&"lookup_alpha"),
+                "the builder-registered tool should reach the wire and be callable; got {called:?}"
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/openai/cassette/error_envelope.rs
+++ b/tests/providers/openai/cassette/error_envelope.rs
@@ -1,0 +1,85 @@
+//! OpenAI error-envelope preservation, recorded from the real API.
+//!
+//! Locks down that a non-2xx provider response keeps its status and raw
+//! error body recoverable through `provider_response_status()` /
+//! `provider_response_body()`, for both the unary Responses API path and
+//! the streaming path.
+//!
+//! Run cassette tests in replay mode by default, or set
+//! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
+use futures::StreamExt;
+use rig::completion::CompletionModel;
+use rig::prelude::*;
+
+use super::super::support::with_openai_cassette;
+
+#[tokio::test]
+async fn nonexistent_model_error_preserves_status_and_body() {
+    with_openai_cassette(
+        "error_envelope/nonexistent_model_error_preserves_status_and_body",
+        |client| async move {
+            let model = client.completion_model("gpt-4o-mini-nonexistent-rig-test");
+            let request = model.completion_request("Say hi.").max_tokens(16).build();
+
+            let error = model
+                .completion(request)
+                .await
+                .expect_err("a nonexistent model should be a provider error");
+
+            let status = error
+                .provider_response_status()
+                .expect("provider status should be preserved");
+            assert_eq!(status.as_u16(), 400, "unexpected status: {status}");
+
+            let body = error
+                .provider_response_json()
+                .expect("provider error body should be JSON")
+                .expect("provider error body should be present");
+            assert_eq!(body["error"]["code"], "model_not_found");
+            assert!(
+                body["error"]["message"]
+                    .as_str()
+                    .expect("error message should be a string")
+                    .contains("gpt-4o-mini-nonexistent-rig-test"),
+                "error message should name the model: {body}"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn nonexistent_model_streaming_error_preserves_status_and_body() {
+    with_openai_cassette(
+        "error_envelope/nonexistent_model_streaming_error_preserves_status_and_body",
+        |client| async move {
+            let model = client.completion_model("gpt-4o-mini-nonexistent-rig-test");
+            let request = model.completion_request("Say hi.").max_tokens(16).build();
+
+            // The SSE connection opens lazily, so the HTTP error may surface
+            // either from `stream()` itself or as the first stream item.
+            let error = match model.stream(request).await {
+                Err(error) => error,
+                Ok(mut stream) => match stream.next().await {
+                    Some(Err(error)) => error,
+                    Some(Ok(item)) => {
+                        panic!("expected a provider error, got stream item: {item:?}")
+                    }
+                    None => panic!("stream ended without surfacing the provider error"),
+                },
+            };
+
+            let status = error
+                .provider_response_status()
+                .expect("provider status should be preserved");
+            assert_eq!(status.as_u16(), 400, "unexpected status: {status}");
+
+            let body = error
+                .provider_response_json()
+                .expect("provider error body should be JSON")
+                .expect("provider error body should be present");
+            assert_eq!(body["error"]["code"], "model_not_found");
+        },
+    )
+    .await;
+}

--- a/tests/providers/openai/mod.rs
+++ b/tests/providers/openai/mod.rs
@@ -3,10 +3,12 @@ mod support;
 mod regressions;
 
 mod cassette {
+    mod additional_params_tools;
     mod agent;
     mod chat_history;
     mod completions_api;
     mod document_ordering;
+    mod error_envelope;
     mod extractor;
     mod extractor_usage;
     mod gpt_5_6_reasoning;


### PR DESCRIPTION
## Summary

Live-traffic bug hunt against the OpenAI, Anthropic, and Gemini providers: new cassette-backed tests were recorded against the real APIs until a genuine defect surfaced; the defect is fixed here with a cassette-backed regression test, and the passing coverage recorded along the way ships too.

## Bug found and fixed

**OpenAI Chat Completions: `additional_params["tools"]` silently replaced builder-registered tools** (issue #1890's chat-path half).

- **Symptom** (reproduced live, recorded): building a request with `.tool(...)` plus `additional_params(json!({"tools": [...]}))` sent only the `additional_params` tools to the wire. With `tool_choice: required` and a prompt demanding the builder tool, the model was *forced to call the wrong tool* — the recorded pre-fix traffic shows the request body containing only the raw `tools` array, and the model answering with `lookup_beta` when told to call `lookup_alpha`.
- **Root cause**: `providers/openai/completion/mod.rs` flattens `additional_params` into the serialized `CompletionRequest`. The body is built via `serde_json::to_value`, where the flattened `tools` key wins over the typed `tools` field — a silent last-write-wins clobber. Every sibling path already merges instead: the Responses API (`responses_api/mod.rs`), Anthropic (`build_tool_definitions`), and Gemini (`extract_tools_from_additional_params`). The chat path was the one hole.
- **Fix**: extract `tools` from `additional_params` in `TryFrom<OpenAIRequestParams> for CompletionRequest` and append it to the typed tool list, mirroring the Responses-path semantics including the loud `RequestError` on a malformed payload.
- **Proof**: `tests/providers/openai/cassette/additional_params_tools.rs` + `tests/cassettes/openai/additional_params_tools/builder_tools_survive_additional_params_tools.yaml` — a fresh post-fix recording whose request body carries **both** tools and whose response calls `lookup_alpha`. The cassette harness matches the outbound body, so any regression back to the clobber fails replay as a mock miss.

## New coverage recorded (independent of the fix)

Error-envelope preservation had **zero** non-2xx interactions in any committed cassette. Six new recordings (unary + streaming per provider) now pin that a real provider error keeps its status and raw body recoverable through `provider_response_status()` / `provider_response_body()`:

- `openai/error_envelope/*` — Responses API, 400 `model_not_found` (note: OpenAI returns **400**, not 404, for an unknown model)
- `anthropic/error_envelope/*` — Messages API, 404 `not_found_error`
- `gemini/error_envelope/*` — generateContent + streamGenerateContent, 404 `NOT_FOUND` (the streaming error arrives on an SSE-content-type response and still surfaces correctly)

These also document that the streaming paths surface the pre-stream HTTP error lazily (from the first poll of the stream), which the tests capture.

## Tracker sweep

All 72 open issues and 52 open PRs were read in full (including comments). Classification:

**Addressed here**
- #1890 (chat-path half): fixed as above. The Responses-path half (hosted `tools` via `additional_params`) was found to already merge correctly on main (`responses_api/mod.rs` removes and merges the key); the issue's remaining ask — first-class `provider_tools()` consumption — is a feature, not fixed here.

**In scope, reproduced or verified, left as follow-ups (open fix PRs exist or fix is a larger surface)**
- #2210 / PR #2211 — response headers (incl. `Retry-After`) structurally dropped on non-success errors; an open PR fixes it. The new error-envelope cassettes confirm bodies/status survive; headers need #2211's new API surface.
- #2269 / PR #2234 — OpenAI Responses `phase` field dropped on message items; `compaction` input items rejected. Overlaps the open compaction PR; fixing `phase` preservation independently risks conflicting with #2234's item-model changes.
- #2170 / PR #2171 — Responses prompt-cache options silently dropped; open PR ships the fix with its own cassette.
- #2168 / PR #2169 — Anthropic per-block `cache_control` discarded; open PR ships the fix with cassettes.
- PR #2255 (Azure tool-call deserialization), PR #2264 (image-gen `additional_params` drop), PR #1480 (adaptive thinking), PR #1221 (embeddings batch token limit), #1593 (telemetry accounting) — each has an open PR or needs keys/surface outside this run's scope.

**Adjacent** (PRs touching these providers that would benefit from recorded regression tests, not added here to avoid churn against their in-flight diffs): #2243, #2234, #1905, #1867, #1185, #2121, #2190, #1279.

**Out of scope**: all remaining open items are other providers, features, docs, or infra — full classification list available in the sweep notes; representative: #2291/#2290 (Mistral), #2241/#2263 (Cohere), #2156 (Ollama), #2292 (CI), #2284/#2278 (agent surface), #2229/#2228 (refactors), etc.

## Recording matrix

| Scenario | Provider | Kind | Outcome |
|---|---|---|---|
| error_envelope unary | openai, anthropic, gemini | coverage gap | recorded, pass |
| error_envelope streaming | openai, anthropic, gemini | coverage gap | recorded, pass |
| additional_params tools clobber | openai (chat) | tracker #1890 | **bug reproduced live → fixed → re-recorded, pass** |

Cassettes: 7 newly recorded, 0 re-recorded (the fix changes the wire body only for requests carrying `additional_params.tools`, and no pre-existing cassette does), 0 touched otherwise. Hygiene review done file-by-file: keys/`request_id`s redacted by the scrubber, no secrets, no unrelated captures, placeholders redact rather than fabricate.

## Verification

- `cargo fmt` — clean
- `cargo clippy --all-targets --all-features` — clean (no errors, no new warnings)
- `cargo test -p rig-core --all-features` — 1325 lib tests + doctests pass (includes a new unit test for the mixed function/native `additional_params.tools` split, which also keeps Groq's `compound_custom` native-tool folding intact)
- Replay suites (`--test-threads=1`): openai 108 passed / anthropic 79 passed / gemini 131 passed (baselines before any change: 105 / 77 / 129 passed, all green — no pre-existing failures)

## Estimated API spend

Under $0.05 total: six error-envelope recordings are rejected requests (no tokens billed), and the two `gpt-4o-mini` tool-call recordings used ~100 tokens each.
