### PR TITLE
ci: reduce Rust cache churn and test rebuilds

### DIFF
--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -32,6 +32,12 @@ inputs:
   cache:
     description: Enable rust-cache (disable for jobs that compile nothing)
     default: "true"
+  cache-save-if:
+    description: >-
+      Additional rust-cache save gate. Cache writes are always restricted to
+      the default branch so pull-request merge refs can restore but cannot
+      evict the reusable caches they consume.
+    default: "true"
   sccache:
     description: >-
       Enable sccache with the GitHub Actions cache backend. Reserved for the
@@ -86,6 +92,7 @@ runs:
         components: ${{ inputs.components }}
         target: ${{ inputs.target }}
         cache: ${{ inputs.cache }}
+        cache-save-if: ${{ inputs.cache-save-if == 'true' && github.ref == 'refs/heads/main' }}
 
     # rust-cache (inside setup-rust-toolchain above) persists *dependency*
     # artifacts but always recompiles the workspace's own crates; sccache
@@ -135,6 +142,12 @@ runs:
         {
           echo "SCCACHE_GHA_ENABLED=true"
           echo "RUSTC_WRAPPER=sccache"
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            # PR caches are scoped to their merge ref and cannot warm other
+            # branches. Read the default branch's entries without creating
+            # thousands of short-lived, quota-consuming PR entries.
+            echo "SCCACHE_GHA_RW_MODE=READ_ONLY"
+          fi
         } >> "$GITHUB_ENV"
 
     - name: Install nextest

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -47,8 +47,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      # protoc: required to compile rig-lancedb, and the `lancedb` crate that
-      # the `rig` facade carries as an unconditional dev-dependency.
+      # protoc: required when release-plz checks or packages rig-lancedb.
       - name: Install Rust toolchain
         uses: ./.github/actions/rust-setup
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -211,21 +211,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      # protoc is required here, and NOT only for the `lancedb` feature: the
-      # `rig` facade lists `lancedb` as an unconditional dev-dependency, so
-      # building its test targets — which both steps below do — compiles the
-      # lance chain, whose build scripts shell out to a *system* protoc.
-      # ubuntu-latest does not ship one, and dropping the install does not
-      # fail loudly — it fails only once the rust-cache entry is invalidated
-      # and lance rebuilds, turning a Cargo.lock or toolchain bump into an
-      # unrelated-looking build-script error. Verify the dependency edge with:
-      #   cargo tree -i lance-encoding -e normal,dev --target all
+      # The raw lancedb dependency used by the facade's integration tests is
+      # feature-gated with those tests. Neither graph below enables it, so a
+      # cold PR run avoids the Lance/Arrow/DataFusion graph and needs no
+      # system protoc. The all-features jobs retain both.
       - name: Install Rust stable
         uses: ./.github/actions/rust-setup
         with:
           sccache: "true"
           nextest: "true"
-          protoc: "true"
 
       # `nextest` below runs with `--features bedrock`, which does not compile
       # the pure default-feature test graph. Check the root integration tests
@@ -233,19 +227,16 @@ jobs:
       # accidentally depend on APIs that only exist under optional features.
       #
       # `cargo check`, not `cargo test --no-run`: the guarded failure class is
-      # purely type-level, and `--no-run` additionally pays codegen + linking
-      # of every lance-heavy test binary under a default-feature hash the
-      # `--features bedrock` step below never reuses (~1-2 wasted minutes even
-      # warm, since rust-cache never persists workspace-member artifacts).
-      # `check` still runs build scripts, so the protoc requirement above is
-      # unchanged. Be precise about what this trades away: the bedrock run
-      # below and nightly's sweep link *superset* feature configurations, so
-      # no lane anywhere links the pure default-feature binaries — a
-      # default-only codegen/link break would surface first in merge_group's
-      # full run. That gap is accepted as theoretical: `bedrock` is purely
-      # additive and the workspace has no `cfg(not(feature = …))` in test
-      # code, so a break that appears only with features *removed* has no
-      # known mechanism.
+      # purely type-level, while `--no-run` additionally pays codegen +
+      # linking under a default-feature hash the `--features bedrock` step
+      # below never reuses. Be precise about what this trades away: the
+      # bedrock run below and nightly's sweep link *superset* feature
+      # configurations, so no lane anywhere links the pure default-feature
+      # binaries — a default-only codegen/link break would surface first in
+      # merge_group's full run. That gap is accepted as theoretical:
+      # `bedrock` is purely additive and the workspace has no
+      # `cfg(not(feature = …))` in test code, so a break that appears only
+      # with features *removed* has no known mechanism.
       - name: Check default-feature root test targets
         run: cargo check --locked -p rig --tests
 
