### PR TITLE
refactor: consolidate provider schema/normalization and agent plumbing (net −365 production LOC)

### DIFF
--- a/crates/rig-agent/src/agent/builder.rs
+++ b/crates/rig-agent/src/agent/builder.rs
@@ -462,27 +462,6 @@ impl AgentBuilder<NoToolConfig> {
         self.into_tool_builder().tool(tool)
     }
 
-    /// Add one runtime-defined tool to the agent.
-    pub fn dynamic_tool(self, tool: DynamicTool) -> AgentBuilder<WithBuilderTools> {
-        self.into_tool_builder().dynamic_tool(tool)
-    }
-
-    /// Add one context-free dynamic tool through the classic registry adapter.
-    pub fn portable_dynamic_tool(
-        self,
-        tool: PortableDynamicTool,
-    ) -> AgentBuilder<WithBuilderTools> {
-        self.into_tool_builder().portable_dynamic_tool(tool)
-    }
-
-    /// Add runtime-defined tools to the agent.
-    ///
-    /// This is useful when tool definitions and callbacks are constructed at runtime.
-    /// Transitions the builder to the `WithBuilderTools` state.
-    pub fn dynamic_tools(self, tools: Vec<DynamicTool>) -> AgentBuilder<WithBuilderTools> {
-        self.into_tool_builder().dynamic_tools(tools)
-    }
-
     /// Add an MCP tool (from `rmcp`) to the agent, bounded by
     /// [`DEFAULT_MCP_TOOL_TIMEOUT`](crate::tool::rmcp::DEFAULT_MCP_TOOL_TIMEOUT)
     /// (see issue #1914). Use [`rmcp_tool_with_timeout`](Self::rmcp_tool_with_timeout)
@@ -516,6 +495,45 @@ impl AgentBuilder<NoToolConfig> {
         self.rmcp_tools_with_timeout(vec![tool], client, timeout)
     }
 