@@ -270,8 +261,21 @@ jobs:
       # archived in 2023 and pins Node 20, which this workflow's own log
       # already reports as force-upgraded to Node 24. It added nothing over
       # invoking cargo directly.
+      # The two nested-Cargo binaries run in `test-guards` under the stronger
+      # configuration they protect: identity_leak with all features and
+      # macro_hygiene through its dedicated downstream-consumer step. Running
+      # them again here made a cold test execution spend over three minutes
+      # recompiling scratch projects after the other ~3,600 tests had nearly
+      # finished.
       - name: Test with latest nextest release
-        run: cargo nextest run --locked --features bedrock --retries 2
+        run: >-
+          cargo nextest run --locked --features bedrock --retries 2
+          -E 'not (binary(identity_leak) | binary(macro_hygiene))'
+
+      - name: Show sccache statistics
+        if: always() && env.RUSTC_WRAPPER == 'sccache'
+        continue-on-error: true
+        run: sccache --show-stats
 
   # The cross-crate contract tripwires, split from `test` so the two halves
   # run in parallel: each step deliberately compiles a package set with its
@@ -290,13 +294,9 @@ jobs:
           sccache: "true"
           nextest: "true"
 
-      # No protoc here, and unlike the `test` job that is genuinely true: the
-      # lance chain enters the graph through the `rig` facade's
-      # dev-dependencies, and every step below names `-p` packages
-      # (rig-agent, rig-core, rig-candle, rig-gemini-grpc) rather than the
-      # facade, so no lance build script runs. rig-gemini-grpc vendors its own
-      # protoc via protoc-bin-vendored. Adding a facade step here means adding
-      # the apt install back.
+      # No system protoc: every step below names packages that do not enable
+      # the facade's `lancedb` feature, and rig-gemini-grpc vendors its own
+      # protoc via protoc-bin-vendored.
 
       # The full rig-core and rig-agent test suites under `--all-features`.
       # Before the fast/full split, the workspace-wide `--all-features` sweep
@@ -310,16 +310,20 @@ jobs:
       # enforced by the dedicated step below, exactly as it was when the
       # workspace sweep ran them with `--retries 2` alongside it.
       #
-      # All test targets, NOT `--lib`: rig-core's `identity_leak` trybuild
-      # suite is an *integration* test whose compile-fail proof (no `Serialize`
-      # path for `PartId`/`StreamPartId`) is only load-bearing under
-      # `--all-features`, because trybuild propagates the outer binary's
-      # enabled features into its scratch builds. `--lib` here would demote
-      # that proof — and rig-agent's non-lib targets such as
-      # `runtime_model_swapping` — to nightly-only coverage, exactly the
-      # silent narrowing this step exists to prevent.
+      # All test targets except macro_hygiene, NOT `--lib`: rig-core's
+      # `identity_leak` trybuild suite is an *integration* test whose
+      # compile-fail proof (no `Serialize` path for `PartId`/`StreamPartId`)
+      # is only load-bearing under `--all-features`, because trybuild
+      # propagates the outer binary's enabled features into its scratch
+      # builds. `--lib` here would demote that proof — and rig-agent's non-lib
+      # targets such as `runtime_model_swapping` — to nightly-only coverage,
+      # exactly the silent narrowing this step exists to prevent.
+      # macro_hygiene also shells out to Cargo, but its dedicated step below
+      # is the authoritative plain-`cargo test` execution.
       - name: Test rig-core and rig-agent with all features
-        run: cargo nextest run --locked -p rig-core -p rig-agent --all-features --retries 2
+        run: >-
+          cargo nextest run --locked -p rig-core -p rig-agent --all-features
+          --retries 2 -E 'not binary(macro_hygiene)'
 
       # `cargo nextest run` (in the `test` job) selects the workspace's
       # *default members* — historically just the `rig` facade, which is why a
@@ -384,6 +388,11 @@ jobs:
       - name: Test out-of-facade streaming conformance and structural guards
         run: cargo nextest run --locked -p rig-core -p rig-candle -p rig-gemini-grpc --all-features -E 'binary(streaming_conformance) + binary(streaming_conformance_websocket) + binary(driver_adoption)'
 
+      - name: Show sccache statistics
+        if: always() && env.RUSTC_WRAPPER == 'sccache'
+        continue-on-error: true
+        run: sccache --show-stats
+
   # rig-derive's own test suite — 43 tests across 12 binaries, including 20
   # trybuild cases and the dependency-rename fixtures. Until this job existed
   # none of them ran anywhere in CI: rig-derive is deliberately outside