+    /// Build the agent with no tools configured.
+    ///
+    /// An empty `ToolServer` will be created for the agent.
+    pub fn build(self) -> Agent {
+        self.build_agent(|_| ToolServer::new().run())
+    }
+}
+
+/// Generate the `NoToolConfig` tool methods that transition into the
+/// `WithBuilderTools` state by forwarding verbatim through
+/// [`AgentBuilder::into_tool_builder`] to the `WithBuilderTools` method of the
+/// same name. Doc comments live at each invocation; `tool` (generic over the
+/// tool type) and the single-tool rmcp helpers stay hand-written above.
+macro_rules! forward_into_tool_builder {
+    ($( $(#[$attr:meta])* $name:ident ( $($arg:ident : $ty:ty),* $(,)? ) );* $(;)?) => {
+        impl AgentBuilder<NoToolConfig> {
+            $(
+                $(#[$attr])*
+                pub fn $name(self, $($arg: $ty),*) -> AgentBuilder<WithBuilderTools> {
+                    self.into_tool_builder().$name($($arg),*)
+                }
+            )*
+        }
+    };
+}
+
+forward_into_tool_builder! {
+    /// Add one runtime-defined tool to the agent.
+    dynamic_tool(tool: DynamicTool);
+
+    /// Add one context-free dynamic tool through the classic registry adapter.
+    portable_dynamic_tool(tool: PortableDynamicTool);
+
+    /// Add runtime-defined tools to the agent.
+    ///
+    /// This is useful when tool definitions and callbacks are constructed at runtime.
+    /// Transitions the builder to the `WithBuilderTools` state.
+    dynamic_tools(tools: Vec<DynamicTool>);
+
     /// Add an array of MCP tools (from `rmcp`) to the agent, each bounded by
     /// [`DEFAULT_MCP_TOOL_TIMEOUT`](crate::tool::rmcp::DEFAULT_MCP_TOOL_TIMEOUT)
     /// (see issue #1914). Use [`rmcp_tools_with_timeout`](Self::rmcp_tools_with_timeout)
@@ -524,13 +542,7 @@ impl AgentBuilder<NoToolConfig> {
     /// Transitions the builder to the `WithBuilderTools` state.
     #[cfg(all(feature = "rmcp", not(target_family = "wasm")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "rmcp")))]
-    pub fn rmcp_tools(
-        self,
-        tools: Vec<rmcp::model::Tool>,
-        client: rmcp::service::ServerSink,
-    ) -> AgentBuilder<WithBuilderTools> {
-        self.rmcp_tools_with_timeout(tools, client, crate::tool::rmcp::DEFAULT_MCP_TOOL_TIMEOUT)
-    }
+    rmcp_tools(tools: Vec<rmcp::model::Tool>, client: rmcp::service::ServerSink);
 
     /// Add an array of MCP tools (from `rmcp`) with a per-call timeout (see
     /// issue #1914).
@@ -541,52 +553,20 @@ impl AgentBuilder<NoToolConfig> {
     /// Transitions the builder to the `WithBuilderTools` state.
     #[cfg(all(feature = "rmcp", not(target_family = "wasm")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "rmcp")))]
-    pub fn rmcp_tools_with_timeout(
-        self,
+    rmcp_tools_with_timeout(
         tools: Vec<rmcp::model::Tool>,
         client: rmcp::service::ServerSink,
-        timeout: impl Into<Option<std::time::Duration>>,
-    ) -> AgentBuilder<WithBuilderTools> {
-        self.with_rmcp_toolset(build_rmcp_tools(tools, client, timeout.into()))
-    }
-
-    /// Transition into the `WithBuilderTools` state carrying the given built
-    /// MCP tools.
-    #[cfg(all(feature = "rmcp", not(target_family = "wasm")))]
-    fn with_rmcp_toolset(self, built: Vec<RmcpTool>) -> AgentBuilder<WithBuilderTools> {
-        let mut tools = ToolSet::default();
-        for tool in built {
-            tools.add_erased(std::sync::Arc::new(tool));
-        }
-        self.with_tool_state(WithBuilderTools {
-            tools,
-            retrieval_indexes: vec![],
-        })
-    }
+        timeout: impl Into<Option<std::time::Duration>>
+    );
 
     /// Configure tools retrieved from a vector index for each prompt.
     ///
     /// Transitions the builder to the `WithBuilderTools` state.
-    pub fn retrieved_tools(
-        self,
+    retrieved_tools(
         sample: usize,
         index: impl VectorStoreIndexDyn + Send + Sync + 'static,
-        toolset: ToolSet,
-    ) -> AgentBuilder<WithBuilderTools> {
-        let mut tools = ToolSet::default();
-        tools.add_retrievable_tools(toolset);
-        self.with_tool_state(WithBuilderTools {
-            tools,
-            retrieval_indexes: vec![(sample, Arc::new(index))],
-        })
-    }
-
-    /// Build the agent with no tools configured.
-    ///
-    /// An empty `ToolServer` will be created for the agent.
-    pub fn build(self) -> Agent {
-        self.build_agent(|_| ToolServer::new().run())
-    }
+        toolset: ToolSet
+    );
 }
 
 impl AgentBuilder<WithToolServerHandle> {

--- a/crates/rig-agent/src/agent/hook.rs
+++ b/crates/rig-agent/src/agent/hook.rs
@@ -1442,6 +1442,21 @@ where
     A::CONTINUE
 }
 
+/// Generate the `HookStack` methods whose dispatch is exactly
+/// [`first_non_continue`] over the erased hooks: `(on_* name, erased name,
+/// event type, action type)`, mirroring `for_each_boxed_hook_event!`. The
+/// genuinely chaining events (`on_model_select`, `on_completion_call`,
+/// `on_invalid_tool_call`, `on_tool_call`, `on_tool_result`) stay hand-written.
+macro_rules! stack_first_non_continue {
+    ($($on:ident, $erased:ident, $event:ident, $action:ident;)+) => {
+        $(
+            async fn $on(&self, ctx: &HookContext, event: $event<'_>) -> $action {
+                first_non_continue(&self.hooks, |hook| hook.$erased(ctx, event)).await
+            }
+        )+
+    };
+}
+
 impl AgentHook for HookStack {
     fn on_model_select(
         &self,
@@ -1490,19 +1505,13 @@ impl AgentHook for HookStack {
         }
     }
 
-    async fn on_completion_response(
-        &self,
-        ctx: &HookContext,
-        event: CompletionResponse<'_>,
-    ) -> ObservationAction {
-        first_non_continue(&self.hooks, |hook| hook.completion_response(ctx, event)).await
-    }
-    async fn on_model_turn_finished(
-        &self,
-        ctx: &HookContext,
-        event: ModelTurnFinished<'_>,
-    ) -> ModelTurnAction {
-        first_non_continue(&self.hooks, |hook| hook.model_turn_finished(ctx, event)).await
+    stack_first_non_continue! {
+        on_completion_response, completion_response, CompletionResponse, ObservationAction;
+        on_model_turn_finished, model_turn_finished, ModelTurnFinished, ModelTurnAction;
+        on_text_delta, text_delta, TextDelta, ObservationAction;
+        on_reasoning_delta, reasoning_delta, ReasoningDelta, ObservationAction;
+        on_tool_call_delta, tool_call_delta, ToolCallDelta, ObservationAction;
+        on_stream_response_finish, stream_response_finish, StreamResponseFinish, ObservationAction;
     }
     async fn on_invalid_tool_call(
         &self,
@@ -1544,30 +1553,6 @@ impl AgentHook for HookStack {
             }
         }
         effective.map_or(ToolResultAction::Keep, ToolResultAction::Rewrite)
-    }
-    async fn on_text_delta(&self, ctx: &HookContext, event: TextDelta<'_>) -> ObservationAction {
-        first_non_continue(&self.hooks, |hook| hook.text_delta(ctx, event)).await
-    }
-    async fn on_reasoning_delta(
-        &self,
-        ctx: &HookContext,
-        event: ReasoningDelta<'_>,
-    ) -> ObservationAction {
-        first_non_continue(&self.hooks, |hook| hook.reasoning_delta(ctx, event)).await
-    }
-    async fn on_tool_call_delta(
-        &self,
-        ctx: &HookContext,
-        event: ToolCallDelta<'_>,
-    ) -> ObservationAction {
-        first_non_continue(&self.hooks, |hook| hook.tool_call_delta(ctx, event)).await
-    }
-    async fn on_stream_response_finish(
-        &self,
-        ctx: &HookContext,
-        event: StreamResponseFinish<'_>,
-    ) -> ObservationAction {
-        first_non_continue(&self.hooks, |hook| hook.stream_response_finish(ctx, event)).await
     }
     fn observes(&self, kind: StepEventKind) -> bool {
         self.hooks.iter().any(|hook| hook.observes(kind))

--- a/crates/rig-agent/src/agent/run/streamed.rs
+++ b/crates/rig-agent/src/agent/run/streamed.rs
@@ -340,12 +340,32 @@ struct ReasoningPart {
     state: ReasoningPartState,
 }
 
+#[derive(Clone)]
 enum ReasoningPartState {
     /// Delta text accumulated so far for a part with no completed block.
     Pending(String),
     /// The authoritative completed block (may carry signatures or encrypted
     /// content the deltas lacked).
     Completed(Reasoning),
+}
+
+/// Assemble one part's reasoning: a completed block as-is, a non-empty pending
+/// delta buffer as its own block carrying only the part's provider-issued id.
+fn reasoning_from_part(
+    state: ReasoningPartState,
+    provider_id: Option<String>,
+) -> Option<Reasoning> {
+    match state {
+        ReasoningPartState::Completed(reasoning) => Some(reasoning),
+        ReasoningPartState::Pending(text) if !text.is_empty() => {
+            let mut assembled = Reasoning::new(&text);
+            if let Some(id) = provider_id {
+                assembled = assembled.with_id(id);
+            }
+            Some(assembled)
+        }
+        ReasoningPartState::Pending(_) => None,
+    }
 }
 
 enum PendingInvalid {
@@ -495,27 +515,22 @@ impl StreamedTurnAssembler {
         // completed block always carries the whole content, the
         // accumulator having merged signatures before yielding). Checked
         // before the provider-id fallbacks so a signed restatement can
-        // never double-extend its own part.
-        let same_part = self
+        // never double-extend its own part. Failing that, the block
+        // supersedes a pending part sharing its durable provider id.
+        let replace_at = self
             .reasoning_parts
-            .iter_mut()
-            .find(|part| part.correlator.as_deref() == Some(correlator));
-        if let Some(part) = same_part {
-            if reasoning.id.is_some() {
-                part.provider_id = reasoning.id.clone();
-            }
-            part.state = ReasoningPartState::Completed(reasoning.clone());
-            return;
-        }
-
-        let superseded = self.reasoning_parts.iter_mut().find(|part| {
-            matches!(part.state, ReasoningPartState::Pending(_))
-                && matches!(
-                    (&part.provider_id, &reasoning.id),
-                    (Some(pending_id), Some(incoming_id)) if pending_id == incoming_id
-                )
-        });
-        if let Some(part) = superseded {
+            .iter()
+            .position(|part| part.correlator.as_deref() == Some(correlator))
+            .or_else(|| {
+                self.reasoning_parts.iter().position(|part| {
+                    matches!(part.state, ReasoningPartState::Pending(_))
+                        && matches!(
+                            (&part.provider_id, &reasoning.id),
+                            (Some(pending_id), Some(incoming_id)) if pending_id == incoming_id
+                        )
+                })
+            });
+        if let Some(part) = replace_at.and_then(|index| self.reasoning_parts.get_mut(index)) {
             if reasoning.id.is_some() {
                 part.provider_id = reasoning.id.clone();
             }
@@ -552,17 +567,7 @@ impl StreamedTurnAssembler {
     fn assembled_reasoning(&self) -> Vec<Reasoning> {
         self.reasoning_parts
             .iter()
-            .filter_map(|part| match &part.state {
-                ReasoningPartState::Completed(reasoning) => Some(reasoning.clone()),
-                ReasoningPartState::Pending(text) if !text.is_empty() => {
-                    let mut assembled = Reasoning::new(text);
-                    if let Some(id) = part.provider_id.clone() {
-                        assembled = assembled.with_id(id);
-                    }
-                    Some(assembled)
-                }
-                ReasoningPartState::Pending(_) => None,
-            })
+            .filter_map(|part| reasoning_from_part(part.state.clone(), part.provider_id.clone()))
             .collect()
     }
 
@@ -572,17 +577,7 @@ impl StreamedTurnAssembler {
     fn drain_reasoning(&mut self) -> Vec<Reasoning> {
         std::mem::take(&mut self.reasoning_parts)
             .into_iter()
-            .filter_map(|part| match part.state {
-                ReasoningPartState::Completed(reasoning) => Some(reasoning),
-                ReasoningPartState::Pending(text) if !text.is_empty() => {
-                    let mut assembled = Reasoning::new(&text);
-                    if let Some(id) = part.provider_id {
-                        assembled = assembled.with_id(id);
-                    }
-                    Some(assembled)
-                }
-                ReasoningPartState::Pending(_) => None,
-            })
+            .filter_map(|part| reasoning_from_part(part.state, part.provider_id))
             .collect()
     }
 

--- a/crates/rig-agent/src/extractor.rs
+++ b/crates/rig-agent/src/extractor.rs
@@ -96,6 +96,37 @@ where
     model: Option<ModelHandle>,
 }
 
+/// Generate the `Extractor` methods that delegate to the same-named
+/// [`ExtractorRun`] method on [`Extractor::default_run`], appending the
+/// retry-semantics doc paragraphs shared by all of them. Methods marked
+/// `=> usage` also carry the shared usage-accounting paragraph.
+macro_rules! forward_default_run {
+    (@usage_doc usage) => {
+        "\nUsage accumulates across all retry attempts, including attempts that received\n\
+         a billed response but failed extraction (e.g. the model never called `submit`).\n\
+         Attempts whose completion call itself returned an error (e.g. network failures\n\
+         or unparseable provider responses) contribute no usage, and when every attempt\n\
+         fails the returned error carries no usage information at all."
+    };
+    ($( $(#[$attr:meta])* $name:ident ( $($arg:ident : $ty:ty),* ) -> $ret:ty
+        $(=> $usage:ident)?; )+) => {$(
+        $(#[$attr])*
+        ///
+        /// The function will retry the extraction if the initial attempt fails or
+        /// if the model does not call the `submit` tool.
+        ///
+        /// The number of retries is determined by the `retries` field on the Extractor struct.
+        $(#[doc = forward_default_run!(@usage_doc $usage)])?
+        pub async fn $name(
+            &self,
+            text: impl Into<Message> + WasmCompatSend,
+            $($arg: $ty),*
+        ) -> Result<$ret, ExtractionError> {
+            self.default_run().$name(text $(, $arg)*).await
+        }
+    )+};
+}
+
 impl<T> Extractor<T>
 where
     T: JsonSchema + for<'a> Deserialize<'a> + WasmCompatSend + WasmCompatSync,
@@ -133,77 +164,22 @@ where
         self.using_model(ModelHandle::new(model))
     }
 
-    /// Attempts to extract data from the given text with a number of retries.
-    ///
-    /// The function will retry the extraction if the initial attempt fails or
-    /// if the model does not call the `submit` tool.
-    ///
-    /// The number of retries is determined by the `retries` field on the Extractor struct.
-    pub async fn extract(
-        &self,
-        text: impl Into<Message> + WasmCompatSend,
-    ) -> Result<T, ExtractionError> {
-        self.default_run().extract(text).await
-    }
+    forward_default_run! {
+        /// Attempts to extract data from the given text with a number of retries.
+        extract() -> T;
 
-    /// Attempts to extract data from the given text with a number of retries.
-    ///
-    /// The function will retry the extraction if the initial attempt fails or
-    /// if the model does not call the `submit` tool.
-    ///
-    /// The number of retries is determined by the `retries` field on the Extractor struct.
-    pub async fn extract_with_chat_history(
-        &self,
-        text: impl Into<Message> + WasmCompatSend,
-        chat_history: Vec<Message>,
-    ) -> Result<T, ExtractionError> {
-        self.default_run()
-            .extract_with_chat_history(text, chat_history)
-            .await
-    }
+        /// Attempts to extract data from the given text with a number of retries.
+        extract_with_chat_history(chat_history: Vec<Message>) -> T;
 
-    /// Attempts to extract data from the given text with a number of retries,
-    /// returning both the extracted data and accumulated token usage.
-    ///
-    /// The function will retry the extraction if the initial attempt fails or
-    /// if the model does not call the `submit` tool.
-    ///
-    /// The number of retries is determined by the `retries` field on the Extractor struct.
-    ///
-    /// Usage accumulates across all retry attempts, including attempts that received
-    /// a billed response but failed extraction (e.g. the model never called `submit`).
-    /// Attempts whose completion call itself returned an error (e.g. network failures
-    /// or unparseable provider responses) contribute no usage, and when every attempt
-    /// fails the returned error carries no usage information at all.
-    pub async fn extract_with_usage(
-        &self,
-        text: impl Into<Message> + WasmCompatSend,
-    ) -> Result<ExtractionResponse<T>, ExtractionError> {
-        self.default_run().extract_with_usage(text).await
-    }
+        /// Attempts to extract data from the given text with a number of retries,
+        /// returning both the extracted data and accumulated token usage.
+        extract_with_usage() -> ExtractionResponse<T> => usage;
 
-    /// Attempts to extract data from the given text with a number of retries,
-    /// providing chat history context, and returning both the extracted data
-    /// and accumulated token usage.
-    ///
-    /// The function will retry the extraction if the initial attempt fails or
-    /// if the model does not call the `submit` tool.
-    ///
-    /// The number of retries is determined by the `retries` field on the Extractor struct.
-    ///
-    /// Usage accumulates across all retry attempts, including attempts that received
-    /// a billed response but failed extraction (e.g. the model never called `submit`).
-    /// Attempts whose completion call itself returned an error (e.g. network failures
-    /// or unparseable provider responses) contribute no usage, and when every attempt
-    /// fails the returned error carries no usage information at all.
-    pub async fn extract_with_chat_history_with_usage(
-        &self,
-        text: impl Into<Message> + WasmCompatSend,
-        chat_history: Vec<Message>,
-    ) -> Result<ExtractionResponse<T>, ExtractionError> {
-        self.default_run()
-            .extract_with_chat_history_with_usage(text, chat_history)
-            .await
+        /// Attempts to extract data from the given text with a number of retries,
+        /// providing chat history context, and returning both the extracted data
+        /// and accumulated token usage.
+        extract_with_chat_history_with_usage(chat_history: Vec<Message>) -> ExtractionResponse<T>
+            => usage;
     }
 
     /// Runs the extraction with the retry semantics shared by all public
@@ -360,6 +336,23 @@ where
     retries: Option<u64>,
 }
 
+/// Generate the `ExtractorBuilder` setters that forward verbatim to the inner
+/// [`AgentBuilder`] method of the same name. Doc comments live at each
+/// invocation; `preamble` (which wraps its argument) and `retries`
+/// (builder-local) stay hand-written.
+macro_rules! forward_agent_builder {
+    ($( $(#[$attr:meta])* $name:ident $([$gen:ident : $($bound:tt)+])?
+        ( $($arg:ident : $ty:ty),* );)+) => {$(
+        $(#[$attr])*
+        pub fn $name $(<$gen>)? (mut self, $($arg: $ty),*) -> Self
+        $(where $gen: $($bound)+)?
+        {
+            self.agent_builder = self.agent_builder.$name($($arg),*);
+            self
+        }
+    )+};
+}
+
 impl<T> ExtractorBuilder<T>
 where
     T: JsonSchema + for<'a> Deserialize<'a> + Serialize + WasmCompatSend + WasmCompatSync + 'static,
@@ -397,56 +390,34 @@ where
         self
     }
 
-    /// Add a context document to the extractor
-    pub fn context(mut self, doc: &str) -> Self {
-        self.agent_builder = self.agent_builder.context(doc);
-        self
-    }
+    forward_agent_builder! {
+        /// Add a context document to the extractor
+        context(doc: &str);
 
-    /// Add dynamic context retrieved from a vector store on every extraction attempt.
-    ///
-    /// This delegates to [`AgentBuilder::dynamic_context`] and therefore uses the
-    /// same completion-call hook lifecycle as an agent.
-    pub fn dynamic_context<I>(mut self, samples: usize, index: I) -> Self
-    where
-        I: VectorStoreIndexDyn + 'static,
-    {
-        self.agent_builder = self.agent_builder.dynamic_context(samples, index);
-        self
-    }
+        /// Add dynamic context retrieved from a vector store on every extraction attempt.
+        ///
+        /// This delegates to [`AgentBuilder::dynamic_context`] and therefore uses the
+        /// same completion-call hook lifecycle as an agent.
+        dynamic_context[I: VectorStoreIndexDyn + 'static](samples: usize, index: I);
 
-    pub fn additional_params(mut self, params: serde_json::Value) -> Self {
-        self.agent_builder = self.agent_builder.additional_params(params);
-        self
-    }
+        additional_params(params: serde_json::Value);
 
-    /// Set the maximum number of tokens for the completion
-    pub fn max_tokens(mut self, max_tokens: u64) -> Self {
-        self.agent_builder = self.agent_builder.max_tokens(max_tokens);
-        self
+        /// Set the maximum number of tokens for the completion
+        max_tokens(max_tokens: u64);
+
+        /// Set the `tool_choice` option for the inner Agent.
+        tool_choice(choice: ToolChoice);
+
+        /// Add a provider-independent lifecycle hook to every extraction attempt.
+        ///
+        /// Completion-response hooks receive canonical Rig content, usage, prompt,
+        /// and message ID fields, just like hooks attached directly to an agent.
+        add_hook[H: AgentHook + 'static](hook: H);
     }
 
     /// Set the maximum number of retries for the extractor.
     pub fn retries(mut self, retries: u64) -> Self {
         self.retries = Some(retries);
-        self
-    }
-
-    /// Set the `tool_choice` option for the inner Agent.
-    pub fn tool_choice(mut self, choice: ToolChoice) -> Self {
-        self.agent_builder = self.agent_builder.tool_choice(choice);
-        self
-    }
-
-    /// Add a provider-independent lifecycle hook to every extraction attempt.
-    ///
-    /// Completion-response hooks receive canonical Rig content, usage, prompt,
-    /// and message ID fields, just like hooks attached directly to an agent.
-    pub fn add_hook<H>(mut self, hook: H) -> Self
-    where
-        H: AgentHook + 'static,
-    {
-        self.agent_builder = self.agent_builder.add_hook(hook);
         self
     }
 

--- a/crates/rig-agent/src/test_utils/model_conformance.rs
+++ b/crates/rig-agent/src/test_utils/model_conformance.rs
@@ -956,6 +956,30 @@ fn report_from_response(
     })
 }
 
+/// Require the extended run's accumulated message history and validate
+/// canonical tool call/result correlation over it.
+fn correlated_messages<'a>(
+    scenario: &'static str,
+    response: &'a crate::agent::PromptResponse,
+) -> Result<&'a [Message], ScenarioError> {
+    let messages = response.messages.as_deref().ok_or_else(|| {
+        ScenarioError::contract(scenario, "extended run omitted accumulated message history")
+    })?;
+    validate_tool_correlation(scenario, messages)?;
+    Ok(messages)
+}
+
+/// [`correlated_messages`], flattened into every tool-result value in history.
+fn correlated_result_values(
+    scenario: &'static str,
+    response: &crate::agent::PromptResponse,
+) -> Result<Vec<serde_json::Value>, ScenarioError> {
+    Ok(correlated_messages(scenario, response)?
+        .iter()
+        .flat_map(tool_result_values)
+        .collect())
+}
+
 fn value_matches_integer(value: &serde_json::Value, expected: i64) -> bool {
     value.as_i64() == Some(expected)
         || value
@@ -1003,10 +1027,7 @@ where
     } else {
         "parallel_tools"
     };
-    let messages = response.messages.as_deref().ok_or_else(|| {
-        ScenarioError::contract(scenario, "extended run omitted accumulated message history")
-    })?;
-    validate_tool_correlation(scenario, messages)?;
+    let messages = correlated_messages(scenario, &response)?;
 
     let Some((call_index, calls)) = messages.iter().enumerate().find_map(|(index, message)| {
         let Message::Assistant { content, .. } = message else {
@@ -1087,14 +1108,7 @@ where
         .max_turns(2)
         .extended_details()
         .await?;
-    let messages = response.messages.as_deref().ok_or_else(|| {
-        ScenarioError::contract(SCENARIO, "extended run omitted accumulated message history")
-    })?;
-    validate_tool_correlation(SCENARIO, messages)?;
-    let values = messages
-        .iter()
-        .flat_map(tool_result_values)
-        .collect::<Vec<_>>();
+    let values = correlated_result_values(SCENARIO, &response)?;
     if calls.load(Ordering::SeqCst) != 1
         || !values
             .iter()
@@ -1139,14 +1153,7 @@ where
         .max_turns(3)
         .extended_details()
         .await?;
-    let messages = response.messages.as_deref().ok_or_else(|| {
-        ScenarioError::contract(SCENARIO, "extended run omitted accumulated message history")
-    })?;
-    validate_tool_correlation(SCENARIO, messages)?;
-    let values = messages
-        .iter()
-        .flat_map(tool_result_values)
-        .collect::<Vec<_>>();
+    let values = correlated_result_values(SCENARIO, &response)?;
     let expected_config = serde_json::to_value(ConfigOutput {
         service: "cassette-lab".to_string(),
         max_retries: 3,
@@ -1225,10 +1232,7 @@ where
             ),
         ));
     }
-    let messages = response.messages.as_deref().ok_or_else(|| {
-        ScenarioError::contract(SCENARIO, "extended run omitted accumulated message history")
-    })?;
-    validate_tool_correlation(SCENARIO, messages)?;
+    correlated_messages(SCENARIO, &response)?;
     report_from_response(SCENARIO, started, 1, response)
 }
 

--- a/crates/rig-core/src/client/mod.rs
+++ b/crates/rig-core/src/client/mod.rs
@@ -933,6 +933,33 @@ where
     }
 }
 
+// Every single-model capability client impl on `Client<Ext, H>` shares the
+// same shape: gate on the matching `Capabilities` slot, name the model type,
+// and construct it with `M::make`. The macro keeps the per-capability
+// variation (trait, slot, associated type, method, extra model bounds, and
+// feature gate) in one invocation each. `CompletionClient` (different
+// constructor protocol) and `EmbeddingsClient` (extra `_with_ndims` method)
+// stay hand-written below.
+macro_rules! impl_capability_client {
+    (
+        $(#[cfg(feature = $feature:literal)])?
+        $client_trait:ident { $slot:ident, $assoc:ident, $method:ident, $model_trait:ident $(+ $extra:path)* }
+    ) => {
+        $(#[cfg(feature = $feature)])?
+        impl<M, Ext, H> $client_trait for Client<Ext, H>
+        where
+            Ext: Capabilities<H, $slot = Capable<M>>,
+            M: $model_trait<Client = Self> $(+ $extra)*,
+        {
+            type $assoc = M;
+
+            fn $method(&self, model: impl Into<String>) -> Self::$assoc {
+                M::make(self, model)
+            }
+        }
+    };
+}
+
 impl<M, Ext, H> CompletionClient for Client<Ext, H>
 where
     Ext: Capabilities<H, Completion = Capable<M>>,
@@ -965,55 +992,39 @@ where
     }
 }
 
-impl<M, Ext, H> RerankingClient for Client<Ext, H>
-where
-    Ext: Capabilities<H, Rerank = Capable<M>>,
-    M: RerankModel<Client = Self>,
-{
-    type RerankModel = M;
+impl_capability_client!(RerankingClient {
+    Rerank,
+    RerankModel,
+    rerank_model,
+    RerankModel
+});
 
-    fn rerank_model(&self, model: impl Into<String>) -> Self::RerankModel {
-        M::make(self, model)
+impl_capability_client!(TranscriptionClient {
+    Transcription,
+    TranscriptionModel,
+    transcription_model,
+    TranscriptionModel + WasmCompatSend
+});
+
+impl_capability_client!(
+    #[cfg(feature = "image")]
+    ImageGenerationClient {
+        ImageGeneration,
+        ImageGenerationModel,
+        image_generation_model,
+        ImageGenerationModel
     }
-}
+);
 
-impl<M, Ext, H> TranscriptionClient for Client<Ext, H>
-where
-    Ext: Capabilities<H, Transcription = Capable<M>>,
-    M: TranscriptionModel<Client = Self> + WasmCompatSend,
-{
-    type TranscriptionModel = M;
-
-    fn transcription_model(&self, model: impl Into<String>) -> Self::TranscriptionModel {
-        M::make(self, model)
+impl_capability_client!(
+    #[cfg(feature = "audio")]
+    AudioGenerationClient {
+        AudioGeneration,
+        AudioGenerationModel,
+        audio_generation_model,
+        AudioGenerationModel
     }
-}
-
-#[cfg(feature = "image")]
-impl<M, Ext, H> ImageGenerationClient for Client<Ext, H>
-where
-    Ext: Capabilities<H, ImageGeneration = Capable<M>>,
-    M: ImageGenerationModel<Client = Self>,
-{
-    type ImageGenerationModel = M;
-
-    fn image_generation_model(&self, model: impl Into<String>) -> Self::ImageGenerationModel {
-        M::make(self, model)
-    }
-}
-
-#[cfg(feature = "audio")]
-impl<M, Ext, H> AudioGenerationClient for Client<Ext, H>
-where
-    Ext: Capabilities<H, AudioGeneration = Capable<M>>,
-    M: AudioGenerationModel<Client = Self>,
-{
-    type AudioGenerationModel = M;
-
-    fn audio_generation_model(&self, model: impl Into<String>) -> Self::AudioGenerationModel {
-        M::make(self, model)
-    }
-}
+);
 
 impl<M, Ext, H> ModelListingClient for Client<Ext, H>
 where

--- a/crates/rig-core/src/completion/message.rs
+++ b/crates/rig-core/src/completion/message.rs
@@ -1390,106 +1390,76 @@ impl Message {
     }
 }
 
+// The media helper constructors differ only in the wrapped content variant,
+// the `DocumentSourceKind` constructor, and the accepted data type; the macro
+// stamps them out while keeping each method's public signature and rustdoc
+// intact. `Image(...)` rows additionally take the `detail` parameter.
+macro_rules! media_ctors {
+    () => {};
+    (
+        $(#[$meta:meta])* $name:ident => Image($kind:ident: $data:ty);
+        $($rest:tt)*
+    ) => {
+        $(#[$meta])*
+        pub fn $name(
+            data: impl Into<$data>,
+            media_type: Option<ImageMediaType>,
+            detail: Option<ImageDetail>,
+        ) -> Self {
+            Self::Image(Image {
+                data: DocumentSourceKind::$kind(data.into()),
+                media_type,
+                detail,
+                additional_params: None,
+            })
+        }
+        media_ctors! { $($rest)* }
+    };
+    (
+        $(#[$meta:meta])* $name:ident => $variant:ident($mt:ty, $kind:ident: $data:ty);
+        $($rest:tt)*
+    ) => {
+        $(#[$meta])*
+        pub fn $name(data: impl Into<$data>, media_type: Option<$mt>) -> Self {
+            Self::$variant($variant {
+                data: DocumentSourceKind::$kind(data.into()),
+                media_type,
+                additional_params: None,
+            })
+        }
+        media_ctors! { $($rest)* }
+    };
+}
+
 impl UserContent {
     /// Helper constructor to make creating user text content easier.
     pub fn text(text: impl Into<String>) -> Self {
         UserContent::Text(text.into().into())
     }
 
-    /// Helper constructor to make creating user image content easier.
-    pub fn image_base64(
-        data: impl Into<String>,
-        media_type: Option<ImageMediaType>,
-        detail: Option<ImageDetail>,
-    ) -> Self {
-        UserContent::Image(Image {
-            data: DocumentSourceKind::Base64(data.into()),
-            media_type,
-            detail,
-            additional_params: None,
-        })
-    }
-
-    /// Helper constructor to make creating user image content from raw unencoded bytes easier.
-    pub fn image_raw(
-        data: impl Into<Vec<u8>>,
-        media_type: Option<ImageMediaType>,
-        detail: Option<ImageDetail>,
-    ) -> Self {
-        UserContent::Image(Image {
-            data: DocumentSourceKind::Raw(data.into()),
-            media_type,
-            detail,
-            ..Default::default()
-        })
-    }
-
-    /// Helper constructor to make creating user image content easier.
-    pub fn image_url(
-        url: impl Into<String>,
-        media_type: Option<ImageMediaType>,
-        detail: Option<ImageDetail>,
-    ) -> Self {
-        UserContent::Image(Image {
-            data: DocumentSourceKind::Url(url.into()),
-            media_type,
-            detail,
-            additional_params: None,
-        })
-    }
-
-    /// Helper constructor to make creating user audio content easier.
-    pub fn audio(data: impl Into<String>, media_type: Option<AudioMediaType>) -> Self {
-        UserContent::Audio(Audio {
-            data: DocumentSourceKind::Base64(data.into()),
-            media_type,
-            additional_params: None,
-        })
-    }
-
-    /// Helper constructor to make creating user audio content from raw unencoded bytes easier.
-    pub fn audio_raw(data: impl Into<Vec<u8>>, media_type: Option<AudioMediaType>) -> Self {
-        UserContent::Audio(Audio {
-            data: DocumentSourceKind::Raw(data.into()),
-            media_type,
-            ..Default::default()
-        })
-    }
-
-    /// Helper to create an audio resource from a URL
-    pub fn audio_url(url: impl Into<String>, media_type: Option<AudioMediaType>) -> Self {
-        UserContent::Audio(Audio {
-            data: DocumentSourceKind::Url(url.into()),
-            media_type,
-            ..Default::default()
-        })
-    }
-
-    /// Helper constructor to make creating user video content easier.
-    pub fn video(data: impl Into<String>, media_type: Option<VideoMediaType>) -> Self {
-        UserContent::Video(Video {
-            data: DocumentSourceKind::Base64(data.into()),
-            media_type,
-            additional_params: None,
-        })
-    }
-
-    /// Helper constructor to make creating user video content from raw unencoded bytes easier.
-    pub fn video_raw(data: impl Into<Vec<u8>>, media_type: Option<VideoMediaType>) -> Self {
-        UserContent::Video(Video {
-            data: DocumentSourceKind::Raw(data.into()),
-            media_type,
-            ..Default::default()
-        })
-    }
-
-    /// Helper to create a video resource from a URL
-    pub fn video_url(url: impl Into<String>, media_type: Option<VideoMediaType>) -> Self {
-        UserContent::Video(Video {
-            data: DocumentSourceKind::Url(url.into()),
-            media_type,
-            ..Default::default()
-        })
+    media_ctors! {
+        /// Helper constructor to make creating user image content easier.
+        image_base64 => Image(Base64: String);
+        /// Helper constructor to make creating user image content from raw unencoded bytes easier.
+        image_raw => Image(Raw: Vec<u8>);
+        /// Helper constructor to make creating user image content easier.
+        image_url => Image(Url: String);
+        /// Helper constructor to make creating user audio content easier.
+        audio => Audio(AudioMediaType, Base64: String);
+        /// Helper constructor to make creating user audio content from raw unencoded bytes easier.
+        audio_raw => Audio(AudioMediaType, Raw: Vec<u8>);
+        /// Helper to create an audio resource from a URL
+        audio_url => Audio(AudioMediaType, Url: String);
+        /// Helper constructor to make creating user video content easier.
+        video => Video(VideoMediaType, Base64: String);
+        /// Helper constructor to make creating user video content from raw unencoded bytes easier.
+        video_raw => Video(VideoMediaType, Raw: Vec<u8>);
+        /// Helper to create a video resource from a URL
+        video_url => Video(VideoMediaType, Url: String);
+        /// Helper to create a document from raw unencoded bytes
+        document_raw => Document(DocumentMediaType, Raw: Vec<u8>);
+        /// Helper to create a document from a URL
+        document_url => Document(DocumentMediaType, Url: String);
     }
 
     /// Helper constructor to make creating user document content easier.
@@ -1500,24 +1470,6 @@ impl UserContent {
             data: DocumentSourceKind::string(&data),
             media_type,
             additional_params: None,
-        })
-    }
-
-    /// Helper to create a document from raw unencoded bytes
-    pub fn document_raw(data: impl Into<Vec<u8>>, media_type: Option<DocumentMediaType>) -> Self {
-        UserContent::Document(Document {
-            data: DocumentSourceKind::Raw(data.into()),
-            media_type,
-            ..Default::default()
-        })
-    }
-
-    /// Helper to create a document from a URL
-    pub fn document_url(url: impl Into<String>, media_type: Option<DocumentMediaType>) -> Self {
-        UserContent::Document(Document {
-            data: DocumentSourceKind::Url(url.into()),
-            media_type,
-            ..Default::default()
         })
     }
 
@@ -1610,18 +1562,9 @@ impl AssistantContent {
         AssistantContent::Text(text.into().into())
     }
 
-    /// Helper constructor to make creating assistant image content easier.
-    pub fn image_base64(
-        data: impl Into<String>,
-        media_type: Option<ImageMediaType>,
-        detail: Option<ImageDetail>,
-    ) -> Self {
-        AssistantContent::Image(Image {
-            data: DocumentSourceKind::Base64(data.into()),
-            media_type,
-            detail,
-            additional_params: None,
-        })
+    media_ctors! {
+        /// Helper constructor to make creating assistant image content easier.
+        image_base64 => Image(Base64: String);
     }
 
     /// Helper constructor to make creating assistant tool call content easier.
@@ -1676,46 +1619,13 @@ impl ToolResultContent {
         ToolResultContent::Json { value }
     }
 
-    /// Helper constructor to make tool result images from a base64-encoded string.
-    pub fn image_base64(
-        data: impl Into<String>,
-        media_type: Option<ImageMediaType>,
-        detail: Option<ImageDetail>,
-    ) -> Self {
-        ToolResultContent::Image(Image {
-            data: DocumentSourceKind::Base64(data.into()),
-            media_type,
-            detail,
-            additional_params: None,
-        })
-    }
-
-    /// Helper constructor to make tool result images from a base64-encoded string.
-    pub fn image_raw(
-        data: impl Into<Vec<u8>>,
-        media_type: Option<ImageMediaType>,
-        detail: Option<ImageDetail>,
-    ) -> Self {
-        ToolResultContent::Image(Image {
-            data: DocumentSourceKind::Raw(data.into()),
-            media_type,
-            detail,
-            ..Default::default()
-        })
-    }
-
-    /// Helper constructor to make tool result images from a URL.
-    pub fn image_url(
-        url: impl Into<String>,
-        media_type: Option<ImageMediaType>,
-        detail: Option<ImageDetail>,
-    ) -> Self {
-        ToolResultContent::Image(Image {
-            data: DocumentSourceKind::Url(url.into()),
-            media_type,
-            detail,
-            additional_params: None,
-        })
+    media_ctors! {
+        /// Helper constructor to make tool result images from a base64-encoded string.
+        image_base64 => Image(Base64: String);
+        /// Helper constructor to make tool result images from a base64-encoded string.
+        image_raw => Image(Raw: Vec<u8>);
+        /// Helper constructor to make tool result images from a URL.
+        image_url => Image(Url: String);
     }
 }
 
@@ -1731,17 +1641,9 @@ impl MimeType for MediaType {
     fn from_mime_type(mime_type: &str) -> Option<Self> {
         ImageMediaType::from_mime_type(mime_type)
             .map(MediaType::Image)
-            .or_else(|| {
-                DocumentMediaType::from_mime_type(mime_type)
-                    .map(MediaType::Document)
-                    .or_else(|| {
-                        AudioMediaType::from_mime_type(mime_type)
-                            .map(MediaType::Audio)
-                            .or_else(|| {
-                                VideoMediaType::from_mime_type(mime_type).map(MediaType::Video)
-                            })
-                    })
-            })
+            .or_else(|| DocumentMediaType::from_mime_type(mime_type).map(MediaType::Document))
+            .or_else(|| AudioMediaType::from_mime_type(mime_type).map(MediaType::Audio))
+            .or_else(|| VideoMediaType::from_mime_type(mime_type).map(MediaType::Video))
     }
 
     fn to_mime_type(&self) -> &'static str {
@@ -1754,122 +1656,71 @@ impl MimeType for MediaType {
     }
 }
 
-impl MimeType for ImageMediaType {
-    fn from_mime_type(mime_type: &str) -> Option<Self> {
-        match mime_type {
-            "image/jpeg" => Some(ImageMediaType::JPEG),
-            "image/png" => Some(ImageMediaType::PNG),
-            "image/gif" => Some(ImageMediaType::GIF),
-            "image/webp" => Some(ImageMediaType::WEBP),
-            "image/heic" => Some(ImageMediaType::HEIC),
-            "image/heif" => Some(ImageMediaType::HEIF),
-            "image/svg+xml" => Some(ImageMediaType::SVG),
-            _ => None,
-        }
-    }
+// Emits both directions of a [`MimeType`] impl from a single pair list, so a
+// variant's parse and emit spellings cannot drift apart. Extra `| "alias"`
+// spellings parse to the same variant; only the first (canonical) string is
+// emitted by `to_mime_type`.
+macro_rules! impl_mime_type {
+    ($ty:ident { $($variant:ident => $canonical:literal $(| $alias:literal)*),+ $(,)? }) => {
+        impl MimeType for $ty {
+            fn from_mime_type(mime_type: &str) -> Option<Self> {
+                match mime_type {
+                    $($canonical $(| $alias)* => Some($ty::$variant),)+
+                    _ => None,
+                }
+            }
 
-    fn to_mime_type(&self) -> &'static str {
-        match self {
-            ImageMediaType::JPEG => "image/jpeg",
-            ImageMediaType::PNG => "image/png",
-            ImageMediaType::GIF => "image/gif",
-            ImageMediaType::WEBP => "image/webp",
-            ImageMediaType::HEIC => "image/heic",
-            ImageMediaType::HEIF => "image/heif",
-            ImageMediaType::SVG => "image/svg+xml",
+            fn to_mime_type(&self) -> &'static str {
+                match self {
+                    $($ty::$variant => $canonical,)+
+                }
+            }
         }
-    }
+    };
 }
 
-impl MimeType for DocumentMediaType {
-    fn from_mime_type(mime_type: &str) -> Option<Self> {
-        match mime_type {
-            "application/pdf" => Some(DocumentMediaType::PDF),
-            "text/plain" => Some(DocumentMediaType::TXT),
-            "text/rtf" => Some(DocumentMediaType::RTF),
-            "text/html" => Some(DocumentMediaType::HTML),
-            "text/css" => Some(DocumentMediaType::CSS),
-            "text/md" | "text/markdown" => Some(DocumentMediaType::MARKDOWN),
-            "text/csv" => Some(DocumentMediaType::CSV),
-            "text/xml" => Some(DocumentMediaType::XML),
-            "application/x-javascript" | "text/x-javascript" => Some(DocumentMediaType::Javascript),
-            "application/x-python" | "text/x-python" => Some(DocumentMediaType::Python),
-            _ => None,
-        }
-    }
+impl_mime_type!(ImageMediaType {
+    JPEG => "image/jpeg",
+    PNG => "image/png",
+    GIF => "image/gif",
+    WEBP => "image/webp",
+    HEIC => "image/heic",
+    HEIF => "image/heif",
+    SVG => "image/svg+xml",
+});
 
-    fn to_mime_type(&self) -> &'static str {
-        match self {
-            DocumentMediaType::PDF => "application/pdf",
-            DocumentMediaType::TXT => "text/plain",
-            DocumentMediaType::RTF => "text/rtf",
-            DocumentMediaType::HTML => "text/html",
-            DocumentMediaType::CSS => "text/css",
-            DocumentMediaType::MARKDOWN => "text/markdown",
-            DocumentMediaType::CSV => "text/csv",
-            DocumentMediaType::XML => "text/xml",
-            DocumentMediaType::Javascript => "application/x-javascript",
-            DocumentMediaType::Python => "application/x-python",
-        }
-    }
-}
+impl_mime_type!(DocumentMediaType {
+    PDF => "application/pdf",
+    TXT => "text/plain",
+    RTF => "text/rtf",
+    HTML => "text/html",
+    CSS => "text/css",
+    MARKDOWN => "text/markdown" | "text/md",
+    CSV => "text/csv",
+    XML => "text/xml",
+    Javascript => "application/x-javascript" | "text/x-javascript",
+    Python => "application/x-python" | "text/x-python",
+});
 
-impl MimeType for AudioMediaType {
-    fn from_mime_type(mime_type: &str) -> Option<Self> {
-        match mime_type {
-            "audio/wav" => Some(AudioMediaType::WAV),
-            "audio/mp3" => Some(AudioMediaType::MP3),
-            "audio/aiff" => Some(AudioMediaType::AIFF),
-            "audio/aac" => Some(AudioMediaType::AAC),
-            "audio/ogg" => Some(AudioMediaType::OGG),
-            "audio/flac" => Some(AudioMediaType::FLAC),
-            "audio/m4a" => Some(AudioMediaType::M4A),
-            "audio/pcm16" => Some(AudioMediaType::PCM16),
-            "audio/pcm24" => Some(AudioMediaType::PCM24),
-            _ => None,
-        }
-    }
+impl_mime_type!(AudioMediaType {
+    WAV => "audio/wav",
+    MP3 => "audio/mp3",
+    AIFF => "audio/aiff",
+    AAC => "audio/aac",
+    OGG => "audio/ogg",
+    FLAC => "audio/flac",
+    M4A => "audio/m4a",
+    PCM16 => "audio/pcm16",
+    PCM24 => "audio/pcm24",
+});
 
-    fn to_mime_type(&self) -> &'static str {
-        match self {
-            AudioMediaType::WAV => "audio/wav",
-            AudioMediaType::MP3 => "audio/mp3",
-            AudioMediaType::AIFF => "audio/aiff",
-            AudioMediaType::AAC => "audio/aac",
-            AudioMediaType::OGG => "audio/ogg",
-            AudioMediaType::FLAC => "audio/flac",
-            AudioMediaType::M4A => "audio/m4a",
-            AudioMediaType::PCM16 => "audio/pcm16",
-            AudioMediaType::PCM24 => "audio/pcm24",
-        }
-    }
-}
-
-impl MimeType for VideoMediaType {
-    fn from_mime_type(mime_type: &str) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match mime_type {
-            "video/avi" => Some(VideoMediaType::AVI),
-            "video/mp4" => Some(VideoMediaType::MP4),
-            "video/mpeg" => Some(VideoMediaType::MPEG),
-            "video/mov" => Some(VideoMediaType::MOV),
-            "video/webm" => Some(VideoMediaType::WEBM),
-            &_ => None,
-        }
-    }
-
-    fn to_mime_type(&self) -> &'static str {
-        match self {
-            VideoMediaType::AVI => "video/avi",
-            VideoMediaType::MP4 => "video/mp4",
-            VideoMediaType::MPEG => "video/mpeg",
-            VideoMediaType::MOV => "video/mov",
-            VideoMediaType::WEBM => "video/webm",
-        }
-    }
-}
+impl_mime_type!(VideoMediaType {
+    AVI => "video/avi",
+    MP4 => "video/mp4",
+    MPEG => "video/mpeg",
+    MOV => "video/mov",
+    WEBM => "video/webm",
+});
 
 impl std::str::FromStr for ImageDetail {
     type Err = ();

--- a/crates/rig-core/src/memory.rs
+++ b/crates/rig-core/src/memory.rs
@@ -116,59 +116,73 @@ pub trait ConversationMemory: WasmCompatSend + WasmCompatSync {
     ) -> WasmBoxedFuture<'a, Result<(), MemoryError>>;
 }
 
-impl<M> ConversationMemory for Arc<M>
-where
-    M: ConversationMemory + ?Sized,
-{
-    fn load<'a>(
-        &'a self,
-        conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
-        (**self).load(conversation_id)
-    }
+// Forwarding impls so callers can pass smart pointers (`Arc<M>`, `Box<M>`,
+// including unsized trait objects) wherever a memory trait is expected. Each
+// arm forwards every method of one trait through `(**self)` for the listed
+// pointer types.
+macro_rules! forward_memory_trait {
+    (ConversationMemory: $($ptr:ident)+) => {$(
+        impl<M> ConversationMemory for $ptr<M>
+        where
+            M: ConversationMemory + ?Sized,
+        {
+            fn load<'a>(
+                &'a self,
+                conversation_id: &'a str,
+            ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
+                (**self).load(conversation_id)
+            }
 
-    fn append<'a>(
-        &'a self,
-        conversation_id: &'a str,
-        messages: Vec<Message>,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
-        (**self).append(conversation_id, messages)
-    }
+            fn append<'a>(
+                &'a self,
+                conversation_id: &'a str,
+                messages: Vec<Message>,
+            ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+                (**self).append(conversation_id, messages)
+            }
 
-    fn clear<'a>(
-        &'a self,
-        conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
-        (**self).clear(conversation_id)
-    }
+            fn clear<'a>(
+                &'a self,
+                conversation_id: &'a str,
+            ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+                (**self).clear(conversation_id)
+            }
+        }
+    )+};
+    (DemotionHook: $($ptr:ident)+) => {$(
+        impl<H> DemotionHook for $ptr<H>
+        where
+            H: DemotionHook + ?Sized,
+        {
+            fn on_demote<'a>(
+                &'a self,
+                conversation_id: &'a str,
+                messages: Vec<Message>,
+            ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+                (**self).on_demote(conversation_id, messages)
+            }
+        }
+    )+};
+    (Compactor: $($ptr:ident)+) => {$(
+        impl<C> Compactor for $ptr<C>
+        where
+            C: Compactor + ?Sized,
+        {
+            type Artifact = C::Artifact;
+
+            fn compact<'a>(
+                &'a self,
+                conversation_id: &'a str,
+                evicted: &'a [Message],
+                carry_over: Option<&'a Self::Artifact>,
+            ) -> WasmBoxedFuture<'a, Result<Self::Artifact, MemoryError>> {
+                (**self).compact(conversation_id, evicted, carry_over)
+            }
+        }
+    )+};
 }
 
-impl<M> ConversationMemory for Box<M>
-where
-    M: ConversationMemory + ?Sized,
-{
-    fn load<'a>(
-        &'a self,
-        conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
-        (**self).load(conversation_id)
-    }
-
-    fn append<'a>(
-        &'a self,
-        conversation_id: &'a str,
-        messages: Vec<Message>,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
-        (**self).append(conversation_id, messages)
-    }
-
-    fn clear<'a>(
-        &'a self,
-        conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
-        (**self).clear(conversation_id)
-    }
-}
+forward_memory_trait!(ConversationMemory: Arc Box);
 
 /// A history-shaping closure applied during [`InMemoryConversationMemory::load`].
 ///
@@ -245,21 +259,10 @@ impl DemotionHook for NoopDemotionHook {
     }
 }
 
-/// Forwarding impl so callers can pass `Arc<H>` wherever a `DemotionHook`
-/// is expected (e.g. when sharing a single hook between multiple memory
-/// adapters).
-impl<H> DemotionHook for Arc<H>
-where
-    H: DemotionHook + ?Sized,
-{
-    fn on_demote<'a>(
-        &'a self,
-        conversation_id: &'a str,
-        messages: Vec<Message>,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
-        (**self).on_demote(conversation_id, messages)
-    }
-}
+// Forwarding impl so callers can pass `Arc<H>` wherever a `DemotionHook`
+// is expected (e.g. when sharing a single hook between multiple memory
+// adapters).
+forward_memory_trait!(DemotionHook: Arc);
 
 /// Derives a single [`Message`]-shaped artifact from a slice of messages
 /// that a memory policy has evicted from the active window.
@@ -319,23 +322,9 @@ pub trait Compactor: WasmCompatSend + WasmCompatSync {
     ) -> WasmBoxedFuture<'a, Result<Self::Artifact, MemoryError>>;
 }
 