@@ -431,10 +440,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      # protoc: required to compile rig-lancedb (and the facade's lance
-      # dev-dependency chain). No sccache: this job is off the critical path
-      # and rustdoc's doctest execution is not cacheable anyway — see the
-      # quota note on the sccache input in the rust-setup action.
+      # protoc: required because this all-features job enables rig-lancedb.
+      # No sccache: this job is off the critical path and rustdoc's doctest
+      # execution is not cacheable anyway — see the quota note on the
+      # sccache input in the rust-setup action.
       - name: Install Rust stable
         uses: ./.github/actions/rust-setup
         with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -132,9 +132,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      # protoc: required to compile rig-lancedb — and the `lancedb` crate
-      # itself, which the `rig` facade carries as an unconditional
-      # dev-dependency. See the longer note on ci.yaml's `test` job.
+      # protoc: required because this all-features lane enables rig-lancedb
+      # and the facade's feature-gated raw lancedb test dependency.
       #
       # No sccache: the all-features sweep mints by far the most
       # per-compilation-unit cache entries, this lane is not

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,7 @@ rig-fastembed = { path = "crates/rig-fastembed", version = "0.41.0", optional = 
 rig-gemini-grpc = { path = "crates/rig-gemini-grpc", version = "0.41.0", optional = true, default-features = false }
 rig-helixdb = { path = "crates/rig-helixdb", version = "0.41.0", optional = true, default-features = false }
 rig-lancedb = { path = "crates/rig-lancedb", version = "0.41.0", optional = true, default-features = false }
+lancedb = { workspace = true, optional = true }
 rig-memory = { path = "crates/rig-memory", version = "0.41.0", optional = true, default-features = false }
 rig-derive = { path = "crates/rig-derive", version = "0.41.0", optional = true }
 rig-milvus = { path = "crates/rig-milvus", version = "0.41.0", optional = true, default-features = false }
@@ -237,7 +238,6 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 httpmock = { workspace = true, features = ["record", "proxy"] }
-lancedb = { workspace = true }
 mongodb = { workspace = true }
 neo4rs = { workspace = true }
 qdrant-client = { workspace = true }
@@ -303,7 +303,7 @@ fastembed-hf-hub = ["dep:rig-fastembed", "rig-fastembed/hf-hub"]
 fastembed-ort-download-binaries = ["dep:rig-fastembed", "rig-fastembed/ort-download-binaries"]
 gemini-grpc = ["dep:rig-gemini-grpc"]
 helixdb = ["dep:rig-helixdb"]
-lancedb = ["dep:rig-lancedb"]
+lancedb = ["dep:rig-lancedb", "dep:lancedb"]
 memory = ["dep:rig-memory"]
 milvus = ["dep:rig-milvus"]
 mongodb = ["dep:rig-mongodb"]


### PR DESCRIPTION
## Summary

- keep Rust dependency caches restorable on pull requests while restricting writes to `main`
- make the GHA-backed sccache read-only outside `main` and expose end-of-job hit/miss statistics
- feature-gate the facade's raw LanceDB test dependency so the default and Bedrock PR graphs no longer compile Lance/Arrow/DataFusion or install system protoc
- run the nested-Cargo `identity_leak` and `macro_hygiene` guards once in their authoritative guard configurations instead of duplicating them in the broad nextest sweep

## Root cause

PR #2305 showed the same test job taking 4m31s with an exact 1.83 GB Rust cache hit and 21m36s after that recently used cache was evicted. The repository was holding about 8.6 GB across roughly 2,884 cache objects; every PR job could write merge-ref-scoped caches, including thousands of sccache objects that cannot warm other PRs.

The cold lane then paid for two different Cargo feature graphs, an unconditional LanceDB dev-dependency, and nested Cargo builds inside tests that already ran in the dedicated guard job.

## Impact

Pull requests still restore caches produced by the default branch, but no longer create low-reuse merge-ref cache entries. Main and scheduled main workflows remain cache writers.

The normal PR test job no longer contains LanceDB. All-features clippy, docs, doctests, nightly tests, and the feature-gated LanceDB integration retain coverage.

The optimized nextest lane still runs all ordinary tests while `identity_leak` remains in the all-features guard and `macro_hygiene` remains in its dedicated downstream-consumer test.

Increasing the repository cache quota remains an optional administrator setting; this PR reduces churn without requiring paid cache storage.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- actionlint 1.7.12
- `cargo check --locked -p rig --tests`
- `cargo test --locked`
- optimized Bedrock nextest lane: 3,621/3,621 passed
- all-features `identity_leak` and dedicated `macro_hygiene` tests
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --all-features`
- feature-gated LanceDB integration: 2/2 passed
- dependency-tree checks: LanceDB absent by default and present with `--features lancedb`
- independent full-diff review: no P0–P3 findings