-/// Forwarding impl so callers can pass `Arc<C>` wherever a `Compactor` is
-/// expected (e.g. when sharing a single compactor across adapters).
-impl<C> Compactor for Arc<C>
-where
-    C: Compactor + ?Sized,
-{
-    type Artifact = C::Artifact;
-
-    fn compact<'a>(
-        &'a self,
-        conversation_id: &'a str,
-        evicted: &'a [Message],
-        carry_over: Option<&'a Self::Artifact>,
-    ) -> WasmBoxedFuture<'a, Result<Self::Artifact, MemoryError>> {
-        (**self).compact(conversation_id, evicted, carry_over)
-    }
-}
+// Forwarding impl so callers can pass `Arc<C>` wherever a `Compactor` is
+// expected (e.g. when sharing a single compactor across adapters).
+forward_memory_trait!(Compactor: Arc);
 
 /// A simple thread-safe in-memory [`ConversationMemory`] backed by a `HashMap`.
 ///

--- a/crates/rig-core/src/model/listing.rs
+++ b/crates/rig-core/src/model/listing.rs
@@ -287,9 +287,10 @@ impl<'a> IntoIterator for &'a ModelList {
 ///
 /// This enum represents the various error conditions that may arise when
 /// attempting to retrieve the list of available models from an LLM provider.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, thiserror::Error)]
 pub enum ModelListingError {
     /// The provider returned an error response with a status code
+    #[error("API error (status {status_code}): {message}")]
     ApiError {
         /// HTTP status code
         status_code: u16,
@@ -298,36 +299,42 @@ pub enum ModelListingError {
     },
 
     /// Failed to send the request to the provider
+    #[error("Request error: {message}")]
     RequestError {
         /// Description of the request error
         message: String,
     },
 
     /// Failed to parse the provider's response
+    #[error("Parse error: {message}")]
     ParseError {
         /// Description of the parsing error
         message: String,
     },
 
     /// Authentication failed (invalid API key, etc.)
+    #[error("Authentication error: {message}")]
     AuthError {
         /// Authentication error details
         message: String,
     },
 
     /// Rate limit was exceeded
+    #[error("Rate limit error: {message}")]
     RateLimitError {
         /// Rate limit error details
         message: String,
     },
 
     /// The provider service is temporarily unavailable
+    #[error("Service unavailable: {message}")]
     ServiceUnavailable {
         /// Unavailable error details
         message: String,
     },
 
     /// An unexpected error occurred
+    #[error("Unknown error: {message}")]
     UnknownError {
         /// Details of the unknown error
         message: String,
@@ -447,25 +454,6 @@ impl ModelListingError {
         }
     }
 }
-
-impl fmt::Display for ModelListingError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::ApiError {
-                status_code,
-                message,
-            } => write!(f, "API error (status {}): {}", status_code, message),
-            Self::RequestError { message } => write!(f, "Request error: {}", message),
-            Self::ParseError { message } => write!(f, "Parse error: {}", message),
-            Self::AuthError { message } => write!(f, "Authentication error: {}", message),
-            Self::RateLimitError { message } => write!(f, "Rate limit error: {}", message),
-            Self::ServiceUnavailable { message } => write!(f, "Service unavailable: {}", message),
-            Self::UnknownError { message } => write!(f, "Unknown error: {}", message),
-        }
-    }
-}
-
-impl std::error::Error for ModelListingError {}
 
 impl From<crate::http_client::Error> for ModelListingError {
     fn from(e: crate::http_client::Error) -> Self {

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -494,48 +494,48 @@ pub enum Citation {
     Unknown(serde_json::Value),
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 struct CharLocationCitationFields {
     cited_text: String,
     document_index: usize,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     document_title: Option<String>,
     start_char_index: usize,
     end_char_index: usize,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 struct PageLocationCitationFields {
     cited_text: String,
     document_index: usize,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     document_title: Option<String>,
     start_page_number: u32,
     end_page_number: u32,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 struct ContentBlockLocationCitationFields {
     cited_text: String,
     document_index: usize,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     document_title: Option<String>,
     start_block_index: usize,
     end_block_index: usize,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 struct SearchResultLocationCitationFields {
     cited_text: String,
     source: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     title: Option<String>,
     search_result_index: usize,
     start_block_index: usize,
     end_block_index: usize,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 struct WebSearchResultLocationCitationFields {
     cited_text: String,
     url: String,
@@ -548,7 +548,19 @@ impl Serialize for Citation {
     where
         S: serde::Serializer,
     {
-        let mut value = serde_json::Map::new();
+        /// Serialize the per-variant DTO and insert the wire `type` tag.
+        fn tagged<S, T>(serializer: S, tag: &str, fields: &T) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+            T: Serialize,
+        {
+            let mut value = serde_json::to_value(fields).map_err(serde::ser::Error::custom)?;
+            if let serde_json::Value::Object(obj) = &mut value {
+                obj.insert("type".into(), serde_json::json!(tag));
+            }
+            value.serialize(serializer)
+        }
+
         match self {
             Citation::CharLocation {
                 cited_text,
@@ -556,57 +568,51 @@ impl Serialize for Citation {
                 document_title,
                 start_char_index,
                 end_char_index,
-            } => {
-                value.insert("type".into(), serde_json::json!("char_location"));
-                value.insert("cited_text".into(), serde_json::json!(cited_text));
-                value.insert("document_index".into(), serde_json::json!(document_index));
-                if let Some(document_title) = document_title {
-                    value.insert("document_title".into(), serde_json::json!(document_title));
-                }
-                value.insert(
-                    "start_char_index".into(),
-                    serde_json::json!(start_char_index),
-                );
-                value.insert("end_char_index".into(), serde_json::json!(end_char_index));
-            }
+            } => tagged(
+                serializer,
+                "char_location",
+                &CharLocationCitationFields {
+                    cited_text: cited_text.clone(),
+                    document_index: *document_index,
+                    document_title: document_title.clone(),
+                    start_char_index: *start_char_index,
+                    end_char_index: *end_char_index,
+                },
+            ),
             Citation::PageLocation {
                 cited_text,
                 document_index,
                 document_title,
                 start_page_number,
                 end_page_number,
-            } => {
-                value.insert("type".into(), serde_json::json!("page_location"));
-                value.insert("cited_text".into(), serde_json::json!(cited_text));
-                value.insert("document_index".into(), serde_json::json!(document_index));
-                if let Some(document_title) = document_title {
-                    value.insert("document_title".into(), serde_json::json!(document_title));
-                }
-                value.insert(
-                    "start_page_number".into(),
-                    serde_json::json!(start_page_number),
-                );
-                value.insert("end_page_number".into(), serde_json::json!(end_page_number));
-            }
+            } => tagged(
+                serializer,
+                "page_location",
+                &PageLocationCitationFields {
+                    cited_text: cited_text.clone(),
+                    document_index: *document_index,
+                    document_title: document_title.clone(),
+                    start_page_number: *start_page_number,
+                    end_page_number: *end_page_number,
+                },
+            ),
             Citation::ContentBlockLocation {
                 cited_text,
                 document_index,
                 document_title,
                 start_block_index,
                 end_block_index,
-            } => {
-                value.insert("type".into(), serde_json::json!("content_block_location"));
-                value.insert("cited_text".into(), serde_json::json!(cited_text));
-                value.insert("document_index".into(), serde_json::json!(document_index));
-                if let Some(document_title) = document_title {
-                    value.insert("document_title".into(), serde_json::json!(document_title));
-                }
-                value.insert(
-                    "start_block_index".into(),
-                    serde_json::json!(start_block_index),
-                );
-                value.insert("end_block_index".into(), serde_json::json!(end_block_index));
-            }
+            } => tagged(
+                serializer,
+                "content_block_location",
+                &ContentBlockLocationCitationFields {
+                    cited_text: cited_text.clone(),
+                    document_index: *document_index,
+                    document_title: document_title.clone(),
+                    start_block_index: *start_block_index,
+                    end_block_index: *end_block_index,
+                },
+            ),
             Citation::SearchResultLocation {
                 cited_text,
                 source,
@@ -614,42 +620,37 @@ impl Serialize for Citation {
                 search_result_index,
                 start_block_index,
                 end_block_index,
-            } => {
-                value.insert("type".into(), serde_json::json!("search_result_location"));
-                value.insert("cited_text".into(), serde_json::json!(cited_text));
-                value.insert("source".into(), serde_json::json!(source));
-                if let Some(title) = title {
-                    value.insert("title".into(), serde_json::json!(title));
-                }
-                value.insert(
-                    "search_result_index".into(),
-                    serde_json::json!(search_result_index),
-                );
-                value.insert(
-                    "start_block_index".into(),
-                    serde_json::json!(start_block_index),
-                );
-                value.insert("end_block_index".into(), serde_json::json!(end_block_index));
-            }
+            } => tagged(
+                serializer,
+                "search_result_location",
+                &SearchResultLocationCitationFields {
+                    cited_text: cited_text.clone(),
+                    source: source.clone(),
+                    title: title.clone(),
+                    search_result_index: *search_result_index,
+                    start_block_index: *start_block_index,
+                    end_block_index: *end_block_index,
+                },
+            ),
             Citation::WebSearchResultLocation {
                 cited_text,
                 url,
                 title,
                 encrypted_index,
-            } => {
-                value.insert(
-                    "type".into(),
-                    serde_json::json!("web_search_result_location"),
-                );
-                value.insert("cited_text".into(), serde_json::json!(cited_text));
-                value.insert("url".into(), serde_json::json!(url));
-                value.insert("title".into(), serde_json::json!(title));
-                value.insert("encrypted_index".into(), serde_json::json!(encrypted_index));
-            }
-            Citation::Unknown(raw) => return raw.serialize(serializer),
+            } => tagged(
+                serializer,
+                "web_search_result_location",
+                // `title` stays a plain field here: the wire writes it even
+                // when `None` (as an explicit `"title": null`).
+                &WebSearchResultLocationCitationFields {
+                    cited_text: cited_text.clone(),
+                    url: url.clone(),
+                    title: title.clone(),
+                    encrypted_index: encrypted_index.clone(),
+                },
+            ),
+            Citation::Unknown(raw) => raw.serialize(serializer),
         }
-
-        serde_json::Value::Object(value).serialize(serializer)
     }
 }
 
@@ -1801,81 +1802,14 @@ impl TryFrom<message::ToolChoice> for ToolChoice {
 ///
 /// Source: <https://docs.anthropic.com/en/docs/build-with-claude/structured-outputs#json-schema-limitations>
 fn sanitize_schema(schema: &mut serde_json::Value) {
-    use serde_json::Value;
-
-    if let Value::Object(obj) = schema {
-        let is_object_schema = obj.get("type") == Some(&Value::String("object".to_string()))
-            || obj.contains_key("properties");
-
-        if is_object_schema && !obj.contains_key("additionalProperties") {
-            obj.insert("additionalProperties".to_string(), Value::Bool(false));
-        }
-
-        if let Some(Value::Object(properties)) = obj.get("properties") {
-            let prop_keys = properties.keys().cloned().map(Value::String).collect();
-            obj.insert("required".to_string(), Value::Array(prop_keys));
-        }
-
-        // Anthropic does not support numerical constraints on integer/number types.
-        let is_numeric_schema = obj.get("type") == Some(&Value::String("integer".to_string()))
-            || obj.get("type") == Some(&Value::String("number".to_string()));
-
-        if is_numeric_schema {
-            for key in [
-                "minimum",
-                "maximum",
-                "exclusiveMinimum",
-                "exclusiveMaximum",
-                "multipleOf",
-            ] {
-                obj.remove(key);
-            }
-        }
-
-        if let Some(defs) = obj.get_mut("$defs")
-            && let Value::Object(defs_obj) = defs
-        {
-            for (_, def_schema) in defs_obj.iter_mut() {
-                sanitize_schema(def_schema);
-            }
-        }
-
-        if let Some(properties) = obj.get_mut("properties")
-            && let Value::Object(props) = properties
-        {
-            for (_, prop_value) in props.iter_mut() {
-                sanitize_schema(prop_value);
-            }
-        }
-
-        if let Some(items) = obj.get_mut("items") {
-            sanitize_schema(items);
-        }
-
-        // Anthropic doesn't support oneOf, convert to anyOf
-        if let Some(one_of) = obj.remove("oneOf") {
-            match obj.get_mut("anyOf") {
-                Some(Value::Array(existing)) => {
-                    if let Value::Array(mut incoming) = one_of {
-                        existing.append(&mut incoming);
-                    }
-                }
-                _ => {
-                    obj.insert("anyOf".to_string(), one_of);
-                }
-            }
-        }
-
-        for key in ["anyOf", "allOf"] {
-            if let Some(variants) = obj.get_mut(key)
-                && let Value::Array(variants_array) = variants
-            {
-                for variant in variants_array.iter_mut() {
-                    sanitize_schema(variant);
-                }
-            }
-        }
-    }
+    crate::providers::internal::schema::sanitize_schema(
+        schema,
+        crate::providers::internal::schema::SanitizeOptions {
+            strip_ref_siblings: false,
+            inject_empty_properties: false,
+            strip_numeric_constraints: true,
+        },
+    );
 }
 
 /// Output format specifier for Anthropic's structured output.

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -17,7 +17,6 @@ use serde_json::Value;
 use crate::client::{self, BearerAuth, DebugExt, ModelLister, Provider, ProviderClient};
 use crate::http_client::HttpClientExt;
 use crate::model::{ModelList, ModelListingError};
-use crate::providers::internal::openai_chat_completions_compatible::map_openai_finish_reason;
 use crate::providers::openai;
 use crate::telemetry::ProviderResponseExt;
 use crate::{
@@ -340,60 +339,44 @@ pub enum ToolType {
 /// wire type.
 impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
     fn normalize(self, provider: &str) -> Result<completion::CompletionResponse, CompletionError> {
-        let response = self;
-        let choice = response.choices.first().ok_or_else(|| {
-            CompletionError::ResponseError("Response contained no choices".to_owned())
-        })?;
+        use crate::providers::internal::openai_chat_completions_compatible as compat;
 
-        let finish_reason = Some(choice.finish_reason.as_str())
-            .filter(|reason| !reason.is_empty())
-            .map(map_openai_finish_reason);
-
-        let content = match &choice.message {
-            Message::Assistant {
-                content,
-                tool_calls,
-                reasoning_content,
-                ..
-            } => {
-                let mut content = if content.trim().is_empty() {
-                    vec![]
-                } else {
-                    vec![completion::AssistantContent::text(content)]
-                };
-
-                content.extend(
-                    tool_calls
-                        .iter()
-                        .map(|call| {
-                            completion::AssistantContent::tool_call(
-                                &call.id,
-                                &call.function.name,
+        let usage = crate::completion::Usage::from(&self.usage);
+        compat::normalize_openai_response(
+            provider,
+            &self.choices,
+            self.id.as_deref(),
+            self.model.as_deref(),
+            usage,
+            |choice| choice.finish_reason.as_str(),
+            |choice| match &choice.message {
+                Message::Assistant {
+                    content,
+                    tool_calls,
+                    reasoning_content,
+                    ..
+                } => {
+                    let mut content = compat::text_then_tool_calls(
+                        content,
+                        content.trim().is_empty(),
+                        tool_calls.iter().map(|call| {
+                            (
+                                call.id.as_str(),
+                                call.function.name.as_str(),
                                 call.function.arguments.clone(),
                             )
-                        })
-                        .collect::<Vec<_>>(),
-                );
+                        }),
+                    );
 
-                if let Some(reasoning_content) = reasoning_content {
-                    content.push(completion::AssistantContent::reasoning(reasoning_content));
+                    if let Some(reasoning_content) = reasoning_content {
+                        content.push(completion::AssistantContent::reasoning(reasoning_content));
+                    }
+
+                    Some(content)
                 }
-
-                Ok(content)
-            }
-            _ => Err(CompletionError::ResponseError(
-                "Response did not contain a valid message or tool call".into(),
-            )),
-        }?;
-
-        let choice = crate::message::require_non_empty_response(content)?;
-
-        let usage = crate::completion::Usage::from(&response.usage);
-
-        Ok(completion::CompletionResponse::new(choice, usage, provider)
-            .with_optional_response_id(response.id.as_deref())
-            .with_optional_model(response.model.as_deref())
-            .with_optional_finish_reason(finish_reason))
+                _ => None,
+            },
+        )
     }
 }
 

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -335,7 +335,7 @@ pub(crate) fn create_request_body(
     Ok(request)
 }
 
-fn split_system_messages_from_history(
+pub(super) fn split_system_messages_from_history(
     history: Vec<completion::Message>,
 ) -> (Vec<String>, Vec<completion::Message>) {
     let mut system = Vec::new();

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -419,21 +419,7 @@ pub(crate) fn create_request_body(
     })
 }
 
-fn split_system_messages_from_history(
-    history: Vec<completion::Message>,
-) -> (Vec<String>, Vec<completion::Message>) {
-    let mut system = Vec::new();
-    let mut remaining = Vec::new();
-
-    for message in history {
-        match message {
-            completion::Message::System { content } => system.push(content),
-            other => remaining.push(other),
-        }
-    }
-
-    (system, remaining)
-}
+use super::completion::split_system_messages_from_history;
 
 async fn send_interaction_request<T>(
     client: &InteractionsClient<T>,
@@ -637,6 +623,23 @@ fn assistant_content_from_output(
     }
 }
 
+/// Shared preamble for Gemini Interactions media parts: require the media
+/// type, render its MIME string, and split the source into data/uri.
+fn media_parts<M: MimeType>(
+    data: message::DocumentSourceKind,
+    media_type: Option<M>,
+    kind: &str,
+) -> Result<(Option<String>, Option<String>, String), message::MessageError> {
+    let media_type = media_type.ok_or_else(|| {
+        message::MessageError::ConversionError(format!(
+            "Media type for {kind} is required for Gemini"
+        ))
+    })?;
+    let mime_type = media_type.to_mime_type().to_string();
+    let (data, uri) = split_data_uri(data)?;
+    Ok((data, uri, mime_type))
+}
+
 fn split_data_uri(
     src: message::DocumentSourceKind,
 ) -> Result<(Option<String>, Option<String>), message::MessageError> {
@@ -658,7 +661,7 @@ fn split_data_uri(
 
 /// Raw request/response types and convenience helpers for the Gemini Interactions API.
 pub mod interactions_api_types {
-    use super::split_data_uri;
+    use super::{media_parts, split_data_uri};
     use crate::completion::{CompletionError, Usage};
     use crate::message::{self, MimeType};
     use crate::telemetry::ProviderResponseExt;
@@ -1974,13 +1977,7 @@ pub mod interactions_api_types {
                 message::UserContent::Image(message::Image {
                     data, media_type, ..
                 }) => {
-                    let media_type = media_type.ok_or_else(|| {
-                        message::MessageError::ConversionError(
-                            "Media type for image is required for Gemini".to_string(),
-                        )
-                    })?;
-                    let mime_type = media_type.to_mime_type().to_string();
-                    let (data, uri) = split_data_uri(data)?;
+                    let (data, uri, mime_type) = media_parts(data, media_type, "image")?;
                     Ok(Self::Image(ImageContent {
                         data,
                         uri,
@@ -1991,13 +1988,7 @@ pub mod interactions_api_types {
                 message::UserContent::Audio(message::Audio {
                     data, media_type, ..
                 }) => {
-                    let media_type = media_type.ok_or_else(|| {
-                        message::MessageError::ConversionError(
-                            "Media type for audio is required for Gemini".to_string(),
-                        )
-                    })?;
-                    let mime_type = media_type.to_mime_type().to_string();
-                    let (data, uri) = split_data_uri(data)?;
+                    let (data, uri, mime_type) = media_parts(data, media_type, "audio")?;
                     Ok(Self::Audio(AudioContent {
                         data,
                         uri,
@@ -2007,13 +1998,7 @@ pub mod interactions_api_types {
                 message::UserContent::Video(message::Video {
                     data, media_type, ..
                 }) => {
-                    let media_type = media_type.ok_or_else(|| {
-                        message::MessageError::ConversionError(
-                            "Media type for video is required for Gemini".to_string(),
-                        )
-                    })?;
-                    let mime_type = media_type.to_mime_type().to_string();
-                    let (data, uri) = split_data_uri(data)?;
+                    let (data, uri, mime_type) = media_parts(data, media_type, "video")?;
                     Ok(Self::Video(VideoContent {
                         data,
                         uri,
@@ -2073,8 +2058,7 @@ pub mod interactions_api_types {
                             annotations: None,
                         }));
                     }
-                    let mime_type = media_type.to_mime_type().to_string();
-                    let (data, uri) = split_data_uri(data)?;
+                    let (data, uri, mime_type) = media_parts(data, Some(media_type), "document")?;
                     Ok(Self::Document(DocumentContent {
                         data,
                         uri,

--- a/crates/rig-core/src/providers/internal/mod.rs
+++ b/crates/rig-core/src/providers/internal/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod envelope;
 pub(crate) mod image_generation;
 pub(crate) mod model_listing;
 pub(crate) mod openai_chat_completions_compatible;
+pub(crate) mod schema;
 #[cfg(any(test, debug_assertions))]
 pub(crate) mod sequence_law;
 pub mod tool_call_bridge;

--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
@@ -70,6 +70,68 @@ pub(crate) fn map_openai_finish_reason(reason: &str) -> FinishReason {
     }
 }
 
+/// Shared skeleton for normalizing an OpenAI-shaped *non-streaming* chat
+/// completion response (OpenAI, DeepSeek, Mistral): first choice or error,
+/// empty-string `finish_reason` treated as absent then mapped through
+/// [`map_openai_finish_reason`], non-assistant messages rejected, and the
+/// normalized response assembled with id/model/finish-reason metadata.
+///
+/// The per-provider deltas stay at the call site: `assistant_content` extracts
+/// the provider's own message shape (returning `None` for a non-assistant
+/// message), and `usage`/`id`/`model` are computed by the caller.
+pub(crate) fn normalize_openai_response<C>(
+    provider: &str,
+    choices: &[C],
+    id: Option<&str>,
+    model: Option<&str>,
+    usage: Usage,
+    finish_reason: impl for<'a> FnOnce(&'a C) -> &'a str,
+    assistant_content: impl FnOnce(&C) -> Option<Vec<crate::completion::AssistantContent>>,
+) -> Result<crate::completion::CompletionResponse, CompletionError> {
+    let choice = choices.first().ok_or_else(|| {
+        CompletionError::ResponseError("Response contained no choices".to_owned())
+    })?;
+
+    let finish_reason = Some(finish_reason(choice))
+        .filter(|reason| !reason.is_empty())
+        .map(map_openai_finish_reason);
+
+    let content = assistant_content(choice).ok_or_else(|| {
+        CompletionError::ResponseError(
+            "Response did not contain a valid message or tool call".into(),
+        )
+    })?;
+
+    let choice = crate::message::require_non_empty_response(content)?;
+
+    Ok(
+        crate::completion::CompletionResponse::new(choice, usage, provider)
+            .with_optional_response_id(id)
+            .with_optional_model(model)
+            .with_optional_finish_reason(finish_reason),
+    )
+}
+
+/// Text-then-tool-calls assistant content for wire messages carrying a single
+/// content string plus a tool-call list (DeepSeek, Mistral). `text_is_empty`
+/// is provider policy — DeepSeek trims before testing, Mistral does not — so
+/// the caller evaluates its own predicate.
+pub(crate) fn text_then_tool_calls<'a>(
+    text: &str,
+    text_is_empty: bool,
+    tool_calls: impl IntoIterator<Item = (&'a str, &'a str, serde_json::Value)>,
+) -> Vec<crate::completion::AssistantContent> {
+    let mut content = if text_is_empty {
+        vec![]
+    } else {
+        vec![crate::completion::AssistantContent::text(text)]
+    };
+    content.extend(tool_calls.into_iter().map(|(id, name, arguments)| {
+        crate::completion::AssistantContent::tool_call(id, name, arguments)
+    }));
+    content
+}
+
 /// A chunk's terminal reason, as reported by an OpenAI-compatible provider.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CompatibleFinishReason {

--- a/crates/rig-core/src/providers/internal/schema.rs
+++ b/crates/rig-core/src/providers/internal/schema.rs
@@ -1,0 +1,111 @@
+//! Shared JSON-schema sanitizer for providers with strict structured-output
+//! restrictions (OpenAI, Anthropic). The common core enforces
+//! `additionalProperties: false`, all-properties-required, recursion into
+//! `$defs`/`properties`/`items`/combinators, and the oneOf→anyOf merge;
+//! [`SanitizeOptions`] flags carry the per-provider deltas.
+
+/// Per-provider deltas applied by [`sanitize_schema`].
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SanitizeOptions {
+    /// OpenAI does not allow sibling keywords next to `$ref`; strip everything
+    /// except `$ref` and stop descending into that node.
+    pub(crate) strip_ref_siblings: bool,
+    /// OpenAI requires `properties` on all object schemas, even empty ones.
+    pub(crate) inject_empty_properties: bool,
+    /// Anthropic does not support numerical constraints on integer/number
+    /// types (`minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`,
+    /// `multipleOf`).
+    pub(crate) strip_numeric_constraints: bool,
+}
+
+/// Recursively rewrites `schema` in place to respect a provider's structured
+/// output restrictions. See [`SanitizeOptions`] for the provider-specific
+/// behavior.
+pub(crate) fn sanitize_schema(schema: &mut serde_json::Value, options: SanitizeOptions) {
+    use serde_json::Value;
+
+    if let Value::Object(obj) = schema {
+        if options.strip_ref_siblings && obj.contains_key("$ref") {
+            obj.retain(|k, _| k == "$ref");
+            return;
+        }
+
+        let is_object_schema = obj.get("type") == Some(&Value::String("object".to_string()))
+            || obj.contains_key("properties");
+
+        if options.inject_empty_properties && is_object_schema && !obj.contains_key("properties") {
+            obj.insert("properties".to_string(), Value::Object(Default::default()));
+        }
+
+        if is_object_schema && !obj.contains_key("additionalProperties") {
+            obj.insert("additionalProperties".to_string(), Value::Bool(false));
+        }
+
+        if let Some(Value::Object(properties)) = obj.get("properties") {
+            let prop_keys = properties.keys().cloned().map(Value::String).collect();
+            obj.insert("required".to_string(), Value::Array(prop_keys));
+        }
+
+        if options.strip_numeric_constraints {
+            let is_numeric_schema = obj.get("type") == Some(&Value::String("integer".to_string()))
+                || obj.get("type") == Some(&Value::String("number".to_string()));
+
+            if is_numeric_schema {
+                for key in [
+                    "minimum",
+                    "maximum",
+                    "exclusiveMinimum",
+                    "exclusiveMaximum",
+                    "multipleOf",
+                ] {
+                    obj.remove(key);
+                }
+            }
+        }
+
+        if let Some(defs) = obj.get_mut("$defs")
+            && let Value::Object(defs_obj) = defs
+        {
+            for (_, def_schema) in defs_obj.iter_mut() {
+                sanitize_schema(def_schema, options);
+            }
+        }
+
+        if let Some(properties) = obj.get_mut("properties")
+            && let Value::Object(props) = properties
+        {
+            for (_, prop_value) in props.iter_mut() {
+                sanitize_schema(prop_value, options);
+            }
+        }
+
+        if let Some(items) = obj.get_mut("items") {
+            sanitize_schema(items, options);
+        }
+
+        // Neither provider supports oneOf; convert to anyOf, merging into an
+        // existing anyOf array if present.
+        if let Some(one_of) = obj.remove("oneOf") {
+            match obj.get_mut("anyOf") {
+                Some(Value::Array(existing)) => {
+                    if let Value::Array(mut incoming) = one_of {
+                        existing.append(&mut incoming);
+                    }
+                }
+                _ => {
+                    obj.insert("anyOf".to_string(), one_of);
+                }
+            }
+        }
+
+        for key in ["anyOf", "allOf"] {
+            if let Some(variants) = obj.get_mut(key)
+                && let Value::Array(variants_array) = variants
+            {
+                for variant in variants_array.iter_mut() {
+                    sanitize_schema(variant, options);
+                }
+            }
+        }
+    }
+}

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Deserializer, Serialize};
 
 use super::client::{MistralExt, Usage};
-use crate::providers::internal::openai_chat_completions_compatible::map_openai_finish_reason;
 use crate::providers::openai;
 use crate::{
     completion::{self, CompletionError},
@@ -184,58 +183,39 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
 /// descriptor that actually produced it.
 impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
     fn normalize(self, provider: &str) -> Result<completion::CompletionResponse, CompletionError> {
-        let response = self;
-        let choice = response.choices.first().ok_or_else(|| {
-            CompletionError::ResponseError("Response contained no choices".to_owned())
-        })?;
+        use crate::providers::internal::openai_chat_completions_compatible as compat;
 
-        let finish_reason = Some(choice.finish_reason.as_str())
-            .filter(|reason| !reason.is_empty())
-            .map(map_openai_finish_reason);
-
-        let content = match &choice.message {
-            Message::Assistant {
-                content,
-                tool_calls,
-                ..
-            } => {
-                let mut content = if content.is_empty() {
-                    vec![]
-                } else {
-                    vec![completion::AssistantContent::text(content.clone())]
-                };
-
-                content.extend(
-                    tool_calls
-                        .iter()
-                        .map(|call| {
-                            completion::AssistantContent::tool_call(
-                                &call.id,
-                                &call.function.name,
-                                call.function.arguments.clone(),
-                            )
-                        })
-                        .collect::<Vec<_>>(),
-                );
-                Ok(content)
-            }
-            _ => Err(CompletionError::ResponseError(
-                "Response did not contain a valid message or tool call".into(),
-            )),
-        }?;
-
-        let choice = crate::message::require_non_empty_response(content)?;
-
-        let usage = response
+        let usage = self
             .usage
             .as_ref()
             .map(completion::Usage::from)
             .unwrap_or_default();
-
-        Ok(completion::CompletionResponse::new(choice, usage, provider)
-            .with_response_id(response.id.as_str())
-            .with_model(response.model.as_str())
-            .with_optional_finish_reason(finish_reason))
+        compat::normalize_openai_response(
+            provider,
+            &self.choices,
+            Some(self.id.as_str()),
+            Some(self.model.as_str()),
+            usage,
+            |choice| choice.finish_reason.as_str(),
+            |choice| match &choice.message {
+                Message::Assistant {
+                    content,
+                    tool_calls,
+                    ..
+                } => Some(compat::text_then_tool_calls(
+                    content,
+                    content.is_empty(),
+                    tool_calls.iter().map(|call| {
+                        (
+                            call.id.as_str(),
+                            call.function.name.as_str(),
+                            call.function.arguments.clone(),
+                        )
+                    }),
+                )),
+                _ => None,
+            },
+        )
     }
 }
 

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -320,12 +320,12 @@ impl From<&CompletionResponse> for Usage {
     fn from(response: &CompletionResponse) -> Usage {
         let input_tokens = response.prompt_eval_count.unwrap_or(0);
         let output_tokens = response.eval_count.unwrap_or(0);
-
-        let mut usage = Usage::new();
-        usage.input_tokens = input_tokens;
-        usage.output_tokens = output_tokens;
-        usage.total_tokens = input_tokens + output_tokens;
-        usage
+        crate::providers::internal::completion_usage(
+            input_tokens,
+            output_tokens,
+            input_tokens + output_tokens,
+            0,
+        )
     }
 }
 
@@ -1427,38 +1427,8 @@ impl From<crate::message::ToolCall> for ToolCall {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
-pub struct SystemContent {
-    #[serde(default)]
-    r#type: SystemContentType,
-    text: String,
-}
-
-#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone)]
-#[serde(rename_all = "lowercase")]
-pub enum SystemContentType {
-    #[default]
-    Text,
-}
-
-impl From<String> for SystemContent {
-    fn from(s: String) -> Self {
-        SystemContent {
-            r#type: SystemContentType::default(),
-            text: s,
-        }
-    }
-}
-
-impl FromStr for SystemContent {
-    type Err = std::convert::Infallible;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(SystemContent {
-            r#type: SystemContentType::default(),
-            text: s.to_string(),
-        })
-    }
-}
+// Byte-for-byte the same wire shape as OpenAI's system content part; reuse it.
+pub use crate::providers::openai::completion::{SystemContent, SystemContentType};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct AssistantContent {

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -1153,75 +1153,61 @@ pub struct CompletionResponse {
 /// it as part of the conversion makes the correct name impossible to forget.
 impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
     fn normalize(self, provider: &str) -> Result<completion::CompletionResponse, CompletionError> {
-        let response = self;
-        let choice = response.choices.first().ok_or_else(|| {
-            CompletionError::ResponseError("Response contained no choices".to_owned())
-        })?;
+        use crate::providers::internal::openai_chat_completions_compatible as compat;
 
-        let finish_reason = Some(choice.finish_reason.as_str())
-            .filter(|reason| !reason.is_empty())
-            .map(crate::providers::internal::openai_chat_completions_compatible::map_openai_finish_reason);
-
-        let content = match &choice.message {
-            Message::Assistant {
-                content,
-                tool_calls,
-                reasoning,
-                ..
-            } => {
-                let mut content = content
-                    .iter()
-                    .filter_map(|c| {
-                        let s = match c {
-                            AssistantContent::Text { text, .. } => text,
-                            AssistantContent::Refusal { refusal } => refusal,
-                        };
-                        if s.is_empty() {
-                            None
-                        } else {
-                            Some(completion::AssistantContent::text(s))
-                        }
-                    })
-                    .collect::<Vec<_>>();
-
-                if let Some(reasoning) = reasoning {
-                    // llama.cpp exposes hidden reasoning on a separate non-standard field.
-                    // Keep it structured here so the non-streaming path matches streaming
-                    // behavior and does not pollute plain-text response surfaces.
-                    content.push(completion::AssistantContent::reasoning(reasoning));
-                }
-
-                content.extend(
-                    tool_calls
-                        .iter()
-                        .map(|call| {
-                            completion::AssistantContent::tool_call(
-                                &call.id,
-                                &call.function.name,
-                                call.function.arguments.clone(),
-                            )
-                        })
-                        .collect::<Vec<_>>(),
-                );
-                Ok(content)
-            }
-            _ => Err(CompletionError::ResponseError(
-                "Response did not contain a valid message or tool call".into(),
-            )),
-        }?;
-
-        let choice = crate::message::require_non_empty_response(content)?;
-
-        let usage = response
+        let usage = self
             .usage
             .as_ref()
             .map(crate::completion::Usage::from)
             .unwrap_or_default();
+        compat::normalize_openai_response(
+            provider,
+            &self.choices,
+            Some(self.id.as_str()),
+            Some(self.model.as_str()),
+            usage,
+            |choice| choice.finish_reason.as_str(),
+            |choice| match &choice.message {
+                Message::Assistant {
+                    content,
+                    tool_calls,
+                    reasoning,
+                    ..
+                } => {
+                    let mut content = content
+                        .iter()
+                        .filter_map(|c| {
+                            let s = match c {
+                                AssistantContent::Text { text, .. } => text,
+                                AssistantContent::Refusal { refusal } => refusal,
+                            };
+                            if s.is_empty() {
+                                None
+                            } else {
+                                Some(completion::AssistantContent::text(s))
+                            }
+                        })
+                        .collect::<Vec<_>>();
 
-        Ok(completion::CompletionResponse::new(choice, usage, provider)
-            .with_response_id(response.id.as_str())
-            .with_model(response.model.as_str())
-            .with_optional_finish_reason(finish_reason))
+                    if let Some(reasoning) = reasoning {
+                        // llama.cpp exposes hidden reasoning on a separate non-standard field.
+                        // Keep it structured here so the non-streaming path matches streaming
+                        // behavior and does not pollute plain-text response surfaces.
+                        content.push(completion::AssistantContent::reasoning(reasoning));
+                    }
+
+                    content.extend(tool_calls.iter().map(|call| {
+                        completion::AssistantContent::tool_call(
+                            &call.id,
+                            &call.function.name,
+                            call.function.arguments.clone(),
+                        )
+                    }));
+                    Some(content)
+                }
+                _ => None,
+            },
+        )
     }
 }
 

--- a/crates/rig-core/src/providers/openai/mod.rs
+++ b/crates/rig-core/src/providers/openai/mod.rs
@@ -36,84 +36,19 @@ pub use model_listing::*;
 
 /// Recursively ensures all object schemas in a JSON schema respect OpenAI structured output restrictions.
 /// Nested arrays, schema $defs, object properties and enums should be handled through this method
+///
+/// Sources:
+/// - <https://platform.openai.com/docs/guides/structured-outputs#additionalproperties-false-must-always-be-set-in-objects>
+/// - <https://platform.openai.com/docs/guides/structured-outputs#all-fields-must-be-required>
 pub(crate) fn sanitize_schema(schema: &mut serde_json::Value) {
-    use serde_json::Value;
-
-    if let Value::Object(obj) = schema {
-        // OpenAI does not allow sibling keywords next to $ref (e.g. "description").
-        // Strip everything except $ref so the reference is the sole key.
-        if obj.contains_key("$ref") {
-            obj.retain(|k, _| k == "$ref");
-            return;
-        }
-
-        let is_object_schema = obj.get("type") == Some(&Value::String("object".to_string()))
-            || obj.contains_key("properties");
-
-        // OpenAI requires "properties" on all object schemas, even empty ones.
-        if is_object_schema && !obj.contains_key("properties") {
-            obj.insert("properties".to_string(), Value::Object(Default::default()));
-        }
-
-        // This is required by OpenAI's Responses API when using strict mode.
-        // Source: https://platform.openai.com/docs/guides/structured-outputs#additionalproperties-false-must-always-be-set-in-objects
-        if is_object_schema && !obj.contains_key("additionalProperties") {
-            obj.insert("additionalProperties".to_string(), Value::Bool(false));
-        }
-
-        // This is also required by OpenAI's Responses API
-        // Source: https://platform.openai.com/docs/guides/structured-outputs#all-fields-must-be-required
-        if let Some(Value::Object(properties)) = obj.get("properties") {
-            let prop_keys = properties.keys().cloned().map(Value::String).collect();
-            obj.insert("required".to_string(), Value::Array(prop_keys));
-        }
-
-        if let Some(defs) = obj.get_mut("$defs")
-            && let Value::Object(defs_obj) = defs
-        {
-            for (_, def_schema) in defs_obj.iter_mut() {
-                sanitize_schema(def_schema);
-            }
-        }
-
-        if let Some(properties) = obj.get_mut("properties")
-            && let Value::Object(props) = properties
-        {
-            for (_, prop_value) in props.iter_mut() {
-                sanitize_schema(prop_value);
-            }
-        }
-
-        if let Some(items) = obj.get_mut("items") {
-            sanitize_schema(items);
-        }
-
-        // OpenAI doesn't support oneOf so we need to switch this to anyOf
-        if let Some(one_of) = obj.remove("oneOf") {
-            // If `anyOf` already exists, merge arrays. If not, insert new.
-            match obj.get_mut("anyOf") {
-                Some(Value::Array(existing)) => {
-                    if let Value::Array(mut incoming) = one_of {
-                        existing.append(&mut incoming);
-                    }
-                }
-                _ => {
-                    obj.insert("anyOf".to_string(), one_of);
-                }
-            }
-        }
-
-        // should handle Enums (anyOf/oneOf)
-        for key in ["anyOf", "oneOf", "allOf"] {
-            if let Some(variants) = obj.get_mut(key)
-                && let Value::Array(variants_array) = variants
-            {
-                for variant in variants_array.iter_mut() {
-                    sanitize_schema(variant);
-                }
-            }
-        }
-    }
+    crate::providers::internal::schema::sanitize_schema(
+        schema,
+        crate::providers::internal::schema::SanitizeOptions {
+            strip_ref_siblings: true,
+            inject_empty_properties: true,
+            strip_numeric_constraints: false,
+        },
+    );
 }
 
 #[cfg(feature = "audio")]

--- a/crates/rig-core/src/providers/xai/api.rs
+++ b/crates/rig-core/src/providers/xai/api.rs
@@ -376,23 +376,6 @@ impl From<completion::ToolDefinition> for ToolDefinition {
     }
 }
 
-// ================================================================
-// Error Types
-// ================================================================
-
-/// API error response
-#[derive(Debug, Deserialize)]
-pub struct ApiError {
-    pub error: String,
-    pub code: String,
-}
-
-impl ApiError {
-    pub fn message(&self) -> String {
-        format!("Code `{}`: {}", self.code, self.error)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::{Content, Message, Role};
@@ -608,11 +591,4 @@ mod tests {
                 if !call_id.is_empty() && name == "my_tool"
         ));
     }
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-pub enum ApiResponse<T> {
-    Ok(T),
-    Error(ApiError),
 }

--- a/crates/rig-core/src/providers/xai/completion.rs
+++ b/crates/rig-core/src/providers/xai/completion.rs
@@ -8,10 +8,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::{Instrument, Level, enabled};
 
-use super::api::{ApiResponse, Message, ToolDefinition};
+use super::api::{Message, ToolDefinition};
 use super::client::Client;
 use crate::completion::{self, CompletionError, CompletionRequest};
 use crate::http_client::HttpClientExt;
+use crate::providers::openai::client::ApiResponse;
 use crate::providers::openai::responses_api::ToolChoice;
 use crate::providers::openai::responses_api::{IncompleteDetailsReason, Output, ResponsesUsage};
 
@@ -339,8 +340,8 @@ where
 
                         Ok(response)
                     }
-                    ApiResponse::Error(error) => {
-                        tracing::warn!(message = %error.message(), "provider returned an error response");
+                    ApiResponse::Err(error) => {
+                        tracing::warn!(message = %error.message, "provider returned an error response");
                         Err(CompletionError::from_http_response(
                             status,
                             String::from_utf8_lossy(&response_body),
@@ -699,7 +700,7 @@ mod tests {
         use crate::completion::{CompletionError, CompletionModel as _};
         use crate::test_utils::RecordingHttpClient;
 
-        // Deserializes to `ApiResponse::Error(ApiError { error, code })` on a 200 OK.
+        // Deserializes to `ApiResponse::Err(ApiErrorResponse)` on a 200 OK.
         let body = r#"{"error":"boom","code":"503"}"#;
         let http_client = RecordingHttpClient::new(body);
         let client = crate::providers::xai::Client::builder()

--- a/crates/rig-core/src/providers/xai/image_generation.rs
+++ b/crates/rig-core/src/providers/xai/image_generation.rs
@@ -1,9 +1,9 @@
-use super::api::ApiResponse;
 use super::client::Client;
 use crate::http_client::HttpClientExt;
 use crate::image_generation;
 use crate::image_generation::{ImageGenerationError, ImageGenerationRequest};
 use crate::json_utils::merge_inplace;
+use crate::providers::openai::client::ApiResponse;
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
 use serde::Deserialize;
@@ -14,17 +14,6 @@ use serde_json::json;
 // ================================================================
 pub const GROK_IMAGINE_IMAGE: &str = "grok-imagine-image";
 pub const GROK_IMAGINE_IMAGE_PRO: &str = "grok-imagine-image-pro";
-
-impl<T> crate::providers::internal::envelope::ProviderEnvelope for ApiResponse<T> {
-    type Payload = T;
-
-    fn into_payload(self) -> Result<T, String> {
-        match self {
-            Self::Ok(value) => Ok(value),
-            Self::Error(error) => Err(error.message()),
-        }
-    }
-}
 
 #[derive(Debug, Deserialize)]
 pub struct ImageGenerationData {
@@ -160,7 +149,7 @@ mod tests {
     async fn image_generation_2xx_error_envelope_preserves_status_and_body() {
         use crate::test_utils::RecordingHttpClient;
 
-        // Deserializes to `ApiResponse::Error(ApiError { error, code })` on a 200 OK.
+        // Deserializes to `ApiResponse::Err(ApiErrorResponse)` on a 200 OK.
         let body = r#"{"error":"boom","code":"503"}"#;
         let http_client = RecordingHttpClient::new(body);
         let client = crate::providers::xai::Client::builder()

--- a/crates/rig-core/src/tool/result.rs
+++ b/crates/rig-core/src/tool/result.rs
@@ -32,45 +32,38 @@ pub enum ToolErrorKind {
     Other,
 }
 
-impl ToolErrorKind {
-    /// Stable machine-readable name.
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::InvalidArgs => "invalid_args",
-            Self::Timeout => "timeout",
-            Self::Cancelled => "cancelled",
-            Self::NotFound => "not_found",
-            Self::PermissionDenied => "permission_denied",
-            Self::RateLimited => "rate_limited",
-            Self::Provider => "provider",
-            Self::Network => "network",
-            Self::Other => "other",
-        }
-    }
-
-    const fn default_retryable(self) -> Option<bool> {
-        match self {
-            Self::Timeout | Self::RateLimited | Self::Network => Some(true),
-            Self::InvalidArgs | Self::Cancelled | Self::NotFound | Self::PermissionDenied => {
-                Some(false)
+// One row per kind: (stable name, default retryability, default model
+// feedback). The macro emits the three parallel accessors from the single
+// table so a new kind cannot update one and miss another.
+macro_rules! kind_defaults {
+    ($($variant:ident => ($name:literal, $retryable:expr, $feedback:literal)),+ $(,)?) => {
+        impl ToolErrorKind {
+            /// Stable machine-readable name.
+            pub const fn as_str(self) -> &'static str {
+                match self { $(Self::$variant => $name,)+ }
             }
-            Self::Provider | Self::Other => None,
-        }
-    }
 
-    const fn default_model_feedback(self) -> &'static str {
-        match self {
-            Self::InvalidArgs => "tool arguments were invalid",
-            Self::Timeout => "tool execution timed out",
-            Self::Cancelled => "tool execution was cancelled",
-            Self::NotFound => "the requested tool or resource was not found",
-            Self::PermissionDenied => "the tool denied the request",
-            Self::RateLimited => "the tool was rate limited; try again later",
-            Self::Provider => "the tool provider failed",
-            Self::Network => "the tool could not reach its upstream service",
-            Self::Other => "the tool failed",
+            const fn default_retryable(self) -> Option<bool> {
+                match self { $(Self::$variant => $retryable,)+ }
+            }
+
+            const fn default_model_feedback(self) -> &'static str {
+                match self { $(Self::$variant => $feedback,)+ }
+            }
         }
-    }
+    };
+}
+
+kind_defaults! {
+    InvalidArgs => ("invalid_args", Some(false), "tool arguments were invalid"),
+    Timeout => ("timeout", Some(true), "tool execution timed out"),
+    Cancelled => ("cancelled", Some(false), "tool execution was cancelled"),
+    NotFound => ("not_found", Some(false), "the requested tool or resource was not found"),
+    PermissionDenied => ("permission_denied", Some(false), "the tool denied the request"),
+    RateLimited => ("rate_limited", Some(true), "the tool was rate limited; try again later"),
+    Provider => ("provider", None, "the tool provider failed"),
+    Network => ("network", Some(true), "the tool could not reach its upstream service"),
+    Other => ("other", None, "the tool failed"),
 }
 
 impl std::fmt::Display for ToolErrorKind {

--- a/crates/rig-core/src/vector_store/in_memory_store.rs
+++ b/crates/rig-core/src/vector_store/in_memory_store.rs
@@ -77,19 +77,9 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
     ///
     /// Uses BruteForce index strategy by default. For custom index strategies, use [InMemoryVectorStore::builder].
     pub fn from_documents(documents: impl IntoIterator<Item = (D, Vec<Embedding>)>) -> Self {
-        let mut store = HashMap::new();
-        documents
-            .into_iter()
-            .enumerate()
-            .for_each(|(i, (doc, embeddings))| {
-                store.insert(format!("doc{i}"), (doc, embeddings));
-            });
-
-        Self {
-            embeddings: store,
-            index_strategy: IndexStrategy::default(),
-            lsh_index: None,
-        }
+        let mut store = Self::from_builder(HashMap::new(), IndexStrategy::default());
+        store.add_documents(documents);
+        store
     }
 
     /// Create a new [InMemoryVectorStore] from documents and their corresponding embeddings with ids.
@@ -98,16 +88,9 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
     pub fn from_documents_with_ids(
         documents: impl IntoIterator<Item = (impl ToString, D, Vec<Embedding>)>,
     ) -> Self {
-        let mut store = HashMap::new();
-        documents.into_iter().for_each(|(i, doc, embeddings)| {
-            store.insert(i.to_string(), (doc, embeddings));
-        });
-
-        Self {
-            embeddings: store,
-            index_strategy: IndexStrategy::default(),
-            lsh_index: None,
-        }
+        let mut store = Self::from_builder(HashMap::new(), IndexStrategy::default());
+        store.add_documents_with_ids(documents);
+        store
     }
 
     /// Create a new [InMemoryVectorStore] from documents and their corresponding embeddings.
@@ -118,16 +101,19 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
         documents: impl IntoIterator<Item = (D, Vec<Embedding>)>,
         f: fn(&D) -> String,
     ) -> Self {
-        let mut store = HashMap::new();
-        documents.into_iter().for_each(|(doc, embeddings)| {
-            store.insert(f(&doc), (doc, embeddings));
-        });
+        let mut store = Self::from_builder(HashMap::new(), IndexStrategy::default());
+        store.add_documents_with_id_f(documents, f);
+        store
+    }
 
-        Self {
-            embeddings: store,
-            index_strategy: IndexStrategy::default(),
-            lsh_index: None,
+    /// Insert a single document, keeping the LSH index (when enabled) in sync.
+    fn insert_document(&mut self, id: String, doc: D, embeddings: Vec<Embedding>) {
+        if let Some(ref mut lsh_index) = self.lsh_index {
+            for embedding in embeddings.iter() {
+                lsh_index.insert(id.clone(), &embedding.vec);
+            }
         }
+        self.embeddings.insert(id, (doc, embeddings));
     }
 
     /// Tests whether a document satisfies the (optional) metadata filter.
@@ -303,7 +289,7 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
 
         // Convert to BinaryHeap format using the original HashMap keys
         for (distance, candidate_id, doc, embed_doc) in scored_docs {
-            if let Some((id_ref, _)) = self.embeddings.iter().find(|(k, _)| **k == candidate_id) {
+            if let Some((id_ref, _)) = self.embeddings.get_key_value(&candidate_id) {
                 docs.push(Reverse(RankingItem(distance, id_ref, doc, embed_doc)));
             }
         }
@@ -356,21 +342,9 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
     /// is the index of the document.
     pub fn add_documents(&mut self, documents: impl IntoIterator<Item = (D, Vec<Embedding>)>) {
         let current_index = self.embeddings.len();
-        documents
-            .into_iter()
-            .enumerate()
-            .for_each(|(index, (doc, embeddings))| {
-                let id = format!("doc{}", index + current_index);
-                self.embeddings
-                    .insert(id.clone(), (doc, embeddings.clone()));
-
-                // Update LSH index if it exists
-                if let Some(ref mut lsh_index) = self.lsh_index {
-                    for embedding in embeddings.iter() {
-                        lsh_index.insert(id.clone(), &embedding.vec);
-                    }
-                }
-            });
+        for (index, (doc, embeddings)) in documents.into_iter().enumerate() {
+            self.insert_document(format!("doc{}", index + current_index), doc, embeddings);
+        }
     }
 
     /// Add documents and their corresponding embeddings to the store with ids.
@@ -378,38 +352,20 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
         &mut self,
         documents: impl IntoIterator<Item = (impl ToString, D, Vec<Embedding>)>,
     ) {
-        documents.into_iter().for_each(|(id, doc, embeddings)| {
-            let id_str = id.to_string();
-            self.embeddings
-                .insert(id_str.clone(), (doc, embeddings.clone()));
-
-            // Update LSH index if it exists
-            if let Some(ref mut lsh_index) = self.lsh_index {
-                for embedding in embeddings.iter() {
-                    lsh_index.insert(id_str.clone(), &embedding.vec);
-                }
-            }
-        });
+        for (id, doc, embeddings) in documents {
+            self.insert_document(id.to_string(), doc, embeddings);
+        }
     }
 
     /// Add documents and their corresponding embeddings to the store.
     /// Document ids are generated using the provided function.
     pub fn add_documents_with_id_f(
         &mut self,
-        documents: Vec<(D, Vec<Embedding>)>,
+        documents: impl IntoIterator<Item = (D, Vec<Embedding>)>,
         f: fn(&D) -> String,
     ) {
         for (doc, embeddings) in documents {
-            let id = f(&doc);
-            self.embeddings
-                .insert(id.clone(), (doc, embeddings.clone()));
-
-            // Update LSH index if it exists
-            if let Some(ref mut lsh_index) = self.lsh_index {
-                for embedding in embeddings.iter() {
-                    lsh_index.insert(id.clone(), &embedding.vec);
-                }
-            }
+            self.insert_document(f(&doc), doc, embeddings);
         }
     }
 


### PR DESCRIPTION
Third LOC-reduction pass over `rig-core` and `rig-agent` (follows #2286/#2289). Production LOC: rig-core 59,508 → 59,208, rig-agent 16,204 → 16,139 (**−365**; whole diff −476 lines, no tests deleted).

## rig-core

**Providers**
- The two forked JSON-schema sanitizers (anthropic + openai) now share `providers/internal/schema.rs`, with a 3-flag `SanitizeOptions` for the genuine deltas ($ref-sibling stripping, empty-`properties` injection, numeric-constraint stripping).
- openai/deepseek/mistral non-streaming response normalization shares `normalize_openai_response`; each provider's empty-content predicate is passed in, so deepseek's `trim()` vs mistral's non-trim divergence is preserved exactly.
- anthropic's 5-arm `Citation` serializer now reuses the existing deserialize DTOs (byte-identical JSON, including `WebSearchResultLocation`'s explicit `"title": null`).
- xai migrated to the shared error envelope; gemini's `split_system_messages_from_history` and interactions-API media preamble deduplicated; ollama reuses openai's `SystemContent` and the shared usage converter.

**Core**
- Table-driven mime-type impls and media constructors in `completion/message.rs` (aliases like `text/md` still parse; canonical spellings still emit).
- `InMemoryVectorStore`: six triplicated ingest paths collapsed to one insert helper — also **fixes two defects**: three full `Vec<Embedding>` clones per insert, and an O(n·k) linear scan in LSH lookup (now `get_key_value`).
- Capability-client impls, Arc/Box memory-trait forwards, and `ToolErrorKind` accessors macro/table-generated (cfg gates, WasmCompat bounds, and rustdoc preserved); `ModelListingError` on thiserror with verbatim Display strings.

## rig-agent
- Doc-carrying forwarding macros for the builder `NoToolConfig` tool methods, `HookStack` short-circuit forwarders, and extractor delegations (chaining hook impls untouched).
- Streamed-reasoning assembly shares one core between borrow/own paths; probe ordering preserved (pinned test passes).

## Behavioral notes
- xai error messages drop the `Code \`{code}\`:` prefix; the raw provider body (including the code) is still preserved on the error and asserted by tests.
- `from_documents*` constructors route through the LSH-aware insert path (no-op today: constructors never start with an LSH index).

## Rejected as net-negative (measured)
copilot/chatgpt OAuth unification, `ProviderResponseExt` blanket (real find_map-vs-join divergence), openrouter converter fork, gemini/copilot/doubleword/huggingface envelope migrations, a `run_scenario` conformance helper (**+51 LOC** in practice), shared `InvalidToolCallContext` ctor (+22 LOC), ToolSetBuilder macro.

## Verification
- `cargo fmt` clean
- `cargo clippy -p rig-core -p rig-agent --all-targets --all-features -- -D warnings` clean
- `cargo test -p rig-core -p rig-agent --all-features`: 1,325 + 483 lib tests plus all integration/doctest suites, 0 failures
- `cargo doc --no-deps` zero warnings
- A separate adversarial full-diff review confirmed JSON-output equivalence on the risky spots (Citation serialization, schema sanitizers, mime tables).