### PR TITLE
refactor: workspace-wide LOC consolidation pass 6 (net −3,424 lines)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10251,6 +10251,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlite-vec",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rusqlite",
  "tracing",

--- a/crates/rig-bedrock/src/embedding.rs
+++ b/crates/rig-bedrock/src/embedding.rs
@@ -19,16 +19,15 @@ pub struct EmbeddingResponse {
     pub input_text_token_count: usize,
 }
 
-/// `amazon.titan-embed-text-v1`
-pub const AMAZON_TITAN_EMBED_TEXT_V1: &str = "amazon.titan-embed-text-v1";
-/// `amazon.titan-embed-text-v2:0`
-pub const AMAZON_TITAN_EMBED_TEXT_V2_0: &str = "amazon.titan-embed-text-v2:0";
-/// `amazon.titan-embed-image-v1`
-pub const AMAZON_TITAN_EMBED_IMAGE_V1: &str = "amazon.titan-embed-image-v1";
-/// `cohere.embed-english-v3`
-pub const COHERE_EMBED_ENGLISH_V3: &str = "cohere.embed-english-v3";
-/// `cohere.embed-multilingual-v3`
-pub const COHERE_EMBED_MULTILINGUAL_V3: &str = "cohere.embed-multilingual-v3";
+// The model-id string values are canonically defined in `crate::completion`;
+// these aliases keep this module's historical public names.
+pub use crate::completion::{
+    AMAZON_TITAN_EMBEDDINGS_G1_TEXT as AMAZON_TITAN_EMBED_TEXT_V1,
+    AMAZON_TITAN_MULTIMODAL_EMBEDDINGS_G1 as AMAZON_TITAN_EMBED_IMAGE_V1,
+    AMAZON_TITAN_TEXT_EMBEDDINGS_V2 as AMAZON_TITAN_EMBED_TEXT_V2_0,
+    COHERE_EMBED_ENGLISH as COHERE_EMBED_ENGLISH_V3,
+    COHERE_EMBED_MULTILINGUAL as COHERE_EMBED_MULTILINGUAL_V3,
+};
 
 #[derive(Clone)]
 pub struct EmbeddingModel {
@@ -95,34 +94,32 @@ impl embeddings::EmbeddingModel for EmbeddingModel {
         &self,
         documents: impl IntoIterator<Item = String> + Send,
     ) -> Result<Vec<Embedding>, EmbeddingError> {
-        let documents: Vec<_> = documents.into_iter().collect();
+        let documents: Vec<String> = documents.into_iter().collect();
 
+        // Deliberately sequential: issuing the requests one at a time keeps
+        // Bedrock's per-account throttling behavior unchanged.
         let mut results = Vec::new();
-        let mut errors = Vec::new();
-
-        let mut iterator = documents.into_iter();
-        while let Some(embedding) = iterator.next().map(|doc| async move {
+        let mut first_error = None;
+        for doc in documents {
             let request = EmbeddingRequest {
-                input_text: doc.to_owned(),
+                input_text: doc.clone(),
                 dimensions: self.ndims(),
                 normalize: true,
             };
-            self.document_to_embeddings(request)
-                .await
-                .map(|embeddings| Embedding {
-                    document: doc.to_owned(),
+            match self.document_to_embeddings(request).await {
+                Ok(embeddings) => results.push(Embedding {
+                    document: doc,
                     vec: embeddings.embedding,
-                })
-        }) {
-            match embedding.await {
-                Ok(embedding) => results.push(embedding),
-                Err(err) => errors.push(err),
+                }),
+                Err(err) => {
+                    first_error.get_or_insert(err);
+                }
             }
         }
 
-        match errors.as_slice() {
-            [] => Ok(results),
-            [err, ..] => Err(EmbeddingError::ResponseError(err.to_string())),
+        match first_error {
+            None => Ok(results),
+            Some(err) => Err(EmbeddingError::ResponseError(err.to_string())),
         }
     }
 }

--- a/crates/rig-bedrock/src/image.rs
+++ b/crates/rig-bedrock/src/image.rs
@@ -6,12 +6,12 @@ use rig_core::image_generation::{
     self, ImageGenerationError, ImageGenerationRequest, ImageGenerationResponse,
 };
 
-/// `amazon.titan-image-generator-v1`
-pub const AMAZON_TITAN_IMAGE_GENERATOR_V1: &str = "amazon.titan-image-generator-v1";
-/// `amazon.titan-image-generator-v2:0`
-pub const AMAZON_TITAN_IMAGE_GENERATOR_V2_0: &str = "amazon.titan-image-generator-v2:0";
-/// `amazon.nova-canvas-v1:0`
-pub const AMAZON_NOVA_CANVAS: &str = "amazon.nova-canvas-v1:0";
+// The model-id string values are canonically defined in `crate::completion`;
+// these aliases keep this module's historical public names.
+pub use crate::completion::{
+    AMAZON_NOVA_CANVAS, AMAZON_TITAN_IMAGE_GENERATOR_G1 as AMAZON_TITAN_IMAGE_GENERATOR_V1,
+    AMAZON_TITAN_IMAGE_GENERATOR_G1_V2 as AMAZON_TITAN_IMAGE_GENERATOR_V2_0,
+};
 
 #[derive(Clone)]
 pub struct ImageGenerationModel {

--- a/crates/rig-bedrock/src/streaming.rs
+++ b/crates/rig-bedrock/src/streaming.rs
@@ -1,6 +1,6 @@
-use crate::types::assistant_content::{PROVIDER_NAME, map_stop_reason};
+use crate::types::assistant_content::{PROVIDER_NAME, map_stop_reason, normalize_usage};
 use crate::types::completion_request::AwsCompletionRequest;
-use crate::types::converse_output::StopReason;
+use crate::types::converse_output::{StopReason, TokenUsage};
 use crate::{
     completion::{CompletionModel, resolve_request_model},
     types::errors::{AwsSdkConverseStreamError, converse_stream_output_completion_error},
@@ -24,22 +24,11 @@ use tracing_futures::Instrument;
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct BedrockStreamingResponse {
-    pub usage: Option<BedrockUsage>,
+    pub usage: Option<TokenUsage>,
     /// Bedrock's own `stopReason` from the terminal `MessageStop` event, when
     /// the stream reported one.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_reason: Option<StopReason>,
-}
-
-#[derive(Clone, Deserialize, Serialize)]
-pub struct BedrockUsage {
-    pub input_tokens: i32,
-    pub output_tokens: i32,
-    pub total_tokens: i32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cache_read_input_tokens: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cache_write_input_tokens: Option<i32>,
 }
 
 impl From<&BedrockStreamingResponse> for rig_core::completion::Usage {
@@ -47,15 +36,7 @@ impl From<&BedrockStreamingResponse> for rig_core::completion::Usage {
         response
             .usage
             .as_ref()
-            .map(|u| rig_core::completion::Usage {
-                input_tokens: u.input_tokens as u64,
-                output_tokens: u.output_tokens as u64,
-                total_tokens: u.total_tokens as u64,
-                cached_input_tokens: u.cache_read_input_tokens.unwrap_or_default() as u64,
-                cache_creation_input_tokens: u.cache_write_input_tokens.unwrap_or_default() as u64,
-                tool_use_prompt_tokens: 0,
-                reasoning_tokens: 0,
-            })
+            .map(normalize_usage)
             .unwrap_or_default()
     }
 }
@@ -335,13 +316,10 @@ fn process_event(
             // Extract usage information from metadata; a missing usage still
             // yields a terminal record so the stream ends with a FinalResponse.
             let final_response = BedrockStreamingResponse {
-                usage: metadata_event.usage.map(|usage| BedrockUsage {
-                    input_tokens: usage.input_tokens,
-                    output_tokens: usage.output_tokens,
-                    total_tokens: usage.total_tokens,
-                    cache_read_input_tokens: usage.cache_read_input_tokens,
-                    cache_write_input_tokens: usage.cache_write_input_tokens,
-                }),
+                // The mirror conversion is infallible for `TokenUsage`.
+                usage: metadata_event
+                    .usage
+                    .and_then(|usage| TokenUsage::try_from(usage).ok()),
                 stop_reason: state.final_stop_reason.clone(),
             };
             items.push(Ok(RawStreamingChoice::FinalResponse(final_response)));
@@ -714,7 +692,7 @@ mod tests {
 
     #[test]
     fn test_bedrock_usage_creation() {
-        let usage = BedrockUsage {
+        let usage = TokenUsage {
             input_tokens: 100,
             output_tokens: 50,
             total_tokens: 150,
@@ -730,7 +708,7 @@ mod tests {
     #[test]
     fn test_bedrock_streaming_response_with_usage() {
         let response = BedrockStreamingResponse {
-            usage: Some(BedrockUsage {
+            usage: Some(TokenUsage {
                 input_tokens: 200,
                 output_tokens: 75,
                 total_tokens: 275,
@@ -773,7 +751,7 @@ mod tests {
     #[test]
     fn test_streaming_response_normalizes_usage() {
         let response = BedrockStreamingResponse {
-            usage: Some(BedrockUsage {
+            usage: Some(TokenUsage {
                 input_tokens: 448,
                 output_tokens: 68,
                 total_tokens: 516,
@@ -800,7 +778,7 @@ mod tests {
 
     #[test]
     fn test_bedrock_usage_serde() {
-        let usage = BedrockUsage {
+        let usage = TokenUsage {
             input_tokens: 100,
             output_tokens: 50,
             total_tokens: 150,
@@ -815,7 +793,7 @@ mod tests {
         assert!(json.contains("\"total_tokens\":150"));
 
         // Test deserialization
-        let deserialized: BedrockUsage = serde_json::from_str(&json).expect("Should deserialize");
+        let deserialized: TokenUsage = serde_json::from_str(&json).expect("Should deserialize");
         assert_eq!(deserialized.input_tokens, usage.input_tokens);
         assert_eq!(deserialized.output_tokens, usage.output_tokens);
         assert_eq!(deserialized.total_tokens, usage.total_tokens);
@@ -832,7 +810,7 @@ mod tests {
     #[test]
     fn test_bedrock_streaming_response_serde() {
         let response = BedrockStreamingResponse {
-            usage: Some(BedrockUsage {
+            usage: Some(TokenUsage {
                 input_tokens: 200,
                 output_tokens: 75,
                 total_tokens: 275,

--- a/crates/rig-bedrock/src/types/assistant_content.rs
+++ b/crates/rig-bedrock/src/types/assistant_content.rs
@@ -19,7 +19,9 @@ use rig_core::telemetry::ProviderResponseExt;
 #[derive(Clone, Deserialize, Serialize)]
 pub struct AwsConverseOutput(pub InternalConverseOutput);
 
-fn normalize_usage(usage: &TokenUsage) -> completion::Usage {
+/// Normalize Bedrock token counts into rig's usage record. Shared by the
+/// unary response path and the streaming terminal record.
+pub(crate) fn normalize_usage(usage: &TokenUsage) -> completion::Usage {
     completion::Usage {
         input_tokens: usage.input_tokens as u64,
         output_tokens: usage.output_tokens as u64,

--- a/crates/rig-bedrock/src/types/completion_request.rs
+++ b/crates/rig-bedrock/src/types/completion_request.rs
@@ -50,20 +50,21 @@ impl AwsCompletionRequest {
             return Ok(None);
         }
 
-        let mut tools = vec![];
-        for tool_definition in self.inner.tools.iter() {
-            let doc: AwsDocument = tool_definition.parameters.clone().into();
-            let schema = ToolInputSchema::Json(doc.0);
-            let tool = Tool::ToolSpec(
+        let tools = self
+            .inner
+            .tools
+            .iter()
+            .map(|tool_definition| {
+                let doc: AwsDocument = tool_definition.parameters.clone().into();
                 ToolSpecification::builder()
                     .name(tool_definition.name.clone())
                     .set_description(Some(tool_definition.description.clone()))
-                    .set_input_schema(Some(schema))
+                    .set_input_schema(Some(ToolInputSchema::Json(doc.0)))
                     .build()
-                    .map_err(|e| CompletionError::RequestError(e.into()))?,
-            );
-            tools.push(tool);
-        }
+                    .map(Tool::ToolSpec)
+                    .map_err(|e| CompletionError::RequestError(e.into()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         if !tools.is_empty() {
             // Convert rig's ToolChoice to AWS Bedrock ToolChoice
@@ -190,11 +191,13 @@ impl AwsCompletionRequest {
             full_history.push(Message::User { content });
         }
 
-        self.inner.chat_history.iter().for_each(|message| {
-            if !matches!(message, Message::System { .. }) {
-                full_history.push(message.clone());
-            }
-        });
+        full_history.extend(
+            self.inner
+                .chat_history
+                .iter()
+                .filter(|message| !matches!(message, Message::System { .. }))
+                .cloned(),
+        );
 
         let mut messages: Vec<aws_bedrock::Message> = full_history
             .into_iter()

--- a/crates/rig-bedrock/src/types/converse_output.rs
+++ b/crates/rig-bedrock/src/types/converse_output.rs
@@ -1,10 +1,18 @@
 //! Types that replace the AWS Bedrock Runtime SDK's `ConverseOutput` type.
 //! This is required so that we can impl Serialize and Deserialize.
-use std::{collections::HashMap, fmt};
+//!
+//! Only the parts of the Converse response that rig actually reads are
+//! mirrored as typed structs. Model-specific extras
+//! (`additional_model_response_fields`) are carried as plain
+//! [`serde_json::Value`]; the guardrail-assessment trace and performance
+//! configuration (telemetry-only, never read) are not mirrored.
+use std::fmt;
 
+use aws_sdk_bedrockruntime::types as aws_bedrock;
 use serde::{Deserialize, Serialize};
 
 use super::errors::TypeConversionError;
+use super::json::AwsDocument;
 
 /// Our own implementation of the AWS Bedrock runtime "converse" operation output.
 /// The reason why we need to implement this is that we need to impl Deserialize/Serialize on top of this.
@@ -19,11 +27,7 @@ pub struct InternalConverseOutput {
     /// <p>Metrics for the call to <code>Converse</code>.</p>
     pub metrics: Option<ConverseMetrics>,
     /// <p>Additional fields in the response that are unique to the model.</p>
-    pub additional_model_response_fields: Option<Document>,
-    /// <p>A trace object that contains information about the Guardrail behavior.</p>
-    pub trace: Option<ConverseTrace>,
-    /// <p>Model performance settings for the request.</p>
-    pub performance_config: Option<PerformanceConfiguration>,
+    pub additional_model_response_fields: Option<serde_json::Value>,
 }
 
 impl InternalConverseOutput {
@@ -46,36 +50,18 @@ impl TryFrom<aws_sdk_bedrockruntime::operation::converse::ConverseOutput>
             usage,
             metrics,
             additional_model_response_fields,
-            trace,
-            performance_config,
             ..
         } = value;
 
-        let res = Self {
+        Ok(Self {
             output: output.map(|x| x.try_into()).transpose()?,
             stop_reason: stop_reason.try_into()?,
             usage: usage.map(|x| x.try_into()).transpose()?,
             metrics: metrics.map(|x| x.try_into()).transpose()?,
             additional_model_response_fields: additional_model_response_fields
-                .map(|x| x.try_into())
-                .transpose()?,
-            trace: trace.map(|x| x.try_into()).transpose()?,
-            performance_config: performance_config.map(|x| x.try_into()).transpose()?,
-        };
-
-        Ok(res)
+                .map(|doc| AwsDocument(doc).into()),
+        })
     }
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub enum StopReason {
-    ContentFiltered,
-    EndTurn,
-    GuardrailIntervened,
-    MaxTokens,
-    StopSequence,
-    ToolUse,
-    Unknown(UnknownVariantValue),
 }
 
 /// Opaque struct used as inner data for the `Unknown` variant defined in enums in
@@ -92,11 +78,24 @@ impl fmt::Display for UnknownVariantValue {
 }
 
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub enum StopReason {
+    ContentFiltered,
+    EndTurn,
+    GuardrailIntervened,
+    MaxTokens,
+    StopSequence,
+    ToolUse,
+    Unknown(UnknownVariantValue),
+}
+
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct TokenUsage {
     pub input_tokens: i32,
     pub output_tokens: i32,
     pub total_tokens: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_read_input_tokens: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_write_input_tokens: Option<i32>,
 }
 
@@ -105,281 +104,6 @@ pub struct ConverseMetrics {
     pub latency_ms: i64,
 }
 
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct ConverseTrace {
-    pub guardrail: Option<GuardrailTraceAssessment>,
-    pub prompt_router: Option<PromptRouterTrace>,
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct PromptRouterTrace {
-    pub invoked_model_id: Option<String>,
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GuardrailTraceAssessment {
-    pub model_output: Option<Vec<String>>,
-    pub input_assessment: Option<HashMap<String, GuardrailAssessment>>,
-    pub output_assessments: Option<HashMap<String, Vec<GuardrailAssessment>>>,
-    pub action_reason: Option<String>,
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GuardrailAssessment {
-    pub topic_policy: Option<GuardrailTopicPolicyAssessment>,
-    pub content_policy: Option<GuardrailContentPolicyAssessment>,
-    pub word_policy: Option<GuardrailWordPolicyAssessment>,
-    pub sensitive_information_policy: Option<GuardrailSensitiveInformationPolicyAssessment>,
-    pub contextual_grounding_policy: Option<GuardrailContextualGroundingPolicyAssessment>,
-    pub invocation_metrics: Option<GuardrailInvocationMetrics>,
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GuardrailTopicPolicyAssessment {
-    pub topics: Vec<GuardrailTopic>,
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GuardrailContentPolicyAssessment {
-    pub filters: Vec<GuardrailContentFilter>,
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GuardrailWordPolicyAssessment {
-    pub custom_words: Vec<GuardrailCustomWord>,
-    pub managed_word_lists: Vec<GuardrailManagedWord>,
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GuardrailSensitiveInformationPolicyAssessment {
-    pub pii_entities: Vec<GuardrailPiiEntityFilter>,
-    pub regexes: Vec<GuardrailRegexFilter>,
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GuardrailContextualGroundingPolicyAssessment {
-    pub filters: Option<Vec<GuardrailContextualGroundingFilter>>,
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GuardrailInvocationMetrics {
-    pub guardrail_processing_latency: Option<i64>,
-    pub usage: Option<GuardrailUsage>,
-    pub guardrail_coverage: Option<GuardrailCoverage>,
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GuardrailTopic {
-    pub name: String,
-    #[serde(rename = "type")]
-    pub kind: GuardrailTopicType,
-    pub action: GuardrailTopicPolicyAction,
-    pub detected: Option<bool>,
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub enum GuardrailTopicType {
-    Deny,
-    Unknown(UnknownVariantValue),
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub enum GuardrailTopicPolicyAction {
-    Blocked,
-    None,
-    Unknown(UnknownVariantValue),
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GuardrailContentFilter {
-    #[serde(rename = "type")]
-    pub kind: GuardrailContentFilterType,
-    pub confidence: GuardrailContentFilterConfidence,
-    pub filter_strength: Option<GuardrailContentFilterStrength>,
-    pub action: GuardrailContentPolicyAction,
-    pub detected: Option<bool>,
-}
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub enum GuardrailContentFilterConfidence {
-    High,
-    Low,
-    Medium,
-    None,
-    Unknown(UnknownVariantValue),
-}
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub enum GuardrailContentFilterStrength {
-    High,
-    Low,
-    Medium,
-    None,
-    Unknown(UnknownVariantValue),
-}
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub enum GuardrailContentPolicyAction {
-    Blocked,
-    None,
-    Unknown(UnknownVariantValue),
-}
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub enum GuardrailContentFilterType {
-    Hate,
-    Insults,
-    Misconduct,
-    PromptAttack,
-    Sexual,
-    Violence,
-    Unknown(UnknownVariantValue),
-}
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GuardrailCustomWord {
-    #[serde(rename = "match")]
-    pub matches_on: String,
-    pub action: GuardrailWordPolicyAction,
-    pub detected: Option<bool>,
-}
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub enum GuardrailWordPolicyAction {
-    Blocked,
-    None,
-    Unknown(UnknownVariantValue),
-}
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GuardrailManagedWord {
-    #[serde(rename = "match")]
-    pub matches_on: String,
-    #[serde(rename = "type")]
-    pub kind: GuardrailManagedWordType,
-    pub action: GuardrailWordPolicyAction,
-    pub detected: Option<bool>,
-}
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub enum GuardrailManagedWordType {
-    Profanity,
-    Unknown(UnknownVariantValue),
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GuardrailPiiEntityFilter {
-    #[serde(rename = "match")]
-    pub matches_on: String,
-    #[serde(rename = "type")]
-    pub kind: GuardrailPiiEntityType,
-    pub action: GuardrailSensitiveInformationPolicyAction,
-    pub detected: Option<bool>,
-}
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub enum GuardrailSensitiveInformationPolicyAction {
-    Anonymized,
-    Blocked,
-    None,
-    Unknown(UnknownVariantValue),
-}
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub enum GuardrailPiiEntityType {
-    Address,
-    Age,
-    AwsAccessKey,
-    AwsSecretKey,
-    CaHealthNumber,
-    CaSocialInsuranceNumber,
-    CreditDebitCardCvv,
-    CreditDebitCardExpiry,
-    CreditDebitCardNumber,
-    DriverId,
-    Email,
-    InternationalBankAccountNumber,
-    IpAddress,
-    LicensePlate,
-    MacAddress,
-    Name,
-    Password,
-    Phone,
-    Pin,
-    SwiftCode,
-    UkNationalHealthServiceNumber,
-    UkNationalInsuranceNumber,
-    UkUniqueTaxpayerReferenceNumber,
-    Url,
-    Username,
-    UsBankAccountNumber,
-    UsBankRoutingNumber,
-    UsIndividualTaxIdentificationNumber,
-    UsPassportNumber,
-    UsSocialSecurityNumber,
-    VehicleIdentificationNumber,
-    Unknown(UnknownVariantValue),
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GuardrailRegexFilter {
-    pub name: Option<String>,
-    #[serde(rename = "match")]
-    pub matches_on: Option<String>,
-    pub regex: Option<String>,
-    pub action: GuardrailSensitiveInformationPolicyAction,
-    pub detected: Option<bool>,
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GuardrailContextualGroundingFilter {
-    #[serde(rename = "type")]
-    pub kind: GuardrailContextualGroundingFilterType,
-    pub threshold: f64,
-    pub score: f64,
-    pub action: GuardrailContextualGroundingPolicyAction,
-    pub detected: Option<bool>,
-}
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub enum GuardrailContextualGroundingFilterType {
-    Grounding,
-    Relevance,
-    Unknown(UnknownVariantValue),
-}
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub enum GuardrailContextualGroundingPolicyAction {
-    Blocked,
-    None,
-    Unknown(UnknownVariantValue),
-}
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GuardrailUsage {
-    pub topic_policy_units: i32,
-    pub content_policy_units: i32,
-    pub word_policy_units: i32,
-    pub sensitive_information_policy_units: i32,
-    pub sensitive_information_policy_free_units: i32,
-    pub contextual_grounding_policy_units: i32,
-    pub content_policy_image_units: Option<i32>,
-}
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GuardrailCoverage {
-    pub text_characters: Option<GuardrailTextCharactersCoverage>,
-    pub images: Option<GuardrailImageCoverage>,
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GuardrailTextCharactersCoverage {
-    pub guarded: Option<i32>,
-    pub total: Option<i32>,
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct GuardrailImageCoverage {
-    pub guarded: Option<i32>,
-    pub total: Option<i32>,
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct PerformanceConfiguration {
-    pub latency: PerformanceConfigLatency,
-}
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub enum PerformanceConfigLatency {
-    Optimized,
-    Standard,
-    Unknown(UnknownVariantValue),
-}
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub enum ConverseOutput {
     Message(Message),
@@ -615,7 +339,7 @@ pub struct ToolResultBlock {
 pub enum ToolResultContentBlock {
     Document(DocumentBlock),
     Image(ImageBlock),
-    Json(Document),
+    Json(serde_json::Value),
     Text(String),
     Video(VideoBlock),
     #[non_exhaustive]
@@ -650,7 +374,7 @@ pub enum VideoSource {
 pub struct ToolUseBlock {
     pub tool_use_id: String,
     pub name: String,
-    pub input: Document,
+    pub input: serde_json::Value,
 }
 
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
@@ -662,2054 +386,221 @@ pub enum ToolResultStatus {
     Unknown(UnknownVariantValue),
 }
 
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub enum Document {
-    Object(HashMap<String, Document>),
-    Array(Vec<Document>),
-    Number(Number),
-    String(String),
-    Bool(bool),
-    Null,
-}
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub enum Number {
-    PosInt(u64),
-    NegInt(i64),
-    Float(f64),
-}
-
-impl From<aws_smithy_types::Number> for Number {
-    fn from(value: aws_smithy_types::Number) -> Self {
-        match value {
-            aws_smithy_types::Number::Float(float) => Self::Float(float),
-            aws_smithy_types::Number::NegInt(int) => Self::NegInt(int),
-            aws_smithy_types::Number::PosInt(int) => Self::PosInt(int),
-        }
-    }
-}
-
-impl From<&aws_smithy_types::Number> for Number {
-    fn from(value: &aws_smithy_types::Number) -> Self {
-        match value {
-            aws_smithy_types::Number::Float(float) => Self::Float(float.to_owned()),
-            aws_smithy_types::Number::NegInt(int) => Self::NegInt(int.to_owned()),
-            aws_smithy_types::Number::PosInt(int) => Self::PosInt(int.to_owned()),
-        }
-    }
-}
-
-impl From<Number> for aws_smithy_types::Number {
-    fn from(value: Number) -> Self {
-        match value {
-            Number::Float(float) => aws_smithy_types::Number::Float(float),
-            Number::NegInt(int) => aws_smithy_types::Number::NegInt(int),
-            Number::PosInt(int) => aws_smithy_types::Number::PosInt(int),
-        }
-    }
-}
-
 // TryFrom<T> implementations
-impl TryFrom<aws_sdk_bedrockruntime::types::StopReason> for StopReason {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::StopReason) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::StopReason::ContentFiltered => {
-                Ok(StopReason::ContentFiltered)
+//
+// The AWS SDK's "string enums" (unit variants only) and unions (one payload
+// per variant) mirror mechanically, so the impls are macro-generated. The
+// error strings match the historical hand-written impls exactly:
+// `Unknown variant for TYPE: {invalid:?}`.
+
+/// Mirror a unit-variant AWS enum: emits owned + borrowed `TryFrom<aws>` impls
+/// and, with the trailing `reverse` flag, a `TryFrom<ours> for aws` impl.
+/// Unlisted variants (including this crate's `Unknown`) fall through to a
+/// `TypeConversionError`.
+macro_rules! mirror_enum {
+    ($ours:ident, $aws:ty { $($aws_variant:ident => $ours_variant:ident),+ $(,)? }) => {
+        impl TryFrom<$aws> for $ours {
+            type Error = TypeConversionError;
+            fn try_from(value: $aws) -> Result<Self, Self::Error> {
+                <$ours>::try_from(&value)
             }
-            aws_sdk_bedrockruntime::types::StopReason::EndTurn => Ok(StopReason::EndTurn),
-            aws_sdk_bedrockruntime::types::StopReason::GuardrailIntervened => {
-                Ok(StopReason::GuardrailIntervened)
-            }
-            aws_sdk_bedrockruntime::types::StopReason::MaxTokens => Ok(StopReason::MaxTokens),
-            aws_sdk_bedrockruntime::types::StopReason::StopSequence => Ok(StopReason::StopSequence),
-            aws_sdk_bedrockruntime::types::StopReason::ToolUse => Ok(StopReason::ToolUse),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for StopReason: {invalid:?}"
-            ))),
         }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::TokenUsage> for TokenUsage {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::TokenUsage) -> Result<Self, Self::Error> {
-        Ok(TokenUsage {
-            input_tokens: value.input_tokens(),
-            output_tokens: value.output_tokens(),
-            total_tokens: value.total_tokens(),
-            cache_read_input_tokens: value.cache_read_input_tokens(),
-            cache_write_input_tokens: value.cache_write_input_tokens(),
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::ConverseMetrics> for ConverseMetrics {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::ConverseMetrics,
-    ) -> Result<Self, Self::Error> {
-        Ok(ConverseMetrics {
-            latency_ms: value.latency_ms(),
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::ConverseTrace> for ConverseTrace {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::ConverseTrace) -> Result<Self, Self::Error> {
-        Ok(ConverseTrace {
-            guardrail: value.guardrail().map(|v| v.try_into()).transpose()?,
-            prompt_router: value.prompt_router().map(|v| v.try_into()).transpose()?,
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::PromptRouterTrace> for PromptRouterTrace {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::PromptRouterTrace,
-    ) -> Result<Self, Self::Error> {
-        Ok(PromptRouterTrace {
-            invoked_model_id: value.invoked_model_id().map(Into::into),
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::PromptRouterTrace> for PromptRouterTrace {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::PromptRouterTrace,
-    ) -> Result<Self, Self::Error> {
-        Ok(PromptRouterTrace {
-            invoked_model_id: value.invoked_model_id().map(Into::into),
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailTraceAssessment> for GuardrailTraceAssessment {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailTraceAssessment,
-    ) -> Result<Self, Self::Error> {
-        let input_assessment = value
-            .input_assessment()
-            .map(|map| {
-                map.iter()
-                    .map(|(k, v)| Ok((k.clone(), v.clone().try_into()?)))
-                    .collect::<Result<_, Self::Error>>()
-            })
-            .transpose()?;
-
-        let output_assessments = value
-            .output_assessments()
-            .map(|map| {
-                map.iter()
-                    .map(|(k, v)| {
-                        let converted_vec: Result<Vec<GuardrailAssessment>, Self::Error> =
-                            v.iter().map(|x| x.clone().try_into()).collect();
-                        Ok((k.clone(), converted_vec?))
-                    })
-                    .collect::<Result<_, Self::Error>>()
-            })
-            .transpose()?;
-
-        Ok(GuardrailTraceAssessment {
-            model_output: Some(value.model_output().iter().map(|x| x.to_owned()).collect()),
-            input_assessment,
-            output_assessments,
-            action_reason: value.action_reason().map(Into::into),
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailTraceAssessment>
-    for GuardrailTraceAssessment
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailTraceAssessment,
-    ) -> Result<Self, Self::Error> {
-        let input_assessment = value
-            .input_assessment()
-            .map(|map| {
-                map.iter()
-                    .map(|(k, v)| Ok((k.clone(), v.clone().try_into()?)))
-                    .collect::<Result<_, Self::Error>>()
-            })
-            .transpose()?;
-
-        let output_assessments = value
-            .output_assessments()
-            .map(|map| {
-                map.iter()
-                    .map(|(k, v)| {
-                        let converted_vec: Result<Vec<GuardrailAssessment>, Self::Error> =
-                            v.iter().map(|x| x.clone().try_into()).collect();
-                        Ok((k.clone(), converted_vec?))
-                    })
-                    .collect::<Result<_, Self::Error>>()
-            })
-            .transpose()?;
-
-        Ok(GuardrailTraceAssessment {
-            model_output: Some(value.model_output().iter().map(|x| x.to_owned()).collect()),
-            input_assessment,
-            output_assessments,
-            action_reason: value.action_reason().map(Into::into),
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailAssessment> for GuardrailAssessment {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailAssessment,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailAssessment {
-            topic_policy: value.topic_policy().map(|v| v.try_into()).transpose()?,
-            content_policy: value.content_policy().map(|v| v.try_into()).transpose()?,
-            word_policy: value.word_policy().map(|v| v.try_into()).transpose()?,
-            sensitive_information_policy: value
-                .sensitive_information_policy()
-                .map(|v| v.try_into())
-                .transpose()?,
-            contextual_grounding_policy: value
-                .contextual_grounding_policy()
-                .map(|v| v.try_into())
-                .transpose()?,
-            invocation_metrics: value
-                .invocation_metrics()
-                .map(|v| v.try_into())
-                .transpose()?,
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailTopicPolicyAssessment>
-    for GuardrailTopicPolicyAssessment
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailTopicPolicyAssessment,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailTopicPolicyAssessment {
-            topics: value
-                .topics()
-                .iter()
-                .map(|v| v.clone().try_into())
-                .collect::<Result<_, Self::Error>>()?,
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailTopicPolicyAssessment>
-    for GuardrailTopicPolicyAssessment
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailTopicPolicyAssessment,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailTopicPolicyAssessment {
-            topics: value
-                .topics()
-                .iter()
-                .map(|v| v.clone().try_into())
-                .collect::<Result<_, Self::Error>>()?,
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailContentPolicyAssessment>
-    for GuardrailContentPolicyAssessment
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailContentPolicyAssessment,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailContentPolicyAssessment {
-            filters: value
-                .filters()
-                .iter()
-                .map(|v| v.clone().try_into())
-                .collect::<Result<_, Self::Error>>()?,
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailContentPolicyAssessment>
-    for GuardrailContentPolicyAssessment
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailContentPolicyAssessment,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailContentPolicyAssessment {
-            filters: value
-                .filters()
-                .iter()
-                .map(|v| v.clone().try_into())
-                .collect::<Result<_, Self::Error>>()?,
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailWordPolicyAssessment>
-    for GuardrailWordPolicyAssessment
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailWordPolicyAssessment,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailWordPolicyAssessment {
-            custom_words: value
-                .custom_words()
-                .iter()
-                .map(|v| v.clone().try_into())
-                .collect::<Result<_, Self::Error>>()?,
-            managed_word_lists: value
-                .managed_word_lists()
-                .iter()
-                .map(|v| v.clone().try_into())
-                .collect::<Result<_, Self::Error>>()?,
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailWordPolicyAssessment>
-    for GuardrailWordPolicyAssessment
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailWordPolicyAssessment,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailWordPolicyAssessment {
-            custom_words: value
-                .custom_words()
-                .iter()
-                .map(|v| v.clone().try_into())
-                .collect::<Result<_, Self::Error>>()?,
-            managed_word_lists: value
-                .managed_word_lists()
-                .iter()
-                .map(|v| v.clone().try_into())
-                .collect::<Result<_, Self::Error>>()?,
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailSensitiveInformationPolicyAssessment>
-    for GuardrailSensitiveInformationPolicyAssessment
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailSensitiveInformationPolicyAssessment,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailSensitiveInformationPolicyAssessment {
-            pii_entities: value
-                .pii_entities()
-                .iter()
-                .map(|v| v.clone().try_into())
-                .collect::<Result<_, Self::Error>>()?,
-            regexes: value
-                .regexes()
-                .iter()
-                .map(|v| v.clone().try_into())
-                .collect::<Result<_, Self::Error>>()?,
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailSensitiveInformationPolicyAssessment>
-    for GuardrailSensitiveInformationPolicyAssessment
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailSensitiveInformationPolicyAssessment,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailSensitiveInformationPolicyAssessment {
-            pii_entities: value
-                .pii_entities()
-                .iter()
-                .map(|v| v.clone().try_into())
-                .collect::<Result<_, Self::Error>>()?,
-            regexes: value
-                .regexes()
-                .iter()
-                .map(|v| v.clone().try_into())
-                .collect::<Result<_, Self::Error>>()?,
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailContextualGroundingPolicyAssessment>
-    for GuardrailContextualGroundingPolicyAssessment
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailContextualGroundingPolicyAssessment,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailContextualGroundingPolicyAssessment {
-            filters: value
-                .filters
-                .map(|x| x.into_iter().map(TryInto::try_into).collect())
-                .transpose()?,
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailContextualGroundingPolicyAssessment>
-    for GuardrailContextualGroundingPolicyAssessment
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailContextualGroundingPolicyAssessment,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailContextualGroundingPolicyAssessment {
-            filters: value
-                .filters
-                .clone()
-                .map(|x| x.into_iter().map(TryInto::try_into).collect())
-                .transpose()?,
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailInvocationMetrics>
-    for GuardrailInvocationMetrics
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailInvocationMetrics,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailInvocationMetrics {
-            guardrail_processing_latency: value.guardrail_processing_latency(),
-            usage: value.usage().map(|v| v.try_into()).transpose()?,
-            guardrail_coverage: value
-                .guardrail_coverage()
-                .map(|v| v.try_into())
-                .transpose()?,
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailInvocationMetrics>
-    for GuardrailInvocationMetrics
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailInvocationMetrics,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailInvocationMetrics {
-            guardrail_processing_latency: value.guardrail_processing_latency(),
-            usage: value.usage().map(|v| v.try_into()).transpose()?,
-            guardrail_coverage: value
-                .guardrail_coverage()
-                .map(|v| v.try_into())
-                .transpose()?,
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailTopic> for GuardrailTopic {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::GuardrailTopic) -> Result<Self, Self::Error> {
-        Ok(GuardrailTopic {
-            name: value.name().into(),
-            kind: value.r#type().try_into()?,
-            action: value.action().try_into()?,
-            detected: value.detected(),
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailTopic> for GuardrailTopic {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailTopic,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailTopic {
-            name: value.name().into(),
-            kind: value.r#type().try_into()?,
-            action: value.action().try_into()?,
-            detected: value.detected(),
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailTopicType> for GuardrailTopicType {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailTopicType,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailTopicType::Deny => Ok(GuardrailTopicType::Deny),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailTopicType: {invalid:?}"
-            ))),
+        impl TryFrom<&$aws> for $ours {
+            type Error = TypeConversionError;
+            fn try_from(value: &$aws) -> Result<Self, Self::Error> {
+                type Aws = $aws;
+                match value {
+                    $(Aws::$aws_variant => Ok($ours::$ours_variant),)+
+                    invalid => Err(TypeConversionError::new(&format!(
+                        concat!("Unknown variant for ", stringify!($ours), ": {:?}"),
+                        invalid
+                    ))),
+                }
+            }
         }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailTopicType> for GuardrailTopicType {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailTopicType,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailTopicType::Deny => Ok(GuardrailTopicType::Deny),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailTopicType: {invalid:?}"
-            ))),
+    };
+    ($ours:ident, $aws:ty { $($aws_variant:ident => $ours_variant:ident),+ $(,)? }, reverse) => {
+        mirror_enum!($ours, $aws { $($aws_variant => $ours_variant),+ });
+        impl TryFrom<$ours> for $aws {
+            type Error = TypeConversionError;
+            fn try_from(value: $ours) -> Result<Self, TypeConversionError> {
+                type Aws = $aws;
+                match value {
+                    $($ours::$ours_variant => Ok(Aws::$aws_variant),)+
+                    invalid => Err(TypeConversionError::new(&format!(
+                        concat!("Unknown variant for ", stringify!($ours), ": {:?}"),
+                        invalid
+                    ))),
+                }
+            }
         }
-    }
+    };
 }
 
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailTopicPolicyAction>
-    for GuardrailTopicPolicyAction
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailTopicPolicyAction,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailTopicPolicyAction::Blocked => {
-                Ok(GuardrailTopicPolicyAction::Blocked)
+/// Mirror an AWS union (every listed variant carries a single payload that
+/// converts via `TryInto`): emits the owned `TryFrom<aws>` impl and, with
+/// `reverse`, the `TryFrom<ours> for aws` impl.
+macro_rules! mirror_union {
+    ($ours:ident, $aws:ty { $($aws_variant:ident => $ours_variant:ident),+ $(,)? }) => {
+        impl TryFrom<$aws> for $ours {
+            type Error = TypeConversionError;
+            fn try_from(value: $aws) -> Result<Self, Self::Error> {
+                type Aws = $aws;
+                match value {
+                    $(Aws::$aws_variant(value) => Ok($ours::$ours_variant(value.try_into()?)),)+
+                    invalid => Err(TypeConversionError::new(&format!(
+                        concat!("Unknown variant for ", stringify!($ours), ": {:?}"),
+                        invalid
+                    ))),
+                }
             }
-            aws_sdk_bedrockruntime::types::GuardrailTopicPolicyAction::None => {
-                Ok(GuardrailTopicPolicyAction::None)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailTopicPolicyAction: {invalid:?}"
-            ))),
         }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailTopicPolicyAction>
-    for GuardrailTopicPolicyAction
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailTopicPolicyAction,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailTopicPolicyAction::Blocked => {
-                Ok(GuardrailTopicPolicyAction::Blocked)
+    };
+    ($ours:ident, $aws:ty { $($aws_variant:ident => $ours_variant:ident),+ $(,)? }, reverse) => {
+        mirror_union!($ours, $aws { $($aws_variant => $ours_variant),+ });
+        impl TryFrom<$ours> for $aws {
+            type Error = TypeConversionError;
+            fn try_from(value: $ours) -> Result<Self, TypeConversionError> {
+                type Aws = $aws;
+                match value {
+                    $($ours::$ours_variant(value) => Ok(Aws::$aws_variant(value.try_into()?)),)+
+                    invalid => Err(TypeConversionError::new(&format!(
+                        concat!("Unknown variant for ", stringify!($ours), ": {:?}"),
+                        invalid
+                    ))),
+                }
             }
-            aws_sdk_bedrockruntime::types::GuardrailTopicPolicyAction::None => {
-                Ok(GuardrailTopicPolicyAction::None)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailTopicPolicyAction: {invalid:?}"
-            ))),
         }
-    }
+    };
 }
 
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailContentFilter> for GuardrailContentFilter {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailContentFilter,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailContentFilter {
-            kind: value.r#type().try_into()?,
-            confidence: value.confidence().try_into()?,
-            filter_strength: value.filter_strength().map(|v| v.try_into()).transpose()?,
-            action: value.action().try_into()?,
-            detected: value.detected(),
-        })
-    }
-}
+mirror_enum!(StopReason, aws_bedrock::StopReason {
+    ContentFiltered => ContentFiltered,
+    EndTurn => EndTurn,
+    GuardrailIntervened => GuardrailIntervened,
+    MaxTokens => MaxTokens,
+    StopSequence => StopSequence,
+    ToolUse => ToolUse,
+});
+mirror_enum!(ConversationRole, aws_bedrock::ConversationRole {
+    Assistant => Assistant,
+    User => User,
+}, reverse);
+mirror_enum!(CachePointType, aws_bedrock::CachePointType {
+    Default => Default,
+}, reverse);
+mirror_enum!(DocumentFormat, aws_bedrock::DocumentFormat {
+    Csv => Csv,
+    Doc => Doc,
+    Docx => Docx,
+    Html => Html,
+    Md => Md,
+    Pdf => Pdf,
+    Txt => Txt,
+    Xls => Xls,
+    Xlsx => Xlsx,
+}, reverse);
+mirror_enum!(ImageFormat, aws_bedrock::ImageFormat {
+    Gif => Gif,
+    Jpeg => Jpeg,
+    Png => Png,
+    Webp => Webp,
+}, reverse);
+mirror_enum!(VideoFormat, aws_bedrock::VideoFormat {
+    Flv => Flv,
+    Mkv => Mkv,
+    Mov => Mov,
+    Mp4 => Mp4,
+    Mpeg => Mpeg,
+    Mpg => Mpg,
+    ThreeGp => ThreeGp,
+    Webm => Webm,
+    Wmv => Wmv,
+}, reverse);
+mirror_enum!(ToolResultStatus, aws_bedrock::ToolResultStatus {
+    Error => IsError,
+    Success => Success,
+}, reverse);
+mirror_enum!(GuardrailConverseImageFormat, aws_bedrock::GuardrailConverseImageFormat {
+    Jpeg => Jpeg,
+    Png => Png,
+}, reverse);
+mirror_enum!(GuardrailConverseContentQualifier, aws_bedrock::GuardrailConverseContentQualifier {
+    GroundingSource => GroundingSource,
+    GuardContent => GuardContent,
+    Query => Query,
+}, reverse);
 
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailContentFilter> for GuardrailContentFilter {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailContentFilter,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailContentFilter {
-            kind: value.r#type().try_into()?,
-            confidence: value.confidence().try_into()?,
-            filter_strength: value.filter_strength().map(|v| v.try_into()).transpose()?,
-            action: value.action().try_into()?,
-            detected: value.detected(),
-        })
-    }
-}
+mirror_union!(ConverseOutput, aws_bedrock::ConverseOutput {
+    Message => Message,
+});
+mirror_union!(ContentBlock, aws_bedrock::ContentBlock {
+    CachePoint => CachePoint,
+    CitationsContent => CitationsContent,
+    Document => Document,
+    GuardContent => GuardContent,
+    Image => Image,
+    ReasoningContent => ReasoningContent,
+    Text => Text,
+    ToolResult => ToolResult,
+    ToolUse => ToolUse,
+    Video => Video,
+}, reverse);
+mirror_union!(CitationGeneratedContent, aws_bedrock::CitationGeneratedContent {
+    Text => Text,
+}, reverse);
+mirror_union!(CitationSourceContent, aws_bedrock::CitationSourceContent {
+    Text => Text,
+}, reverse);
+mirror_union!(CitationLocation, aws_bedrock::CitationLocation {
+    DocumentChar => DocumentChar,
+    DocumentChunk => DocumentChunk,
+    DocumentPage => DocumentPage,
+}, reverse);
+mirror_union!(DocumentContentBlock, aws_bedrock::DocumentContentBlock {
+    Text => Text,
+}, reverse);
+mirror_union!(GuardrailConverseContentBlock, aws_bedrock::GuardrailConverseContentBlock {
+    Image => Image,
+    Text => Text,
+}, reverse);
+mirror_union!(GuardrailConverseImageSource, aws_bedrock::GuardrailConverseImageSource {
+    Bytes => Bytes,
+}, reverse);
+mirror_union!(ImageSource, aws_bedrock::ImageSource {
+    Bytes => Bytes,
+    S3Location => S3Location,
+}, reverse);
+mirror_union!(VideoSource, aws_bedrock::VideoSource {
+    Bytes => Bytes,
+    S3Location => S3Location,
+}, reverse);
+mirror_union!(ReasoningContentBlock, aws_bedrock::ReasoningContentBlock {
+    ReasoningText => ReasoningText,
+    RedactedContent => RedactedContent,
+}, reverse);
 
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailContentFilterConfidence>
-    for GuardrailContentFilterConfidence
-{
+// `DocumentSource::Content` carries a `Vec` payload and
+// `ToolResultContentBlock::Json` bridges Smithy `Document` <-> `serde_json::Value`,
+// so those two unions stay hand-written.
+
+impl TryFrom<aws_bedrock::DocumentSource> for DocumentSource {
     type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailContentFilterConfidence,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(value: aws_bedrock::DocumentSource) -> Result<Self, Self::Error> {
         match value {
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterConfidence::High => {
-                Ok(GuardrailContentFilterConfidence::High)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterConfidence::Low => {
-                Ok(GuardrailContentFilterConfidence::Low)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterConfidence::Medium => {
-                Ok(GuardrailContentFilterConfidence::Medium)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterConfidence::None => {
-                Ok(GuardrailContentFilterConfidence::None)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailContentFilterConfidence: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailContentFilterConfidence>
-    for GuardrailContentFilterConfidence
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailContentFilterConfidence,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterConfidence::High => {
-                Ok(GuardrailContentFilterConfidence::High)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterConfidence::Low => {
-                Ok(GuardrailContentFilterConfidence::Low)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterConfidence::Medium => {
-                Ok(GuardrailContentFilterConfidence::Medium)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterConfidence::None => {
-                Ok(GuardrailContentFilterConfidence::None)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailContentFilterConfidence: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailContentFilterStrength>
-    for GuardrailContentFilterStrength
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailContentFilterStrength,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterStrength::High => {
-                Ok(GuardrailContentFilterStrength::High)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterStrength::Low => {
-                Ok(GuardrailContentFilterStrength::Low)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterStrength::Medium => {
-                Ok(GuardrailContentFilterStrength::Medium)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterStrength::None => {
-                Ok(GuardrailContentFilterStrength::None)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailContentFilterStrength: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailContentFilterStrength>
-    for GuardrailContentFilterStrength
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailContentFilterStrength,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterStrength::High => {
-                Ok(GuardrailContentFilterStrength::High)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterStrength::Low => {
-                Ok(GuardrailContentFilterStrength::Low)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterStrength::Medium => {
-                Ok(GuardrailContentFilterStrength::Medium)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterStrength::None => {
-                Ok(GuardrailContentFilterStrength::None)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailContentFilterStrength: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailContentPolicyAction>
-    for GuardrailContentPolicyAction
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailContentPolicyAction,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailContentPolicyAction::Blocked => {
-                Ok(GuardrailContentPolicyAction::Blocked)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContentPolicyAction::None => {
-                Ok(GuardrailContentPolicyAction::None)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailContentPolicyAction: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailContentPolicyAction>
-    for GuardrailContentPolicyAction
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailContentPolicyAction,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailContentPolicyAction::Blocked => {
-                Ok(GuardrailContentPolicyAction::Blocked)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContentPolicyAction::None => {
-                Ok(GuardrailContentPolicyAction::None)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailContentPolicyAction: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailContentFilterType>
-    for GuardrailContentFilterType
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailContentFilterType,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterType::Hate => {
-                Ok(GuardrailContentFilterType::Hate)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterType::Insults => {
-                Ok(GuardrailContentFilterType::Insults)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterType::Misconduct => {
-                Ok(GuardrailContentFilterType::Misconduct)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterType::PromptAttack => {
-                Ok(GuardrailContentFilterType::PromptAttack)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterType::Sexual => {
-                Ok(GuardrailContentFilterType::Sexual)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContentFilterType::Violence => {
-                Ok(GuardrailContentFilterType::Violence)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailContentFilterType: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailCustomWord> for GuardrailCustomWord {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailCustomWord,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailCustomWord {
-            matches_on: value.r#match().into(),
-            action: value.action().try_into()?,
-            detected: value.detected(),
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailWordPolicyAction>
-    for GuardrailWordPolicyAction
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailWordPolicyAction,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailWordPolicyAction::Blocked => {
-                Ok(GuardrailWordPolicyAction::Blocked)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailWordPolicyAction::None => {
-                Ok(GuardrailWordPolicyAction::None)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailWordPolicyAction: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailWordPolicyAction>
-    for GuardrailWordPolicyAction
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailWordPolicyAction,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailWordPolicyAction::Blocked => {
-                Ok(GuardrailWordPolicyAction::Blocked)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailWordPolicyAction::None => {
-                Ok(GuardrailWordPolicyAction::None)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailWordPolicyAction: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailManagedWord> for GuardrailManagedWord {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailManagedWord,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailManagedWord {
-            matches_on: value.r#match().into(),
-            kind: value.r#type().try_into()?,
-            action: value.action().try_into()?,
-            detected: value.detected(),
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailManagedWordType> for GuardrailManagedWordType {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailManagedWordType,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailManagedWordType::Profanity => {
-                Ok(GuardrailManagedWordType::Profanity)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailManagedWordType: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailManagedWordType>
-    for GuardrailManagedWordType
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailManagedWordType,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailManagedWordType::Profanity => {
-                Ok(GuardrailManagedWordType::Profanity)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailManagedWordType: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailPiiEntityFilter> for GuardrailPiiEntityFilter {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailPiiEntityFilter,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailPiiEntityFilter {
-            matches_on: value.r#match().into(),
-            kind: value.r#type().try_into()?,
-            action: value.action().try_into()?,
-            detected: value.detected(),
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailSensitiveInformationPolicyAction>
-    for GuardrailSensitiveInformationPolicyAction
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailSensitiveInformationPolicyAction,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailSensitiveInformationPolicyAction::Anonymized => {
-                Ok(GuardrailSensitiveInformationPolicyAction::Anonymized)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailSensitiveInformationPolicyAction::Blocked => {
-                Ok(GuardrailSensitiveInformationPolicyAction::Blocked)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailSensitiveInformationPolicyAction::None => {
-                Ok(GuardrailSensitiveInformationPolicyAction::None)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailSensitiveInformationPolicyAction: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailSensitiveInformationPolicyAction>
-    for GuardrailSensitiveInformationPolicyAction
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailSensitiveInformationPolicyAction,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailSensitiveInformationPolicyAction::Anonymized => {
-                Ok(GuardrailSensitiveInformationPolicyAction::Anonymized)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailSensitiveInformationPolicyAction::Blocked => {
-                Ok(GuardrailSensitiveInformationPolicyAction::Blocked)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailSensitiveInformationPolicyAction::None => {
-                Ok(GuardrailSensitiveInformationPolicyAction::None)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailSensitiveInformationPolicyAction: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailPiiEntityType> for GuardrailPiiEntityType {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailPiiEntityType,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::Address => Ok(GuardrailPiiEntityType::Address),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::Age => Ok(GuardrailPiiEntityType::Age),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::AwsAccessKey => Ok(GuardrailPiiEntityType::AwsAccessKey),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::AwsSecretKey => Ok(GuardrailPiiEntityType::AwsSecretKey),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::CaHealthNumber => Ok(GuardrailPiiEntityType::CaHealthNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::CaSocialInsuranceNumber => Ok(GuardrailPiiEntityType::CaSocialInsuranceNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::CreditDebitCardCvv => Ok(GuardrailPiiEntityType::CreditDebitCardCvv),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::CreditDebitCardExpiry => Ok(GuardrailPiiEntityType::CreditDebitCardExpiry),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::CreditDebitCardNumber => Ok(GuardrailPiiEntityType::CreditDebitCardNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::DriverId => Ok(GuardrailPiiEntityType::DriverId),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::Email => Ok(GuardrailPiiEntityType::Email),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::InternationalBankAccountNumber => Ok(GuardrailPiiEntityType::InternationalBankAccountNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::IpAddress => Ok(GuardrailPiiEntityType::IpAddress),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::LicensePlate => Ok(GuardrailPiiEntityType::LicensePlate),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::MacAddress => Ok(GuardrailPiiEntityType::MacAddress),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::Name => Ok(GuardrailPiiEntityType::Name),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::Password => Ok(GuardrailPiiEntityType::Password),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::Phone => Ok(GuardrailPiiEntityType::Phone),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::Pin => Ok(GuardrailPiiEntityType::Pin),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::SwiftCode => Ok(GuardrailPiiEntityType::SwiftCode),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::UkNationalHealthServiceNumber => Ok(GuardrailPiiEntityType::UkNationalHealthServiceNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::UkNationalInsuranceNumber => Ok(GuardrailPiiEntityType::UkNationalInsuranceNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::UkUniqueTaxpayerReferenceNumber => Ok(GuardrailPiiEntityType::UkUniqueTaxpayerReferenceNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::Url => Ok(GuardrailPiiEntityType::Url),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::Username => Ok(GuardrailPiiEntityType::Username),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::UsBankAccountNumber => Ok(GuardrailPiiEntityType::UsBankAccountNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::UsBankRoutingNumber => Ok(GuardrailPiiEntityType::UsBankRoutingNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::UsIndividualTaxIdentificationNumber => Ok(GuardrailPiiEntityType::UsIndividualTaxIdentificationNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::UsPassportNumber => Ok(GuardrailPiiEntityType::UsPassportNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::UsSocialSecurityNumber => Ok(GuardrailPiiEntityType::UsSocialSecurityNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::VehicleIdentificationNumber => Ok(GuardrailPiiEntityType::VehicleIdentificationNumber),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailPiiEntityType: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailPiiEntityType> for GuardrailPiiEntityType {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailPiiEntityType,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::Address => Ok(GuardrailPiiEntityType::Address),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::Age => Ok(GuardrailPiiEntityType::Age),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::AwsAccessKey => Ok(GuardrailPiiEntityType::AwsAccessKey),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::AwsSecretKey => Ok(GuardrailPiiEntityType::AwsSecretKey),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::CaHealthNumber => Ok(GuardrailPiiEntityType::CaHealthNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::CaSocialInsuranceNumber => Ok(GuardrailPiiEntityType::CaSocialInsuranceNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::CreditDebitCardCvv => Ok(GuardrailPiiEntityType::CreditDebitCardCvv),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::CreditDebitCardExpiry => Ok(GuardrailPiiEntityType::CreditDebitCardExpiry),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::CreditDebitCardNumber => Ok(GuardrailPiiEntityType::CreditDebitCardNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::DriverId => Ok(GuardrailPiiEntityType::DriverId),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::Email => Ok(GuardrailPiiEntityType::Email),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::InternationalBankAccountNumber => Ok(GuardrailPiiEntityType::InternationalBankAccountNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::IpAddress => Ok(GuardrailPiiEntityType::IpAddress),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::LicensePlate => Ok(GuardrailPiiEntityType::LicensePlate),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::MacAddress => Ok(GuardrailPiiEntityType::MacAddress),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::Name => Ok(GuardrailPiiEntityType::Name),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::Password => Ok(GuardrailPiiEntityType::Password),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::Phone => Ok(GuardrailPiiEntityType::Phone),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::Pin => Ok(GuardrailPiiEntityType::Pin),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::SwiftCode => Ok(GuardrailPiiEntityType::SwiftCode),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::UkNationalHealthServiceNumber => Ok(GuardrailPiiEntityType::UkNationalHealthServiceNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::UkNationalInsuranceNumber => Ok(GuardrailPiiEntityType::UkNationalInsuranceNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::UkUniqueTaxpayerReferenceNumber => Ok(GuardrailPiiEntityType::UkUniqueTaxpayerReferenceNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::Url => Ok(GuardrailPiiEntityType::Url),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::Username => Ok(GuardrailPiiEntityType::Username),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::UsBankAccountNumber => Ok(GuardrailPiiEntityType::UsBankAccountNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::UsBankRoutingNumber => Ok(GuardrailPiiEntityType::UsBankRoutingNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::UsIndividualTaxIdentificationNumber => Ok(GuardrailPiiEntityType::UsIndividualTaxIdentificationNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::UsPassportNumber => Ok(GuardrailPiiEntityType::UsPassportNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::UsSocialSecurityNumber => Ok(GuardrailPiiEntityType::UsSocialSecurityNumber),
-            aws_sdk_bedrockruntime::types::GuardrailPiiEntityType::VehicleIdentificationNumber => Ok(GuardrailPiiEntityType::VehicleIdentificationNumber),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailPiiEntityType: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailRegexFilter> for GuardrailRegexFilter {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailRegexFilter,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailRegexFilter {
-            name: value.name().map(Into::into),
-            matches_on: value.r#match().map(Into::into),
-            regex: value.regex().map(Into::into),
-            action: value.action().try_into()?,
-            detected: value.detected(),
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailRegexFilter> for GuardrailRegexFilter {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailRegexFilter,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailRegexFilter {
-            name: value.name().map(Into::into),
-            matches_on: value.r#match().map(Into::into),
-            regex: value.regex().map(Into::into),
-            action: value.action().try_into()?,
-            detected: value.detected(),
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailContextualGroundingFilter>
-    for GuardrailContextualGroundingFilter
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailContextualGroundingFilter,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailContextualGroundingFilter {
-            kind: value.r#type().try_into()?,
-            threshold: value.threshold(),
-            score: value.score(),
-            action: value.action().try_into()?,
-            detected: value.detected(),
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailContextualGroundingFilter>
-    for GuardrailContextualGroundingFilter
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailContextualGroundingFilter,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailContextualGroundingFilter {
-            kind: value.r#type().try_into()?,
-            threshold: value.threshold(),
-            score: value.score(),
-            action: value.action().try_into()?,
-            detected: value.detected(),
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailContextualGroundingFilterType>
-    for GuardrailContextualGroundingFilterType
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailContextualGroundingFilterType,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailContextualGroundingFilterType::Grounding => {
-                Ok(GuardrailContextualGroundingFilterType::Grounding)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContextualGroundingFilterType::Relevance => {
-                Ok(GuardrailContextualGroundingFilterType::Relevance)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailContextualGroundingFilterType: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailContextualGroundingFilterType>
-    for GuardrailContextualGroundingFilterType
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailContextualGroundingFilterType,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailContextualGroundingFilterType::Grounding => {
-                Ok(GuardrailContextualGroundingFilterType::Grounding)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContextualGroundingFilterType::Relevance => {
-                Ok(GuardrailContextualGroundingFilterType::Relevance)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailContextualGroundingFilterType: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailContextualGroundingPolicyAction>
-    for GuardrailContextualGroundingPolicyAction
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailContextualGroundingPolicyAction,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailContextualGroundingPolicyAction::Blocked => {
-                Ok(GuardrailContextualGroundingPolicyAction::Blocked)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContextualGroundingPolicyAction::None => {
-                Ok(GuardrailContextualGroundingPolicyAction::None)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailContextualGroundingPolicyAction: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailContextualGroundingPolicyAction>
-    for GuardrailContextualGroundingPolicyAction
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailContextualGroundingPolicyAction,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailContextualGroundingPolicyAction::Blocked => {
-                Ok(GuardrailContextualGroundingPolicyAction::Blocked)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailContextualGroundingPolicyAction::None => {
-                Ok(GuardrailContextualGroundingPolicyAction::None)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailContextualGroundingPolicyAction: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailUsage> for GuardrailUsage {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::GuardrailUsage) -> Result<Self, Self::Error> {
-        Ok(GuardrailUsage {
-            topic_policy_units: value.topic_policy_units(),
-            content_policy_units: value.content_policy_units(),
-            word_policy_units: value.word_policy_units(),
-            sensitive_information_policy_units: value.sensitive_information_policy_units(),
-            sensitive_information_policy_free_units: value
-                .sensitive_information_policy_free_units(),
-            contextual_grounding_policy_units: value.contextual_grounding_policy_units(),
-            content_policy_image_units: value.content_policy_image_units(),
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailUsage> for GuardrailUsage {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailUsage,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailUsage {
-            topic_policy_units: value.topic_policy_units(),
-            content_policy_units: value.content_policy_units(),
-            word_policy_units: value.word_policy_units(),
-            sensitive_information_policy_units: value.sensitive_information_policy_units(),
-            sensitive_information_policy_free_units: value
-                .sensitive_information_policy_free_units(),
-            contextual_grounding_policy_units: value.contextual_grounding_policy_units(),
-            content_policy_image_units: value.content_policy_image_units(),
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailCoverage> for GuardrailCoverage {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailCoverage,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailCoverage {
-            text_characters: value.text_characters().map(TryInto::try_into).transpose()?,
-            images: value.images().map(TryInto::try_into).transpose()?,
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailCoverage> for GuardrailCoverage {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailCoverage,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailCoverage {
-            text_characters: value.text_characters().map(TryInto::try_into).transpose()?,
-            images: value.images().map(TryInto::try_into).transpose()?,
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailTextCharactersCoverage>
-    for GuardrailTextCharactersCoverage
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailTextCharactersCoverage,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailTextCharactersCoverage {
-            guarded: value.guarded(),
-            total: value.total(),
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailTextCharactersCoverage>
-    for GuardrailTextCharactersCoverage
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailTextCharactersCoverage,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailTextCharactersCoverage {
-            guarded: value.guarded(),
-            total: value.total(),
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailImageCoverage> for GuardrailImageCoverage {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailImageCoverage,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailImageCoverage {
-            guarded: value.guarded(),
-            total: value.total(),
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailImageCoverage> for GuardrailImageCoverage {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailImageCoverage,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailImageCoverage {
-            guarded: value.guarded(),
-            total: value.total(),
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::PerformanceConfiguration> for PerformanceConfiguration {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::PerformanceConfiguration,
-    ) -> Result<Self, Self::Error> {
-        Ok(PerformanceConfiguration {
-            latency: value.latency().try_into()?,
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::PerformanceConfigLatency> for PerformanceConfigLatency {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::PerformanceConfigLatency,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::PerformanceConfigLatency::Optimized => {
-                Ok(PerformanceConfigLatency::Optimized)
-            }
-            aws_sdk_bedrockruntime::types::PerformanceConfigLatency::Standard => {
-                Ok(PerformanceConfigLatency::Standard)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for PerformanceConfigLatency: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::PerformanceConfigLatency>
-    for PerformanceConfigLatency
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::PerformanceConfigLatency,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::PerformanceConfigLatency::Optimized => {
-                Ok(PerformanceConfigLatency::Optimized)
-            }
-            aws_sdk_bedrockruntime::types::PerformanceConfigLatency::Standard => {
-                Ok(PerformanceConfigLatency::Standard)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for PerformanceConfigLatency: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::ConverseOutput> for ConverseOutput {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::ConverseOutput) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::ConverseOutput::Message(message) => {
-                Ok(ConverseOutput::Message(message.try_into()?))
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for ConverseOutput: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::Message> for Message {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::Message) -> Result<Self, Self::Error> {
-        Ok(Message {
-            role: value.role().try_into()?,
-            content: value
-                .content()
-                .iter()
-                .map(|v| v.clone().try_into())
-                .collect::<Result<_, Self::Error>>()?,
-        })
-    }
-}
-
-impl TryFrom<Message> for aws_sdk_bedrockruntime::types::Message {
-    type Error = TypeConversionError;
-    fn try_from(value: Message) -> Result<Self, Self::Error> {
-        let role = Some(value.role.try_into()?);
-        let content = Some(
-            value
-                .content
-                .iter()
-                .map(|v| v.clone().try_into())
-                .collect::<Result<_, Self::Error>>()?,
-        );
-        let res = aws_sdk_bedrockruntime::types::Message::builder()
-            .set_role(role)
-            .set_content(content)
-            .build()
-            .map_err(|e| TypeConversionError::new(&e.to_string()))?;
-
-        Ok(res)
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::ConversationRole> for ConversationRole {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::ConversationRole,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::ConversationRole::Assistant => {
-                Ok(ConversationRole::Assistant)
-            }
-            aws_sdk_bedrockruntime::types::ConversationRole::User => Ok(ConversationRole::User),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for ConversationRole: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::ConversationRole> for ConversationRole {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::ConversationRole,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::ConversationRole::Assistant => {
-                Ok(ConversationRole::Assistant)
-            }
-            aws_sdk_bedrockruntime::types::ConversationRole::User => Ok(ConversationRole::User),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for ConversationRole: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<ConversationRole> for aws_sdk_bedrockruntime::types::ConversationRole {
-    type Error = TypeConversionError;
-    fn try_from(value: ConversationRole) -> Result<Self, Self::Error> {
-        match value {
-            ConversationRole::Assistant => {
-                Ok(aws_sdk_bedrockruntime::types::ConversationRole::Assistant)
-            }
-            ConversationRole::User => Ok(aws_sdk_bedrockruntime::types::ConversationRole::User),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for ConversationRole: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::ContentBlock> for ContentBlock {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::ContentBlock) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::ContentBlock::CachePoint(value) => {
-                Ok(ContentBlock::CachePoint(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::ContentBlock::CitationsContent(value) => {
-                Ok(ContentBlock::CitationsContent(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::ContentBlock::Document(value) => {
-                Ok(ContentBlock::Document(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::ContentBlock::GuardContent(value) => {
-                Ok(ContentBlock::GuardContent(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::ContentBlock::Image(value) => {
-                Ok(ContentBlock::Image(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::ContentBlock::ReasoningContent(value) => {
-                Ok(ContentBlock::ReasoningContent(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::ContentBlock::Text(value) => {
-                Ok(ContentBlock::Text(value))
-            }
-            aws_sdk_bedrockruntime::types::ContentBlock::ToolResult(value) => {
-                Ok(ContentBlock::ToolResult(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::ContentBlock::ToolUse(value) => {
-                Ok(ContentBlock::ToolUse(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::ContentBlock::Video(value) => {
-                Ok(ContentBlock::Video(value.try_into()?))
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for ContentBlock: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<ContentBlock> for aws_sdk_bedrockruntime::types::ContentBlock {
-    type Error = TypeConversionError;
-    fn try_from(value: ContentBlock) -> Result<Self, Self::Error> {
-        match value {
-            ContentBlock::CachePoint(value) => Ok(
-                aws_sdk_bedrockruntime::types::ContentBlock::CachePoint(value.try_into()?),
-            ),
-            ContentBlock::CitationsContent(value) => Ok(
-                aws_sdk_bedrockruntime::types::ContentBlock::CitationsContent(value.try_into()?),
-            ),
-            ContentBlock::Document(value) => Ok(
-                aws_sdk_bedrockruntime::types::ContentBlock::Document(value.try_into()?),
-            ),
-            ContentBlock::GuardContent(value) => Ok(
-                aws_sdk_bedrockruntime::types::ContentBlock::GuardContent(value.try_into()?),
-            ),
-            ContentBlock::Image(value) => Ok(aws_sdk_bedrockruntime::types::ContentBlock::Image(
-                value.try_into()?,
-            )),
-            ContentBlock::ReasoningContent(value) => Ok(
-                aws_sdk_bedrockruntime::types::ContentBlock::ReasoningContent(value.try_into()?),
-            ),
-            ContentBlock::Text(value) => {
-                Ok(aws_sdk_bedrockruntime::types::ContentBlock::Text(value))
-            }
-            ContentBlock::ToolResult(value) => Ok(
-                aws_sdk_bedrockruntime::types::ContentBlock::ToolResult(value.try_into()?),
-            ),
-            ContentBlock::ToolUse(value) => Ok(
-                aws_sdk_bedrockruntime::types::ContentBlock::ToolUse(value.try_into()?),
-            ),
-            ContentBlock::Video(value) => Ok(aws_sdk_bedrockruntime::types::ContentBlock::Video(
-                value.try_into()?,
-            )),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for ContentBlock: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::CachePointBlock> for CachePointBlock {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::CachePointBlock,
-    ) -> Result<Self, Self::Error> {
-        Ok(CachePointBlock {
-            kind: value.r#type().try_into()?,
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::CachePointBlock> for CachePointBlock {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::CachePointBlock,
-    ) -> Result<Self, Self::Error> {
-        Ok(CachePointBlock {
-            kind: value.r#type().try_into()?,
-        })
-    }
-}
-
-impl TryFrom<CachePointBlock> for aws_sdk_bedrockruntime::types::CachePointBlock {
-    type Error = TypeConversionError;
-    fn try_from(value: CachePointBlock) -> Result<Self, Self::Error> {
-        let res = aws_sdk_bedrockruntime::types::CachePointBlock::builder()
-            .set_type(Some(value.kind.try_into()?))
-            .build()
-            .map_err(|x| TypeConversionError::new(format!("Converting from CachePointBlock to AWS CachePointBlock should never fail but it seems to have done so: {x}").as_ref()))?;
-
-        Ok(res)
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::CachePointType> for CachePointType {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::CachePointType) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::CachePointType::Default => Ok(CachePointType::Default),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for CachePointType: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<CachePointType> for aws_sdk_bedrockruntime::types::CachePointType {
-    type Error = TypeConversionError;
-    fn try_from(value: CachePointType) -> Result<Self, Self::Error> {
-        match value {
-            CachePointType::Default => Ok(aws_sdk_bedrockruntime::types::CachePointType::Default),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for CachePointType: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::CachePointType> for CachePointType {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::CachePointType,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::CachePointType::Default => Ok(CachePointType::Default),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for CachePointType: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::CitationsContentBlock> for CitationsContentBlock {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::CitationsContentBlock,
-    ) -> Result<Self, Self::Error> {
-        Ok(CitationsContentBlock {
-            content: Some(
-                value
-                    .content()
-                    .iter()
-                    .map(|x| x.clone().try_into())
-                    .collect::<Result<_, Self::Error>>()?,
-            ),
-
-            citations: Some(
-                value
-                    .citations()
-                    .iter()
-                    .map(|x| x.clone().try_into())
-                    .collect::<Result<_, Self::Error>>()?,
-            ),
-        })
-    }
-}
-
-impl TryFrom<CitationsContentBlock> for aws_sdk_bedrockruntime::types::CitationsContentBlock {
-    type Error = TypeConversionError;
-    fn try_from(value: CitationsContentBlock) -> Result<Self, Self::Error> {
-        let citations = value
-            .citations
-            .map(|x| x.into_iter().map(|x| x.try_into()).collect())
-            .transpose()?;
-        let content = value
-            .content
-            .map(|x| x.into_iter().map(|x| x.try_into()).collect())
-            .transpose()?;
-        let citations = aws_sdk_bedrockruntime::types::CitationsContentBlock::builder()
-            .set_citations(citations)
-            .set_content(content)
-            .build();
-        Ok(citations)
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::CitationGeneratedContent> for CitationGeneratedContent {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::CitationGeneratedContent,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::CitationGeneratedContent::Text(value) => {
-                Ok(CitationGeneratedContent::Text(value))
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for CitationGeneratedContent: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<CitationGeneratedContent> for aws_sdk_bedrockruntime::types::CitationGeneratedContent {
-    type Error = TypeConversionError;
-    fn try_from(value: CitationGeneratedContent) -> Result<Self, Self::Error> {
-        match value {
-            CitationGeneratedContent::Text(value) => {
-                Ok(aws_sdk_bedrockruntime::types::CitationGeneratedContent::Text(value))
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for CitationGeneratedContent: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::CitationGeneratedContent>
-    for CitationGeneratedContent
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::CitationGeneratedContent,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::CitationGeneratedContent::Text(value) => {
-                Ok(CitationGeneratedContent::Text(value.to_owned()))
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for CitationGeneratedContent: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::Citation> for Citation {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::Citation) -> Result<Self, Self::Error> {
-        Ok(Citation {
-            title: value.title().map(Into::into),
-            source_content: Some(
-                value
-                    .source_content()
-                    .iter()
-                    .map(|x| x.try_into())
-                    .collect::<Result<_, Self::Error>>()?,
-            ),
-            location: value.location().map(|v| v.try_into()).transpose()?,
-        })
-    }
-}
-
-impl TryFrom<Citation> for aws_sdk_bedrockruntime::types::Citation {
-    type Error = TypeConversionError;
-    fn try_from(value: Citation) -> Result<Self, Self::Error> {
-        let title = value.title;
-        let location = value.location.map(|x| x.try_into()).transpose()?;
-        let content = value
-            .source_content
-            .map(|x| {
-                x.into_iter()
-                    .map(|x| x.try_into())
-                    .collect::<Result<_, Self::Error>>()
-            })
-            .transpose()?;
-
-        let builder = aws_sdk_bedrockruntime::types::Citation::builder()
-            .set_title(title)
-            .set_location(location)
-            .set_source_content(content)
-            .build();
-        Ok(builder)
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::CitationSourceContent> for CitationSourceContent {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::CitationSourceContent,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::CitationSourceContent::Text(value) => {
-                Ok(CitationSourceContent::Text(value))
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for CitationSourceContent: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::CitationSourceContent> for CitationSourceContent {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::CitationSourceContent,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::CitationSourceContent::Text(value) => {
-                Ok(CitationSourceContent::Text(value.to_owned()))
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for CitationSourceContent: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<CitationSourceContent> for aws_sdk_bedrockruntime::types::CitationSourceContent {
-    type Error = TypeConversionError;
-    fn try_from(value: CitationSourceContent) -> Result<Self, Self::Error> {
-        match value {
-            CitationSourceContent::Text(value) => Ok(
-                aws_sdk_bedrockruntime::types::CitationSourceContent::Text(value),
-            ),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for CitationSourceContent: {invalid:?}"
-            ))),
-        }
-    }
-}
-impl TryFrom<aws_sdk_bedrockruntime::types::CitationLocation> for CitationLocation {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::CitationLocation,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::CitationLocation::DocumentChar(value) => {
-                Ok(CitationLocation::DocumentChar(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::CitationLocation::DocumentChunk(value) => {
-                Ok(CitationLocation::DocumentChunk(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::CitationLocation::DocumentPage(value) => {
-                Ok(CitationLocation::DocumentPage(value.try_into()?))
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for CitationLocation: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::CitationLocation> for CitationLocation {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::CitationLocation,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::CitationLocation::DocumentChar(value) => {
-                Ok(CitationLocation::DocumentChar(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::CitationLocation::DocumentChunk(value) => {
-                Ok(CitationLocation::DocumentChunk(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::CitationLocation::DocumentPage(value) => {
-                Ok(CitationLocation::DocumentPage(value.try_into()?))
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for CitationLocation: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<CitationLocation> for aws_sdk_bedrockruntime::types::CitationLocation {
-    type Error = TypeConversionError;
-    fn try_from(value: CitationLocation) -> Result<Self, Self::Error> {
-        match value {
-            CitationLocation::DocumentChar(value) => Ok(
-                aws_sdk_bedrockruntime::types::CitationLocation::DocumentChar(value.try_into()?),
-            ),
-            CitationLocation::DocumentChunk(value) => Ok(
-                aws_sdk_bedrockruntime::types::CitationLocation::DocumentChunk(value.try_into()?),
-            ),
-            CitationLocation::DocumentPage(value) => Ok(
-                aws_sdk_bedrockruntime::types::CitationLocation::DocumentPage(value.try_into()?),
-            ),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for CitationLocation: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::DocumentCharLocation> for DocumentCharLocation {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::DocumentCharLocation,
-    ) -> Result<Self, Self::Error> {
-        Ok(DocumentCharLocation {
-            document_index: value.document_index(),
-            start: value.start(),
-            end: value.end(),
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::DocumentCharLocation> for DocumentCharLocation {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::DocumentCharLocation,
-    ) -> Result<Self, Self::Error> {
-        Ok(DocumentCharLocation {
-            document_index: value.document_index(),
-            start: value.start(),
-            end: value.end(),
-        })
-    }
-}
-
-impl TryFrom<DocumentCharLocation> for aws_sdk_bedrockruntime::types::DocumentCharLocation {
-    type Error = TypeConversionError;
-    fn try_from(value: DocumentCharLocation) -> Result<Self, Self::Error> {
-        let res = aws_sdk_bedrockruntime::types::DocumentCharLocation::builder()
-            .set_document_index(value.document_index)
-            .set_start(value.start)
-            .set_end(value.end)
-            .build();
-
-        Ok(res)
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::DocumentChunkLocation> for DocumentChunkLocation {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::DocumentChunkLocation,
-    ) -> Result<Self, Self::Error> {
-        Ok(DocumentChunkLocation {
-            document_index: value.document_index(),
-            start: value.start(),
-            end: value.end(),
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::DocumentChunkLocation> for DocumentChunkLocation {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::DocumentChunkLocation,
-    ) -> Result<Self, Self::Error> {
-        Ok(DocumentChunkLocation {
-            document_index: value.document_index(),
-            start: value.start(),
-            end: value.end(),
-        })
-    }
-}
-
-impl TryFrom<DocumentChunkLocation> for aws_sdk_bedrockruntime::types::DocumentChunkLocation {
-    type Error = TypeConversionError;
-    fn try_from(value: DocumentChunkLocation) -> Result<Self, Self::Error> {
-        let res = aws_sdk_bedrockruntime::types::DocumentChunkLocation::builder()
-            .set_document_index(value.document_index)
-            .set_start(value.start)
-            .set_end(value.end)
-            .build();
-        Ok(res)
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::DocumentPageLocation> for DocumentPageLocation {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::DocumentPageLocation,
-    ) -> Result<Self, Self::Error> {
-        Ok(DocumentPageLocation {
-            document_index: value.document_index(),
-            start: value.start(),
-            end: value.end(),
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::DocumentPageLocation> for DocumentPageLocation {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::DocumentPageLocation,
-    ) -> Result<Self, Self::Error> {
-        Ok(DocumentPageLocation {
-            document_index: value.document_index(),
-            start: value.start(),
-            end: value.end(),
-        })
-    }
-}
-
-impl TryFrom<DocumentPageLocation> for aws_sdk_bedrockruntime::types::DocumentPageLocation {
-    type Error = TypeConversionError;
-    fn try_from(value: DocumentPageLocation) -> Result<Self, Self::Error> {
-        let res = aws_sdk_bedrockruntime::types::DocumentPageLocation::builder()
-            .set_document_index(value.document_index)
-            .set_start(value.start)
-            .set_end(value.end)
-            .build();
-
-        Ok(res)
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::DocumentBlock> for DocumentBlock {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::DocumentBlock) -> Result<Self, Self::Error> {
-        Ok(DocumentBlock {
-            format: value.format().try_into()?,
-            name: value.name().into(),
-            source: value.source().map(|v| v.try_into()).transpose()?,
-            context: value.context().map(Into::into),
-            citations: value.citations().map(|v| v.try_into()).transpose()?,
-        })
-    }
-}
-
-impl TryFrom<DocumentBlock> for aws_sdk_bedrockruntime::types::DocumentBlock {
-    type Error = TypeConversionError;
-    fn try_from(value: DocumentBlock) -> Result<Self, Self::Error> {
-        let format = Some(aws_sdk_bedrockruntime::types::DocumentFormat::try_from(
-            value.format,
-        )?);
-        let name = value.name.into();
-        let source = value.source.map(|v| v.try_into()).transpose()?;
-        let context = value.context;
-        let citations = value.citations.map(|v| v.try_into()).transpose()?;
-
-        let res = aws_sdk_bedrockruntime::types::DocumentBlock::builder()
-            .set_format(format)
-            .set_name(name)
-            .set_source(source)
-            .set_context(context)
-            .set_citations(citations)
-            .build()
-            .map_err(|e| TypeConversionError::new(&e.to_string()))?;
-
-        Ok(res)
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::DocumentFormat> for DocumentFormat {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::DocumentFormat) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::DocumentFormat::Csv => Ok(DocumentFormat::Csv),
-            aws_sdk_bedrockruntime::types::DocumentFormat::Doc => Ok(DocumentFormat::Doc),
-            aws_sdk_bedrockruntime::types::DocumentFormat::Docx => Ok(DocumentFormat::Docx),
-            aws_sdk_bedrockruntime::types::DocumentFormat::Html => Ok(DocumentFormat::Html),
-            aws_sdk_bedrockruntime::types::DocumentFormat::Md => Ok(DocumentFormat::Md),
-            aws_sdk_bedrockruntime::types::DocumentFormat::Pdf => Ok(DocumentFormat::Pdf),
-            aws_sdk_bedrockruntime::types::DocumentFormat::Txt => Ok(DocumentFormat::Txt),
-            aws_sdk_bedrockruntime::types::DocumentFormat::Xls => Ok(DocumentFormat::Xls),
-            aws_sdk_bedrockruntime::types::DocumentFormat::Xlsx => Ok(DocumentFormat::Xlsx),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for DocumentFormat: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::DocumentFormat> for DocumentFormat {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::DocumentFormat,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::DocumentFormat::Csv => Ok(DocumentFormat::Csv),
-            aws_sdk_bedrockruntime::types::DocumentFormat::Doc => Ok(DocumentFormat::Doc),
-            aws_sdk_bedrockruntime::types::DocumentFormat::Docx => Ok(DocumentFormat::Docx),
-            aws_sdk_bedrockruntime::types::DocumentFormat::Html => Ok(DocumentFormat::Html),
-            aws_sdk_bedrockruntime::types::DocumentFormat::Md => Ok(DocumentFormat::Md),
-            aws_sdk_bedrockruntime::types::DocumentFormat::Pdf => Ok(DocumentFormat::Pdf),
-            aws_sdk_bedrockruntime::types::DocumentFormat::Txt => Ok(DocumentFormat::Txt),
-            aws_sdk_bedrockruntime::types::DocumentFormat::Xls => Ok(DocumentFormat::Xls),
-            aws_sdk_bedrockruntime::types::DocumentFormat::Xlsx => Ok(DocumentFormat::Xlsx),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for DocumentFormat: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<DocumentFormat> for aws_sdk_bedrockruntime::types::DocumentFormat {
-    type Error = TypeConversionError;
-    fn try_from(value: DocumentFormat) -> Result<Self, Self::Error> {
-        match value {
-            DocumentFormat::Csv => Ok(aws_sdk_bedrockruntime::types::DocumentFormat::Csv),
-            DocumentFormat::Doc => Ok(aws_sdk_bedrockruntime::types::DocumentFormat::Doc),
-            DocumentFormat::Docx => Ok(aws_sdk_bedrockruntime::types::DocumentFormat::Docx),
-            DocumentFormat::Html => Ok(aws_sdk_bedrockruntime::types::DocumentFormat::Html),
-            DocumentFormat::Md => Ok(aws_sdk_bedrockruntime::types::DocumentFormat::Md),
-            DocumentFormat::Pdf => Ok(aws_sdk_bedrockruntime::types::DocumentFormat::Pdf),
-            DocumentFormat::Txt => Ok(aws_sdk_bedrockruntime::types::DocumentFormat::Txt),
-            DocumentFormat::Xls => Ok(aws_sdk_bedrockruntime::types::DocumentFormat::Xls),
-            DocumentFormat::Xlsx => Ok(aws_sdk_bedrockruntime::types::DocumentFormat::Xlsx),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for DocumentFormat: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::DocumentSource> for DocumentSource {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::DocumentSource) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::DocumentSource::Bytes(value) => {
+            aws_bedrock::DocumentSource::Bytes(value) => {
                 Ok(DocumentSource::Bytes(value.try_into()?))
             }
-            aws_sdk_bedrockruntime::types::DocumentSource::Content(value) => {
-                Ok(DocumentSource::Content(
-                    value
-                        .iter()
-                        .map(|x| x.clone().try_into())
-                        .collect::<Result<_, Self::Error>>()?,
-                ))
-            }
-            aws_sdk_bedrockruntime::types::DocumentSource::S3Location(value) => {
+            aws_bedrock::DocumentSource::Content(value) => Ok(DocumentSource::Content(
+                value
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<_, Self::Error>>()?,
+            )),
+            aws_bedrock::DocumentSource::S3Location(value) => {
                 Ok(DocumentSource::S3Location(value.try_into()?))
             }
-            aws_sdk_bedrockruntime::types::DocumentSource::Text(value) => {
-                Ok(DocumentSource::Text(value))
-            }
+            aws_bedrock::DocumentSource::Text(value) => Ok(DocumentSource::Text(value)),
             invalid => Err(TypeConversionError::new(&format!(
                 "Unknown variant for DocumentSource: {invalid:?}"
             ))),
@@ -2717,57 +608,23 @@ impl TryFrom<aws_sdk_bedrockruntime::types::DocumentSource> for DocumentSource {
     }
 }
 
-impl TryFrom<&aws_sdk_bedrockruntime::types::DocumentSource> for DocumentSource {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::DocumentSource,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::DocumentSource::Bytes(value) => {
-                Ok(DocumentSource::Bytes(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::DocumentSource::Content(value) => {
-                Ok(DocumentSource::Content(
-                    value
-                        .iter()
-                        .map(|x| x.clone().try_into())
-                        .collect::<Result<_, Self::Error>>()?,
-                ))
-            }
-            aws_sdk_bedrockruntime::types::DocumentSource::S3Location(value) => {
-                Ok(DocumentSource::S3Location(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::DocumentSource::Text(value) => {
-                Ok(DocumentSource::Text(value.to_string()))
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for DocumentSource: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<DocumentSource> for aws_sdk_bedrockruntime::types::DocumentSource {
+impl TryFrom<DocumentSource> for aws_bedrock::DocumentSource {
     type Error = TypeConversionError;
     fn try_from(value: DocumentSource) -> Result<Self, Self::Error> {
         match value {
-            DocumentSource::Bytes(value) => Ok(
-                aws_sdk_bedrockruntime::types::DocumentSource::Bytes(value.try_into()?),
-            ),
-            DocumentSource::Content(value) => {
-                Ok(aws_sdk_bedrockruntime::types::DocumentSource::Content(
-                    value
-                        .iter()
-                        .map(|x| x.clone().try_into())
-                        .collect::<Result<_, Self::Error>>()?,
-                ))
+            DocumentSource::Bytes(value) => {
+                Ok(aws_bedrock::DocumentSource::Bytes(value.try_into()?))
             }
-            DocumentSource::S3Location(value) => Ok(
-                aws_sdk_bedrockruntime::types::DocumentSource::S3Location(value.try_into()?),
-            ),
-            DocumentSource::Text(value) => {
-                Ok(aws_sdk_bedrockruntime::types::DocumentSource::Text(value))
+            DocumentSource::Content(value) => Ok(aws_bedrock::DocumentSource::Content(
+                value
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<_, Self::Error>>()?,
+            )),
+            DocumentSource::S3Location(value) => {
+                Ok(aws_bedrock::DocumentSource::S3Location(value.try_into()?))
             }
+            DocumentSource::Text(value) => Ok(aws_bedrock::DocumentSource::Text(value)),
             invalid => Err(TypeConversionError::new(&format!(
                 "Unknown variant for DocumentSource: {invalid:?}"
             ))),
@@ -2775,673 +632,23 @@ impl TryFrom<DocumentSource> for aws_sdk_bedrockruntime::types::DocumentSource {
     }
 }
 
-impl TryFrom<aws_sdk_bedrockruntime::types::DocumentContentBlock> for DocumentContentBlock {
+impl TryFrom<aws_bedrock::ToolResultContentBlock> for ToolResultContentBlock {
     type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::DocumentContentBlock,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(value: aws_bedrock::ToolResultContentBlock) -> Result<Self, Self::Error> {
         match value {
-            aws_sdk_bedrockruntime::types::DocumentContentBlock::Text(value) => {
-                Ok(DocumentContentBlock::Text(value))
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for DocumentContentBlock: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<DocumentContentBlock> for aws_sdk_bedrockruntime::types::DocumentContentBlock {
-    type Error = TypeConversionError;
-    fn try_from(value: DocumentContentBlock) -> Result<Self, Self::Error> {
-        match value {
-            DocumentContentBlock::Text(value) => Ok(
-                aws_sdk_bedrockruntime::types::DocumentContentBlock::Text(value),
-            ),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for DocumentContentBlock: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::S3Location> for S3Location {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::S3Location) -> Result<Self, Self::Error> {
-        Ok(S3Location {
-            uri: value.uri().into(),
-            bucket_owner: value.bucket_owner().map(Into::into),
-        })
-    }
-}
-
-impl TryFrom<S3Location> for aws_sdk_bedrockruntime::types::S3Location {
-    type Error = TypeConversionError;
-    fn try_from(value: S3Location) -> Result<Self, Self::Error> {
-        let res = aws_sdk_bedrockruntime::types::S3Location::builder()
-            .set_uri(Some(value.uri))
-            .set_bucket_owner(value.bucket_owner)
-            .build()
-            .map_err(|e| TypeConversionError::new(&e.to_string()))?;
-
-        Ok(res)
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::S3Location> for S3Location {
-    type Error = TypeConversionError;
-    fn try_from(value: &aws_sdk_bedrockruntime::types::S3Location) -> Result<Self, Self::Error> {
-        Ok(S3Location {
-            uri: value.uri().into(),
-            bucket_owner: value.bucket_owner().map(Into::into),
-        })
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::primitives::Blob> for Blob {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::primitives::Blob) -> Result<Self, Self::Error> {
-        Ok(Blob {
-            inner: value.clone().into_inner(),
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::primitives::Blob> for Blob {
-    type Error = TypeConversionError;
-    fn try_from(value: &aws_sdk_bedrockruntime::primitives::Blob) -> Result<Self, Self::Error> {
-        Ok(Blob {
-            inner: value.clone().into_inner(),
-        })
-    }
-}
-
-impl TryFrom<Blob> for aws_sdk_bedrockruntime::primitives::Blob {
-    type Error = TypeConversionError;
-    fn try_from(value: Blob) -> Result<Self, Self::Error> {
-        let res = aws_sdk_bedrockruntime::primitives::Blob::new(value.inner);
-        Ok(res)
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::CitationsConfig> for CitationsConfig {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::CitationsConfig,
-    ) -> Result<Self, Self::Error> {
-        Ok(CitationsConfig {
-            enabled: value.enabled(),
-        })
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::CitationsConfig> for CitationsConfig {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::CitationsConfig,
-    ) -> Result<Self, Self::Error> {
-        Ok(CitationsConfig {
-            enabled: value.enabled(),
-        })
-    }
-}
-
-impl TryFrom<CitationsConfig> for aws_sdk_bedrockruntime::types::CitationsConfig {
-    type Error = TypeConversionError;
-    fn try_from(value: CitationsConfig) -> Result<Self, Self::Error> {
-        let res = aws_sdk_bedrockruntime::types::CitationsConfig::builder()
-            .set_enabled(Some(value.enabled))
-            .build()
-            .map_err(|e| TypeConversionError::new(&e.to_string()))?;
-
-        Ok(res)
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailConverseContentBlock>
-    for GuardrailConverseContentBlock
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailConverseContentBlock,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailConverseContentBlock::Image(value) => {
-                Ok(GuardrailConverseContentBlock::Image(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::GuardrailConverseContentBlock::Text(value) => {
-                Ok(GuardrailConverseContentBlock::Text(value.try_into()?))
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailConverseContentBlock: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<GuardrailConverseContentBlock>
-    for aws_sdk_bedrockruntime::types::GuardrailConverseContentBlock
-{
-    type Error = TypeConversionError;
-    fn try_from(value: GuardrailConverseContentBlock) -> Result<Self, Self::Error> {
-        match value {
-            GuardrailConverseContentBlock::Image(value) => Ok(
-                aws_sdk_bedrockruntime::types::GuardrailConverseContentBlock::Image(
-                    value.try_into()?,
-                ),
-            ),
-            GuardrailConverseContentBlock::Text(value) => Ok(
-                aws_sdk_bedrockruntime::types::GuardrailConverseContentBlock::Text(
-                    value.try_into()?,
-                ),
-            ),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailConverseContentBlock: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailConverseImageBlock>
-    for GuardrailConverseImageBlock
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailConverseImageBlock,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailConverseImageBlock {
-            format: value.format().try_into()?,
-            source: value.source().map(|v| v.try_into()).transpose()?,
-        })
-    }
-}
-
-impl TryFrom<GuardrailConverseImageBlock>
-    for aws_sdk_bedrockruntime::types::GuardrailConverseImageBlock
-{
-    type Error = TypeConversionError;
-    fn try_from(value: GuardrailConverseImageBlock) -> Result<Self, Self::Error> {
-        let format = Some(value.format.try_into()?);
-        let source = value.source.map(|v| v.try_into()).transpose()?;
-        let res = aws_sdk_bedrockruntime::types::GuardrailConverseImageBlock::builder()
-            .set_format(format)
-            .set_source(source)
-            .build()
-            .map_err(|e| TypeConversionError::new(&e.to_string()))?;
-        Ok(res)
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailConverseImageFormat>
-    for GuardrailConverseImageFormat
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailConverseImageFormat,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailConverseImageFormat::Jpeg => {
-                Ok(GuardrailConverseImageFormat::Jpeg)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailConverseImageFormat::Png => {
-                Ok(GuardrailConverseImageFormat::Png)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailConverseImageFormat: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<GuardrailConverseImageFormat>
-    for aws_sdk_bedrockruntime::types::GuardrailConverseImageFormat
-{
-    type Error = TypeConversionError;
-    fn try_from(value: GuardrailConverseImageFormat) -> Result<Self, Self::Error> {
-        match value {
-            GuardrailConverseImageFormat::Jpeg => {
-                Ok(aws_sdk_bedrockruntime::types::GuardrailConverseImageFormat::Jpeg)
-            }
-            GuardrailConverseImageFormat::Png => {
-                Ok(aws_sdk_bedrockruntime::types::GuardrailConverseImageFormat::Png)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailConverseImageFormat: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailConverseImageFormat>
-    for GuardrailConverseImageFormat
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailConverseImageFormat,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailConverseImageFormat::Jpeg => {
-                Ok(GuardrailConverseImageFormat::Jpeg)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailConverseImageFormat::Png => {
-                Ok(GuardrailConverseImageFormat::Png)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailConverseImageFormat: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailConverseImageSource>
-    for GuardrailConverseImageSource
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailConverseImageSource,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailConverseImageSource::Bytes(value) => {
-                Ok(GuardrailConverseImageSource::Bytes(value.try_into()?))
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailConverseImageSource: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailConverseImageSource>
-    for GuardrailConverseImageSource
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailConverseImageSource,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailConverseImageSource::Bytes(value) => {
-                Ok(GuardrailConverseImageSource::Bytes(value.try_into()?))
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailConverseImageSource: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<GuardrailConverseImageSource>
-    for aws_sdk_bedrockruntime::types::GuardrailConverseImageSource
-{
-    type Error = TypeConversionError;
-    fn try_from(value: GuardrailConverseImageSource) -> Result<Self, Self::Error> {
-        match value {
-            GuardrailConverseImageSource::Bytes(value) => Ok(
-                aws_sdk_bedrockruntime::types::GuardrailConverseImageSource::Bytes(
-                    value.try_into()?,
-                ),
-            ),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailConverseImageSource: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailConverseTextBlock>
-    for GuardrailConverseTextBlock
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailConverseTextBlock,
-    ) -> Result<Self, Self::Error> {
-        Ok(GuardrailConverseTextBlock {
-            text: value.text().into(),
-            qualifiers: Some(
-                value
-                    .qualifiers()
-                    .iter()
-                    .map(|v| v.try_into())
-                    .collect::<Result<_, Self::Error>>()?,
-            ),
-        })
-    }
-}
-
-impl TryFrom<GuardrailConverseTextBlock>
-    for aws_sdk_bedrockruntime::types::GuardrailConverseTextBlock
-{
-    type Error = TypeConversionError;
-    fn try_from(value: GuardrailConverseTextBlock) -> Result<Self, Self::Error> {
-        let text = Some(value.text);
-        let qualifiers = value
-            .qualifiers
-            .map(|v| v.into_iter().map(|x| x.try_into()).collect())
-            .transpose()?;
-        let res = aws_sdk_bedrockruntime::types::GuardrailConverseTextBlock::builder()
-            .set_text(text)
-            .set_qualifiers(qualifiers)
-            .build()
-            .map_err(|e| TypeConversionError::new(&e.to_string()))?;
-
-        Ok(res)
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::GuardrailConverseContentQualifier>
-    for GuardrailConverseContentQualifier
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::GuardrailConverseContentQualifier,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailConverseContentQualifier::GroundingSource => {
-                Ok(GuardrailConverseContentQualifier::GroundingSource)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailConverseContentQualifier::GuardContent => {
-                Ok(GuardrailConverseContentQualifier::GuardContent)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailConverseContentQualifier::Query => {
-                Ok(GuardrailConverseContentQualifier::Query)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailConverseContentQualifier: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::GuardrailConverseContentQualifier>
-    for GuardrailConverseContentQualifier
-{
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::GuardrailConverseContentQualifier,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::GuardrailConverseContentQualifier::GroundingSource => {
-                Ok(GuardrailConverseContentQualifier::GroundingSource)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailConverseContentQualifier::GuardContent => {
-                Ok(GuardrailConverseContentQualifier::GuardContent)
-            }
-            aws_sdk_bedrockruntime::types::GuardrailConverseContentQualifier::Query => {
-                Ok(GuardrailConverseContentQualifier::Query)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailConverseContentQualifier: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<GuardrailConverseContentQualifier>
-    for aws_sdk_bedrockruntime::types::GuardrailConverseContentQualifier
-{
-    type Error = TypeConversionError;
-    fn try_from(value: GuardrailConverseContentQualifier) -> Result<Self, Self::Error> {
-        match value {
-            GuardrailConverseContentQualifier::GroundingSource => Ok(
-                aws_sdk_bedrockruntime::types::GuardrailConverseContentQualifier::GroundingSource,
-            ),
-            GuardrailConverseContentQualifier::GuardContent => {
-                Ok(aws_sdk_bedrockruntime::types::GuardrailConverseContentQualifier::GuardContent)
-            }
-            GuardrailConverseContentQualifier::Query => {
-                Ok(aws_sdk_bedrockruntime::types::GuardrailConverseContentQualifier::Query)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for GuardrailConverseContentQualifier: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::ImageBlock> for ImageBlock {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::ImageBlock) -> Result<Self, Self::Error> {
-        Ok(ImageBlock {
-            format: value.format().try_into()?,
-            source: value.source().map(|v| v.try_into()).transpose()?,
-        })
-    }
-}
-
-impl TryFrom<ImageBlock> for aws_sdk_bedrockruntime::types::ImageBlock {
-    type Error = TypeConversionError;
-    fn try_from(value: ImageBlock) -> Result<Self, Self::Error> {
-        let format = Some(value.format.try_into()?);
-        let source = value.source.map(|v| v.try_into()).transpose()?;
-        let res = aws_sdk_bedrockruntime::types::ImageBlock::builder()
-            .set_format(format)
-            .set_source(source)
-            .build()
-            .map_err(|e| TypeConversionError::new(&e.to_string()))?;
-        Ok(res)
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::ImageFormat> for ImageFormat {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::ImageFormat) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::ImageFormat::Gif => Ok(ImageFormat::Gif),
-            aws_sdk_bedrockruntime::types::ImageFormat::Jpeg => Ok(ImageFormat::Jpeg),
-            aws_sdk_bedrockruntime::types::ImageFormat::Png => Ok(ImageFormat::Png),
-            aws_sdk_bedrockruntime::types::ImageFormat::Webp => Ok(ImageFormat::Webp),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for ImageFormat: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::ImageFormat> for ImageFormat {
-    type Error = TypeConversionError;
-    fn try_from(value: &aws_sdk_bedrockruntime::types::ImageFormat) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::ImageFormat::Gif => Ok(ImageFormat::Gif),
-            aws_sdk_bedrockruntime::types::ImageFormat::Jpeg => Ok(ImageFormat::Jpeg),
-            aws_sdk_bedrockruntime::types::ImageFormat::Png => Ok(ImageFormat::Png),
-            aws_sdk_bedrockruntime::types::ImageFormat::Webp => Ok(ImageFormat::Webp),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for ImageFormat: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<ImageFormat> for aws_sdk_bedrockruntime::types::ImageFormat {
-    type Error = TypeConversionError;
-    fn try_from(value: ImageFormat) -> Result<Self, Self::Error> {
-        match value {
-            ImageFormat::Gif => Ok(aws_sdk_bedrockruntime::types::ImageFormat::Gif),
-            ImageFormat::Jpeg => Ok(aws_sdk_bedrockruntime::types::ImageFormat::Jpeg),
-            ImageFormat::Png => Ok(aws_sdk_bedrockruntime::types::ImageFormat::Png),
-            ImageFormat::Webp => Ok(aws_sdk_bedrockruntime::types::ImageFormat::Webp),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for ImageFormat: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::ImageSource> for ImageSource {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::ImageSource) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::ImageSource::Bytes(value) => {
-                Ok(ImageSource::Bytes(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::ImageSource::S3Location(value) => {
-                Ok(ImageSource::S3Location(value.try_into()?))
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for ImageSource: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::ImageSource> for ImageSource {
-    type Error = TypeConversionError;
-    fn try_from(value: &aws_sdk_bedrockruntime::types::ImageSource) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::ImageSource::Bytes(value) => {
-                Ok(ImageSource::Bytes(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::ImageSource::S3Location(value) => {
-                Ok(ImageSource::S3Location(value.try_into()?))
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for ImageSource: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<ImageSource> for aws_sdk_bedrockruntime::types::ImageSource {
-    type Error = TypeConversionError;
-    fn try_from(value: ImageSource) -> Result<Self, Self::Error> {
-        match value {
-            ImageSource::Bytes(value) => Ok(aws_sdk_bedrockruntime::types::ImageSource::Bytes(
-                value.try_into()?,
-            )),
-            ImageSource::S3Location(value) => Ok(
-                aws_sdk_bedrockruntime::types::ImageSource::S3Location(value.try_into()?),
-            ),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for ImageSource: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::ReasoningContentBlock> for ReasoningContentBlock {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::ReasoningContentBlock,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::ReasoningContentBlock::ReasoningText(value) => {
-                Ok(ReasoningContentBlock::ReasoningText(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::ReasoningContentBlock::RedactedContent(value) => {
-                Ok(ReasoningContentBlock::RedactedContent(value.try_into()?))
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for ReasoningContentBlock: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<ReasoningContentBlock> for aws_sdk_bedrockruntime::types::ReasoningContentBlock {
-    type Error = TypeConversionError;
-    fn try_from(value: ReasoningContentBlock) -> Result<Self, Self::Error> {
-        match value {
-            ReasoningContentBlock::ReasoningText(value) => Ok(
-                aws_sdk_bedrockruntime::types::ReasoningContentBlock::ReasoningText(
-                    value.try_into()?,
-                ),
-            ),
-            ReasoningContentBlock::RedactedContent(value) => Ok(
-                aws_sdk_bedrockruntime::types::ReasoningContentBlock::RedactedContent(
-                    value.try_into()?,
-                ),
-            ),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for ReasoningContentBlock: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::ReasoningTextBlock> for ReasoningTextBlock {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::ReasoningTextBlock,
-    ) -> Result<Self, Self::Error> {
-        Ok(ReasoningTextBlock {
-            text: value.text().into(),
-            signature: value.signature().map(Into::into),
-        })
-    }
-}
-
-impl TryFrom<ReasoningTextBlock> for aws_sdk_bedrockruntime::types::ReasoningTextBlock {
-    type Error = TypeConversionError;
-    fn try_from(value: ReasoningTextBlock) -> Result<Self, Self::Error> {
-        let text = value.text.into();
-        let signature = value.signature;
-        let res = aws_sdk_bedrockruntime::types::ReasoningTextBlock::builder()
-            .set_text(text)
-            .set_signature(signature)
-            .build()
-            .map_err(|e| TypeConversionError::new(&e.to_string()))?;
-
-        Ok(res)
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::ToolResultBlock> for ToolResultBlock {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::ToolResultBlock,
-    ) -> Result<Self, Self::Error> {
-        Ok(ToolResultBlock {
-            tool_use_id: value.tool_use_id().into(),
-            content: value
-                .content()
-                .iter()
-                .map(|v| v.clone().try_into())
-                .collect::<Result<_, Self::Error>>()?,
-            status: value.status().map(|v| v.try_into()).transpose()?,
-        })
-    }
-}
-
-impl TryFrom<ToolResultBlock> for aws_sdk_bedrockruntime::types::ToolResultBlock {
-    type Error = TypeConversionError;
-    fn try_from(value: ToolResultBlock) -> Result<Self, Self::Error> {
-        let tool_use_id = Some(value.tool_use_id);
-        let content = Some(
-            value
-                .content
-                .into_iter()
-                .map(|v| v.try_into())
-                .collect::<Result<_, Self::Error>>()?,
-        );
-        let status = value.status.map(|v| v.try_into()).transpose()?;
-        let res = aws_sdk_bedrockruntime::types::ToolResultBlock::builder()
-            .set_tool_use_id(tool_use_id)
-            .set_content(content)
-            .set_status(status)
-            .build()
-            .map_err(|e| TypeConversionError::new(&e.to_string()))?;
-        Ok(res)
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::ToolResultContentBlock> for ToolResultContentBlock {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::ToolResultContentBlock,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::ToolResultContentBlock::Document(value) => {
+            aws_bedrock::ToolResultContentBlock::Document(value) => {
                 Ok(ToolResultContentBlock::Document(value.try_into()?))
             }
-            aws_sdk_bedrockruntime::types::ToolResultContentBlock::Image(value) => {
+            aws_bedrock::ToolResultContentBlock::Image(value) => {
                 Ok(ToolResultContentBlock::Image(value.try_into()?))
             }
-            aws_sdk_bedrockruntime::types::ToolResultContentBlock::Json(value) => {
-                Ok(ToolResultContentBlock::Json(value.try_into()?))
+            aws_bedrock::ToolResultContentBlock::Json(value) => {
+                Ok(ToolResultContentBlock::Json(AwsDocument(value).into()))
             }
-            aws_sdk_bedrockruntime::types::ToolResultContentBlock::Text(value) => {
+            aws_bedrock::ToolResultContentBlock::Text(value) => {
                 Ok(ToolResultContentBlock::Text(value))
             }
-            aws_sdk_bedrockruntime::types::ToolResultContentBlock::Video(value) => {
+            aws_bedrock::ToolResultContentBlock::Video(value) => {
                 Ok(ToolResultContentBlock::Video(value.try_into()?))
             }
             invalid => Err(TypeConversionError::new(&format!(
@@ -3451,25 +658,25 @@ impl TryFrom<aws_sdk_bedrockruntime::types::ToolResultContentBlock> for ToolResu
     }
 }
 
-impl TryFrom<ToolResultContentBlock> for aws_sdk_bedrockruntime::types::ToolResultContentBlock {
+impl TryFrom<ToolResultContentBlock> for aws_bedrock::ToolResultContentBlock {
     type Error = TypeConversionError;
     fn try_from(value: ToolResultContentBlock) -> Result<Self, Self::Error> {
         match value {
             ToolResultContentBlock::Document(value) => Ok(
-                aws_sdk_bedrockruntime::types::ToolResultContentBlock::Document(value.try_into()?),
+                aws_bedrock::ToolResultContentBlock::Document(value.try_into()?),
             ),
-            ToolResultContentBlock::Image(value) => {
-                Ok(aws_sdk_bedrockruntime::types::ToolResultContentBlock::Image(value.try_into()?))
+            ToolResultContentBlock::Image(value) => Ok(aws_bedrock::ToolResultContentBlock::Image(
+                value.try_into()?,
+            )),
+            ToolResultContentBlock::Json(value) => Ok(aws_bedrock::ToolResultContentBlock::Json(
+                AwsDocument::from(value).0,
+            )),
+            ToolResultContentBlock::Text(value) => {
+                Ok(aws_bedrock::ToolResultContentBlock::Text(value))
             }
-            ToolResultContentBlock::Json(value) => Ok(
-                aws_sdk_bedrockruntime::types::ToolResultContentBlock::Json(value.try_into()?),
-            ),
-            ToolResultContentBlock::Text(value) => Ok(
-                aws_sdk_bedrockruntime::types::ToolResultContentBlock::Text(value),
-            ),
-            ToolResultContentBlock::Video(value) => {
-                Ok(aws_sdk_bedrockruntime::types::ToolResultContentBlock::Video(value.try_into()?))
-            }
+            ToolResultContentBlock::Video(value) => Ok(aws_bedrock::ToolResultContentBlock::Video(
+                value.try_into()?,
+            )),
             invalid => Err(TypeConversionError::new(&format!(
                 "Unknown variant for ToolResultContentBlock: {invalid:?}"
             ))),
@@ -3477,294 +684,536 @@ impl TryFrom<ToolResultContentBlock> for aws_sdk_bedrockruntime::types::ToolResu
     }
 }
 
-impl TryFrom<aws_sdk_bedrockruntime::types::VideoBlock> for VideoBlock {
+// Struct conversions.
+
+impl TryFrom<aws_bedrock::TokenUsage> for TokenUsage {
     type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::VideoBlock) -> Result<Self, Self::Error> {
-        Ok(VideoBlock {
-            format: value.format().try_into()?,
-            source: value.source().map(|v| v.try_into()).transpose()?,
+    fn try_from(value: aws_bedrock::TokenUsage) -> Result<Self, Self::Error> {
+        Ok(TokenUsage {
+            input_tokens: value.input_tokens,
+            output_tokens: value.output_tokens,
+            total_tokens: value.total_tokens,
+            cache_read_input_tokens: value.cache_read_input_tokens,
+            cache_write_input_tokens: value.cache_write_input_tokens,
         })
     }
 }
 
-impl TryFrom<VideoBlock> for aws_sdk_bedrockruntime::types::VideoBlock {
+impl TryFrom<aws_bedrock::ConverseMetrics> for ConverseMetrics {
+    type Error = TypeConversionError;
+    fn try_from(value: aws_bedrock::ConverseMetrics) -> Result<Self, Self::Error> {
+        Ok(ConverseMetrics {
+            latency_ms: value.latency_ms,
+        })
+    }
+}
+
+impl TryFrom<aws_bedrock::Message> for Message {
+    type Error = TypeConversionError;
+    fn try_from(value: aws_bedrock::Message) -> Result<Self, Self::Error> {
+        Ok(Message {
+            role: value.role.try_into()?,
+            content: value
+                .content
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<_, Self::Error>>()?,
+        })
+    }
+}
+
+impl TryFrom<Message> for aws_bedrock::Message {
+    type Error = TypeConversionError;
+    fn try_from(value: Message) -> Result<Self, Self::Error> {
+        aws_bedrock::Message::builder()
+            .set_role(Some(value.role.try_into()?))
+            .set_content(Some(
+                value
+                    .content
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<_, Self::Error>>()?,
+            ))
+            .build()
+            .map_err(|e| TypeConversionError::new(&e.to_string()))
+    }
+}
+
+impl TryFrom<aws_bedrock::CachePointBlock> for CachePointBlock {
+    type Error = TypeConversionError;
+    fn try_from(value: aws_bedrock::CachePointBlock) -> Result<Self, Self::Error> {
+        Ok(CachePointBlock {
+            kind: value.r#type.try_into()?,
+        })
+    }
+}
+
+impl TryFrom<CachePointBlock> for aws_bedrock::CachePointBlock {
+    type Error = TypeConversionError;
+    fn try_from(value: CachePointBlock) -> Result<Self, Self::Error> {
+        aws_bedrock::CachePointBlock::builder()
+            .set_type(Some(value.kind.try_into()?))
+            .build()
+            .map_err(|x| TypeConversionError::new(format!("Converting from CachePointBlock to AWS CachePointBlock should never fail but it seems to have done so: {x}").as_ref()))
+    }
+}
+
+impl TryFrom<aws_bedrock::CitationsContentBlock> for CitationsContentBlock {
+    type Error = TypeConversionError;
+    fn try_from(value: aws_bedrock::CitationsContentBlock) -> Result<Self, Self::Error> {
+        Ok(CitationsContentBlock {
+            content: Some(
+                value
+                    .content
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<_, Self::Error>>()?,
+            ),
+            citations: Some(
+                value
+                    .citations
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<_, Self::Error>>()?,
+            ),
+        })
+    }
+}
+
+impl TryFrom<CitationsContentBlock> for aws_bedrock::CitationsContentBlock {
+    type Error = TypeConversionError;
+    fn try_from(value: CitationsContentBlock) -> Result<Self, Self::Error> {
+        let citations = value
+            .citations
+            .map(|x| x.into_iter().map(TryInto::try_into).collect())
+            .transpose()?;
+        let content = value
+            .content
+            .map(|x| x.into_iter().map(TryInto::try_into).collect())
+            .transpose()?;
+        Ok(aws_bedrock::CitationsContentBlock::builder()
+            .set_citations(citations)
+            .set_content(content)
+            .build())
+    }
+}
+
+impl TryFrom<aws_bedrock::Citation> for Citation {
+    type Error = TypeConversionError;
+    fn try_from(value: aws_bedrock::Citation) -> Result<Self, Self::Error> {
+        Ok(Citation {
+            title: value.title,
+            source_content: Some(
+                value
+                    .source_content
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<_, Self::Error>>()?,
+            ),
+            location: value.location.map(TryInto::try_into).transpose()?,
+        })
+    }
+}
+
+impl TryFrom<Citation> for aws_bedrock::Citation {
+    type Error = TypeConversionError;
+    fn try_from(value: Citation) -> Result<Self, Self::Error> {
+        let location = value.location.map(TryInto::try_into).transpose()?;
+        let content = value
+            .source_content
+            .map(|x| {
+                x.into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<_, Self::Error>>()
+            })
+            .transpose()?;
+        Ok(aws_bedrock::Citation::builder()
+            .set_title(value.title)
+            .set_location(location)
+            .set_source_content(content)
+            .build())
+    }
+}
+
+/// The three citation-location structs are field-identical; mirror them with
+/// one macro.
+macro_rules! mirror_location {
+    ($($name:ident),+ $(,)?) => {$(
+        impl TryFrom<aws_bedrock::$name> for $name {
+            type Error = TypeConversionError;
+            fn try_from(value: aws_bedrock::$name) -> Result<Self, Self::Error> {
+                Ok($name {
+                    document_index: value.document_index,
+                    start: value.start,
+                    end: value.end,
+                })
+            }
+        }
+        impl TryFrom<$name> for aws_bedrock::$name {
+            type Error = TypeConversionError;
+            fn try_from(value: $name) -> Result<Self, Self::Error> {
+                Ok(aws_bedrock::$name::builder()
+                    .set_document_index(value.document_index)
+                    .set_start(value.start)
+                    .set_end(value.end)
+                    .build())
+            }
+        }
+    )+};
+}
+mirror_location!(
+    DocumentCharLocation,
+    DocumentChunkLocation,
+    DocumentPageLocation
+);
+
+impl TryFrom<aws_bedrock::DocumentBlock> for DocumentBlock {
+    type Error = TypeConversionError;
+    fn try_from(value: aws_bedrock::DocumentBlock) -> Result<Self, Self::Error> {
+        Ok(DocumentBlock {
+            format: value.format.try_into()?,
+            name: value.name,
+            source: value.source.map(TryInto::try_into).transpose()?,
+            context: value.context,
+            citations: value.citations.map(TryInto::try_into).transpose()?,
+        })
+    }
+}
+
+impl TryFrom<DocumentBlock> for aws_bedrock::DocumentBlock {
+    type Error = TypeConversionError;
+    fn try_from(value: DocumentBlock) -> Result<Self, Self::Error> {
+        aws_bedrock::DocumentBlock::builder()
+            .set_format(Some(value.format.try_into()?))
+            .set_name(Some(value.name))
+            .set_source(value.source.map(TryInto::try_into).transpose()?)
+            .set_context(value.context)
+            .set_citations(value.citations.map(TryInto::try_into).transpose()?)
+            .build()
+            .map_err(|e| TypeConversionError::new(&e.to_string()))
+    }
+}
+
+impl TryFrom<aws_bedrock::S3Location> for S3Location {
+    type Error = TypeConversionError;
+    fn try_from(value: aws_bedrock::S3Location) -> Result<Self, Self::Error> {
+        Ok(S3Location {
+            uri: value.uri,
+            bucket_owner: value.bucket_owner,
+        })
+    }
+}
+
+impl TryFrom<S3Location> for aws_bedrock::S3Location {
+    type Error = TypeConversionError;
+    fn try_from(value: S3Location) -> Result<Self, Self::Error> {
+        aws_bedrock::S3Location::builder()
+            .set_uri(Some(value.uri))
+            .set_bucket_owner(value.bucket_owner)
+            .build()
+            .map_err(|e| TypeConversionError::new(&e.to_string()))
+    }
+}
+
+impl TryFrom<aws_sdk_bedrockruntime::primitives::Blob> for Blob {
+    type Error = TypeConversionError;
+    fn try_from(value: aws_sdk_bedrockruntime::primitives::Blob) -> Result<Self, Self::Error> {
+        Ok(Blob {
+            inner: value.into_inner(),
+        })
+    }
+}
+
+impl TryFrom<Blob> for aws_sdk_bedrockruntime::primitives::Blob {
+    type Error = TypeConversionError;
+    fn try_from(value: Blob) -> Result<Self, Self::Error> {
+        Ok(aws_sdk_bedrockruntime::primitives::Blob::new(value.inner))
+    }
+}
+
+impl TryFrom<aws_bedrock::CitationsConfig> for CitationsConfig {
+    type Error = TypeConversionError;
+    fn try_from(value: aws_bedrock::CitationsConfig) -> Result<Self, Self::Error> {
+        Ok(CitationsConfig {
+            enabled: value.enabled,
+        })
+    }
+}
+
+impl TryFrom<CitationsConfig> for aws_bedrock::CitationsConfig {
+    type Error = TypeConversionError;
+    fn try_from(value: CitationsConfig) -> Result<Self, Self::Error> {
+        aws_bedrock::CitationsConfig::builder()
+            .set_enabled(Some(value.enabled))
+            .build()
+            .map_err(|e| TypeConversionError::new(&e.to_string()))
+    }
+}
+
+impl TryFrom<aws_bedrock::GuardrailConverseImageBlock> for GuardrailConverseImageBlock {
+    type Error = TypeConversionError;
+    fn try_from(value: aws_bedrock::GuardrailConverseImageBlock) -> Result<Self, Self::Error> {
+        Ok(GuardrailConverseImageBlock {
+            format: value.format.try_into()?,
+            source: value.source.map(TryInto::try_into).transpose()?,
+        })
+    }
+}
+
+impl TryFrom<GuardrailConverseImageBlock> for aws_bedrock::GuardrailConverseImageBlock {
+    type Error = TypeConversionError;
+    fn try_from(value: GuardrailConverseImageBlock) -> Result<Self, Self::Error> {
+        aws_bedrock::GuardrailConverseImageBlock::builder()
+            .set_format(Some(value.format.try_into()?))
+            .set_source(value.source.map(TryInto::try_into).transpose()?)
+            .build()
+            .map_err(|e| TypeConversionError::new(&e.to_string()))
+    }
+}
+
+impl TryFrom<aws_bedrock::GuardrailConverseTextBlock> for GuardrailConverseTextBlock {
+    type Error = TypeConversionError;
+    fn try_from(value: aws_bedrock::GuardrailConverseTextBlock) -> Result<Self, Self::Error> {
+        Ok(GuardrailConverseTextBlock {
+            text: value.text,
+            qualifiers: Some(
+                value
+                    .qualifiers
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|v| (&v).try_into())
+                    .collect::<Result<_, Self::Error>>()?,
+            ),
+        })
+    }
+}
+
+impl TryFrom<GuardrailConverseTextBlock> for aws_bedrock::GuardrailConverseTextBlock {
+    type Error = TypeConversionError;
+    fn try_from(value: GuardrailConverseTextBlock) -> Result<Self, Self::Error> {
+        let qualifiers = value
+            .qualifiers
+            .map(|v| v.into_iter().map(TryInto::try_into).collect())
+            .transpose()?;
+        aws_bedrock::GuardrailConverseTextBlock::builder()
+            .set_text(Some(value.text))
+            .set_qualifiers(qualifiers)
+            .build()
+            .map_err(|e| TypeConversionError::new(&e.to_string()))
+    }
+}
+
+impl TryFrom<aws_bedrock::ImageBlock> for ImageBlock {
+    type Error = TypeConversionError;
+    fn try_from(value: aws_bedrock::ImageBlock) -> Result<Self, Self::Error> {
+        Ok(ImageBlock {
+            format: value.format.try_into()?,
+            source: value.source.map(TryInto::try_into).transpose()?,
+        })
+    }
+}
+
+impl TryFrom<ImageBlock> for aws_bedrock::ImageBlock {
+    type Error = TypeConversionError;
+    fn try_from(value: ImageBlock) -> Result<Self, Self::Error> {
+        aws_bedrock::ImageBlock::builder()
+            .set_format(Some(value.format.try_into()?))
+            .set_source(value.source.map(TryInto::try_into).transpose()?)
+            .build()
+            .map_err(|e| TypeConversionError::new(&e.to_string()))
+    }
+}
+
+impl TryFrom<aws_bedrock::ReasoningTextBlock> for ReasoningTextBlock {
+    type Error = TypeConversionError;
+    fn try_from(value: aws_bedrock::ReasoningTextBlock) -> Result<Self, Self::Error> {
+        Ok(ReasoningTextBlock {
+            text: value.text,
+            signature: value.signature,
+        })
+    }
+}
+
+impl TryFrom<ReasoningTextBlock> for aws_bedrock::ReasoningTextBlock {
+    type Error = TypeConversionError;
+    fn try_from(value: ReasoningTextBlock) -> Result<Self, Self::Error> {
+        aws_bedrock::ReasoningTextBlock::builder()
+            .set_text(Some(value.text))
+            .set_signature(value.signature)
+            .build()
+            .map_err(|e| TypeConversionError::new(&e.to_string()))
+    }
+}
+
+impl TryFrom<aws_bedrock::ToolResultBlock> for ToolResultBlock {
+    type Error = TypeConversionError;
+    fn try_from(value: aws_bedrock::ToolResultBlock) -> Result<Self, Self::Error> {
+        Ok(ToolResultBlock {
+            tool_use_id: value.tool_use_id,
+            content: value
+                .content
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<_, Self::Error>>()?,
+            status: value.status.map(|v| (&v).try_into()).transpose()?,
+        })
+    }
+}
+
+impl TryFrom<ToolResultBlock> for aws_bedrock::ToolResultBlock {
+    type Error = TypeConversionError;
+    fn try_from(value: ToolResultBlock) -> Result<Self, Self::Error> {
+        aws_bedrock::ToolResultBlock::builder()
+            .set_tool_use_id(Some(value.tool_use_id))
+            .set_content(Some(
+                value
+                    .content
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<_, Self::Error>>()?,
+            ))
+            .set_status(value.status.map(TryInto::try_into).transpose()?)
+            .build()
+            .map_err(|e| TypeConversionError::new(&e.to_string()))
+    }
+}
+
+impl TryFrom<aws_bedrock::VideoBlock> for VideoBlock {
+    type Error = TypeConversionError;
+    fn try_from(value: aws_bedrock::VideoBlock) -> Result<Self, Self::Error> {
+        Ok(VideoBlock {
+            format: value.format.try_into()?,
+            source: value.source.map(TryInto::try_into).transpose()?,
+        })
+    }
+}
+
+impl TryFrom<VideoBlock> for aws_bedrock::VideoBlock {
     type Error = TypeConversionError;
     fn try_from(value: VideoBlock) -> Result<Self, Self::Error> {
-        let format = Some(value.format.try_into()?);
-        let source = value.source.map(|v| v.try_into()).transpose()?;
-
-        let res = aws_sdk_bedrockruntime::types::VideoBlock::builder()
-            .set_format(format)
-            .set_source(source)
+        aws_bedrock::VideoBlock::builder()
+            .set_format(Some(value.format.try_into()?))
+            .set_source(value.source.map(TryInto::try_into).transpose()?)
             .build()
-            .map_err(|e| TypeConversionError::new(&e.to_string()))?;
-
-        Ok(res)
+            .map_err(|e| TypeConversionError::new(&e.to_string()))
     }
 }
 
-impl TryFrom<aws_sdk_bedrockruntime::types::VideoFormat> for VideoFormat {
+impl TryFrom<aws_bedrock::ToolUseBlock> for ToolUseBlock {
     type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::VideoFormat) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::VideoFormat::Flv => Ok(VideoFormat::Flv),
-            aws_sdk_bedrockruntime::types::VideoFormat::Mkv => Ok(VideoFormat::Mkv),
-            aws_sdk_bedrockruntime::types::VideoFormat::Mov => Ok(VideoFormat::Mov),
-            aws_sdk_bedrockruntime::types::VideoFormat::Mp4 => Ok(VideoFormat::Mp4),
-            aws_sdk_bedrockruntime::types::VideoFormat::Mpeg => Ok(VideoFormat::Mpeg),
-            aws_sdk_bedrockruntime::types::VideoFormat::Mpg => Ok(VideoFormat::Mpg),
-            aws_sdk_bedrockruntime::types::VideoFormat::ThreeGp => Ok(VideoFormat::ThreeGp),
-            aws_sdk_bedrockruntime::types::VideoFormat::Webm => Ok(VideoFormat::Webm),
-            aws_sdk_bedrockruntime::types::VideoFormat::Wmv => Ok(VideoFormat::Wmv),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for VideoFormat: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::VideoFormat> for VideoFormat {
-    type Error = TypeConversionError;
-    fn try_from(value: &aws_sdk_bedrockruntime::types::VideoFormat) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::VideoFormat::Flv => Ok(VideoFormat::Flv),
-            aws_sdk_bedrockruntime::types::VideoFormat::Mkv => Ok(VideoFormat::Mkv),
-            aws_sdk_bedrockruntime::types::VideoFormat::Mov => Ok(VideoFormat::Mov),
-            aws_sdk_bedrockruntime::types::VideoFormat::Mp4 => Ok(VideoFormat::Mp4),
-            aws_sdk_bedrockruntime::types::VideoFormat::Mpeg => Ok(VideoFormat::Mpeg),
-            aws_sdk_bedrockruntime::types::VideoFormat::Mpg => Ok(VideoFormat::Mpg),
-            aws_sdk_bedrockruntime::types::VideoFormat::ThreeGp => Ok(VideoFormat::ThreeGp),
-            aws_sdk_bedrockruntime::types::VideoFormat::Webm => Ok(VideoFormat::Webm),
-            aws_sdk_bedrockruntime::types::VideoFormat::Wmv => Ok(VideoFormat::Wmv),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for VideoFormat: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<VideoFormat> for aws_sdk_bedrockruntime::types::VideoFormat {
-    type Error = TypeConversionError;
-    fn try_from(value: VideoFormat) -> Result<Self, Self::Error> {
-        match value {
-            VideoFormat::Flv => Ok(aws_sdk_bedrockruntime::types::VideoFormat::Flv),
-            VideoFormat::Mkv => Ok(aws_sdk_bedrockruntime::types::VideoFormat::Mkv),
-            VideoFormat::Mov => Ok(aws_sdk_bedrockruntime::types::VideoFormat::Mov),
-            VideoFormat::Mp4 => Ok(aws_sdk_bedrockruntime::types::VideoFormat::Mp4),
-            VideoFormat::Mpeg => Ok(aws_sdk_bedrockruntime::types::VideoFormat::Mpeg),
-            VideoFormat::Mpg => Ok(aws_sdk_bedrockruntime::types::VideoFormat::Mpg),
-            VideoFormat::ThreeGp => Ok(aws_sdk_bedrockruntime::types::VideoFormat::ThreeGp),
-            VideoFormat::Webm => Ok(aws_sdk_bedrockruntime::types::VideoFormat::Webm),
-            VideoFormat::Wmv => Ok(aws_sdk_bedrockruntime::types::VideoFormat::Wmv),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for VideoFormat: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::VideoSource> for VideoSource {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::VideoSource) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::VideoSource::Bytes(value) => {
-                Ok(VideoSource::Bytes(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::VideoSource::S3Location(value) => {
-                Ok(VideoSource::S3Location(value.try_into()?))
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for VideoSource: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&aws_sdk_bedrockruntime::types::VideoSource> for VideoSource {
-    type Error = TypeConversionError;
-    fn try_from(value: &aws_sdk_bedrockruntime::types::VideoSource) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::VideoSource::Bytes(value) => {
-                Ok(VideoSource::Bytes(value.try_into()?))
-            }
-            aws_sdk_bedrockruntime::types::VideoSource::S3Location(value) => {
-                Ok(VideoSource::S3Location(value.try_into()?))
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for VideoSource: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<VideoSource> for aws_sdk_bedrockruntime::types::VideoSource {
-    type Error = TypeConversionError;
-    fn try_from(value: VideoSource) -> Result<Self, Self::Error> {
-        match value {
-            VideoSource::Bytes(value) => Ok(aws_sdk_bedrockruntime::types::VideoSource::Bytes(
-                value.try_into()?,
-            )),
-            VideoSource::S3Location(value) => Ok(
-                aws_sdk_bedrockruntime::types::VideoSource::S3Location(value.try_into()?),
-            ),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for VideoSource: {invalid:?}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<aws_sdk_bedrockruntime::types::ToolUseBlock> for ToolUseBlock {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_sdk_bedrockruntime::types::ToolUseBlock) -> Result<Self, Self::Error> {
+    fn try_from(value: aws_bedrock::ToolUseBlock) -> Result<Self, Self::Error> {
         Ok(ToolUseBlock {
-            tool_use_id: value.tool_use_id().into(),
-            name: value.name().into(),
-            input: value.input().try_into()?,
+            tool_use_id: value.tool_use_id,
+            name: value.name,
+            input: AwsDocument(value.input).into(),
         })
     }
 }
 
-impl TryFrom<ToolUseBlock> for aws_sdk_bedrockruntime::types::ToolUseBlock {
+impl TryFrom<ToolUseBlock> for aws_bedrock::ToolUseBlock {
     type Error = TypeConversionError;
     fn try_from(value: ToolUseBlock) -> Result<Self, Self::Error> {
-        let tool_use_id = value.tool_use_id.into();
-        let name = value.name.into();
-        let input = Some(value.input.try_into()?);
-
-        let res = aws_sdk_bedrockruntime::types::ToolUseBlock::builder()
-            .set_tool_use_id(tool_use_id)
-            .set_name(name)
-            .set_input(input)
+        aws_bedrock::ToolUseBlock::builder()
+            .set_tool_use_id(Some(value.tool_use_id))
+            .set_name(Some(value.name))
+            .set_input(Some(AwsDocument::from(value.input).0))
             .build()
-            .map_err(|e| TypeConversionError::new(&e.to_string()))?;
-
-        Ok(res)
+            .map_err(|e| TypeConversionError::new(&e.to_string()))
     }
 }
 
-impl TryFrom<aws_sdk_bedrockruntime::types::ToolResultStatus> for ToolResultStatus {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: aws_sdk_bedrockruntime::types::ToolResultStatus,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::ToolResultStatus::Error => Ok(ToolResultStatus::IsError),
-            aws_sdk_bedrockruntime::types::ToolResultStatus::Success => {
-                Ok(ToolResultStatus::Success)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for ToolResultStatus: {invalid:?}"
-            ))),
-        }
-    }
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
 
-impl TryFrom<&aws_sdk_bedrockruntime::types::ToolResultStatus> for ToolResultStatus {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: &aws_sdk_bedrockruntime::types::ToolResultStatus,
-    ) -> Result<Self, Self::Error> {
-        match value {
-            aws_sdk_bedrockruntime::types::ToolResultStatus::Error => Ok(ToolResultStatus::IsError),
-            aws_sdk_bedrockruntime::types::ToolResultStatus::Success => {
-                Ok(ToolResultStatus::Success)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for ToolResultStatus: {invalid:?}"
-            ))),
-        }
+    #[test]
+    fn mirror_enum_converts_known_variants_both_ways() {
+        assert_eq!(
+            StopReason::try_from(aws_bedrock::StopReason::EndTurn).unwrap(),
+            StopReason::EndTurn
+        );
+        // Borrowed impl.
+        assert_eq!(
+            StopReason::try_from(&aws_bedrock::StopReason::ToolUse).unwrap(),
+            StopReason::ToolUse
+        );
+        // Reverse impl, including a renamed pairing (aws `Error` -> ours `IsError`).
+        assert_eq!(
+            ToolResultStatus::try_from(aws_bedrock::ToolResultStatus::Error).unwrap(),
+            ToolResultStatus::IsError
+        );
+        assert_eq!(
+            aws_bedrock::ToolResultStatus::try_from(ToolResultStatus::IsError).unwrap(),
+            aws_bedrock::ToolResultStatus::Error
+        );
     }
-}
 
-impl TryFrom<ToolResultStatus> for aws_sdk_bedrockruntime::types::ToolResultStatus {
-    type Error = TypeConversionError;
-    fn try_from(
-        value: ToolResultStatus,
-    ) -> Result<
-        Self,
-        <aws_sdk_bedrockruntime::types::ToolResultStatus as TryFrom<ToolResultStatus>>::Error,
-    > {
-        match value {
-            ToolResultStatus::IsError => Ok(aws_sdk_bedrockruntime::types::ToolResultStatus::Error),
-            ToolResultStatus::Success => {
-                Ok(aws_sdk_bedrockruntime::types::ToolResultStatus::Success)
-            }
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for ToolResultStatus: {invalid:?}"
-            ))),
-        }
+    #[test]
+    fn mirror_enum_unknown_variant_preserves_error_string() {
+        let unknown = aws_bedrock::StopReason::from("weird_stop");
+        let err = StopReason::try_from(unknown.clone()).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            format!("Unknown variant for StopReason: {unknown:?}")
+        );
+
+        let err = aws_bedrock::ConversationRole::try_from(ConversationRole::Unknown(
+            UnknownVariantValue("nope".to_owned()),
+        ))
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .starts_with("Unknown variant for ConversationRole:")
+        );
     }
-}
 
-impl TryFrom<aws_smithy_types::Document> for Document {
-    type Error = TypeConversionError;
-    fn try_from(value: aws_smithy_types::Document) -> Result<Self, Self::Error> {
-        match value {
-            aws_smithy_types::Document::Object(value) => Ok(Document::Object(
-                value
-                    .into_iter()
-                    .map(|(k, v)| Ok((k, v.try_into()?)))
-                    .collect::<Result<_, Self::Error>>()?,
-            )),
-            aws_smithy_types::Document::Array(value) => Ok(Document::Array(
-                value
-                    .into_iter()
-                    .map(TryInto::try_into)
-                    .collect::<Result<_, Self::Error>>()?,
-            )),
-            aws_smithy_types::Document::Number(value) => Ok(Document::Number(value.into())),
-            aws_smithy_types::Document::String(value) => Ok(Document::String(value)),
-            aws_smithy_types::Document::Bool(value) => Ok(Document::Bool(value)),
-            aws_smithy_types::Document::Null => Ok(Document::Null),
-        }
+    #[test]
+    fn additional_model_response_fields_survive_as_json() {
+        let doc: AwsDocument = json!({"reasoning_effort": "low", "depth": 3}).into();
+        let output = aws_sdk_bedrockruntime::operation::converse::ConverseOutput::builder()
+            .stop_reason(aws_bedrock::StopReason::EndTurn)
+            .additional_model_response_fields(doc.0)
+            .build()
+            .unwrap();
+
+        let internal = InternalConverseOutput::try_from(output).unwrap();
+        assert_eq!(
+            internal.additional_model_response_fields,
+            Some(json!({"reasoning_effort": "low", "depth": 3}))
+        );
+
+        // The whole normalized output stays serializable and the extras
+        // survive a serde round trip.
+        let value = serde_json::to_value(&internal).unwrap();
+        assert_eq!(
+            value.get("additional_model_response_fields"),
+            Some(&json!({"reasoning_effort": "low", "depth": 3}))
+        );
+        let back: InternalConverseOutput = serde_json::from_value(value).unwrap();
+        assert_eq!(back, internal);
     }
-}
 
-impl TryFrom<&aws_smithy_types::Document> for Document {
-    type Error = TypeConversionError;
-    fn try_from(value: &aws_smithy_types::Document) -> Result<Self, Self::Error> {
-        match value {
-            aws_smithy_types::Document::Object(value) => Ok(Document::Object(
-                value
-                    .iter()
-                    .map(|(k, v)| Ok((k.to_owned(), v.try_into()?)))
-                    .collect::<Result<_, Self::Error>>()?,
-            )),
-            aws_smithy_types::Document::Array(value) => Ok(Document::Array(
-                value
-                    .iter()
-                    .map(TryInto::try_into)
-                    .collect::<Result<_, Self::Error>>()?,
-            )),
-            aws_smithy_types::Document::Number(value) => Ok(Document::Number(value.into())),
-            aws_smithy_types::Document::String(value) => Ok(Document::String(value.to_owned())),
-            aws_smithy_types::Document::Bool(value) => Ok(Document::Bool(value.to_owned())),
-            aws_smithy_types::Document::Null => Ok(Document::Null),
-        }
-    }
-}
+    #[test]
+    fn tool_use_input_round_trips_through_json_value() {
+        let aws_block = aws_bedrock::ToolUseBlock::builder()
+            .tool_use_id("call_1")
+            .name("add")
+            .input(AwsDocument::from(json!({"x": 1, "y": 2})).0)
+            .build()
+            .unwrap();
 
-impl TryFrom<Document> for aws_smithy_types::Document {
-    type Error = TypeConversionError;
-    fn try_from(value: Document) -> Result<Self, Self::Error> {
-        match value {
-            Document::Object(value) => Ok(aws_smithy_types::Document::Object(
-                value
-                    .into_iter()
-                    .map(|(k, v)| Ok((k, v.try_into()?)))
-                    .collect::<Result<_, Self::Error>>()?,
-            )),
-            Document::Array(value) => Ok(aws_smithy_types::Document::Array(
-                value
-                    .into_iter()
-                    .map(TryInto::try_into)
-                    .collect::<Result<_, Self::Error>>()?,
-            )),
-            Document::Number(value) => Ok(aws_smithy_types::Document::Number(value.into())),
-            Document::String(value) => Ok(aws_smithy_types::Document::String(value)),
-            Document::Bool(value) => Ok(aws_smithy_types::Document::Bool(value)),
-            Document::Null => Ok(aws_smithy_types::Document::Null),
-        }
+        let ours = ToolUseBlock::try_from(aws_block).unwrap();
+        assert_eq!(ours.input, json!({"x": 1, "y": 2}));
+
+        let back = aws_bedrock::ToolUseBlock::try_from(ours).unwrap();
+        assert_eq!(back.tool_use_id, "call_1");
+        assert_eq!(
+            serde_json::Value::from(AwsDocument(back.input)),
+            json!({"x": 1, "y": 2})
+        );
     }
 }

--- a/crates/rig-bedrock/src/types/document.rs
+++ b/crates/rig-bedrock/src/types/document.rs
@@ -19,13 +19,9 @@ impl TryFrom<RigDocument> for aws_bedrock::DocumentBlock {
             data, media_type, ..
         }): RigDocument,
     ) -> Result<Self, Self::Error> {
-        let document_media_type = media_type.map(|doc| RigDocumentMediaType(doc).try_into());
-
-        let document_media_type = match document_media_type {
-            Some(Ok(document_format)) => Ok(Some(document_format)),
-            Some(Err(err)) => Err(err),
-            None => Ok(None),
-        }?;
+        let document_media_type = media_type
+            .map(|doc| RigDocumentMediaType(doc).try_into())
+            .transpose()?;
 
         let document_source = match data {
             DocumentSourceKind::Base64(blob) => {

--- a/crates/rig-bedrock/src/types/errors.rs
+++ b/crates/rig-bedrock/src/types/errors.rs
@@ -10,103 +10,112 @@ use rig_core::completion::CompletionError;
 use rig_core::embeddings::EmbeddingError;
 use rig_core::image_generation::ImageGenerationError;
 
-/// Extracts the provider-supplied message from an [`InvokeModelError`] service
-/// error.
+/// Emit a `fn(err) -> (Option<String>, String)` that extracts the
+/// provider-supplied message from an AWS service error.
 ///
-/// Returns `(Some(message), _)` when the service supplied a genuine error
-/// message (which should be surfaced as a provider response body), otherwise
-/// `(None, fallback)` where `fallback` is Rig-authored diagnostic prose. The
-/// caller decides which arm to surface so that Rig prose never leaks into
-/// `provider_response_body()`.
-fn invoke_model_message(err: InvokeModelError) -> (Option<String>, String) {
-    match err {
-        InvokeModelError::ModelTimeoutException(e) => (e.message, "The request took too long to process. Processing time exceeded the model timeout length.".into()),
-        InvokeModelError::AccessDeniedException(e) => (e.message, "The request is denied because you do not have sufficient permissions to perform the requested action.".into()),
-        InvokeModelError::ResourceNotFoundException(e) => (e.message, "The specified resource ARN was not found.".into()),
-        InvokeModelError::ThrottlingException(e) => (e.message, "Your request was denied due to exceeding the account quotas for Amazon Bedrock.".into()),
-        InvokeModelError::ServiceUnavailableException(e) => (e.message, "The service isn't currently available.".into()),
-        InvokeModelError::InternalServerException(e) => (e.message, "An internal server error occurred.".into()),
-        InvokeModelError::ValidationException(e) => (e.message, "The input fails to satisfy the constraints specified by Amazon Bedrock.".into()),
-        InvokeModelError::ModelNotReadyException(e) => (e.message, "The model specified in the request is not ready to serve inference requests. The AWS SDK will automatically retry the operation up to 5 times.".into()),
-        InvokeModelError::ModelErrorException(e) => (e.message, "The request failed due to an error while processing the model.".into()),
-        InvokeModelError::ServiceQuotaExceededException(e) => (e.message, "Your request exceeds the service quota for your account.".into()),
-        _ => (None, "An unexpected error occurred. Verify Internet connection or AWS keys".into()),
+/// Each generated fn returns `(Some(message), _)` when the service supplied a
+/// genuine error message (which should be surfaced as a provider response
+/// body), otherwise `(None, fallback)` where `fallback` is Rig-authored
+/// diagnostic prose. The caller decides which arm to surface (see [`gated`])
+/// so that Rig prose never leaks into `provider_response_body()`.
+macro_rules! service_error_message {
+    ($fn_name:ident, $err_ty:ty, $default:expr, { $($variant:ident => $msg:expr),+ $(,)? }) => {
+        fn $fn_name(err: $err_ty) -> (Option<String>, String) {
+            type E = $err_ty;
+            match err {
+                $(E::$variant(e) => (e.message, $msg.into()),)+
+                _ => (None, $default.into()),
+            }
+        }
+    };
+}
+
+/// Route a `(provider_message, fallback)` pair into an error type: a genuine
+/// provider message becomes a provider response body, otherwise the
+/// Rig-authored fallback becomes a plain provider error.
+fn gated<E>(
+    (message, fallback): (Option<String>, String),
+    from_body: impl FnOnce(String) -> E,
+    provider_error: impl FnOnce(String) -> E,
+) -> E {
+    match message {
+        Some(msg) => from_body(msg),
+        None => provider_error(fallback),
     }
 }
 
-/// Extracts the provider-supplied message from a [`ConverseError`] service
-/// error. See [`invoke_model_message`] for the gating contract.
-fn converse_message(err: ConverseError) -> (Option<String>, String) {
-    match err {
-        ConverseError::ModelTimeoutException(e) => (e.message, "The request took too long to process. Processing time exceeded the model timeout length.".into()),
-        ConverseError::AccessDeniedException(e) => (e.message, "The request is denied because you do not have sufficient permissions to perform the requested action.".into()),
-        ConverseError::ResourceNotFoundException(e) => (e.message, "The specified resource ARN was not found.".into()),
-        ConverseError::ThrottlingException(e) => (e.message, "Your request was denied due to exceeding the account quotas for AWS Bedrock.".into()),
-        ConverseError::ServiceUnavailableException(e) => (e.message, "The service isn't currently available.".into()),
-        ConverseError::InternalServerException(e) => (e.message, "An internal server error occurred.".into()),
-        ConverseError::ValidationException(e) => (e.message, "The input fails to satisfy the constraints specified by AWS Bedrock.".into()),
-        ConverseError::ModelNotReadyException(e) => (e.message, "The model specified in the request is not ready to serve inference requests. The AWS SDK will automatically retry the operation up to 5 times.".into()),
-        ConverseError::ModelErrorException(e) => (e.message, "The request failed due to an error while processing the model.".into()),
-        _ => (None, "An unexpected error occurred. Verify Internet connection or AWS keys".into()),
-    }
-}
+const UNEXPECTED: &str = "An unexpected error occurred. Verify Internet connection or AWS keys";
 
-/// Extracts the provider-supplied message from a [`ConverseStreamError`]
-/// service error. See [`invoke_model_message`] for the gating contract.
-fn converse_stream_message(err: ConverseStreamError) -> (Option<String>, String) {
-    match err {
-        ConverseStreamError::ModelTimeoutException(e) => {
-            (e.message, "Bedrock model timed out".into())
-        }
-        ConverseStreamError::AccessDeniedException(e) => {
-            (e.message, "Bedrock access denied".into())
-        }
-        ConverseStreamError::ResourceNotFoundException(e) => {
-            (e.message, "Bedrock resource not found".into())
-        }
-        ConverseStreamError::ThrottlingException(e) => {
-            (e.message, "Bedrock request throttled".into())
-        }
-        ConverseStreamError::ServiceUnavailableException(e) => {
-            (e.message, "Bedrock service unavailable".into())
-        }
-        ConverseStreamError::InternalServerException(e) => {
-            (e.message, "Bedrock internal server error".into())
-        }
-        ConverseStreamError::ModelStreamErrorException(e) => {
-            (e.message, "Bedrock streaming model error".into())
-        }
-        ConverseStreamError::ValidationException(e) => {
-            (e.message, "Bedrock validation error".into())
-        }
-        ConverseStreamError::ModelNotReadyException(e) => {
-            (e.message, "Bedrock model not ready".into())
-        }
-        ConverseStreamError::ModelErrorException(e) => (e.message, "Bedrock model error".into()),
-        _ => (
-            None,
-            "An unexpected error occurred. Verify Internet connection or AWS keys".into(),
-        ),
+service_error_message!(invoke_model_message, InvokeModelError, UNEXPECTED, {
+    ModelTimeoutException => "The request took too long to process. Processing time exceeded the model timeout length.",
+    AccessDeniedException => "The request is denied because you do not have sufficient permissions to perform the requested action.",
+    ResourceNotFoundException => "The specified resource ARN was not found.",
+    ThrottlingException => "Your request was denied due to exceeding the account quotas for Amazon Bedrock.",
+    ServiceUnavailableException => "The service isn't currently available.",
+    InternalServerException => "An internal server error occurred.",
+    ValidationException => "The input fails to satisfy the constraints specified by Amazon Bedrock.",
+    ModelNotReadyException => "The model specified in the request is not ready to serve inference requests. The AWS SDK will automatically retry the operation up to 5 times.",
+    ModelErrorException => "The request failed due to an error while processing the model.",
+    ServiceQuotaExceededException => "Your request exceeds the service quota for your account.",
+});
+
+service_error_message!(converse_message, ConverseError, UNEXPECTED, {
+    ModelTimeoutException => "The request took too long to process. Processing time exceeded the model timeout length.",
+    AccessDeniedException => "The request is denied because you do not have sufficient permissions to perform the requested action.",
+    ResourceNotFoundException => "The specified resource ARN was not found.",
+    ThrottlingException => "Your request was denied due to exceeding the account quotas for AWS Bedrock.",
+    ServiceUnavailableException => "The service isn't currently available.",
+    InternalServerException => "An internal server error occurred.",
+    ValidationException => "The input fails to satisfy the constraints specified by AWS Bedrock.",
+    ModelNotReadyException => "The model specified in the request is not ready to serve inference requests. The AWS SDK will automatically retry the operation up to 5 times.",
+    ModelErrorException => "The request failed due to an error while processing the model.",
+});
+
+service_error_message!(converse_stream_message, ConverseStreamError, UNEXPECTED, {
+    ModelTimeoutException => "Bedrock model timed out",
+    AccessDeniedException => "Bedrock access denied",
+    ResourceNotFoundException => "Bedrock resource not found",
+    ThrottlingException => "Bedrock request throttled",
+    ServiceUnavailableException => "Bedrock service unavailable",
+    InternalServerException => "Bedrock internal server error",
+    ModelStreamErrorException => "Bedrock streaming model error",
+    ValidationException => "Bedrock validation error",
+    ModelNotReadyException => "Bedrock model not ready",
+    ModelErrorException => "Bedrock model error",
+});
+
+service_error_message!(
+    converse_stream_output_message,
+    ConverseStreamOutputError,
+    "Bedrock event stream failed",
+    {
+        InternalServerException => "Bedrock internal server error",
+        ModelStreamErrorException => "Bedrock streaming model error",
+        ValidationException => "Bedrock validation error",
+        ThrottlingException => "Bedrock request throttled",
+        ServiceUnavailableException => "Bedrock service unavailable",
     }
-}
+);
 
 pub struct AwsSdkInvokeModelError(pub SdkError<InvokeModelError, HttpResponse>);
 
 impl From<AwsSdkInvokeModelError> for ImageGenerationError {
     fn from(value: AwsSdkInvokeModelError) -> Self {
-        match invoke_model_message(value.0.into_service_error()) {
-            (Some(msg), _) => ImageGenerationError::from_provider_body(msg),
-            (None, fallback) => ImageGenerationError::ProviderError(fallback),
-        }
+        gated(
+            invoke_model_message(value.0.into_service_error()),
+            ImageGenerationError::from_provider_body,
+            ImageGenerationError::ProviderError,
+        )
     }
 }
 
 impl From<AwsSdkInvokeModelError> for EmbeddingError {
     fn from(value: AwsSdkInvokeModelError) -> Self {
-        match invoke_model_message(value.0.into_service_error()) {
-            (Some(msg), _) => EmbeddingError::from_provider_body(msg),
-            (None, fallback) => EmbeddingError::ProviderError(fallback),
-        }
+        gated(
+            invoke_model_message(value.0.into_service_error()),
+            EmbeddingError::from_provider_body,
+            EmbeddingError::ProviderError,
+        )
     }
 }
 
@@ -114,52 +123,32 @@ pub struct AwsSdkConverseError(pub SdkError<ConverseError, HttpResponse>);
 
 impl From<AwsSdkConverseError> for CompletionError {
     fn from(value: AwsSdkConverseError) -> Self {
-        match converse_message(value.0.into_service_error()) {
-            (Some(msg), _) => CompletionError::from_provider_body(msg),
-            (None, fallback) => CompletionError::ProviderError(fallback),
-        }
+        gated(
+            converse_message(value.0.into_service_error()),
+            CompletionError::from_provider_body,
+            CompletionError::ProviderError,
+        )
     }
 }
 
 pub(crate) fn converse_stream_output_completion_error(
     err: ConverseStreamOutputError,
 ) -> CompletionError {
-    let (message, fallback) = match err {
-        ConverseStreamOutputError::InternalServerException(err) => {
-            (err.message, "Bedrock internal server error".into())
-        }
-        ConverseStreamOutputError::ModelStreamErrorException(err) => {
-            (err.message, "Bedrock streaming model error".into())
-        }
-        ConverseStreamOutputError::ValidationException(err) => {
-            (err.message, "Bedrock validation error".into())
-        }
-        ConverseStreamOutputError::ThrottlingException(err) => {
-            (err.message, "Bedrock request throttled".into())
-        }
-        ConverseStreamOutputError::ServiceUnavailableException(err) => {
-            (err.message, "Bedrock service unavailable".into())
-        }
-        _ => (None, "Bedrock event stream failed".into()),
-    };
-
-    match message {
-        Some(message) => CompletionError::from_provider_body(message),
-        None => CompletionError::ProviderError(fallback),
-    }
-}
-
-fn converse_stream_completion_error(err: ConverseStreamError) -> CompletionError {
-    match converse_stream_message(err) {
-        (Some(msg), _) => CompletionError::from_provider_body(msg),
-        (None, fallback) => CompletionError::ProviderError(fallback),
-    }
+    gated(
+        converse_stream_output_message(err),
+        CompletionError::from_provider_body,
+        CompletionError::ProviderError,
+    )
 }
 
 pub struct AwsSdkConverseStreamError(pub SdkError<ConverseStreamError, HttpResponse>);
 impl From<AwsSdkConverseStreamError> for CompletionError {
     fn from(value: AwsSdkConverseStreamError) -> Self {
-        converse_stream_completion_error(value.0.into_service_error())
+        gated(
+            converse_stream_message(value.0.into_service_error()),
+            CompletionError::from_provider_body,
+            CompletionError::ProviderError,
+        )
     }
 }
 
@@ -180,6 +169,12 @@ impl fmt::Display for TypeConversionError {
 }
 
 impl std::error::Error for TypeConversionError {}
+
+impl From<std::convert::Infallible> for TypeConversionError {
+    fn from(value: std::convert::Infallible) -> Self {
+        match value {}
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/rig-candle/src/protocol.rs
+++ b/crates/rig-candle/src/protocol.rs
@@ -360,64 +360,40 @@ fn render_plain_chat(
         ));
     }
     let messages = messages_with_documents(request);
-    let mut rendered = match family {
-        ModelFamily::Llama3 => String::from(BEGIN_OF_TEXT),
-        ModelFamily::SmolLm2 => {
-            if !matches!(messages.first(), Some(Message::System { .. })) {
-                format!("{IM_START}system\n{SMOLLM2_DEFAULT_SYSTEM_PROMPT}{IM_END}\n")
-            } else {
-                String::new()
-            }
-        }
-        ModelFamily::Qwen3 => {
-            return Err(CandleError::UnsupportedModelFamily(
-                "Qwen3 requires its dedicated conversation renderer".to_string(),
-            ));
-        }
-    };
-    for message in messages {
-        let (role, content) = render_plain_message(&message)?;
+    // Byte-exact turn framing per family: turn_start, role, role_suffix
+    // pieces, content, then turn_end pieces.
+    type Pieces = &'static [&'static str];
+    let (turn_start, role_suffix, turn_end, mut rendered): (&str, Pieces, Pieces, String) =
         match family {
-            ModelFamily::Llama3 => {
-                rendered.push_str(START_HEADER);
-                rendered.push_str(role);
-                rendered.push_str(END_HEADER);
-                rendered.push_str("\n\n");
-                rendered.push_str(&content);
-                rendered.push_str(END_OF_TURN);
-            }
-            ModelFamily::SmolLm2 => {
-                rendered.push_str(IM_START);
-                rendered.push_str(role);
-                rendered.push('\n');
-                rendered.push_str(&content);
-                rendered.push_str(IM_END);
-                rendered.push('\n');
-            }
+            ModelFamily::Llama3 => (
+                START_HEADER,
+                &[END_HEADER, "\n\n"],
+                &[END_OF_TURN],
+                String::from(BEGIN_OF_TEXT),
+            ),
+            ModelFamily::SmolLm2 => (
+                IM_START,
+                &["\n"],
+                &[IM_END, "\n"],
+                if matches!(messages.first(), Some(Message::System { .. })) {
+                    String::new()
+                } else {
+                    format!("{IM_START}system\n{SMOLLM2_DEFAULT_SYSTEM_PROMPT}{IM_END}\n")
+                },
+            ),
             ModelFamily::Qwen3 => {
                 return Err(CandleError::UnsupportedModelFamily(
                     "Qwen3 requires its dedicated conversation renderer".to_string(),
                 ));
             }
+        };
+    for message in messages {
+        let (role, content) = render_plain_message(&message)?;
+        for piece in [&[turn_start, role][..], role_suffix, &[&content], turn_end].concat() {
+            rendered.push_str(piece);
         }
     }
-    match family {
-        ModelFamily::Llama3 => {
-            rendered.push_str(START_HEADER);
-            rendered.push_str("assistant");
-            rendered.push_str(END_HEADER);
-            rendered.push_str("\n\n");
-        }
-        ModelFamily::SmolLm2 => {
-            rendered.push_str(IM_START);
-            rendered.push_str("assistant\n");
-        }
-        ModelFamily::Qwen3 => {
-            return Err(CandleError::UnsupportedModelFamily(
-                "Qwen3 requires its dedicated conversation renderer".to_string(),
-            ));
-        }
-    }
+    rendered.extend([&[turn_start, "assistant"][..], role_suffix].concat());
     Ok(rendered)
 }
 

--- a/crates/rig-candle/src/validation.rs
+++ b/crates/rig-candle/src/validation.rs
@@ -353,7 +353,7 @@ pub(crate) fn validate_gguf_metadata(
     tokenizer: &Tokenizer,
     definition: &ProfileDefinition,
 ) -> Result<(), CandleError> {
-    let expected = [
+    let dims = [
         ("llama.vocab_size", config.vocab_size),
         ("llama.embedding_length", config.hidden_size),
         ("llama.feed_forward_length", config.intermediate_size),
@@ -366,27 +366,44 @@ pub(crate) fn validate_gguf_metadata(
             config.hidden_size / config.num_attention_heads,
         ),
     ];
-    for (key, expected) in expected {
+    let floats = [
+        ("llama.rope.freq_base", config.rope_theta as f64),
+        (
+            "llama.attention.layer_norm_rms_epsilon",
+            config.rms_norm_eps,
+        ),
+    ];
+    validate_gguf_common(
+        content,
+        &dims,
+        &floats,
+        definition,
+        tokenizer,
+        config.vocab_size,
+        false,
+    )
+}
+
+fn validate_gguf_common(
+    content: &gguf_file::Content,
+    dims: &[(&str, usize)],
+    floats: &[(&str, f64)],
+    definition: &ProfileDefinition,
+    tokenizer: &Tokenizer,
+    vocab_size: usize,
+    allow_padding: bool,
+) -> Result<(), CandleError> {
+    for (key, expected) in dims {
         let actual = metadata_usize(content, key)?;
-        if actual != expected {
+        if actual != *expected {
             return Err(CandleError::ArtifactMismatch {
                 artifact: "model.gguf",
                 reason: format!("metadata `{key}` is {actual}, but config requires {expected}"),
             });
         }
     }
-    for (key, actual, expected) in [
-        (
-            "llama.rope.freq_base",
-            metadata_f64(content, "llama.rope.freq_base")?,
-            config.rope_theta as f64,
-        ),
-        (
-            "llama.attention.layer_norm_rms_epsilon",
-            metadata_f64(content, "llama.attention.layer_norm_rms_epsilon")?,
-            config.rms_norm_eps,
-        ),
-    ] {
+    for (key, expected) in floats {
+        let actual = metadata_f64(content, key)?;
         if (actual - expected).abs() > 1e-5 * expected.abs().max(f64::MIN_POSITIVE) {
             return Err(CandleError::ArtifactMismatch {
                 artifact: "model.gguf",
@@ -394,59 +411,11 @@ pub(crate) fn validate_gguf_metadata(
             });
         }
     }
-    let requirements = definition.gguf.as_ref().ok_or_else(|| {
-        CandleError::UnsupportedModelFamily(format!(
-            "{} does not support GGUF artifacts",
-            definition.name
-        ))
-    })?;
+    let requirements = gguf_requirements(definition)?;
     for requirement in requirements.metadata_strings {
         require_metadata_string(content, requirement.key, requirement.value)?;
     }
-    let tokens = match content.metadata.get("tokenizer.ggml.tokens") {
-        Some(gguf_file::Value::Array(tokens)) => tokens,
-        Some(value) => {
-            return Err(CandleError::InvalidQuantizedCheckpoint(format!(
-                "metadata `tokenizer.ggml.tokens` must be an array, found {value:?}"
-            )));
-        }
-        None => {
-            return Err(CandleError::InvalidQuantizedCheckpoint(
-                "missing `tokenizer.ggml.tokens` metadata".to_string(),
-            ));
-        }
-    };
-    if tokens.len() != config.vocab_size {
-        return Err(CandleError::ArtifactMismatch {
-            artifact: "model.gguf",
-            reason: format!(
-                "GGUF tokenizer has {} tokens, but config requires {}",
-                tokens.len(),
-                config.vocab_size
-            ),
-        });
-    }
-    for (id, value) in tokens.iter().enumerate() {
-        let gguf_token = match value {
-            gguf_file::Value::String(token) => token,
-            value => {
-                return Err(CandleError::InvalidQuantizedCheckpoint(format!(
-                    "tokenizer.ggml.tokens[{id}] must be a string, found {value:?}"
-                )));
-            }
-        };
-        let id = u32::try_from(id).map_err(|_| {
-            CandleError::InvalidQuantizedCheckpoint(
-                "GGUF tokenizer index does not fit in u32".to_string(),
-            )
-        })?;
-        if tokenizer.id_to_token(id).as_deref() != Some(gguf_token.as_str()) {
-            return Err(CandleError::ArtifactMismatch {
-                artifact: "tokenizer.json",
-                reason: format!("token ID {id} does not match the GGUF tokenizer vocabulary"),
-            });
-        }
-    }
+    validate_gguf_tokenizer_vocabulary(content, vocab_size, tokenizer, allow_padding)?;
     for (key, token) in [
         ("tokenizer.ggml.bos_token_id", definition.start_token),
         ("tokenizer.ggml.eos_token_id", definition.end_token),
@@ -471,7 +440,7 @@ pub(crate) fn validate_qwen3_gguf_metadata(
     tokenizer: &Tokenizer,
     definition: &ProfileDefinition,
 ) -> Result<(), CandleError> {
-    let expected = [
+    let dims = [
         ("qwen3.embedding_length", config.hidden_size),
         ("qwen3.feed_forward_length", config.intermediate_size),
         ("qwen3.block_count", config.num_hidden_layers),
@@ -481,59 +450,23 @@ pub(crate) fn validate_qwen3_gguf_metadata(
         ("qwen3.attention.value_length", config.head_dim),
         ("qwen3.context_length", config.max_position_embeddings),
     ];
-    for (key, expected) in expected {
-        let actual = metadata_usize(content, key)?;
-        if actual != expected {
-            return Err(CandleError::ArtifactMismatch {
-                artifact: "model.gguf",
-                reason: format!("metadata `{key}` is {actual}, but config requires {expected}"),
-            });
-        }
-    }
-    for (key, actual, expected) in [
-        (
-            "qwen3.rope.freq_base",
-            metadata_f64(content, "qwen3.rope.freq_base")?,
-            config.rope_theta,
-        ),
+    let floats = [
+        ("qwen3.rope.freq_base", config.rope_theta),
         (
             "qwen3.attention.layer_norm_rms_epsilon",
-            metadata_f64(content, "qwen3.attention.layer_norm_rms_epsilon")?,
             config.rms_norm_eps,
         ),
-    ] {
-        if (actual - expected).abs() > 1e-5 * expected.abs().max(f64::MIN_POSITIVE) {
-            return Err(CandleError::ArtifactMismatch {
-                artifact: "model.gguf",
-                reason: format!("metadata `{key}` is {actual}, but config requires {expected}"),
-            });
-        }
-    }
-    let requirements = definition.gguf.as_ref().ok_or_else(|| {
-        CandleError::UnsupportedModelFamily(format!(
-            "{} does not support GGUF artifacts",
-            definition.name
-        ))
-    })?;
-    for requirement in requirements.metadata_strings {
-        require_metadata_string(content, requirement.key, requirement.value)?;
-    }
-    validate_gguf_tokenizer_vocabulary(content, config.vocab_size, tokenizer)?;
-    for (key, token) in [
-        ("tokenizer.ggml.bos_token_id", definition.start_token),
-        ("tokenizer.ggml.eos_token_id", definition.end_token),
-    ] {
-        let actual = metadata_usize(content, key)?;
-        let expected = tokenizer
-            .token_to_id(token)
-            .ok_or(CandleError::MissingSpecialToken { token })? as usize;
-        if actual != expected {
-            return Err(CandleError::ArtifactMismatch {
-                artifact: "model.gguf",
-                reason: format!("metadata `{key}` is {actual}, but tokenizer requires {expected}"),
-            });
-        }
-    }
+    ];
+    validate_gguf_common(
+        content,
+        &dims,
+        &floats,
+        definition,
+        tokenizer,
+        config.vocab_size,
+        true,
+    )?;
+    let requirements = gguf_requirements(definition)?;
     match content.metadata.get("tokenizer.chat_template") {
         Some(gguf_file::Value::String(template))
             if requirements
@@ -555,10 +488,22 @@ pub(crate) fn validate_qwen3_gguf_metadata(
     Ok(())
 }
 
+fn gguf_requirements(
+    definition: &ProfileDefinition,
+) -> Result<&crate::profile::GgufRequirements, CandleError> {
+    definition.gguf.as_ref().ok_or_else(|| {
+        CandleError::UnsupportedModelFamily(format!(
+            "{} does not support GGUF artifacts",
+            definition.name
+        ))
+    })
+}
+
 pub(crate) fn validate_gguf_tokenizer_vocabulary(
     content: &gguf_file::Content,
     vocab_size: usize,
     tokenizer: &Tokenizer,
+    allow_padding: bool,
 ) -> Result<(), CandleError> {
     let tokens = match content.metadata.get("tokenizer.ggml.tokens") {
         Some(gguf_file::Value::Array(tokens)) => tokens,
@@ -597,15 +542,20 @@ pub(crate) fn validate_gguf_tokenizer_vocabulary(
             )
         })?;
         let matches = tokenizer.id_to_token(id).map_or_else(
-            || *gguf_token == format!("[PAD{id}]"),
+            || allow_padding && *gguf_token == format!("[PAD{id}]"),
             |token| token == gguf_token.as_str(),
         );
         if !matches {
+            let reason = if allow_padding {
+                format!(
+                    "token ID {id} does not match the GGUF tokenizer vocabulary or its required padding token"
+                )
+            } else {
+                format!("token ID {id} does not match the GGUF tokenizer vocabulary")
+            };
             return Err(CandleError::ArtifactMismatch {
                 artifact: "tokenizer.json",
-                reason: format!(
-                    "token ID {id} does not match the GGUF tokenizer vocabulary or its required padding token"
-                ),
+                reason,
             });
         }
     }
@@ -662,17 +612,63 @@ pub(crate) fn require_metadata_string(
     }
 }
 
+/// Per-layer weight shapes shared by the Llama-architecture GGUF and
+/// safetensors layouts: (GGUF suffix, safetensors suffix, shape).
+fn llama_layer_shapes(config: &Config) -> [(&'static str, &'static str, Vec<usize>); 9] {
+    let hidden = config.hidden_size;
+    let intermediate = config.intermediate_size;
+    let kv_size = (hidden / config.num_attention_heads) * config.num_key_value_heads;
+    [
+        (
+            "attn_q.weight",
+            "self_attn.q_proj.weight",
+            vec![hidden, hidden],
+        ),
+        (
+            "attn_k.weight",
+            "self_attn.k_proj.weight",
+            vec![kv_size, hidden],
+        ),
+        (
+            "attn_v.weight",
+            "self_attn.v_proj.weight",
+            vec![kv_size, hidden],
+        ),
+        (
+            "attn_output.weight",
+            "self_attn.o_proj.weight",
+            vec![hidden, hidden],
+        ),
+        (
+            "ffn_gate.weight",
+            "mlp.gate_proj.weight",
+            vec![intermediate, hidden],
+        ),
+        (
+            "ffn_down.weight",
+            "mlp.down_proj.weight",
+            vec![hidden, intermediate],
+        ),
+        (
+            "ffn_up.weight",
+            "mlp.up_proj.weight",
+            vec![intermediate, hidden],
+        ),
+        ("attn_norm.weight", "input_layernorm.weight", vec![hidden]),
+        (
+            "ffn_norm.weight",
+            "post_attention_layernorm.weight",
+            vec![hidden],
+        ),
+    ]
+}
+
 pub(crate) fn validate_gguf_tensors(
     content: &gguf_file::Content,
     config: &Config,
     definition: &ProfileDefinition,
 ) -> Result<(), CandleError> {
-    let requirements = definition.gguf.as_ref().ok_or_else(|| {
-        CandleError::UnsupportedModelFamily(format!(
-            "{} does not support GGUF artifacts",
-            definition.name
-        ))
-    })?;
+    let requirements = gguf_requirements(definition)?;
     for (name, tensor) in &content.tensor_infos {
         if !requirements
             .allowed_tensor_dtypes
@@ -707,37 +703,9 @@ pub(crate) fn validate_gguf_tensors(
             &[config.vocab_size, config.hidden_size],
         )?;
     }
-    let head_dim = config.hidden_size / config.num_attention_heads;
-    let kv_size = head_dim * config.num_key_value_heads;
     for layer in 0..config.num_hidden_layers {
-        let prefix = format!("blk.{layer}");
-        for (suffix, shape) in [
-            (
-                "attn_q.weight",
-                vec![config.hidden_size, config.hidden_size],
-            ),
-            ("attn_k.weight", vec![kv_size, config.hidden_size]),
-            ("attn_v.weight", vec![kv_size, config.hidden_size]),
-            (
-                "attn_output.weight",
-                vec![config.hidden_size, config.hidden_size],
-            ),
-            (
-                "ffn_gate.weight",
-                vec![config.intermediate_size, config.hidden_size],
-            ),
-            (
-                "ffn_down.weight",
-                vec![config.hidden_size, config.intermediate_size],
-            ),
-            (
-                "ffn_up.weight",
-                vec![config.intermediate_size, config.hidden_size],
-            ),
-            ("attn_norm.weight", vec![config.hidden_size]),
-            ("ffn_norm.weight", vec![config.hidden_size]),
-        ] {
-            validate_gguf_tensor(content, &format!("{prefix}.{suffix}"), &shape)?;
+        for (suffix, _, shape) in &llama_layer_shapes(config) {
+            validate_gguf_tensor(content, &format!("blk.{layer}.{suffix}"), shape)?;
         }
     }
     Ok(())
@@ -748,12 +716,7 @@ pub(crate) fn validate_qwen3_gguf_tensors(
     config: &Qwen3Config,
     definition: &ProfileDefinition,
 ) -> Result<(), CandleError> {
-    let requirements = definition.gguf.as_ref().ok_or_else(|| {
-        CandleError::UnsupportedModelFamily(format!(
-            "{} does not support GGUF artifacts",
-            definition.name
-        ))
-    })?;
+    let requirements = gguf_requirements(definition)?;
     for (name, tensor) in &content.tensor_infos {
         if !requirements
             .allowed_tensor_dtypes
@@ -805,68 +768,29 @@ pub(crate) fn validate_qwen3_gguf_tensors(
         &[config.hidden_size],
         requirements.norm_dtypes,
     )?;
+    let (hidden, intermediate) = (config.hidden_size, config.intermediate_size);
     let query_size = config.num_attention_heads * config.head_dim;
     let kv_size = config.num_key_value_heads * config.head_dim;
+    let (matrix, mixed, norm) = (
+        requirements.matrix_dtypes,
+        requirements.mixed_matrix_dtypes,
+        requirements.norm_dtypes,
+    );
     for layer in 0..config.num_hidden_layers {
-        let prefix = format!("blk.{layer}");
         for (suffix, shape, dtypes) in [
-            (
-                "attn_q.weight",
-                vec![query_size, config.hidden_size],
-                requirements.matrix_dtypes,
-            ),
-            (
-                "attn_k.weight",
-                vec![kv_size, config.hidden_size],
-                requirements.matrix_dtypes,
-            ),
-            (
-                "attn_v.weight",
-                vec![kv_size, config.hidden_size],
-                requirements.mixed_matrix_dtypes,
-            ),
-            (
-                "attn_output.weight",
-                vec![config.hidden_size, query_size],
-                requirements.matrix_dtypes,
-            ),
-            (
-                "attn_q_norm.weight",
-                vec![config.head_dim],
-                requirements.norm_dtypes,
-            ),
-            (
-                "attn_k_norm.weight",
-                vec![config.head_dim],
-                requirements.norm_dtypes,
-            ),
-            (
-                "ffn_gate.weight",
-                vec![config.intermediate_size, config.hidden_size],
-                requirements.matrix_dtypes,
-            ),
-            (
-                "ffn_down.weight",
-                vec![config.hidden_size, config.intermediate_size],
-                requirements.mixed_matrix_dtypes,
-            ),
-            (
-                "ffn_up.weight",
-                vec![config.intermediate_size, config.hidden_size],
-                requirements.matrix_dtypes,
-            ),
-            (
-                "attn_norm.weight",
-                vec![config.hidden_size],
-                requirements.norm_dtypes,
-            ),
-            (
-                "ffn_norm.weight",
-                vec![config.hidden_size],
-                requirements.norm_dtypes,
-            ),
+            ("attn_q.weight", vec![query_size, hidden], matrix),
+            ("attn_k.weight", vec![kv_size, hidden], matrix),
+            ("attn_v.weight", vec![kv_size, hidden], mixed),
+            ("attn_output.weight", vec![hidden, query_size], matrix),
+            ("attn_q_norm.weight", vec![config.head_dim], norm),
+            ("attn_k_norm.weight", vec![config.head_dim], norm),
+            ("ffn_gate.weight", vec![intermediate, hidden], matrix),
+            ("ffn_down.weight", vec![hidden, intermediate], mixed),
+            ("ffn_up.weight", vec![intermediate, hidden], matrix),
+            ("attn_norm.weight", vec![hidden], norm),
+            ("ffn_norm.weight", vec![hidden], norm),
         ] {
-            validate_gguf_tensor_dtype(content, &format!("{prefix}.{suffix}"), &shape, dtypes)?;
+            validate_gguf_tensor_dtype(content, &format!("blk.{layer}.{suffix}"), &shape, dtypes)?;
         }
     }
     Ok(())
@@ -911,9 +835,6 @@ pub(crate) fn validate_gguf_tensor(
 pub(crate) fn validate_checkpoint(weights: &[u8], config: &Config) -> Result<(), CandleError> {
     let tensors = SafeTensors::deserialize(weights)
         .map_err(|error| CandleError::InvalidCheckpoint(error.to_string()))?;
-    let head_dim = config.hidden_size / config.num_attention_heads;
-    let kv_size = head_dim * config.num_key_value_heads;
-
     validate_tensor(
         &tensors,
         "model.embed_tokens.weight",
@@ -928,34 +849,8 @@ pub(crate) fn validate_checkpoint(weights: &[u8], config: &Config) -> Result<(),
         )?;
     }
     for layer in 0..config.num_hidden_layers {
-        let prefix = format!("model.layers.{layer}");
-        for (suffix, shape) in [
-            (
-                "self_attn.q_proj.weight",
-                vec![config.hidden_size, config.hidden_size],
-            ),
-            ("self_attn.k_proj.weight", vec![kv_size, config.hidden_size]),
-            ("self_attn.v_proj.weight", vec![kv_size, config.hidden_size]),
-            (
-                "self_attn.o_proj.weight",
-                vec![config.hidden_size, config.hidden_size],
-            ),
-            (
-                "mlp.gate_proj.weight",
-                vec![config.intermediate_size, config.hidden_size],
-            ),
-            (
-                "mlp.up_proj.weight",
-                vec![config.intermediate_size, config.hidden_size],
-            ),
-            (
-                "mlp.down_proj.weight",
-                vec![config.hidden_size, config.intermediate_size],
-            ),
-            ("input_layernorm.weight", vec![config.hidden_size]),
-            ("post_attention_layernorm.weight", vec![config.hidden_size]),
-        ] {
-            validate_tensor(&tensors, &format!("{prefix}.{suffix}"), &shape)?;
+        for (_, suffix, shape) in &llama_layer_shapes(config) {
+            validate_tensor(&tensors, &format!("model.layers.{layer}.{suffix}"), shape)?;
         }
     }
     Ok(())

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -33,9 +33,7 @@ use crate::model::{Model, ModelList, ModelListingError};
 use crate::providers::openai;
 use crate::providers::openai::responses_api::{self, CompletionRequest as ResponsesRequest};
 use crate::streaming::StreamingCompletionResponse;
-use crate::telemetry::{
-    CompletionOperation, CompletionSpanBuilder, ProviderResponseExt, SpanCombinator,
-};
+use crate::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
 use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
 use futures::StreamExt;
 use http::Request;
@@ -562,7 +560,7 @@ fn route_for_model(model: &str) -> CompletionRoute {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "api", rename_all = "snake_case")]
 pub enum CopilotCompletionResponse {
-    Chat(Box<ChatCompletionResponse>),
+    Chat(Box<openai::completion::CompletionResponse>),
     Responses(Box<responses_api::CompletionResponse>),
 }
 
@@ -593,107 +591,8 @@ impl From<(&str, CopilotStreamingResponse)> for crate::streaming::StreamFinal {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ChatCompletionResponse {
-    pub id: String,
-    #[serde(default)]
-    pub object: Option<String>,
-    #[serde(default)]
-    pub created: Option<u64>,
-    pub model: String,
-    pub system_fingerprint: Option<String>,
-    pub choices: Vec<ChatChoice>,
-    pub usage: Option<openai::completion::Usage>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ChatChoice {
-    #[serde(default)]
-    pub index: usize,
-    pub message: openai::completion::Message,
-    pub logprobs: Option<serde_json::Value>,
-    #[serde(default)]
-    pub finish_reason: Option<String>,
-}
-
 /// Stable descriptor name reported on normalized Copilot responses.
 pub const PROVIDER_NAME: &str = "copilot";
-
-impl From<ChatChoice> for openai::completion::Choice {
-    fn from(choice: ChatChoice) -> Self {
-        Self {
-            index: choice.index,
-            message: choice.message,
-            logprobs: choice.logprobs,
-            // OpenAI's normalization treats an empty `finish_reason` as
-            // absent, so Copilot's optional field folds onto it losslessly.
-            finish_reason: choice.finish_reason.unwrap_or_default(),
-        }
-    }
-}
-
-impl From<ChatCompletionResponse> for openai::completion::CompletionResponse {
-    fn from(response: ChatCompletionResponse) -> Self {
-        Self {
-            id: response.id,
-            object: response.object.unwrap_or_default(),
-            created: response.created.unwrap_or_default(),
-            model: response.model,
-            system_fingerprint: response.system_fingerprint,
-            choices: response.choices.into_iter().map(Into::into).collect(),
-            usage: response.usage,
-        }
-    }
-}
-
-impl TryFrom<ChatCompletionResponse> for completion::CompletionResponse {
-    type Error = CompletionError;
-
-    fn try_from(response: ChatCompletionResponse) -> Result<Self, Self::Error> {
-        // Copilot's chat route speaks OpenAI's chat-completions wire (with a
-        // few fields optional), so normalization is OpenAI's, under Copilot's
-        // own provider name.
-        openai::completion::CompletionResponse::from(response).normalize(PROVIDER_NAME)
-    }
-}
-
-impl ProviderResponseExt for ChatCompletionResponse {
-    type OutputMessage = ChatChoice;
-    type Usage = openai::completion::Usage;
-
-    fn get_response_id(&self) -> Option<String> {
-        Some(self.id.clone())
-    }
-
-    fn get_response_model_name(&self) -> Option<String> {
-        Some(self.model.clone())
-    }
-
-    fn get_output_messages(&self) -> Vec<Self::OutputMessage> {
-        self.choices.clone()
-    }
-
-    fn get_text_response(&self) -> Option<String> {
-        let response = self
-            .choices
-            .iter()
-            .filter_map(|choice| {
-                openai::completion::assistant_message_text_response(&choice.message)
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        if response.is_empty() {
-            None
-        } else {
-            Some(response)
-        }
-    }
-
-    fn get_usage(&self) -> Option<Self::Usage> {
-        self.usage.clone()
-    }
-}
 
 #[derive(Debug, Deserialize)]
 pub struct ChatApiErrorResponse {
@@ -820,7 +719,7 @@ where
     async fn raw_completion_chat(
         &self,
         completion_request: completion::CompletionRequest,
-    ) -> Result<ChatCompletionResponse, CompletionError> {
+    ) -> Result<openai::completion::CompletionResponse, CompletionError> {
         let initiator = request_initiator(&completion_request);
         let has_vision = request_has_vision(&completion_request);
         let system_instructions = completion_request.preamble.clone();
@@ -847,7 +746,9 @@ where
             let status = response.status();
             if status.is_success() {
                 let body = http_client::text(response).await?;
-                match serde_json::from_str::<ChatApiResponse<ChatCompletionResponse>>(&body)? {
+                match serde_json::from_str::<ChatApiResponse<openai::completion::CompletionResponse>>(
+                    &body,
+                )? {
                     ChatApiResponse::Ok(response) => {
                         let span = tracing::Span::current();
                         span.record_response_metadata(&response);
@@ -1089,7 +990,7 @@ where
             CompletionRoute::ChatCompletions => self
                 .raw_completion_chat(completion_request)
                 .await?
-                .try_into(),
+                .normalize(PROVIDER_NAME),
             CompletionRoute::Responses => self
                 .raw_completion_responses(completion_request)
                 .await?
@@ -1403,9 +1304,9 @@ use crate::providers::internal::auth::config_dir;
 #[cfg(test)]
 mod tests {
     use super::{
-        ChatApiErrorResponse, ChatCompletionResponse, Client, CompletionRoute, CopilotIntent,
-        TEXT_EMBEDDING_3_SMALL, base_url_from_token, default_headers, env_api_key, env_base_url,
-        env_github_access_token, route_for_model,
+        ChatApiErrorResponse, Client, CompletionRoute, CopilotIntent, TEXT_EMBEDDING_3_SMALL,
+        base_url_from_token, default_headers, env_api_key, env_base_url, env_github_access_token,
+        route_for_model,
     };
     use crate::client::CompletionClient;
     use crate::completion::CompletionModel;
@@ -1413,6 +1314,7 @@ mod tests {
     use crate::providers::internal::openai_chat_completions_compatible::test_support::{
         sse_bytes_from_data_lines, sse_bytes_from_json_events,
     };
+    use crate::providers::openai;
     use crate::streaming::StreamedAssistantContent;
     use crate::test_utils::MockStreamingClient;
     use crate::test_utils::{RecordingHttpClient, SequencedStreamingHttpClient};
@@ -1516,24 +1418,25 @@ mod tests {
             }
         }"#;
 
-        let response: ChatCompletionResponse =
+        let response: openai::completion::CompletionResponse =
             serde_json::from_str(json).expect("standard OpenAI response should deserialize");
         assert_eq!(response.id, "chatcmpl-abc123");
-        assert_eq!(response.object.as_deref(), Some("chat.completion"));
-        assert_eq!(response.created, Some(1700000000));
+        assert_eq!(response.object, "chat.completion");
+        assert_eq!(response.created, 1700000000);
         assert_eq!(response.model, "gpt-4o");
         assert_eq!(response.choices.len(), 1);
-        assert_eq!(response.choices[0].finish_reason.as_deref(), Some("stop"));
+        assert_eq!(response.choices[0].finish_reason, "stop");
     }
 
     #[test]
     fn deserialize_copilot_response_without_object_and_created() {
-        let response: ChatCompletionResponse = serde_json::from_str(minimal_chat_response())
-            .expect("Copilot response should deserialize");
+        let response: openai::completion::CompletionResponse =
+            serde_json::from_str(minimal_chat_response())
+                .expect("Copilot response should deserialize");
 
         assert_eq!(response.id, "chatcmpl-123");
-        assert_eq!(response.object, None);
-        assert_eq!(response.created, None);
+        assert_eq!(response.object, "");
+        assert_eq!(response.created, 0);
         assert_eq!(response.model, "gpt-4o");
         assert_eq!(response.choices.len(), 1);
     }
@@ -1555,11 +1458,11 @@ mod tests {
             }
         }"#;
 
-        let response: ChatCompletionResponse =
+        let response: openai::completion::CompletionResponse =
             serde_json::from_str(json).expect("Claude-via-Copilot response should deserialize");
 
         assert_eq!(response.model, "claude-3.5-sonnet");
-        assert_eq!(response.choices[0].finish_reason, None);
+        assert_eq!(response.choices[0].finish_reason, "");
         assert_eq!(response.choices[0].index, 0);
     }
 

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -335,7 +335,9 @@ pub(crate) fn create_request_body(
     Ok(request)
 }
 
-pub(super) fn split_system_messages_from_history(
+/// Split system messages out of a chat history, keeping their contents in
+/// order. Shared with sibling Gemini transports (e.g. `rig-gemini-grpc`).
+pub fn split_system_messages_from_history(
     history: Vec<completion::Message>,
 ) -> (Vec<String>, Vec<completion::Message>) {
     let mut system = Vec::new();

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -1130,14 +1130,15 @@ impl FromStr for SystemContent {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CompletionResponse {
     pub id: String,
-    // Defaulted on deserialization: some OpenAI-compatible gateways
-    // (HuggingFace router sub-providers, TGI variants) omit them.
-    #[serde(default)]
+    // Null-or-missing tolerated on deserialization: some OpenAI-compatible
+    // gateways (HuggingFace router sub-providers, TGI variants, Copilot's
+    // multi-vendor chat route) omit them or send explicit `null`.
+    #[serde(default, deserialize_with = "json_utils::null_or_default")]
     pub object: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "json_utils::null_or_default")]
     pub created: u64,
     pub model: String,
     pub system_fingerprint: Option<String>,
@@ -1278,9 +1279,14 @@ pub(crate) fn assistant_message_text_response(message: &Message) -> Option<Strin
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Choice {
+    // Null-or-missing tolerated on deserialization: Copilot's chat route
+    // (fronting non-OpenAI vendors) can omit either field or send explicit
+    // `null`; normalization treats "" as absent.
+    #[serde(default, deserialize_with = "json_utils::null_or_default")]
     pub index: usize,
     pub message: Message,
     pub logprobs: Option<serde_json::Value>,
+    #[serde(default, deserialize_with = "json_utils::null_or_default")]
     pub finish_reason: String,
 }
 
@@ -2169,6 +2175,33 @@ where
 
 #[cfg(test)]
 mod tests {
+    /// The shared chat-completions response type is deliberately lenient about
+    /// envelope metadata: `object`, `created`, `choices[].index`, and
+    /// `choices[].finish_reason` may be missing or explicit `null` (lossy
+    /// OpenAI-compatible gateways and Copilot's multi-vendor chat route both
+    /// rely on this). An empty `finish_reason` normalizes to `None` rather
+    /// than erroring. This pins that contract next to the type itself.
+    #[test]
+    fn completion_response_tolerates_null_or_missing_envelope_metadata() {
+        let json = r#"{
+            "id": "chatcmpl-1",
+            "object": null,
+            "created": null,
+            "model": "some-model",
+            "choices": [{
+                "index": null,
+                "message": { "role": "assistant", "content": "hi" },
+                "finish_reason": null
+            }]
+        }"#;
+        let response: super::CompletionResponse =
+            serde_json::from_str(json).expect("null envelope metadata should deserialize");
+        assert_eq!(response.object, "");
+        assert_eq!(response.created, 0);
+        assert_eq!(response.choices[0].index, 0);
+        assert_eq!(response.choices[0].finish_reason, "");
+    }
+
     /// Boundary-minted tool ids (`tool-{index}`, from id-less streamed calls)
     /// replay to the chat wire as a self-consistent pair: the assistant
     /// message's `tool_calls[].id` and the tool result's `tool_call_id` carry

--- a/crates/rig-core/src/vector_store/mod.rs
+++ b/crates/rig-core/src/vector_store/mod.rs
@@ -71,6 +71,23 @@ pub enum VectorStoreError {
     BuilderError(String),
 }
 
+impl VectorStoreError {
+    /// Wraps a backend error as [`VectorStoreError::DatastoreError`].
+    ///
+    /// Handles the wasm/non-wasm trait-bound split in one place; use as
+    /// `.map_err(VectorStoreError::datastore)`.
+    #[cfg(not(target_family = "wasm"))]
+    pub fn datastore(e: impl std::error::Error + Send + Sync + 'static) -> Self {
+        Self::DatastoreError(Box::new(e))
+    }
+
+    /// Wraps a backend error as [`VectorStoreError::DatastoreError`].
+    #[cfg(target_family = "wasm")]
+    pub fn datastore(e: impl std::error::Error + 'static) -> Self {
+        Self::DatastoreError(Box::new(e))
+    }
+}
+
 /// Trait for inserting documents and embeddings into a vector store.
 pub trait InsertDocuments: WasmCompatSend + WasmCompatSync {
     /// Insert precomputed embeddings for each document.
@@ -324,5 +341,12 @@ mod tests {
         assert_eq!(result.score, 0.9);
         assert_eq!(result.id, "doc-1");
         assert_eq!(result.document, json!({ "answer": 42 }));
+    }
+
+    #[test]
+    fn datastore_wraps_backend_errors() {
+        let err = VectorStoreError::datastore(std::io::Error::other("db down"));
+        assert!(matches!(err, VectorStoreError::DatastoreError(_)));
+        assert_eq!(err.to_string(), "Datastore error: db down");
     }
 }

--- a/crates/rig-core/src/vector_store/request.rs
+++ b/crates/rig-core/src/vector_store/request.rs
@@ -182,13 +182,34 @@ where
     where
         F: SearchFilter<Value = V>,
     {
-        match self {
-            Self::Eq(key, val) => F::eq(key, val),
-            Self::Gt(key, val) => F::gt(key, val),
-            Self::Lt(key, val) => F::lt(key, val),
-            Self::And(lhs, rhs) => F::and(lhs.interpret(), rhs.interpret()),
-            Self::Or(lhs, rhs) => F::or(lhs.interpret(), rhs.interpret()),
+        self.interpret_with(|v| v)
+    }
+
+    /// Converts this filter into a backend-specific filter type, converting
+    /// each leaf value with `conv`.
+    pub fn interpret_with<F, W>(self, conv: impl Fn(V) -> W + Copy) -> F
+    where
+        F: SearchFilter<Value = W>,
+    {
+        match self.try_interpret(|v| Ok::<W, std::convert::Infallible>(conv(v))) {
+            Ok(filter) => filter,
+            Err(never) => match never {},
         }
+    }
+
+    /// Converts this filter into a backend-specific filter type, converting
+    /// each leaf value with `conv`. Fails on the first value that fails to convert.
+    pub fn try_interpret<F, W, E>(self, conv: impl Fn(V) -> Result<W, E> + Copy) -> Result<F, E>
+    where
+        F: SearchFilter<Value = W>,
+    {
+        Ok(match self {
+            Self::Eq(key, val) => F::eq(key, conv(val)?),
+            Self::Gt(key, val) => F::gt(key, conv(val)?),
+            Self::Lt(key, val) => F::lt(key, conv(val)?),
+            Self::And(lhs, rhs) => F::and(lhs.try_interpret(conv)?, rhs.try_interpret(conv)?),
+            Self::Or(lhs, rhs) => F::or(lhs.try_interpret(conv)?, rhs.try_interpret(conv)?),
+        })
     }
 }
 
@@ -396,5 +417,35 @@ mod tests {
 
         let either = F::eq("category", json!("veg")).or(F::lt("price", json!(50)));
         assert!(either.satisfies(&doc));
+    }
+
+    #[test]
+    fn try_interpret_converts_nested_leaf_values() {
+        let f: Filter<i64> =
+            Filter::Eq("a".into(), 1).and(Filter::Gt("b".into(), 2).or(Filter::Lt("c".into(), 3)));
+        let out: Filter<String> = f
+            .try_interpret(|v| Ok::<_, std::convert::Infallible>(v.to_string()))
+            .unwrap();
+        match out {
+            Filter::And(lhs, rhs) => {
+                assert!(matches!(*lhs, Filter::Eq(ref k, ref v) if k == "a" && v == "1"));
+                match *rhs {
+                    Filter::Or(l, r) => {
+                        assert!(matches!(*l, Filter::Gt(ref k, ref v) if k == "b" && v == "2"));
+                        assert!(matches!(*r, Filter::Lt(ref k, ref v) if k == "c" && v == "3"));
+                    }
+                    other => panic!("expected Or, got {other:?}"),
+                }
+            }
+            other => panic!("expected And, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_interpret_propagates_conversion_errors() {
+        let f: Filter<i64> = Filter::Eq("a".into(), 1).and(Filter::Gt("b".into(), -2));
+        let out: Result<Filter<u64>, String> =
+            f.try_interpret(|v| u64::try_from(v).map_err(|e| e.to_string()));
+        assert!(out.is_err());
     }
 }

--- a/crates/rig-core/tests/serde_policy_allowlist.txt
+++ b/crates/rig-core/tests/serde_policy_allowlist.txt
@@ -34,7 +34,7 @@ providers/openai/responses_api/streaming.rs | let kind = serde_json::from_str::<
 # Single-file providers: unary/non-stream parses sharing a file with streaming code.
 providers/ollama.rs | serde_json::from_slice(&bytes)?; | unary embedding response body, not a stream frame
 providers/ollama.rs | serde_json::from_slice(&response_body)?; | unary completion response body, not a stream frame
-providers/copilot/mod.rs | ChatApiResponse<ChatCompletionResponse>>(&body)? | unary chat completion body, not a stream frame
+providers/copilot/mod.rs | ChatApiResponse<openai::completion::CompletionResponse>>( | unary chat completion body, not a stream frame
 providers/copilot/mod.rs | responses_api::CompletionResponse>(&body)? | unary responses completion body, not a stream frame
 providers/copilot/mod.rs | CopilotEmbeddingResponse = match serde_json::from_slice | unary embedding response body, not a stream frame
 providers/copilot/mod.rs | serde_json::from_slice::<NestedApiError>(&body) | unary error-envelope decode on a non-2xx body, not a stream frame

--- a/crates/rig-derive/src/tool/args.rs
+++ b/crates/rig-derive/src/tool/args.rs
@@ -30,6 +30,16 @@ impl MacroArgs {
     }
 }
 
+fn unsupported_argument(path: &syn::Path) -> syn::Error {
+    let message = if let Some(ident) = path.get_ident() {
+        format!("unsupported top-level #[rig_tool] argument `{ident}`")
+    } else {
+        "unsupported top-level #[rig_tool] argument".to_string()
+    };
+
+    syn::Error::new_spanned(path, message)
+}
+
 fn parse_string_literal(expr: &Expr, field_name: &str) -> syn::Result<String> {
     match expr {
         Expr::Lit(ExprLit {
@@ -107,12 +117,10 @@ impl Parse for MacroArgs {
         for meta in meta_list {
             match meta {
                 Meta::NameValue(nv) => {
-                    let ident = nv.path.get_ident().ok_or_else(|| {
-                        syn::Error::new_spanned(
-                            &nv.path,
-                            "unsupported top-level #[rig_tool] argument",
-                        )
-                    })?;
+                    let ident = nv
+                        .path
+                        .get_ident()
+                        .ok_or_else(|| unsupported_argument(&nv.path))?;
 
                     match ident.to_string().as_str() {
                         "name" => {
@@ -126,20 +134,15 @@ impl Parse for MacroArgs {
                             description = Some(parse_string_literal(&nv.value, "description")?);
                         }
                         _ => {
-                            return Err(syn::Error::new_spanned(
-                                &nv.path,
-                                format!("unsupported top-level #[rig_tool] argument `{ident}`"),
-                            ));
+                            return Err(unsupported_argument(&nv.path));
                         }
                     }
                 }
                 Meta::List(list) => {
-                    let ident = list.path.get_ident().ok_or_else(|| {
-                        syn::Error::new_spanned(
-                            &list.path,
-                            "unsupported top-level #[rig_tool] argument",
-                        )
-                    })?;
+                    let ident = list
+                        .path
+                        .get_ident()
+                        .ok_or_else(|| unsupported_argument(&list.path))?;
 
                     match ident.to_string().as_str() {
                         "params" => {
@@ -196,21 +199,12 @@ impl Parse for MacroArgs {
                             required = Some(names);
                         }
                         _ => {
-                            return Err(syn::Error::new_spanned(
-                                &list.path,
-                                format!("unsupported top-level #[rig_tool] argument `{ident}`"),
-                            ));
+                            return Err(unsupported_argument(&list.path));
                         }
                     }
                 }
                 Meta::Path(path) => {
-                    let message = if let Some(ident) = path.get_ident() {
-                        format!("unsupported top-level #[rig_tool] argument `{ident}`")
-                    } else {
-                        "unsupported top-level #[rig_tool] argument".to_string()
-                    };
-
-                    return Err(syn::Error::new_spanned(path, message));
+                    return Err(unsupported_argument(&path));
                 }
             }
         }

--- a/crates/rig-derive/src/tool/classify.rs
+++ b/crates/rig-derive/src/tool/classify.rs
@@ -12,14 +12,19 @@ use crate::resolve::CrateRefs;
 /// types with the same name, so only paths rooted at a crate name Rig resolves
 /// to in this build (including Cargo renames) are recognized. Imported aliases
 /// use the explicit `#[rig(context)]` parameter marker instead.
-fn is_tool_context_type(ty: &Type, refs: &CrateRefs) -> bool {
-    let ty = match ty {
-        Type::Group(group) => &*group.elem,
-        Type::Paren(paren) => &*paren.elem,
-        ty => ty,
-    };
+const MUT_CONTEXT_MSG: &str = "a `ToolContext` parameter must have type `&mut ToolContext`";
 
-    let Type::Path(type_path) = ty else {
+/// Peel grouping (`Group`/`Paren`) wrappers off a type.
+fn peel(ty: &Type) -> &Type {
+    match ty {
+        Type::Group(group) => &group.elem,
+        Type::Paren(paren) => &paren.elem,
+        ty => ty,
+    }
+}
+
+fn is_tool_context_type(ty: &Type, refs: &CrateRefs) -> bool {
+    let Type::Path(type_path) = peel(ty) else {
         return false;
     };
     let segments = type_path
@@ -77,30 +82,20 @@ pub(crate) fn is_tool_context_parameter(
     explicitly_marked: bool,
     refs: &CrateRefs,
 ) -> syn::Result<bool> {
-    let ty = match ty {
-        Type::Group(group) => &*group.elem,
-        Type::Paren(paren) => &*paren.elem,
-        ty => ty,
-    };
+    let ty = peel(ty);
 
     if let Type::Reference(reference) = ty
         && (explicitly_marked || is_tool_context_type(&reference.elem, refs))
     {
         if reference.mutability.is_none() {
-            return Err(syn::Error::new_spanned(
-                ty,
-                "a `ToolContext` parameter must have type `&mut ToolContext`",
-            ));
+            return Err(syn::Error::new_spanned(ty, MUT_CONTEXT_MSG));
         }
 
         return Ok(true);
     }
 
     if explicitly_marked || is_tool_context_type(ty, refs) {
-        return Err(syn::Error::new_spanned(
-            ty,
-            "a `ToolContext` parameter must have type `&mut ToolContext`",
-        ));
+        return Err(syn::Error::new_spanned(ty, MUT_CONTEXT_MSG));
     }
 
     Ok(false)

--- a/crates/rig-derive/src/tool/expand.rs
+++ b/crates/rig-derive/src/tool/expand.rs
@@ -57,6 +57,9 @@ fn is_option_type(ty: &Type) -> bool {
 }
 
 fn result_type_tokens(return_type: &ReturnType) -> syn::Result<(TokenStream, TokenStream)> {
+    const RESULT_TY_MSG: &str = "return type must be Result<T, E>";
+    const RESULT_ARITY_MSG: &str = "expected Result<T, E> with exactly two type parameters";
+
     let ReturnType::Type(_, ty) = return_type else {
         return Err(syn::Error::new_spanned(
             return_type,
@@ -65,24 +68,15 @@ fn result_type_tokens(return_type: &ReturnType) -> syn::Result<(TokenStream, Tok
     };
 
     let Type::Path(type_path) = ty.deref() else {
-        return Err(syn::Error::new_spanned(
-            ty,
-            "return type must be Result<T, E>",
-        ));
+        return Err(syn::Error::new_spanned(ty, RESULT_TY_MSG));
     };
 
     let Some(last_segment) = type_path.path.segments.last() else {
-        return Err(syn::Error::new_spanned(
-            &type_path.path,
-            "return type must be Result<T, E>",
-        ));
+        return Err(syn::Error::new_spanned(&type_path.path, RESULT_TY_MSG));
     };
 
     if last_segment.ident != "Result" {
-        return Err(syn::Error::new_spanned(
-            &last_segment.ident,
-            "return type must be Result<T, E>",
-        ));
+        return Err(syn::Error::new_spanned(&last_segment.ident, RESULT_TY_MSG));
     }
 
     let PathArguments::AngleBracketed(args) = &last_segment.arguments else {
@@ -94,17 +88,11 @@ fn result_type_tokens(return_type: &ReturnType) -> syn::Result<(TokenStream, Tok
 
     let mut generic_args = args.args.iter();
     let (Some(output), Some(error)) = (generic_args.next(), generic_args.next()) else {
-        return Err(syn::Error::new_spanned(
-            &args.args,
-            "expected Result<T, E> with exactly two type parameters",
-        ));
+        return Err(syn::Error::new_spanned(&args.args, RESULT_ARITY_MSG));
     };
 
     if generic_args.next().is_some() {
-        return Err(syn::Error::new_spanned(
-            &args.args,
-            "expected Result<T, E> with exactly two type parameters",
-        ));
+        return Err(syn::Error::new_spanned(&args.args, RESULT_ARITY_MSG));
     }
 
     Ok((quote!(#output), quote!(#error)))

--- a/crates/rig-fastembed/src/lib.rs
+++ b/crates/rig-fastembed/src/lib.rs
@@ -206,7 +206,10 @@ impl embeddings::EmbeddingModel for EmbeddingModel {
         let documents_as_strings: Vec<String> = documents.into_iter().collect();
 
         let documents_as_vec = embedder
-            .embed(documents_as_strings.clone(), None)
+            .embed(
+                documents_as_strings.iter().map(String::as_str).collect(),
+                None,
+            )
             .map_err(|err| EmbeddingError::ProviderError(err.to_string()))?;
 
         let docs = documents_as_strings

--- a/crates/rig-gemini-grpc/src/completion.rs
+++ b/crates/rig-gemini-grpc/src/completion.rs
@@ -159,6 +159,21 @@ impl completion::CompletionModel for CompletionModel {
     }
 }
 
+/// Build a non-thought `proto::Part` around the given data payload.
+pub(crate) fn data_part(data: proto::part::Data) -> proto::Part {
+    proto::Part {
+        data: Some(data),
+        thought: false,
+        thought_signature: Vec::new(),
+        part_metadata: None,
+    }
+}
+
+/// Build a plain (non-thought) text `proto::Part`.
+pub(crate) fn text_part(text: String) -> proto::Part {
+    data_part(proto::part::Data::Text(text))
+}
+
 // Map a failed gRPC call into a `CompletionError` that preserves the provider's
 // error payload verbatim. gRPC is a non-HTTP transport, so there is no
 // `http::StatusCode`; the body is preserved via `from_provider_body` (status:
@@ -205,21 +220,11 @@ pub(crate) fn create_grpc_request(
     if let Some(preamble) = preamble
         && !preamble.is_empty()
     {
-        system_parts.push(proto::Part {
-            data: Some(proto::part::Data::Text(preamble)),
-            thought: false,
-            thought_signature: Vec::new(),
-            part_metadata: None,
-        });
+        system_parts.push(text_part(preamble));
     }
     for content in history_system {
         if !content.is_empty() {
-            system_parts.push(proto::Part {
-                data: Some(proto::part::Data::Text(content)),
-                thought: false,
-                thought_signature: Vec::new(),
-                part_metadata: None,
-            });
+            system_parts.push(text_part(content));
         }
     }
     let system_instruction = if system_parts.is_empty() {
@@ -307,33 +312,14 @@ fn rig_message_to_grpc_content(msg: message::Message) -> Result<proto::Content, 
     }
 }
 
-fn split_system_messages_from_history(
-    history: Vec<message::Message>,
-) -> (Vec<String>, Vec<message::Message>) {
-    let mut system = Vec::new();
-    let mut remaining = Vec::new();
-
-    for message in history {
-        match message {
-            message::Message::System { content } => system.push(content),
-            other => remaining.push(other),
-        }
-    }
-
-    (system, remaining)
-}
+use rig_core::providers::gemini::completion::split_system_messages_from_history;
 
 // Convert Rig UserContent to gRPC Part
 fn rig_user_content_to_grpc_part(
     content: message::UserContent,
 ) -> Result<proto::Part, CompletionError> {
     match content {
-        message::UserContent::Text(message::Text { text, .. }) => Ok(proto::Part {
-            data: Some(proto::part::Data::Text(text)),
-            thought: false,
-            thought_signature: Vec::new(),
-            part_metadata: None,
-        }),
+        message::UserContent::Text(message::Text { text, .. }) => Ok(text_part(text)),
         message::UserContent::ToolResult(result) => {
             let mut values = result
                 .content
@@ -358,21 +344,16 @@ fn rig_user_content_to_grpc_part(
             // `FunctionResponse.name` is the executed function's name —
             // required data on the result. Only a provider-issued id may
             // travel back on the wire (the proto field is optional-empty).
-            Ok(proto::Part {
-                data: Some(proto::part::Data::FunctionResponse(
-                    proto::FunctionResponse {
-                        name: result.name,
-                        response: Some(response_struct),
-                        id: result
-                            .provider
-                            .map(|provider| provider.call_id)
-                            .unwrap_or_default(),
-                    },
-                )),
-                thought: false,
-                thought_signature: Vec::new(),
-                part_metadata: None,
-            })
+            Ok(data_part(proto::part::Data::FunctionResponse(
+                proto::FunctionResponse {
+                    name: result.name,
+                    response: Some(response_struct),
+                    id: result
+                        .provider
+                        .map(|provider| provider.call_id)
+                        .unwrap_or_default(),
+                },
+            )))
         }
         message::UserContent::Image(img) => {
             let Some(media_type) = img.media_type else {
@@ -398,15 +379,10 @@ fn rig_user_content_to_grpc_part(
 
             let data = match img.data {
                 message::DocumentSourceKind::Url(file_uri) => {
-                    return Ok(proto::Part {
-                        data: Some(proto::part::Data::FileData(proto::FileData {
-                            mime_type,
-                            file_uri,
-                        })),
-                        thought: false,
-                        thought_signature: Vec::new(),
-                        part_metadata: None,
-                    });
+                    return Ok(data_part(proto::part::Data::FileData(proto::FileData {
+                        mime_type,
+                        file_uri,
+                    })));
                 }
                 message::DocumentSourceKind::Raw(bytes) => bytes,
                 message::DocumentSourceKind::Base64(data)
@@ -423,15 +399,10 @@ fn rig_user_content_to_grpc_part(
                 }
             };
 
-            Ok(proto::Part {
-                data: Some(proto::part::Data::InlineData(proto::Blob {
-                    mime_type,
-                    data,
-                })),
-                thought: false,
-                thought_signature: Vec::new(),
-                part_metadata: None,
-            })
+            Ok(data_part(proto::part::Data::InlineData(proto::Blob {
+                mime_type,
+                data,
+            })))
         }
         _ => Err(CompletionError::RequestError(
             "Unsupported user content type".into(),
@@ -444,17 +415,13 @@ fn rig_assistant_content_to_grpc_part(
     content: message::AssistantContent,
 ) -> Result<proto::Part, CompletionError> {
     match content {
-        message::AssistantContent::Text(message::Text { text, .. }) => Ok(proto::Part {
-            data: Some(proto::part::Data::Text(text)),
-            thought: false,
-            thought_signature: Vec::new(),
-            part_metadata: None,
-        }),
+        message::AssistantContent::Text(message::Text { text, .. }) => Ok(text_part(text)),
         message::AssistantContent::ToolCall(tool_call) => {
             let args = json_to_prost_struct(tool_call.function.arguments)?;
 
             Ok(proto::Part {
-                data: Some(proto::part::Data::FunctionCall(proto::FunctionCall {
+                thought_signature: decode_optional_base64(tool_call.signature)?,
+                ..data_part(proto::part::Data::FunctionCall(proto::FunctionCall {
                     name: tool_call.function.name,
                     args: Some(args),
                     // Only a provider-issued id may travel back on the
@@ -463,10 +430,7 @@ fn rig_assistant_content_to_grpc_part(
                         .provider
                         .map(|provider| provider.call_id)
                         .unwrap_or_default(),
-                })),
-                thought: false,
-                thought_signature: decode_optional_base64(tool_call.signature)?,
-                part_metadata: None,
+                }))
             })
         }
         message::AssistantContent::Reasoning(reasoning) => Ok(proto::Part {
@@ -570,19 +534,7 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse {
 
         let choice = rig_core::message::require_non_empty_response(assistant_contents)?;
 
-        let usage = response
-            .usage_metadata
-            .as_ref()
-            .map(|usage| completion::Usage {
-                input_tokens: usage.prompt_token_count as u64,
-                output_tokens: usage.candidates_token_count as u64,
-                total_tokens: usage.total_token_count as u64,
-                cached_input_tokens: usage.cached_content_token_count as u64,
-                cache_creation_input_tokens: 0,
-                tool_use_prompt_tokens: 0,
-                reasoning_tokens: 0,
-            })
-            .unwrap_or_default();
+        let usage = map_usage(response.usage_metadata.as_ref());
 
         let finish_reason = response
             .candidates
@@ -691,7 +643,26 @@ fn decode_optional_base64(sig: Option<String>) -> Result<Vec<u8>, CompletionErro
     decode_base64_bytes(&sig)
 }
 
-fn encode_optional_base64(bytes: &[u8]) -> Option<String> {
+/// Map Gemini's `UsageMetadata` onto rig's normalized `Usage`.
+///
+/// Known gap (unchanged here): `tool_use_prompt_token_count` and
+/// `thoughts_token_count` are not yet surfaced, so `tool_use_prompt_tokens`
+/// and `reasoning_tokens` read as 0.
+pub(crate) fn map_usage(usage: Option<&proto::UsageMetadata>) -> completion::Usage {
+    usage
+        .map(|usage| completion::Usage {
+            input_tokens: usage.prompt_token_count as u64,
+            output_tokens: usage.candidates_token_count as u64,
+            total_tokens: usage.total_token_count as u64,
+            cached_input_tokens: usage.cached_content_token_count as u64,
+            cache_creation_input_tokens: 0,
+            tool_use_prompt_tokens: 0,
+            reasoning_tokens: 0,
+        })
+        .unwrap_or_default()
+}
+
+pub(crate) fn encode_optional_base64(bytes: &[u8]) -> Option<String> {
     if bytes.is_empty() {
         None
     } else {
@@ -747,7 +718,7 @@ fn json_to_prost_value(value: serde_json::Value) -> proto::Value {
     }
 }
 
-fn prost_struct_to_json(st: &proto::Struct) -> serde_json::Value {
+pub(crate) fn prost_struct_to_json(st: &proto::Struct) -> serde_json::Value {
     let mut out = serde_json::Map::with_capacity(st.fields.len());
     for (k, v) in &st.fields {
         out.insert(k.clone(), prost_value_to_json(v));

--- a/crates/rig-gemini-grpc/src/streaming.rs
+++ b/crates/rig-gemini-grpc/src/streaming.rs
@@ -3,7 +3,6 @@
 // ================================================================
 
 use async_stream::stream;
-use base64::Engine as _;
 use futures::StreamExt;
 use serde_json::{Map, Value};
 
@@ -15,6 +14,7 @@ use rig_core::wasm_compat::WasmCompatSend;
 
 use super::Client;
 use super::GenerateContentResponse;
+use super::completion::{encode_optional_base64 as encode_signature, prost_struct_to_json};
 use super::proto;
 
 pub type StreamingCompletionResponse = GenerateContentResponse;
@@ -304,19 +304,7 @@ fn normalize_grpc_stream(
     raw: streaming::RawStreamingResult<StreamingCompletionResponse>,
 ) -> streaming::StreamingResult {
     streaming::normalize_stream(raw, |response| {
-        let usage = response
-            .usage_metadata
-            .as_ref()
-            .map(|usage| rig_core::completion::Usage {
-                input_tokens: usage.prompt_token_count as u64,
-                output_tokens: usage.candidates_token_count as u64,
-                total_tokens: usage.total_token_count as u64,
-                cached_input_tokens: usage.cached_content_token_count as u64,
-                cache_creation_input_tokens: 0,
-                tool_use_prompt_tokens: 0,
-                reasoning_tokens: 0,
-            })
-            .unwrap_or_default();
+        let usage = super::completion::map_usage(response.usage_metadata.as_ref());
         let finish_reason = response
             .candidates
             .first()
@@ -335,41 +323,11 @@ fn normalize_grpc_stream(
     })
 }
 
-fn encode_signature(bytes: &[u8]) -> Option<String> {
-    if bytes.is_empty() {
-        None
-    } else {
-        Some(base64::engine::general_purpose::STANDARD.encode(bytes))
-    }
-}
-
-fn prost_struct_to_json(st: &proto::Struct) -> Value {
-    let mut out = Map::with_capacity(st.fields.len());
-    for (k, v) in &st.fields {
-        out.insert(k.clone(), prost_value_to_json(v));
-    }
-    Value::Object(out)
-}
-
-fn prost_value_to_json(v: &proto::Value) -> Value {
-    match &v.kind {
-        None | Some(proto::value::Kind::NullValue(_)) => Value::Null,
-        Some(proto::value::Kind::BoolValue(b)) => Value::Bool(*b),
-        Some(proto::value::Kind::NumberValue(n)) => serde_json::Number::from_f64(*n)
-            .map(Value::Number)
-            .unwrap_or(Value::Null),
-        Some(proto::value::Kind::StringValue(s)) => Value::String(s.clone()),
-        Some(proto::value::Kind::StructValue(st)) => prost_struct_to_json(st),
-        Some(proto::value::Kind::ListValue(list)) => {
-            Value::Array(list.values.iter().map(prost_value_to_json).collect())
-        }
-    }
-}
-
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
+    use base64::Engine as _;
     use rig_core::message::{Reasoning, ReasoningContent};
     use rig_core::streaming::StreamedAssistantContent;
 

--- a/crates/rig-helixdb/src/lib.rs
+++ b/crates/rig-helixdb/src/lib.rs
@@ -111,22 +111,6 @@ impl HelixDBClient for HelixDB {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
-fn datastore_error<E>(error: E) -> VectorStoreError
-where
-    E: std::error::Error + Send + Sync + 'static,
-{
-    VectorStoreError::DatastoreError(Box::new(error))
-}
-
-#[cfg(target_family = "wasm")]
-fn datastore_error<E>(error: E) -> VectorStoreError
-where
-    E: std::error::Error + 'static,
-{
-    VectorStoreError::DatastoreError(Box::new(error))
-}
-
 /// A client for easily carrying out Rig-related vector store operations.
 ///
 /// If you are unsure what type to use for the client, [`HelixDB`] is the typical default.
@@ -181,6 +165,12 @@ impl QueryInput {
     }
 }
 
+/// The shape of a `VectorSearch` query response.
+#[derive(Serialize, Deserialize, Debug)]
+struct VecResult {
+    vec_docs: Vec<QueryResult>,
+}
+
 impl<C, E> HelixDBVectorStore<C, E>
 where
     C: HelixDBClient + WasmCompatSend,
@@ -194,6 +184,32 @@ where
     /// Returns the underlying HelixDB client.
     pub fn client(&self) -> &C {
         &self.client
+    }
+}
+
+impl<C, E> HelixDBVectorStore<C, E>
+where
+    C: HelixDBClient + WasmCompatSend + WasmCompatSync,
+    C::Err: std::error::Error + WasmCompatSend + WasmCompatSync + 'static,
+    E: EmbeddingModel + WasmCompatSend + WasmCompatSync,
+{
+    /// Embeds the query and runs the `VectorSearch` HelixDB query.
+    async fn vector_search(
+        &self,
+        req: &rig_core::vector_store::VectorSearchRequest<HelixDBFilter>,
+    ) -> Result<Vec<QueryResult>, VectorStoreError> {
+        let vector = self.model.embed_text(req.query()).await?.vec;
+
+        let query_input =
+            QueryInput::new(vector, req.samples(), req.threshold().unwrap_or_default());
+
+        let result: VecResult = self
+            .client
+            .query::<QueryInput, VecResult>("VectorSearch", &query_input)
+            .await
+            .map_err(VectorStoreError::datastore)?;
+
+        Ok(result.vec_docs)
     }
 }
 
@@ -236,7 +252,7 @@ where
                 self.client
                     .query::<QueryInput, QueryOutput>("InsertVector", &query)
                     .await
-                    .map_err(datastore_error)?;
+                    .map_err(VectorStoreError::datastore)?;
             }
         }
         Ok(())
@@ -255,24 +271,9 @@ where
         &self,
         req: rig_core::vector_store::VectorSearchRequest<HelixDBFilter>,
     ) -> Result<Vec<(f64, String, T)>, rig_core::vector_store::VectorStoreError> {
-        let vector = self.model.embed_text(req.query()).await?.vec;
-
-        let query_input =
-            QueryInput::new(vector, req.samples(), req.threshold().unwrap_or_default());
-
-        #[derive(Serialize, Deserialize, Debug)]
-        struct VecResult {
-            vec_docs: Vec<QueryResult>,
-        }
-
-        let result: VecResult = self
-            .client
-            .query::<QueryInput, VecResult>("VectorSearch", &query_input)
-            .await
-            .map_err(datastore_error)?;
-
-        let docs = result
-            .vec_docs
+        let docs = self
+            .vector_search(&req)
+            .await?
             .into_iter()
             .filter(|x| {
                 let is_threshold = req
@@ -307,25 +308,10 @@ where
         &self,
         req: rig_core::vector_store::VectorSearchRequest<HelixDBFilter>,
     ) -> Result<Vec<(f64, String)>, rig_core::vector_store::VectorStoreError> {
-        let vector = self.model.embed_text(req.query()).await?.vec;
-
-        let query_input =
-            QueryInput::new(vector, req.samples(), req.threshold().unwrap_or_default());
-
-        #[derive(Serialize, Deserialize, Debug)]
-        struct VecResult {
-            vec_docs: Vec<QueryResult>,
-        }
-
-        let result: VecResult = self
-            .client
-            .query::<QueryInput, VecResult>("VectorSearch", &query_input)
-            .await
-            .map_err(datastore_error)?;
-
         // HelixDB gives us the cosine distance, so we need to use `-(cosine_dist - 1)` to get the cosine similarity score.
-        let docs = result
-            .vec_docs
+        let docs = self
+            .vector_search(&req)
+            .await?
             .into_iter()
             .filter(|x| -(x.score - 1.) >= req.threshold().unwrap_or_default())
             .map(|x| Ok((-(x.score - 1.), x.id)))

--- a/crates/rig-lancedb/src/lib.rs
+++ b/crates/rig-lancedb/src/lib.rs
@@ -37,14 +37,6 @@ use utils::{FilterTableColumns, QueryToJson};
 
 mod utils;
 
-fn lancedb_to_rig_error(e: lancedb::Error) -> VectorStoreError {
-    VectorStoreError::DatastoreError(Box::new(e))
-}
-
-fn serde_to_rig_error(e: serde_json::Error) -> VectorStoreError {
-    VectorStoreError::JsonError(e)
-}
-
 /// Type on which vector searches can be performed for a lanceDb table.
 /// # Example
 /// ```ignore
@@ -409,14 +401,14 @@ where
         let mut query = self
             .table
             .vector_search(prompt_embedding.vec.clone())
-            .map_err(lancedb_to_rig_error)?
+            .map_err(VectorStoreError::datastore)?
             .limit(req.samples() as usize)
             .distance_range(None, req.threshold().map(|x| x as f32))
             .select(lancedb::query::Select::Columns(
                 self.table
                     .schema()
                     .await
-                    .map_err(lancedb_to_rig_error)?
+                    .map_err(VectorStoreError::datastore)?
                     .filter_embeddings(),
             ));
 
@@ -439,7 +431,7 @@ where
                         Some(Value::String(id)) => id.to_string(),
                         _ => format!("unknown{i}"),
                     },
-                    serde_json::from_value(value).map_err(serde_to_rig_error)?,
+                    serde_json::from_value(value).map_err(VectorStoreError::JsonError)?,
                 ))
             })
             .collect()
@@ -474,7 +466,7 @@ where
             .query()
             .select(lancedb::query::Select::Columns(vec![self.id_field.clone()]))
             .nearest_to(prompt_embedding.vec.clone())
-            .map_err(lancedb_to_rig_error)?
+            .map_err(VectorStoreError::datastore)?
             .distance_range(None, req.threshold().map(|x| x as f32))
             .limit(req.samples() as usize);
 

--- a/crates/rig-lancedb/src/utils/deserializer.rs
+++ b/crates/rig-lancedb/src/utils/deserializer.rs
@@ -19,12 +19,6 @@ use rig_core::vector_store::VectorStoreError;
 use serde::Serialize;
 use serde_json::{Value, json};
 
-use crate::serde_to_rig_error;
-
-fn arrow_to_rig_error(e: ArrowError) -> VectorStoreError {
-    VectorStoreError::DatastoreError(Box::new(e))
-}
-
 /// Trait used to deserialize data returned from LanceDB queries into a serde_json::Value vector.
 /// Data returned by LanceDB is a vector of `RecordBatch` items.
 pub(crate) trait RecordBatchDeserializer {
@@ -83,82 +77,82 @@ fn type_matcher(column: &Arc<dyn Array>) -> Result<Vec<Value>, VectorStoreError>
         DataType::Null => Ok(vec![serde_json::Value::Null]),
         DataType::Float32 => column
             .to_primitive_value::<Float32Type>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Float64 => column
             .to_primitive_value::<Float64Type>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Int8 => column
             .to_primitive_value::<Int8Type>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Int16 => column
             .to_primitive_value::<Int16Type>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Int32 => column
             .to_primitive_value::<Int32Type>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Int64 => column
             .to_primitive_value::<Int64Type>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::UInt8 => column
             .to_primitive_value::<UInt8Type>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::UInt16 => column
             .to_primitive_value::<UInt16Type>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::UInt32 => column
             .to_primitive_value::<UInt32Type>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::UInt64 => column
             .to_primitive_value::<UInt64Type>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Date32 => column
             .to_primitive_value::<Date32Type>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Date64 => column
             .to_primitive_value::<Date64Type>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Decimal128(..) => column
             .to_primitive_value::<Decimal128Type>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Time32(TimeUnit::Second) => column
             .to_primitive_value::<Time32SecondType>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Time32(TimeUnit::Millisecond) => column
             .to_primitive_value::<Time32MillisecondType>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Time64(TimeUnit::Microsecond) => column
             .to_primitive_value::<Time64MicrosecondType>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Time64(TimeUnit::Nanosecond) => column
             .to_primitive_value::<Time64NanosecondType>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Timestamp(TimeUnit::Microsecond, ..) => column
             .to_primitive_value::<TimestampMicrosecondType>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Timestamp(TimeUnit::Millisecond, ..) => column
             .to_primitive_value::<TimestampMillisecondType>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Timestamp(TimeUnit::Second, ..) => column
             .to_primitive_value::<TimestampSecondType>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Timestamp(TimeUnit::Nanosecond, ..) => column
             .to_primitive_value::<TimestampNanosecondType>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Duration(TimeUnit::Microsecond) => column
             .to_primitive_value::<DurationMicrosecondType>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Duration(TimeUnit::Millisecond) => column
             .to_primitive_value::<DurationMillisecondType>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Duration(TimeUnit::Nanosecond) => column
             .to_primitive_value::<DurationNanosecondType>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Duration(TimeUnit::Second) => column
             .to_primitive_value::<DurationSecondType>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Interval(IntervalUnit::YearMonth) => column
             .to_primitive_value::<IntervalYearMonthType>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Interval(IntervalUnit::DayTime) => Ok(column
             .to_primitive::<IntervalDayTimeType>()
             .iter()
@@ -188,27 +182,27 @@ fn type_matcher(column: &Arc<dyn Array>) -> Result<Vec<Value>, VectorStoreError>
             .collect()),
         DataType::Utf8 => column
             .to_str_value::<Utf8Type>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::LargeUtf8 => column
             .to_str_value::<LargeUtf8Type>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Binary => column
             .to_str_value::<BinaryType>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::LargeBinary => column
             .to_str_value::<LargeBinaryType>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::FixedSizeBinary(n) => (0..*n)
             .map(|i| serde_json::to_value(column.as_fixed_size_binary().value(i as usize)))
             .collect::<Result<Vec<_>, _>>()
-            .map_err(serde_to_rig_error),
+            .map_err(VectorStoreError::JsonError),
         DataType::Boolean => {
             let bool_array = column.as_boolean();
             (0..bool_array.len())
                 .map(|i| bool_array.value(i))
                 .map(serde_json::to_value)
                 .collect::<Result<Vec<_>, _>>()
-                .map_err(serde_to_rig_error)
+                .map_err(VectorStoreError::JsonError)
         }
         DataType::FixedSizeList(..) => column.to_fixed_lists().iter().map(type_matcher).map_ok(),
         DataType::List(..) => column.to_list::<i32>().iter().map(type_matcher).map_ok(),
@@ -245,11 +239,9 @@ fn type_matcher(column: &Arc<dyn Array>) -> Result<Vec<Value>, VectorStoreError>
                 DataType::UInt32 => column.to_dict_values::<UInt32Type>()?,
                 DataType::UInt64 => column.to_dict_values::<UInt64Type>()?,
                 _ => {
-                    return Err(VectorStoreError::DatastoreError(Box::new(
-                        ArrowError::CastError(format!(
-                            "Dictionary keys type is not accepted: {keys_type:?}"
-                        )),
-                    )));
+                    return Err(VectorStoreError::datastore(ArrowError::CastError(format!(
+                        "Dictionary keys type is not accepted: {keys_type:?}"
+                    ))));
                 }
             };
 
@@ -273,16 +265,16 @@ fn type_matcher(column: &Arc<dyn Array>) -> Result<Vec<Value>, VectorStoreError>
                 .iter()
                 .map(type_matcher)
                 .map_ok(),
-            None => Err(VectorStoreError::DatastoreError(Box::new(
-                ArrowError::CastError(format!("Can't cast column {column:?} to union array")),
-            ))),
+            None => Err(VectorStoreError::datastore(ArrowError::CastError(format!(
+                "Can't cast column {column:?} to union array"
+            )))),
         },
         DataType::RunEndEncoded(index_type, ..) => {
             let items = match index_type.data_type() {
                 DataType::Int16 => {
                     let (indexes, v) = column
                         .to_run_end::<Int16Type>()
-                        .map_err(arrow_to_rig_error)?;
+                        .map_err(VectorStoreError::datastore)?;
 
                     let mut prev = vec![0];
                     prev.extend(indexes.clone());
@@ -297,7 +289,7 @@ fn type_matcher(column: &Arc<dyn Array>) -> Result<Vec<Value>, VectorStoreError>
                 DataType::Int32 => {
                     let (indexes, v) = column
                         .to_run_end::<Int32Type>()
-                        .map_err(arrow_to_rig_error)?;
+                        .map_err(VectorStoreError::datastore)?;
 
                     let mut prev = vec![0];
                     prev.extend(indexes.clone());
@@ -312,7 +304,7 @@ fn type_matcher(column: &Arc<dyn Array>) -> Result<Vec<Value>, VectorStoreError>
                 DataType::Int64 => {
                     let (indexes, v) = column
                         .to_run_end::<Int64Type>()
-                        .map_err(arrow_to_rig_error)?;
+                        .map_err(VectorStoreError::datastore)?;
 
                     let mut prev = vec![0];
                     prev.extend(indexes.clone());
@@ -325,37 +317,33 @@ fn type_matcher(column: &Arc<dyn Array>) -> Result<Vec<Value>, VectorStoreError>
                         .collect::<Vec<_>>()
                 }
                 _ => {
-                    return Err(VectorStoreError::DatastoreError(Box::new(
-                        ArrowError::CastError(format!(
-                            "RunEndEncoded index type is not accepted: {index_type:?}"
-                        )),
-                    )));
+                    return Err(VectorStoreError::datastore(ArrowError::CastError(format!(
+                        "RunEndEncoded index type is not accepted: {index_type:?}"
+                    ))));
                 }
             };
 
             items
                 .iter()
-                .map(|item| serde_json::to_value(item).map_err(serde_to_rig_error))
+                .map(|item| serde_json::to_value(item).map_err(VectorStoreError::JsonError))
                 .collect()
         }
         DataType::BinaryView
         | DataType::Utf8View
         | DataType::ListView(..)
-        | DataType::LargeListView(..) => Err(VectorStoreError::DatastoreError(Box::new(
-            ArrowError::CastError(format!(
-                "Data type: {} not yet fully supported",
-                column.data_type()
-            )),
+        | DataType::LargeListView(..) => Err(VectorStoreError::datastore(ArrowError::CastError(
+            format!("Data type: {} not yet fully supported", column.data_type()),
         ))),
-        DataType::Float16 | DataType::Decimal256(..) => Err(VectorStoreError::DatastoreError(
-            Box::new(ArrowError::CastError(format!(
+        DataType::Float16 | DataType::Decimal256(..) => {
+            Err(VectorStoreError::datastore(ArrowError::CastError(format!(
                 "Data type: {} currently unstable",
                 column.data_type()
-            ))),
-        )),
-        _ => Err(VectorStoreError::DatastoreError(Box::new(
-            ArrowError::CastError(format!("Unsupported data type: {}", column.data_type())),
-        ))),
+            ))))
+        }
+        _ => Err(VectorStoreError::datastore(ArrowError::CastError(format!(
+            "Unsupported data type: {}",
+            column.data_type()
+        )))),
     }
 }
 
@@ -559,7 +547,7 @@ where
 {
     fn map_ok(self) -> Result<Vec<Value>, VectorStoreError> {
         self.map(|maybe_list| match maybe_list {
-            Ok(list) => serde_json::to_value(list).map_err(serde_to_rig_error),
+            Ok(list) => serde_json::to_value(list).map_err(VectorStoreError::JsonError),
             Err(e) => Err(e),
         })
         .collect::<Result<Vec<_>, _>>()

--- a/crates/rig-lancedb/src/utils/mod.rs
+++ b/crates/rig-lancedb/src/utils/mod.rs
@@ -10,8 +10,6 @@ use lancedb::{
 };
 use rig_core::vector_store::VectorStoreError;
 
-use crate::lancedb_to_rig_error;
-
 /// Trait that facilitates the conversion of columnar data returned by a lanceDb query to serde_json::Value.
 /// Used whenever a lanceDb table is queried.
 pub(crate) trait QueryToJson {
@@ -23,10 +21,10 @@ impl QueryToJson for lancedb::query::VectorQuery {
         let record_batches = self
             .execute()
             .await
-            .map_err(lancedb_to_rig_error)?
+            .map_err(VectorStoreError::datastore)?
             .try_collect::<Vec<_>>()
             .await
-            .map_err(lancedb_to_rig_error)?;
+            .map_err(VectorStoreError::datastore)?;
 
         record_batches.deserialize()
     }

--- a/crates/rig-memory/src/lib.rs
+++ b/crates/rig-memory/src/lib.rs
@@ -131,29 +131,7 @@ pub trait IntoFilter: MemoryPolicy + Sized + 'static {
     /// `tracing::warn!` is emitted, so a transient policy bug degrades
     /// gracefully (the model still sees the unfiltered history) instead of
     /// silently erasing context.
-    #[cfg(not(target_family = "wasm"))]
-    fn into_filter(self) -> Box<dyn Fn(Vec<Message>) -> Vec<Message> + Send + Sync> {
-        let policy = Arc::new(self);
-        Box::new(move |msgs| {
-            let fallback = msgs.clone();
-            match policy.apply(msgs) {
-                Ok(out) => out,
-                Err(err) => {
-                    tracing::warn!(error = %err, "memory policy failed; returning unfiltered history");
-                    fallback
-                }
-            }
-        })
-    }
-
-    /// Convert this policy into a filter closure.
-    ///
-    /// On policy error the original input is returned unchanged and a
-    /// `tracing::warn!` is emitted, so a transient policy bug degrades
-    /// gracefully (the model still sees the unfiltered history) instead of
-    /// silently erasing context.
-    #[cfg(target_family = "wasm")]
-    fn into_filter(self) -> Box<dyn Fn(Vec<Message>) -> Vec<Message>> {
+    fn into_filter(self) -> BoxedFilter {
         let policy = Arc::new(self);
         Box::new(move |msgs| {
             let fallback = msgs.clone();
@@ -167,6 +145,14 @@ pub trait IntoFilter: MemoryPolicy + Sized + 'static {
         })
     }
 }
+
+/// Boxed filter closure returned by [`IntoFilter::into_filter`].
+#[cfg(not(target_family = "wasm"))]
+pub type BoxedFilter = Box<dyn Fn(Vec<Message>) -> Vec<Message> + Send + Sync>;
+
+/// Boxed filter closure returned by [`IntoFilter::into_filter`].
+#[cfg(target_family = "wasm")]
+pub type BoxedFilter = Box<dyn Fn(Vec<Message>) -> Vec<Message>>;
 
 impl<P> IntoFilter for P where P: MemoryPolicy + 'static {}
 
@@ -629,6 +615,99 @@ pub struct DemotingPolicyMemory<M, P, H> {
 
 type InFlightReservation = Arc<()>;
 
+/// Emits the members shared by the stateful wrappers
+/// ([`DemotingPolicyMemory`], [`CompactingMemory`]): accessors,
+/// `forget`/`tracked_conversations` over the per-conversation state map, and
+/// a `Debug` impl that elides the non-`Debug` third component.
+macro_rules! stateful_wrapper_common {
+    ($ty:ident, $third:ident: $tgen:ident $(: $tbound:ident)?) => {
+        impl<M, P, $tgen $(: $tbound)?> $ty<M, P, $tgen> {
+            /// Return a reference to the wrapped backend.
+            pub fn inner(&self) -> &M {
+                &self.inner
+            }
+
+            /// Return a reference to the wrapped policy.
+            pub fn policy(&self) -> &P {
+                &self.policy
+            }
+
+            /// Return a reference to the third component.
+            pub fn $third(&self) -> &$tgen {
+                &self.$third
+            }
+
+            /// Consume the wrapper and return its three components.
+            pub fn into_inner(self) -> (M, P, $tgen) {
+                (self.inner, self.policy, self.$third)
+            }
+
+            /// Drop the in-process state for `conversation_id`.
+            ///
+            /// Call this when a conversation has ended to bound memory usage;
+            /// the state map is otherwise unbounded — entries persist for the
+            /// lifetime of the wrapper. If the internal state lock has been
+            /// poisoned by a panic in another thread, this is a no-op (the
+            /// state will be dropped naturally when the wrapper itself is
+            /// dropped).
+            pub fn forget(&self, conversation_id: &str) {
+                if let Ok(mut guard) = self.state.lock() {
+                    guard.remove(conversation_id);
+                }
+            }
+
+            /// Number of conversations currently tracked in the state map.
+            /// Useful for telemetry and leak detection. Returns `0` if the
+            /// internal state lock is poisoned.
+            pub fn tracked_conversations(&self) -> usize {
+                self.state.lock().map(|g| g.len()).unwrap_or(0)
+            }
+        }
+
+        impl<M, P, $tgen $(: $tbound)?> std::fmt::Debug for $ty<M, P, $tgen>
+        where
+            M: std::fmt::Debug,
+            P: std::fmt::Debug,
+        {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_struct(stringify!($ty))
+                    .field("inner", &self.inner)
+                    .field("policy", &self.policy)
+                    .field(
+                        stringify!($third),
+                        &concat!("<", stringify!($third), ">"),
+                    )
+                    .finish()
+            }
+        }
+    };
+}
+
+/// Emits the delegating `append` and the `clear`-then-`forget` methods of a
+/// stateful wrapper's [`ConversationMemory`] impl.
+macro_rules! stateful_wrapper_append_clear {
+    () => {
+        fn append<'a>(
+            &'a self,
+            conversation_id: &'a str,
+            messages: Vec<Message>,
+        ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+            self.inner.append(conversation_id, messages)
+        }
+
+        fn clear<'a>(
+            &'a self,
+            conversation_id: &'a str,
+        ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+            Box::pin(async move {
+                self.inner.clear(conversation_id).await?;
+                self.forget(conversation_id);
+                Ok(())
+            })
+        }
+    };
+}
+
 #[derive(Debug, Default, Clone)]
 struct ConversationDemotionState {
     /// Number of demoted messages already delivered to the hook within
@@ -651,63 +730,9 @@ impl<M, P, H> DemotingPolicyMemory<M, P, H> {
             state: StdMutex::new(HashMap::new()),
         }
     }
-
-    /// Return a reference to the wrapped backend.
-    pub fn inner(&self) -> &M {
-        &self.inner
-    }
-
-    /// Return a reference to the wrapped policy.
-    pub fn policy(&self) -> &P {
-        &self.policy
-    }
-
-    /// Return a reference to the demotion hook.
-    pub fn hook(&self) -> &H {
-        &self.hook
-    }
-
-    /// Consume the wrapper and return its three components.
-    pub fn into_inner(self) -> (M, P, H) {
-        (self.inner, self.policy, self.hook)
-    }
-
-    /// Drop the in-process delivery watermark for `conversation_id`.
-    ///
-    /// Call this when a conversation has ended to bound memory usage.
-    /// The watermark map is otherwise unbounded — entries persist for
-    /// the lifetime of the wrapper.
-    ///
-    /// If the internal state lock has been poisoned by a panic in another
-    /// thread, this is a no-op (the watermark will be dropped naturally
-    /// when the wrapper itself is dropped).
-    pub fn forget(&self, conversation_id: &str) {
-        if let Ok(mut guard) = self.state.lock() {
-            guard.remove(conversation_id);
-        }
-    }
-
-    /// Number of conversations currently tracked in the watermark map.
-    /// Useful for telemetry and leak detection. Returns `0` if the internal
-    /// state lock is poisoned.
-    pub fn tracked_conversations(&self) -> usize {
-        self.state.lock().map(|g| g.len()).unwrap_or(0)
-    }
 }
 
-impl<M, P, H> std::fmt::Debug for DemotingPolicyMemory<M, P, H>
-where
-    M: std::fmt::Debug,
-    P: std::fmt::Debug,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DemotingPolicyMemory")
-            .field("inner", &self.inner)
-            .field("policy", &self.policy)
-            .field("hook", &"<hook>")
-            .finish()
-    }
-}
+stateful_wrapper_common!(DemotingPolicyMemory, hook: H);
 
 impl<M, P, H> ConversationMemory for DemotingPolicyMemory<M, P, H>
 where
@@ -777,7 +802,7 @@ where
             // clearing newer in-flight loads after clear()/forget() reuse the
             // same conversation id.
             let in_flight_guard =
-                DemotionInFlightGuard::new(&self.state, conversation_id, reservation.clone());
+                InFlightGuard::new(&self.state, conversation_id, reservation.clone());
 
             let result = self.hook.on_demote(conversation_id, pending).await;
 
@@ -810,104 +835,52 @@ where
         })
     }
 
-    fn append<'a>(
-        &'a self,
-        conversation_id: &'a str,
-        messages: Vec<Message>,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
-        self.inner.append(conversation_id, messages)
-    }
-
-    fn clear<'a>(
-        &'a self,
-        conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
-        Box::pin(async move {
-            self.inner.clear(conversation_id).await?;
-            self.forget(conversation_id);
-            Ok(())
-        })
-    }
+    stateful_wrapper_append_clear!();
 }
 
 fn poisoned<E: std::fmt::Display>(err: E) -> MemoryError {
     MemoryError::Internal(err.to_string())
 }
 
-/// RAII guard that clears the `in_flight` flag for a conversation in the
-/// shared demotion state map when dropped, unless the consumer explicitly
-/// disarms it after a successful post-await update.
-///
-/// This prevents the in-flight gate from leaking when the awaiting
-/// `load(...)` future is dropped (caller timeout, `tokio::select!`, etc.)
-/// or when the hook panics. A missing entry is a no-op, covering the case
-/// where a concurrent `clear` removed the conversation while delivery was
-/// awaiting.
-struct DemotionInFlightGuard<'a> {
-    state: &'a StdMutex<HashMap<String, ConversationDemotionState>>,
-    key: &'a str,
-    reservation: InFlightReservation,
-    armed: bool,
+/// A per-conversation state entry with an `in_flight` delivery reservation,
+/// letting [`InFlightGuard`] work over both the demotion and compaction
+/// state maps.
+trait InFlightSlot {
+    fn in_flight_mut(&mut self) -> &mut Option<InFlightReservation>;
 }
 
-impl<'a> DemotionInFlightGuard<'a> {
-    fn new(
-        state: &'a StdMutex<HashMap<String, ConversationDemotionState>>,
-        key: &'a str,
-        reservation: InFlightReservation,
-    ) -> Self {
-        Self {
-            state,
-            key,
-            reservation,
-            armed: true,
-        }
-    }
-
-    /// Disable the `Drop` clean-up. Call after the post-await state
-    /// update has already cleared `in_flight` while holding the lock.
-    fn disarm(mut self) {
-        self.armed = false;
+impl InFlightSlot for ConversationDemotionState {
+    fn in_flight_mut(&mut self) -> &mut Option<InFlightReservation> {
+        &mut self.in_flight
     }
 }
 
-impl Drop for DemotionInFlightGuard<'_> {
-    fn drop(&mut self) {
-        if !self.armed {
-            return;
-        }
-        if let Ok(mut guard) = self.state.lock()
-            && let Some(entry) = guard.get_mut(self.key)
-            && entry
-                .in_flight
-                .as_ref()
-                .is_some_and(|current| Arc::ptr_eq(current, &self.reservation))
-        {
-            entry.in_flight = None;
-        }
+impl<A> InFlightSlot for ConversationCompactionState<A> {
+    fn in_flight_mut(&mut self) -> &mut Option<InFlightReservation> {
+        &mut self.in_flight
     }
 }
 
 /// RAII guard that clears the `in_flight` flag for a conversation in the
-/// shared compaction state map when dropped, unless the consumer
+/// shared demotion/compaction state map when dropped, unless the consumer
 /// explicitly disarms it after a successful post-await update.
 ///
 /// This prevents the in-flight gate from leaking when the awaiting
 /// `load(...)` future is dropped (caller timeout, `tokio::select!`, etc.)
-/// or when the compactor panics: in either case `Drop` runs and releases
-/// the gate so subsequent loads can retry. A missing entry is a no-op,
-/// covering the case where a concurrent `clear` removed the conversation
-/// while compaction was awaiting.
-struct InFlightGuard<'a, A> {
-    state: &'a StdMutex<HashMap<String, ConversationCompactionState<A>>>,
+/// or when the hook/compactor panics: in either case `Drop` runs and
+/// releases the gate so subsequent loads can retry. A missing entry is a
+/// no-op, covering the case where a concurrent `clear` removed the
+/// conversation while delivery was awaiting.
+struct InFlightGuard<'a, S: InFlightSlot> {
+    state: &'a StdMutex<HashMap<String, S>>,
     key: &'a str,
     reservation: InFlightReservation,
     armed: bool,
 }
 
-impl<'a, A> InFlightGuard<'a, A> {
+impl<'a, S: InFlightSlot> InFlightGuard<'a, S> {
     fn new(
-        state: &'a StdMutex<HashMap<String, ConversationCompactionState<A>>>,
+        state: &'a StdMutex<HashMap<String, S>>,
         key: &'a str,
         reservation: InFlightReservation,
     ) -> Self {
@@ -926,7 +899,7 @@ impl<'a, A> InFlightGuard<'a, A> {
     }
 }
 
-impl<A> Drop for InFlightGuard<'_, A> {
+impl<S: InFlightSlot> Drop for InFlightGuard<'_, S> {
     fn drop(&mut self) {
         if !self.armed {
             return;
@@ -934,11 +907,11 @@ impl<A> Drop for InFlightGuard<'_, A> {
         if let Ok(mut guard) = self.state.lock()
             && let Some(entry) = guard.get_mut(self.key)
             && entry
-                .in_flight
+                .in_flight_mut()
                 .as_ref()
                 .is_some_and(|current| Arc::ptr_eq(current, &self.reservation))
         {
-            entry.in_flight = None;
+            *entry.in_flight_mut() = None;
         }
     }
 }
@@ -1043,60 +1016,9 @@ impl<M, P, C: Compactor> CompactingMemory<M, P, C> {
             state: StdMutex::new(HashMap::new()),
         }
     }
-
-    /// Return a reference to the wrapped backend.
-    pub fn inner(&self) -> &M {
-        &self.inner
-    }
-
-    /// Return a reference to the wrapped policy.
-    pub fn policy(&self) -> &P {
-        &self.policy
-    }
-
-    /// Return a reference to the compactor.
-    pub fn compactor(&self) -> &C {
-        &self.compactor
-    }
-
-    /// Consume the wrapper and return its three components.
-    pub fn into_inner(self) -> (M, P, C) {
-        (self.inner, self.policy, self.compactor)
-    }
-
-    /// Drop the in-process compaction state for `conversation_id`.
-    ///
-    /// Call this when a conversation has ended to bound memory usage; the
-    /// state map is otherwise unbounded. If the internal lock has been
-    /// poisoned by a panic in another thread, this is a no-op.
-    pub fn forget(&self, conversation_id: &str) {
-        if let Ok(mut guard) = self.state.lock() {
-            guard.remove(conversation_id);
-        }
-    }
-
-    /// Number of conversations currently tracked in the compaction state
-    /// map. Useful for telemetry and leak detection. Returns `0` if the
-    /// internal lock is poisoned.
-    pub fn tracked_conversations(&self) -> usize {
-        self.state.lock().map(|g| g.len()).unwrap_or(0)
-    }
 }
 
-impl<M, P, C> std::fmt::Debug for CompactingMemory<M, P, C>
-where
-    M: std::fmt::Debug,
-    P: std::fmt::Debug,
-    C: Compactor,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CompactingMemory")
-            .field("inner", &self.inner)
-            .field("policy", &self.policy)
-            .field("compactor", &"<compactor>")
-            .finish()
-    }
-}
+stateful_wrapper_common!(CompactingMemory, compactor: C: Compactor);
 
 impl<M, P, C> ConversationMemory for CompactingMemory<M, P, C>
 where
@@ -1253,24 +1175,7 @@ where
         })
     }
 
-    fn append<'a>(
-        &'a self,
-        conversation_id: &'a str,
-        messages: Vec<Message>,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
-        self.inner.append(conversation_id, messages)
-    }
-
-    fn clear<'a>(
-        &'a self,
-        conversation_id: &'a str,
-    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
-        Box::pin(async move {
-            self.inner.clear(conversation_id).await?;
-            self.forget(conversation_id);
-            Ok(())
-        })
-    }
+    stateful_wrapper_append_clear!();
 }
 
 struct CompactionPlan<A> {

--- a/crates/rig-milvus/src/filter.rs
+++ b/crates/rig-milvus/src/filter.rs
@@ -215,14 +215,6 @@ impl Filter {
 impl TryFrom<CoreFilter<serde_json::Value>> for Filter {
     type Error = FilterError;
     fn try_from(value: CoreFilter<serde_json::Value>) -> Result<Self, Self::Error> {
-        let value = match value {
-            CoreFilter::Eq(k, val) => Filter::eq(k, val.try_into()?),
-            CoreFilter::Gt(k, val) => Filter::gt(k, val.try_into()?),
-            CoreFilter::Lt(k, val) => Filter::lt(k, val.try_into()?),
-            CoreFilter::And(l, r) => Self::try_from(*l)?.and(Self::try_from(*r)?),
-            CoreFilter::Or(l, r) => Self::try_from(*l)?.or(Self::try_from(*r)?),
-        };
-
-        Ok(value)
+        value.try_interpret(MilvusValue::try_from)
     }
 }

--- a/crates/rig-milvus/src/lib.rs
+++ b/crates/rig-milvus/src/lib.rs
@@ -167,6 +167,39 @@ where
             output_fields,
         }
     }
+
+    /// Embeds the query, runs the Milvus search endpoint, and parses the response.
+    async fn search<T: for<'a> Deserialize<'a>>(
+        &self,
+        req: &VectorSearchRequest<Filter>,
+        id_only: bool,
+    ) -> Result<T, VectorStoreError> {
+        let embedding = self.model.embed_text(req.query()).await?;
+        let url = format!(
+            "{base_url}/v2/vectordb/entities/search",
+            base_url = self.base_url
+        );
+
+        let body = self.create_search_request(embedding.vec, req, id_only);
+
+        let mut client = self.client.post(url);
+        if let Some(ref token) = self.token {
+            client = client.header("Authorization", format!("Bearer {token}"));
+        }
+
+        let body = serde_json::to_string(&body)?;
+
+        let res = client.body(body).send().await?;
+
+        if res.status() != StatusCode::OK {
+            let status = res.status();
+            let text = res.text().await?;
+
+            return Err(VectorStoreError::ExternalAPIError(status, text));
+        }
+
+        Ok(res.json().await?)
+    }
 }
 
 impl<Model> InsertDocuments for MilvusVectorStore<Model>
@@ -210,7 +243,7 @@ where
 
         let mut client = self.client.post(url);
         if let Some(ref token) = self.token {
-            client = client.header("Authentication", format!("Bearer {token}"));
+            client = client.header("Authorization", format!("Bearer {token}"));
         }
 
         let insert_request = self.create_insert_request(data);
@@ -242,31 +275,7 @@ where
         &self,
         req: VectorSearchRequest<Filter>,
     ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
-        let embedding = self.model.embed_text(req.query()).await?;
-        let url = format!(
-            "{base_url}/v2/vectordb/entities/search",
-            base_url = self.base_url
-        );
-
-        let body = self.create_search_request(embedding.vec, &req, false);
-
-        let mut client = self.client.post(url);
-        if let Some(ref token) = self.token {
-            client = client.header("Authentication", format!("Bearer {token}"));
-        }
-
-        let body = serde_json::to_string(&body)?;
-
-        let res = client.body(body).send().await?;
-
-        if res.status() != StatusCode::OK {
-            let status = res.status();
-            let text = res.text().await?;
-
-            return Err(VectorStoreError::ExternalAPIError(status, text));
-        }
-
-        let json: SearchResult<T> = res.json().await?;
+        let json: SearchResult<T> = self.search(&req, false).await?;
 
         let res = json
             .data
@@ -283,31 +292,7 @@ where
         &self,
         req: VectorSearchRequest<Filter>,
     ) -> Result<Vec<(f64, String)>, VectorStoreError> {
-        let embedding = self.model.embed_text(req.query()).await?;
-        let url = format!(
-            "{base_url}/v2/vectordb/entities/search",
-            base_url = self.base_url
-        );
-
-        let body = self.create_search_request(embedding.vec, &req, true);
-
-        let mut client = self.client.post(url);
-        if let Some(ref token) = self.token {
-            client = client.header("Authentication", format!("Bearer {token}"));
-        }
-
-        let body = serde_json::to_string(&body)?;
-
-        let res = client.body(body).send().await?;
-
-        if res.status() != StatusCode::OK {
-            let status = res.status();
-            let text = res.text().await?;
-
-            return Err(VectorStoreError::ExternalAPIError(status, text));
-        }
-
-        let json: SearchResultOnlyId = res.json().await?;
+        let json: SearchResultOnlyId = self.search(&req, true).await?;
 
         let res = json
             .data

--- a/crates/rig-mongodb/src/lib.rs
+++ b/crates/rig-mongodb/src/lib.rs
@@ -41,12 +41,12 @@ impl SearchIndex {
             .list_search_indexes()
             .name(index_name)
             .await
-            .map_err(mongodb_to_rig_error)?
+            .map_err(VectorStoreError::datastore)?
             .with_type::<SearchIndex>()
             .next()
             .await
             .transpose()
-            .map_err(mongodb_to_rig_error)?
+            .map_err(VectorStoreError::datastore)?
             .ok_or(VectorStoreError::DatastoreError("Index not found".into()))
     }
 }
@@ -64,10 +64,6 @@ struct Field {
     path: String,
     num_dimensions: i32,
     similarity: String,
-}
-
-fn mongodb_to_rig_error(e: mongodb::error::Error) -> VectorStoreError {
-    VectorStoreError::DatastoreError(Box::new(e))
 }
 
 /// A vector index for a MongoDB collection.
@@ -165,6 +161,61 @@ where
             "exact": exact.unwrap_or(false)
           }
         }
+    }
+
+    /// Embeds the query, runs the vector-search aggregation pipeline with the
+    /// given `$project` stage, and extracts `(score, id, document)` per row.
+    async fn run_search_pipeline(
+        &self,
+        req: &VectorSearchRequest<MongoDbSearchFilter>,
+        project_stage: bson::Document,
+    ) -> Result<Vec<(f64, String, serde_json::Value)>, VectorStoreError> {
+        let prompt_embedding = self.model.embed_text(req.query()).await?;
+
+        let pipeline = vec![
+            self.pipeline_search_stage(&prompt_embedding, req),
+            self.pipeline_score_stage(),
+            project_stage,
+        ];
+
+        let mut cursor = self
+            .collection
+            .aggregate(pipeline)
+            .await
+            .map_err(VectorStoreError::datastore)?
+            .with_type::<serde_json::Value>();
+
+        let mut results = Vec::new();
+        while let Some(doc) = cursor.next().await {
+            let doc = doc.map_err(VectorStoreError::datastore)?;
+            let score = doc
+                .get("score")
+                .and_then(serde_json::Value::as_f64)
+                .ok_or_else(|| {
+                    VectorStoreError::DatastoreError(
+                        "MongoDB vector search result missing numeric score".into(),
+                    )
+                })?;
+            let id = doc
+                .get("_id")
+                .ok_or_else(|| {
+                    VectorStoreError::DatastoreError(
+                        "MongoDB vector search result missing _id".into(),
+                    )
+                })?
+                .to_string();
+            results.push((score, id, doc));
+        }
+
+        tracing::info!(target: "rig",
+            "Selected documents: {}",
+            results.iter()
+                .map(|(distance, id, _)| format!("{id} ({distance})"))
+                .collect::<Vec<String>>()
+                .join(", ")
+        );
+
+        Ok(results)
     }
 
     /// Score declaration stage of aggregation pipeline of mongoDB collection.
@@ -327,26 +378,7 @@ impl MongoDbSearchFilter {
 
 impl From<Filter<serde_json::Value>> for MongoDbSearchFilter {
     fn from(value: Filter<serde_json::Value>) -> Self {
-        fn serde_json_value_to_bson(v: &serde_json::Value) -> Bson {
-            to_bson(v).unwrap_or(Bson::Null)
-        }
-
-        match value {
-            Filter::Eq(k, val) => {
-                let bson_val = serde_json_value_to_bson(&val);
-                MongoDbSearchFilter::eq(k, bson_val)
-            }
-            Filter::Gt(k, val) => {
-                let bson_val = serde_json_value_to_bson(&val);
-                MongoDbSearchFilter::gt(k, bson_val)
-            }
-            Filter::Lt(k, val) => {
-                let bson_val = serde_json_value_to_bson(&val);
-                MongoDbSearchFilter::lt(k, bson_val)
-            }
-            Filter::And(l, r) => Self::from(*l).and(Self::from(*r)),
-            Filter::Or(l, r) => Self::from(*l).or(Self::from(*r)),
-        }
+        value.interpret_with(|v| to_bson(&v).unwrap_or(Bson::Null))
     }
 }
 
@@ -364,55 +396,20 @@ where
         &self,
         req: VectorSearchRequest<MongoDbSearchFilter>,
     ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
-        let prompt_embedding = self.model.embed_text(req.query()).await?;
+        let project_stage = doc! {
+            "$project": {
+                self.embedded_field.clone(): 0
+            }
+        };
 
-        let pipeline = vec![
-            self.pipeline_search_stage(&prompt_embedding, &req),
-            self.pipeline_score_stage(),
-            doc! {
-                "$project": {
-                    self.embedded_field.clone(): 0
-                }
-            },
-        ];
-
-        let mut cursor = self
-            .collection
-            .aggregate(pipeline)
-            .await
-            .map_err(mongodb_to_rig_error)?
-            .with_type::<serde_json::Value>();
-
-        let mut results = Vec::new();
-        while let Some(doc) = cursor.next().await {
-            let doc = doc.map_err(mongodb_to_rig_error)?;
-            let score = doc
-                .get("score")
-                .and_then(serde_json::Value::as_f64)
-                .ok_or_else(|| {
-                    VectorStoreError::DatastoreError(Box::new(std::io::Error::other(
-                        "MongoDB vector search result missing numeric score",
-                    )))
-                })?;
-            let id = doc.get("_id").ok_or_else(|| {
-                VectorStoreError::DatastoreError(Box::new(std::io::Error::other(
-                    "MongoDB vector search result missing _id",
-                )))
-            })?;
-            let id = id.to_string();
-            let doc_t: T = serde_json::from_value(doc).map_err(VectorStoreError::JsonError)?;
-            results.push((score, id, doc_t));
-        }
-
-        tracing::info!(target: "rig",
-            "Selected documents: {}",
-            results.iter()
-                .map(|(distance, id, _)| format!("{id} ({distance})"))
-                .collect::<Vec<String>>()
-                .join(", ")
-        );
-
-        Ok(results)
+        self.run_search_pipeline(&req, project_stage)
+            .await?
+            .into_iter()
+            .map(|(score, id, doc)| {
+                let doc_t: T = serde_json::from_value(doc).map_err(VectorStoreError::JsonError)?;
+                Ok((score, id, doc_t))
+            })
+            .collect()
     }
 
     /// Implement the `top_n_ids` method of the `VectorStoreIndex` trait for `MongoDbVectorIndex`.
@@ -420,55 +417,19 @@ where
         &self,
         req: VectorSearchRequest<MongoDbSearchFilter>,
     ) -> Result<Vec<(f64, String)>, VectorStoreError> {
-        let prompt_embedding = self.model.embed_text(req.query()).await?;
-
-        let pipeline = vec![
-            self.pipeline_search_stage(&prompt_embedding, &req),
-            self.pipeline_score_stage(),
-            doc! {
-                "$project": {
-                    "_id": 1,
-                    "score": 1
-                },
+        let project_stage = doc! {
+            "$project": {
+                "_id": 1,
+                "score": 1
             },
-        ];
+        };
 
-        let mut cursor = self
-            .collection
-            .aggregate(pipeline)
-            .await
-            .map_err(mongodb_to_rig_error)?
-            .with_type::<serde_json::Value>();
-
-        let mut results = Vec::new();
-        while let Some(doc) = cursor.next().await {
-            let doc = doc.map_err(mongodb_to_rig_error)?;
-            let score = doc
-                .get("score")
-                .and_then(serde_json::Value::as_f64)
-                .ok_or_else(|| {
-                    VectorStoreError::DatastoreError(Box::new(std::io::Error::other(
-                        "MongoDB vector search result missing numeric score",
-                    )))
-                })?;
-            let id = doc.get("_id").ok_or_else(|| {
-                VectorStoreError::DatastoreError(Box::new(std::io::Error::other(
-                    "MongoDB vector search result missing _id",
-                )))
-            })?;
-            let id = id.to_string();
-            results.push((score, id));
-        }
-
-        tracing::info!(target: "rig",
-            "Selected documents: {}",
-            results.iter()
-                .map(|(distance, id)| format!("{id} ({distance})"))
-                .collect::<Vec<String>>()
-                .join(", ")
-        );
-
-        Ok(results)
+        Ok(self
+            .run_search_pipeline(&req, project_stage)
+            .await?
+            .into_iter()
+            .map(|(score, id, _)| (score, id))
+            .collect())
     }
 }
 
@@ -520,7 +481,7 @@ where
 
                 embeddings.into_iter().map(|embedding| -> Result<mongodb::bson::Document, VectorStoreError> {
                     Ok(doc! {
-                        "document": mongodb::bson::to_bson(&json_doc).map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?,
+                        "document": mongodb::bson::to_bson(&json_doc).map_err(VectorStoreError::datastore)?,
                         "embedding": embedding.vec,
                         "embedded_text": embedding.document,
                     })
@@ -536,7 +497,7 @@ where
         collection
             .insert_many(mongo_documents)
             .await
-            .map_err(mongodb_to_rig_error)?;
+            .map_err(VectorStoreError::datastore)?;
 
         Ok(())
     }

--- a/crates/rig-neo4j/src/lib.rs
+++ b/crates/rig-neo4j/src/lib.rs
@@ -100,10 +100,6 @@ pub struct Neo4jClient {
     pub graph: Graph,
 }
 
-fn neo4j_to_rig_error(e: neo4rs::Error) -> VectorStoreError {
-    VectorStoreError::DatastoreError(Box::new(e))
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Neo4jSearchFilter(String);
 
@@ -294,7 +290,7 @@ impl Neo4jClient {
         tracing::info!("Connecting to Neo4j DB at {} ...", uri);
         let graph = Graph::new(uri, user, password)
             .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            .map_err(VectorStoreError::datastore)?;
         tracing::info!("Connected to Neo4j");
         Ok(Self { graph })
     }
@@ -302,7 +298,7 @@ impl Neo4jClient {
     pub async fn from_config(config: Config) -> Result<Self, VectorStoreError> {
         let graph = Graph::connect(config)
             .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            .map_err(VectorStoreError::datastore)?;
         Ok(Self { graph })
     }
 
@@ -313,11 +309,11 @@ impl Neo4jClient {
         graph
             .execute(query)
             .await
-            .map_err(neo4j_to_rig_error)?
+            .map_err(VectorStoreError::datastore)?
             .into_stream_as::<T>()
             .try_collect::<Vec<T>>()
             .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))
+            .map_err(VectorStoreError::datastore)
     }
 
     /// Returns a `Neo4jVectorIndex` that mirrors an existing Neo4j Vector Index.
@@ -371,9 +367,9 @@ impl Neo4jClient {
                 );
             }
             let embedding_property = index.properties.first().ok_or_else(|| {
-                VectorStoreError::DatastoreError(Box::new(std::io::Error::other(
-                    "Neo4j index is missing an embedding property",
-                )))
+                VectorStoreError::DatastoreError(
+                    "Neo4j index is missing an embedding property".into(),
+                )
             })?;
             let mut config = IndexConfig::new(index.name.clone())
                 .embedding_property(embedding_property)
@@ -392,12 +388,10 @@ impl Neo4jClient {
                 neo4rs::query(Self::SHOW_INDEXES_QUERY),
             )
             .await?;
-            return Err(VectorStoreError::DatastoreError(Box::new(
-                std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    format!(
-                        "Index `{index_name}` not found in database. Available indexes: {indexes:?}"
-                    ),
+            return Err(VectorStoreError::datastore(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!(
+                    "Index `{index_name}` not found in database. Available indexes: {indexes:?}"
                 ),
             )));
         };
@@ -453,7 +447,7 @@ impl Neo4jClient {
                     .param("dimensions", model.ndims() as i64),
             )
             .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            .map_err(VectorStoreError::datastore)?;
 
         // Check if the index exists with db.awaitIndex(), the call timeouts if the index is not ready
         let index_exists = self

--- a/crates/rig-neo4j/src/vector_index.rs
+++ b/crates/rig-neo4j/src/vector_index.rs
@@ -185,33 +185,6 @@ where
     }
 }
 
-/// Search parameters for a vector search. Neo4j currently only supports post-vector-search filtering.
-pub struct SearchParams {
-    /// Sets the **post-filter** field of the search params. Uses a WHERE clause.
-    /// See [Neo4j WHERE clause](https://neo4j.com/docs/cypher-manual/current/clauses/where/) for more information.
-    post_vector_search_filter: Option<String>,
-}
-
-impl SearchParams {
-    /// Initializes a new `SearchParams` with default values.
-    pub fn new(filter: Option<String>) -> Self {
-        Self {
-            post_vector_search_filter: filter,
-        }
-    }
-
-    pub fn filter(mut self, filter: String) -> Self {
-        self.post_vector_search_filter = Some(filter);
-        self
-    }
-}
-
-impl Default for SearchParams {
-    fn default() -> Self {
-        Self::new(None)
-    }
-}
-
 #[derive(Debug, Deserialize)]
 pub struct RowResultNode<T> {
     score: f64,
@@ -340,7 +313,7 @@ where
         self.graph
             .run(neo4rs::query(&insert_documents_query(node_label)).param("items", items))
             .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            .map_err(VectorStoreError::datastore)?;
 
         Ok(())
     }

--- a/crates/rig-postgres/src/lib.rs
+++ b/crates/rig-postgres/src/lib.rs
@@ -120,14 +120,14 @@ impl PgSearchFilter {
 
     pub fn gte(key: String, value: <Self as SearchFilter>::Value) -> Self {
         Self {
-            condition: format!("{key} >= ?"),
+            condition: format!("{key} >= $"),
             values: vec![value],
         }
     }
 
     pub fn lte(key: String, value: <Self as SearchFilter>::Value) -> Self {
         Self {
-            condition: format!("{key} <= ?"),
+            condition: format!("{key} <= $"),
             values: vec![value],
         }
     }
@@ -274,18 +274,47 @@ where
         Self::new(model, pg_pool, None, PgVectorDistanceFunction::Cosine)
     }
 
-    fn search_query_full(
+    /// Validates the sample count, embeds the query, and runs the similarity
+    /// search, returning one row per result.
+    async fn run_search<R>(
         &self,
         req: &VectorSearchRequest<PgSearchFilter>,
-    ) -> (String, Vec<serde_json::Value>) {
-        self.search_query(true, req)
-    }
+        with_document: bool,
+    ) -> Result<Vec<R>, VectorStoreError>
+    where
+        R: for<'r> sqlx::FromRow<'r, sqlx::postgres::PgRow> + Send + Unpin,
+    {
+        if req.samples() > i64::MAX as u64 {
+            return Err(VectorStoreError::DatastoreError(
+                format!(
+                    "The maximum amount of samples to return with the `rig` Postgres integration cannot be larger than {}",
+                    i64::MAX
+                )
+                .into(),
+            ));
+        }
 
-    fn search_query_only_ids(
-        &self,
-        req: &VectorSearchRequest<PgSearchFilter>,
-    ) -> (String, Vec<serde_json::Value>) {
-        self.search_query(false, req)
+        let embedded_query: pgvector::Vector = self
+            .model
+            .embed_text(req.query())
+            .await?
+            .vec
+            .iter()
+            .map(|&x| x as f32)
+            .collect::<Vec<f32>>()
+            .into();
+
+        let (search_query, params) = self.search_query(with_document, req);
+        let builder = sqlx::query_as(sqlx::AssertSqlSafe(search_query))
+            .bind(embedded_query)
+            .bind(req.samples() as i64);
+
+        let builder = params.iter().cloned().fold(builder, bind_value);
+
+        builder
+            .fetch_all(&self.pg_pool)
+            .await
+            .map_err(VectorStoreError::datastore)
     }
 
     fn search_query(
@@ -369,7 +398,7 @@ where
                 .bind(&embedding)
                 .execute(&self.pg_pool)
                 .await
-                .map_err(|e| VectorStoreError::DatastoreError(e.into()))?;
+                .map_err(VectorStoreError::datastore)?;
             }
         }
 
@@ -389,37 +418,7 @@ where
         &self,
         req: VectorSearchRequest<PgSearchFilter>,
     ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
-        if req.samples() > i64::MAX as u64 {
-            return Err(VectorStoreError::DatastoreError(
-                format!(
-                    "The maximum amount of samples to return with the `rig` Postgres integration cannot be larger than {}",
-                    i64::MAX
-                )
-                .into(),
-            ));
-        }
-
-        let embedded_query: pgvector::Vector = self
-            .model
-            .embed_text(req.query())
-            .await?
-            .vec
-            .iter()
-            .map(|&x| x as f32)
-            .collect::<Vec<f32>>()
-            .into();
-
-        let (search_query, params) = self.search_query_full(&req);
-        let builder = sqlx::query_as(sqlx::AssertSqlSafe(search_query))
-            .bind(embedded_query)
-            .bind(req.samples() as i64);
-
-        let builder = params.iter().cloned().fold(builder, bind_value);
-
-        let rows = builder
-            .fetch_all(&self.pg_pool)
-            .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+        let rows: Vec<SearchResult> = self.run_search(&req, true).await?;
 
         let rows: Vec<(f64, String, T)> = rows
             .into_iter()
@@ -434,36 +433,7 @@ where
         &self,
         req: VectorSearchRequest<PgSearchFilter>,
     ) -> Result<Vec<(f64, String)>, VectorStoreError> {
-        if req.samples() > i64::MAX as u64 {
-            return Err(VectorStoreError::DatastoreError(
-                format!(
-                    "The maximum amount of samples to return with the `rig` Postgres integration cannot be larger than {}",
-                    i64::MAX
-                )
-                .into(),
-            ));
-        }
-        let embedded_query: pgvector::Vector = self
-            .model
-            .embed_text(req.query())
-            .await?
-            .vec
-            .iter()
-            .map(|&x| x as f32)
-            .collect::<Vec<f32>>()
-            .into();
-
-        let (search_query, params) = self.search_query_only_ids(&req);
-        let builder = sqlx::query_as(sqlx::AssertSqlSafe(search_query))
-            .bind(embedded_query)
-            .bind(req.samples() as i64);
-
-        let builder = params.iter().cloned().fold(builder, bind_value);
-
-        let rows: Vec<SearchResultOnlyId> = builder
-            .fetch_all(&self.pg_pool)
-            .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+        let rows: Vec<SearchResultOnlyId> = self.run_search(&req, false).await?;
 
         let rows: Vec<(f64, String)> = rows
             .into_iter()
@@ -471,5 +441,25 @@ where
             .collect();
 
         Ok(rows)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PgSearchFilter, SearchFilter};
+    use serde_json::json;
+
+    /// `gte`/`lte` previously emitted `?` placeholders while `eq`/`gt`/`lt`
+    /// emitted `$`; the query renumbering only rewrites `$`, so any `?` would
+    /// reach Postgres verbatim and break the query.
+    #[test]
+    fn gte_and_lte_use_dollar_placeholders() {
+        let gte = PgSearchFilter::gte("price".into(), json!(5));
+        let lte = PgSearchFilter::lte("price".into(), json!(10));
+
+        let (cond, values) = gte.and(lte).into_clause();
+        assert_eq!(cond, "(price >= $) AND (price <= $)");
+        assert!(!cond.contains('?'));
+        assert_eq!(cond.matches('$').count(), values.len());
     }
 }

--- a/crates/rig-qdrant/src/lib.rs
+++ b/crates/rig-qdrant/src/lib.rs
@@ -81,6 +81,38 @@ where
         params.filter = filter;
         params
     }
+
+    /// Embeds the query (unless overridden by `query_params`), applies the
+    /// request filter, and runs the Qdrant query, returning the scored points.
+    async fn run_query(
+        &self,
+        req: &VectorSearchRequest<QdrantFilter>,
+    ) -> Result<Vec<qdrant_client::qdrant::ScoredPoint>, VectorStoreError> {
+        let query = match self.query_params.query {
+            Some(ref q) => Some(q.clone()),
+            None => Some(Query::new_nearest(
+                self.generate_query_vector(req.query()).await?,
+            )),
+        };
+
+        let filter = req
+            .filter()
+            .as_ref()
+            .cloned()
+            .map(QdrantFilter::interpret)
+            .transpose()?
+            .flatten();
+
+        let params =
+            self.prepare_query_params(query, req.samples() as usize, req.threshold(), filter);
+
+        Ok(self
+            .client
+            .query(params)
+            .await
+            .map_err(VectorStoreError::datastore)?
+            .result)
+    }
 }
 
 impl<Model> InsertDocuments for QdrantVectorStore<Model>
@@ -95,8 +127,8 @@ where
 
         for (document, embeddings) in documents {
             let json_document = serde_json::to_value(&document)?;
-            let doc_as_payload = Payload::try_from(json_document)
-                .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            let doc_as_payload =
+                Payload::try_from(json_document).map_err(VectorStoreError::datastore)?;
 
             let embeddings_as_point_structs = embeddings
                 .into_iter()
@@ -145,32 +177,8 @@ where
         &self,
         req: VectorSearchRequest<Self::Filter>,
     ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
-        let query = match self.query_params.query {
-            Some(ref q) => Some(q.clone()),
-            None => Some(Query::new_nearest(
-                self.generate_query_vector(req.query()).await?,
-            )),
-        };
-
-        let filter = req
-            .filter()
-            .as_ref()
-            .cloned()
-            .map(QdrantFilter::interpret)
-            .transpose()?
-            .flatten();
-
-        let params =
-            self.prepare_query_params(query, req.samples() as usize, req.threshold(), filter);
-
-        let result = self
-            .client
-            .query(params)
-            .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
-
-        result
-            .result
+        self.run_query(&req)
+            .await?
             .into_iter()
             .map(|item| {
                 let id =
@@ -190,32 +198,8 @@ where
         &self,
         req: VectorSearchRequest<Self::Filter>,
     ) -> Result<Vec<(f64, String)>, VectorStoreError> {
-        let query = match self.query_params.query {
-            Some(ref q) => Some(q.clone()),
-            None => Some(Query::new_nearest(
-                self.generate_query_vector(req.query()).await?,
-            )),
-        };
-
-        let filter = req
-            .filter()
-            .as_ref()
-            .cloned()
-            .map(QdrantFilter::interpret)
-            .transpose()?
-            .flatten();
-
-        let params =
-            self.prepare_query_params(query, req.samples() as usize, req.threshold(), filter);
-
-        let points = self
-            .client
-            .query(params)
-            .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?
-            .result;
-
-        points
+        self.run_query(&req)
+            .await?
             .into_iter()
             .map(|point| {
                 let id =

--- a/crates/rig-s3vectors/src/lib.rs
+++ b/crates/rig-s3vectors/src/lib.rs
@@ -136,6 +136,67 @@ where
     pub fn client(&self) -> &Client {
         &self.client
     }
+
+    /// Validates the sample count, embeds the query, and runs the S3Vectors
+    /// query, returning the `(distance, vector)` pairs passing the threshold.
+    async fn run_query(
+        &self,
+        req: &VectorSearchRequest<S3SearchFilter>,
+        return_metadata: bool,
+    ) -> Result<Vec<(f64, aws_sdk_s3vectors::types::QueryOutputVector)>, VectorStoreError> {
+        if req.samples() > i32::MAX as u64 {
+            return Err(VectorStoreError::DatastoreError(format!("The number of samples to return with the `rig` AWS S3Vectors integration cannot be higher than {}", i32::MAX).into()));
+        }
+
+        let embedding = self
+            .embedding_model
+            .embed_text(req.query())
+            .await?
+            .vec
+            .into_iter()
+            .map(|x| x as f32)
+            .collect();
+
+        let mut query_builder = self
+            .client
+            .query_vectors()
+            .query_vector(VectorData::Float32(embedding))
+            .top_k(req.samples() as i32)
+            .return_distance(true)
+            .vector_bucket_name(self.bucket_name())
+            .index_name(self.index_name());
+
+        if return_metadata {
+            query_builder = query_builder.return_metadata(true);
+        }
+
+        if let Some(filter) = req.filter() {
+            query_builder = query_builder.filter(filter.inner().clone())
+        }
+
+        let query = query_builder
+            .send()
+            .await
+            .map_err(VectorStoreError::datastore)?;
+
+        Ok(query
+            .vectors
+            .into_iter()
+            .map(|x| {
+                let distance = x.distance.ok_or_else(|| {
+                    VectorStoreError::DatastoreError("S3Vectors response missing distance".into())
+                })? as f64;
+
+                Ok((distance, x))
+            })
+            .collect::<Result<Vec<_>, VectorStoreError>>()?
+            .into_iter()
+            .filter(|(distance, _)| {
+                !req.threshold()
+                    .is_some_and(|threshold| *distance < threshold)
+            })
+            .collect())
+    }
 }
 
 impl<M> InsertDocuments for S3VectorsVectorStore<M>
@@ -264,132 +325,30 @@ where
         &self,
         req: VectorSearchRequest<S3SearchFilter>,
     ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
-        if req.samples() > i32::MAX as u64 {
-            return Err(VectorStoreError::DatastoreError(format!("The number of samples to return with the `rig` AWS S3Vectors integration cannot be higher than {}", i32::MAX).into()));
-        }
-
-        let embedding = self
-            .embedding_model
-            .embed_text(req.query())
+        self.run_query(&req, true)
             .await?
-            .vec
             .into_iter()
-            .map(|x| x as f32)
-            .collect();
-
-        let mut query_builder = self
-            .client
-            .query_vectors()
-            .query_vector(VectorData::Float32(embedding))
-            .top_k(req.samples() as i32)
-            .return_distance(true)
-            .return_metadata(true)
-            .vector_bucket_name(self.bucket_name())
-            .index_name(self.index_name());
-
-        if let Some(filter) = req.filter() {
-            query_builder = query_builder.filter(filter.inner().clone())
-        }
-
-        let query = query_builder
-            .send()
-            .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
-
-        let res: Vec<(f64, String, T)> = query
-            .vectors
-            .into_iter()
-            .map(|x| {
-                let distance = x.distance.ok_or_else(|| {
-                    VectorStoreError::DatastoreError(Box::new(std::io::Error::other(
-                        "S3Vectors response missing distance",
-                    )))
-                })? as f64;
-
-                if req
-                    .threshold()
-                    .is_some_and(|threshold| distance < threshold)
-                {
-                    return Ok(None);
-                }
-
+            .map(|(distance, x)| {
                 let metadata_document = x.metadata.ok_or_else(|| {
-                    VectorStoreError::DatastoreError(Box::new(std::io::Error::other(
-                        "S3Vectors response missing metadata",
-                    )))
+                    VectorStoreError::DatastoreError("S3Vectors response missing metadata".into())
                 })?;
                 let val = document_to_json_value(&metadata_document);
                 let metadata: T = serde_json::from_value(val)?;
 
-                Ok(Some((distance, x.key, metadata)))
+                Ok((distance, x.key, metadata))
             })
-            .collect::<Result<Vec<_>, VectorStoreError>>()?
-            .into_iter()
-            .flatten()
-            .collect();
-
-        Ok(res)
+            .collect()
     }
 
     async fn top_n_ids(
         &self,
         req: VectorSearchRequest<S3SearchFilter>,
     ) -> Result<Vec<(f64, String)>, VectorStoreError> {
-        if req.samples() > i32::MAX as u64 {
-            return Err(VectorStoreError::DatastoreError(format!("The number of samples to return with the `rig` AWS S3Vectors integration cannot be higher than {}", i32::MAX).into()));
-        }
-
-        let embedding = self
-            .embedding_model
-            .embed_text(req.query())
+        Ok(self
+            .run_query(&req, false)
             .await?
-            .vec
             .into_iter()
-            .map(|x| x as f32)
-            .collect();
-
-        let mut query_builder = self
-            .client
-            .query_vectors()
-            .query_vector(VectorData::Float32(embedding))
-            .top_k(req.samples() as i32)
-            .return_distance(true)
-            .vector_bucket_name(self.bucket_name())
-            .index_name(self.index_name());
-
-        if let Some(filter) = req.filter() {
-            query_builder = query_builder.filter(filter.inner().clone())
-        }
-
-        let query = query_builder
-            .send()
-            .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
-
-        let res: Vec<(f64, String)> = query
-            .vectors
-            .into_iter()
-            .map(|x| {
-                let distance = x.distance.ok_or_else(|| {
-                    VectorStoreError::DatastoreError(Box::new(std::io::Error::other(
-                        "S3Vectors response missing distance",
-                    )))
-                })? as f64;
-
-                if req
-                    .threshold()
-                    .is_some_and(|threshold| distance < threshold)
-                {
-                    return Ok(None);
-                }
-
-                Ok(Some((distance, x.key)))
-            })
-            .collect::<Result<Vec<_>, VectorStoreError>>()?
-            .into_iter()
-            .flatten()
-            .collect();
-
-        Ok(res)
+            .map(|(distance, x)| (distance, x.key))
+            .collect())
     }
 }

--- a/crates/rig-scylladb/src/lib.rs
+++ b/crates/rig-scylladb/src/lib.rs
@@ -192,13 +192,7 @@ impl TryFrom<Filter<serde_json::Value>> for ScyllaSearchFilter {
     type Error = FilterError;
 
     fn try_from(value: Filter<serde_json::Value>) -> Result<Self, Self::Error> {
-        match value {
-            Filter::Eq(k, val) => Ok(ScyllaSearchFilter::eq(k, cql_value_from_json(val)?)),
-            Filter::Gt(k, val) => Ok(ScyllaSearchFilter::gt(k, cql_value_from_json(val)?)),
-            Filter::Lt(k, val) => Ok(ScyllaSearchFilter::lt(k, cql_value_from_json(val)?)),
-            Filter::And(l, r) => Ok(Self::try_from(*l)?.and(Self::try_from(*r)?)),
-            Filter::Or(l, r) => Ok(Self::try_from(*l)?.or(Self::try_from(*r)?)),
-        }
+        value.try_interpret(cql_value_from_json)
     }
 }
 
@@ -233,7 +227,7 @@ where
         session
             .query_unpaged(create_keyspace_cql, &[])
             .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            .map_err(VectorStoreError::datastore)?;
 
         // Create table for storing vectors
         // Note: Once ScyllaDB vector search is fully available, we'll use VECTOR type
@@ -249,7 +243,7 @@ where
         session
             .query_unpaged(create_table_cql, &[])
             .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            .map_err(VectorStoreError::datastore)?;
 
         // Prepare statements for better performance
         let insert_stmt = session
@@ -257,21 +251,21 @@ where
                 "INSERT INTO {keyspace}.{table} (id, vector, metadata, created_at) VALUES (?, ?, ?, ?)"
             ))
             .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            .map_err(VectorStoreError::datastore)?;
 
         let search_stmt = session
             .prepare(format!(
                 "SELECT id, vector, metadata, created_at FROM {keyspace}.{table}"
             ))
             .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            .map_err(VectorStoreError::datastore)?;
 
         let get_by_id_stmt = session
             .prepare(format!(
                 "SELECT id, vector, metadata, created_at FROM {keyspace}.{table} WHERE id = ?"
             ))
             .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            .map_err(VectorStoreError::datastore)?;
 
         Ok(Self {
             model,
@@ -306,26 +300,24 @@ where
         &self,
         id: &str,
     ) -> Result<Option<T>, VectorStoreError> {
-        let uuid =
-            Uuid::parse_str(id).map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+        let uuid = Uuid::parse_str(id).map_err(VectorStoreError::datastore)?;
 
         let result = self
             .session
             .execute_unpaged(&self.get_by_id_stmt, (uuid,))
             .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            .map_err(VectorStoreError::datastore)?;
 
         let rows_result = result
             .into_rows_result()
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            .map_err(VectorStoreError::datastore)?;
 
         if let Some(first_row) = rows_result
             .rows::<(Uuid, Vec<f32>, String, i64)>()
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?
+            .map_err(VectorStoreError::datastore)?
             .next()
         {
-            let (_, _, metadata, _) =
-                first_row.map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            let (_, _, metadata, _) = first_row.map_err(VectorStoreError::datastore)?;
 
             let payload: T = serde_json::from_str(&metadata)?;
             return Ok(Some(payload));
@@ -379,7 +371,7 @@ where
                     .session
                     .prepare(query)
                     .await
-                    .map_err(|e| VectorStoreError::DatastoreError(e.into()))?;
+                    .map_err(VectorStoreError::datastore)?;
 
                 let mut cache = self.cache.write().map_err(|e| {
                     VectorStoreError::DatastoreError(
@@ -394,6 +386,56 @@ where
         } else {
             Ok(self.search_stmt.clone())
         }
+    }
+
+    /// Runs the (optionally filtered) scan and scores every row against the
+    /// query, returning the sorted, truncated `(score, id, metadata)` list.
+    async fn search_candidates(
+        &self,
+        req: &VectorSearchRequest<ScyllaSearchFilter>,
+    ) -> Result<Vec<(f64, String, String)>, VectorStoreError> {
+        let query_vector = self.generate_query_vector(req.query()).await?;
+
+        let statement = self.get_filter_statement_or_default(req).await?;
+        let params = req
+            .filter()
+            .as_ref()
+            .map(ScyllaSearchFilter::params)
+            .unwrap_or_default();
+
+        // Fetch all vectors (this will be optimized once ScyllaDB vector search is available)
+        let results = self
+            .session
+            .execute_unpaged(&statement, params)
+            .await
+            .map_err(VectorStoreError::datastore)?;
+
+        let rows_result = results
+            .into_rows_result()
+            .map_err(VectorStoreError::datastore)?;
+
+        let mut candidates = Vec::new();
+
+        for row_result in rows_result
+            .rows::<(Uuid, Vec<f32>, String, i64)>()
+            .map_err(VectorStoreError::datastore)?
+        {
+            let (id, vector, metadata, _) = row_result.map_err(VectorStoreError::datastore)?;
+
+            let score = Self::cosine_similarity(&query_vector, &vector) as f64;
+
+            if req.threshold().is_some_and(|threshold| score < threshold) {
+                continue;
+            }
+
+            candidates.push((score, id.to_string(), metadata));
+        }
+
+        // Sort by similarity score (descending) and take top n
+        candidates.sort_by(|a, b| b.0.total_cmp(&a.0));
+        candidates.truncate(req.samples() as usize);
+
+        Ok(candidates)
     }
 }
 
@@ -428,7 +470,7 @@ where
                 self.session
                     .execute_unpaged(&self.insert_stmt, (id, vector, &metadata, now))
                     .await
-                    .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+                    .map_err(VectorStoreError::datastore)?;
             }
         }
 
@@ -452,52 +494,11 @@ where
         &self,
         req: VectorSearchRequest<ScyllaSearchFilter>,
     ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
-        let query_vector = self.generate_query_vector(req.query()).await?;
-
-        let statement = self.get_filter_statement_or_default(&req).await?;
-        let params = req
-            .filter()
-            .as_ref()
-            .map(ScyllaSearchFilter::params)
-            .unwrap_or([].as_slice());
-
-        // Fetch all vectors (this will be optimized once ScyllaDB vector search is available)
-        let results = self
-            .session
-            .execute_unpaged(&statement, params)
-            .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
-
-        let rows_result = results
-            .into_rows_result()
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
-
-        let mut candidates = Vec::new();
-
-        for row_result in rows_result
-            .rows::<(Uuid, Vec<f32>, String, i64)>()
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?
-        {
-            let (id, vector, metadata, _) =
-                row_result.map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
-
-            let similarity = Self::cosine_similarity(&query_vector, &vector);
-            let score = similarity as f64;
-
-            if req.threshold().is_some_and(|threshold| score < threshold) {
-                continue;
-            }
-
-            let payload: T = serde_json::from_str(&metadata)?;
-
-            candidates.push((score, id.to_string(), payload));
-        }
-
-        // Sort by similarity score (descending) and take top n
-        candidates.sort_by(|a, b| b.0.total_cmp(&a.0));
-        candidates.truncate(req.samples() as usize);
-
-        Ok(candidates)
+        self.search_candidates(&req)
+            .await?
+            .into_iter()
+            .map(|(score, id, metadata)| Ok((score, id, serde_json::from_str(&metadata)?)))
+            .collect()
     }
 
     /// Search for the top `n` nearest neighbors to the given query.
@@ -506,49 +507,12 @@ where
         &self,
         req: VectorSearchRequest<ScyllaSearchFilter>,
     ) -> Result<Vec<(f64, String)>, VectorStoreError> {
-        let query_vector = self.generate_query_vector(req.query()).await?;
-
-        let statement = self.get_filter_statement_or_default(&req).await?;
-        let params = req
-            .filter()
-            .as_ref()
-            .map(ScyllaSearchFilter::params)
-            .unwrap_or_default();
-
-        let results = self
-            .session
-            .execute_unpaged(&statement, params)
-            .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
-
-        let rows_result = results
-            .into_rows_result()
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
-
-        let mut candidates = Vec::new();
-
-        for row_result in rows_result
-            .rows::<(Uuid, Vec<f32>, String, i64)>()
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?
-        {
-            let (id, vector, _, _) =
-                row_result.map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
-
-            let similarity = Self::cosine_similarity(&query_vector, &vector);
-            let score = similarity as f64;
-
-            if req.threshold().is_some_and(|threshold| score < threshold) {
-                continue;
-            }
-
-            candidates.push((score, id.to_string()));
-        }
-
-        // Sort by similarity score (descending) and take top n
-        candidates.sort_by(|a, b| b.0.total_cmp(&a.0));
-        candidates.truncate(req.samples() as usize);
-
-        Ok(candidates)
+        Ok(self
+            .search_candidates(&req)
+            .await?
+            .into_iter()
+            .map(|(score, id, _)| (score, id))
+            .collect())
     }
 }
 
@@ -586,5 +550,5 @@ pub async fn create_session(uri: &str) -> Result<Session, VectorStoreError> {
         .compression(Some(Compression::Lz4))
         .build()
         .await
-        .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))
+        .map_err(VectorStoreError::datastore)
 }

--- a/crates/rig-sqlite/Cargo.toml
+++ b/crates/rig-sqlite/Cargo.toml
@@ -19,6 +19,7 @@ rusqlite = { workspace = true, features = ["bundled"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sqlite-vec = { workspace = true }
+thiserror = { workspace = true }
 tokio-rusqlite = { workspace = true, features = ["bundled"] }
 tracing = { workspace = true }
 zerocopy = { workspace = true }

--- a/crates/rig-sqlite/src/lib.rs
+++ b/crates/rig-sqlite/src/lib.rs
@@ -15,7 +15,6 @@ use rig_core::wasm_compat::{WasmCompatSend, WasmCompatSync};
 use rusqlite::OptionalExtension;
 use rusqlite::types::{Type, Value, ValueRef};
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display};
 use std::marker::PhantomData;
 use std::ops::RangeInclusive;
 use tokio_rusqlite::Connection;
@@ -160,41 +159,46 @@ impl SqliteDistanceMetric {
     }
 }
 
-#[derive(Debug)]
-struct SqliteDistanceMetricMismatch {
-    table_name: String,
-    requested: SqliteDistanceMetric,
-    configured: SqliteDistanceMetric,
+#[derive(Debug, thiserror::Error)]
+enum SqliteInternalError {
+    #[error(
+        "SQLite vector table `{table_name}` uses {configured:?}, but {requested:?} was requested"
+    )]
+    DistanceMetricMismatch {
+        table_name: String,
+        requested: SqliteDistanceMetric,
+        configured: SqliteDistanceMetric,
+    },
+    #[error("SQLite vector table `{0}` was created but is missing from sqlite_schema")]
+    VectorTableMissingSchema(String),
+    #[error("SQLite metadata column `{column_name}` has unsupported type `{column_type}`")]
+    UnsupportedMetadataColumn {
+        column_name: &'static str,
+        column_type: &'static str,
+    },
+    #[error("SQLite vector table `{table_name}` is missing metadata column `{column_name} {}`", column_type.vec0_name())]
+    MetadataSchemaMismatch {
+        table_name: String,
+        column_name: &'static str,
+        column_type: SqliteMetadataType,
+    },
+    #[error("could not convert SQLite value type `{value_type:?}` for metadata column `{column_name} {}`", column_type.vec0_name())]
+    MetadataValueError {
+        column_name: &'static str,
+        column_type: SqliteMetadataType,
+        value_type: Type,
+    },
+    #[error("SQLite vector store table `{0}` is missing an `id` column")]
+    MissingIdColumn(String),
+    #[error(
+        "could not convert SQLite column `{column_name}` with declared type `{column_type}`: {message}"
+    )]
+    ColumnValueError {
+        column_name: &'static str,
+        column_type: &'static str,
+        message: String,
+    },
 }
-
-impl Display for SqliteDistanceMetricMismatch {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "SQLite vector table `{}` uses {:?}, but {:?} was requested",
-            self.table_name, self.configured, self.requested
-        )
-    }
-}
-
-impl std::error::Error for SqliteDistanceMetricMismatch {}
-
-#[derive(Debug)]
-struct SqliteVectorTableMissingSchema {
-    table_name: String,
-}
-
-impl Display for SqliteVectorTableMissingSchema {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "SQLite vector table `{}` was created but is missing from sqlite_schema",
-            self.table_name
-        )
-    }
-}
-
-impl std::error::Error for SqliteVectorTableMissingSchema {}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SqliteMetadataType {
@@ -292,83 +296,6 @@ struct SqliteMetadataColumn {
     metadata_type: SqliteMetadataType,
 }
 
-#[derive(Debug)]
-struct SqliteUnsupportedMetadataColumn {
-    column_name: &'static str,
-    column_type: &'static str,
-}
-
-impl Display for SqliteUnsupportedMetadataColumn {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "SQLite metadata column `{}` has unsupported type `{}`",
-            self.column_name, self.column_type
-        )
-    }
-}
-
-impl std::error::Error for SqliteUnsupportedMetadataColumn {}
-
-#[derive(Debug)]
-struct SqliteMetadataSchemaMismatch {
-    table_name: String,
-    column_name: &'static str,
-    column_type: SqliteMetadataType,
-}
-
-impl Display for SqliteMetadataSchemaMismatch {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "SQLite vector table `{}` is missing metadata column `{} {}`",
-            self.table_name,
-            self.column_name,
-            self.column_type.vec0_name()
-        )
-    }
-}
-
-impl std::error::Error for SqliteMetadataSchemaMismatch {}
-
-#[derive(Debug)]
-struct SqliteMetadataValueError {
-    column_name: &'static str,
-    column_type: SqliteMetadataType,
-    value_type: Type,
-}
-
-impl Display for SqliteMetadataValueError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "could not convert SQLite value type `{:?}` for metadata column `{} {}`",
-            self.value_type,
-            self.column_name,
-            self.column_type.vec0_name()
-        )
-    }
-}
-
-impl std::error::Error for SqliteMetadataValueError {}
-
-#[derive(Debug)]
-struct SqliteMissingIdColumn {
-    table_name: String,
-}
-
-impl Display for SqliteMissingIdColumn {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "SQLite vector store table `{}` is missing an `id` column",
-            self.table_name
-        )
-    }
-}
-
-impl std::error::Error for SqliteMissingIdColumn {}
-
 fn sqlite_metadata_columns(
     schema: &[Column],
 ) -> Result<Vec<SqliteMetadataColumn>, VectorStoreError> {
@@ -378,10 +305,10 @@ fn sqlite_metadata_columns(
         .map(|column| {
             let metadata_type =
                 SqliteMetadataType::from_column_type(column.col_type).ok_or_else(|| {
-                    VectorStoreError::DatastoreError(Box::new(SqliteUnsupportedMetadataColumn {
+                    VectorStoreError::datastore(SqliteInternalError::UnsupportedMetadataColumn {
                         column_name: column.name,
                         column_type: column.col_type,
-                    }))
+                    })
                 })?;
 
             Ok(SqliteMetadataColumn {
@@ -410,7 +337,7 @@ fn sqlite_metadata_value(
         (SqliteMetadataType::Float, Value::Integer(value)) => Ok(Value::Real(value as f64)),
         (SqliteMetadataType::Boolean, Value::Integer(value @ (0 | 1))) => Ok(Value::Integer(value)),
         (_, value) => Err(rusqlite::Error::ToSqlConversionFailure(Box::new(
-            SqliteMetadataValueError {
+            SqliteInternalError::MetadataValueError {
                 column_name: column.name,
                 column_type: column.metadata_type,
                 value_type: value.data_type(),
@@ -457,7 +384,7 @@ where
                 )?)
             })
             .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            .map_err(VectorStoreError::datastore)?;
 
         let embedding_count = u64::try_from(embedding_count).unwrap_or(0);
         let document_count = u64::try_from(document_count).unwrap_or(0);
@@ -593,33 +520,33 @@ where
                 Ok(schema_sql)
             })
             .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            .map_err(VectorStoreError::datastore)?;
 
         let schema_sql = embeddings_table_sql.ok_or_else(|| {
-            VectorStoreError::DatastoreError(Box::new(SqliteVectorTableMissingSchema {
-                table_name: embeddings_table_name.clone(),
-            }))
+            VectorStoreError::datastore(SqliteInternalError::VectorTableMissingSchema(
+                embeddings_table_name.clone(),
+            ))
         })?;
 
         let configured = sqlite_distance_metric_from_schema(&schema_sql);
         if configured != distance_metric {
-            return Err(VectorStoreError::DatastoreError(Box::new(
-                SqliteDistanceMetricMismatch {
+            return Err(VectorStoreError::datastore(
+                SqliteInternalError::DistanceMetricMismatch {
                     table_name: embeddings_table_name,
                     requested: distance_metric,
                     configured,
                 },
-            )));
+            ));
         }
         for column in metadata_columns_for_schema_check {
             if !sqlite_schema_contains_metadata_column(&schema_sql, &column) {
-                return Err(VectorStoreError::DatastoreError(Box::new(
-                    SqliteMetadataSchemaMismatch {
+                return Err(VectorStoreError::datastore(
+                    SqliteInternalError::MetadataSchemaMismatch {
                         table_name: embeddings_table_name.clone(),
                         column_name: column.name,
                         column_type: column.metadata_type,
                     },
-                )));
+                ));
             }
         }
 
@@ -758,7 +685,7 @@ where
                 Ok(result)
             })
             .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))
+            .map_err(VectorStoreError::datastore)
     }
 }
 
@@ -814,10 +741,7 @@ pub struct SqliteSearchFilter {
 impl Default for SqliteSearchFilter {
     fn default() -> Self {
         Self {
-            expr: SqliteSearchFilterExpr::Raw {
-                condition: "1 = 1".to_string(),
-                params: Vec::new(),
-            },
+            expr: SqliteSearchFilterExpr::Noop,
         }
     }
 }
@@ -846,10 +770,8 @@ enum SqliteSearchFilterExpr {
         op: SqlitePatternOp,
         pattern: String,
     },
-    Raw {
-        condition: String,
-        params: Vec<serde_json::Value>,
-    },
+    /// Matches every document; used by [`SqliteSearchFilter::default`].
+    Noop,
 }
 
 #[derive(Clone, Copy, Deserialize, Eq, PartialEq, Serialize, Debug)]
@@ -908,6 +830,13 @@ struct SqliteRenderedFilters {
 }
 
 impl SqliteRenderedFilters {
+    fn post_only(filter: SqliteRenderedFilter) -> Self {
+        Self {
+            native: Vec::new(),
+            post: vec![filter],
+        }
+    }
+
     fn extend(&mut self, rhs: Self) {
         self.native.extend(rhs.native);
         self.post.extend(rhs.post);
@@ -924,6 +853,15 @@ struct SqliteRenderedFilter {
     params: Vec<Value>,
 }
 
+impl SqliteRenderedFilter {
+    fn combine(joiner: &str, lhs: Self, rhs: Self) -> Self {
+        Self {
+            condition: format!("({}) {joiner} ({})", lhs.condition, rhs.condition),
+            params: lhs.params.into_iter().chain(rhs.params).collect(),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SqliteDocumentValueMode {
     Sql,
@@ -937,37 +875,47 @@ struct SqliteQualifiedDocumentKey {
     plain_column: Option<String>,
 }
 
+impl SqliteSearchFilter {
+    fn cmp(key: impl AsRef<str>, op: SqliteComparisonOp, value: serde_json::Value) -> Self {
+        Self {
+            expr: SqliteSearchFilterExpr::Comparison {
+                key: key.as_ref().to_string(),
+                op,
+                value,
+            },
+        }
+    }
+
+    fn pattern(key: String, op: SqlitePatternOp, pattern: impl Into<String>) -> Self {
+        Self {
+            expr: SqliteSearchFilterExpr::Pattern {
+                key,
+                op,
+                pattern: pattern.into(),
+            },
+        }
+    }
+
+    fn null_check(key: String, negated: bool) -> Self {
+        Self {
+            expr: SqliteSearchFilterExpr::NullCheck { key, negated },
+        }
+    }
+}
+
 impl SearchFilter for SqliteSearchFilter {
     type Value = serde_json::Value;
 
     fn eq(key: impl AsRef<str>, value: Self::Value) -> Self {
-        Self {
-            expr: SqliteSearchFilterExpr::Comparison {
-                key: key.as_ref().to_string(),
-                op: SqliteComparisonOp::Eq,
-                value,
-            },
-        }
+        Self::cmp(key, SqliteComparisonOp::Eq, value)
     }
 
     fn gt(key: impl AsRef<str>, value: Self::Value) -> Self {
-        Self {
-            expr: SqliteSearchFilterExpr::Comparison {
-                key: key.as_ref().to_string(),
-                op: SqliteComparisonOp::Gt,
-                value,
-            },
-        }
+        Self::cmp(key, SqliteComparisonOp::Gt, value)
     }
 
     fn lt(key: impl AsRef<str>, value: Self::Value) -> Self {
-        Self {
-            expr: SqliteSearchFilterExpr::Comparison {
-                key: key.as_ref().to_string(),
-                op: SqliteComparisonOp::Lt,
-                value,
-            },
-        }
+        Self::cmp(key, SqliteComparisonOp::Lt, value)
     }
 
     fn and(self, rhs: Self) -> Self {
@@ -1019,18 +967,11 @@ impl SqliteSearchFilter {
 
     // Null checks
     pub fn is_null(key: String) -> Self {
-        Self {
-            expr: SqliteSearchFilterExpr::NullCheck {
-                key,
-                negated: false,
-            },
-        }
+        Self::null_check(key, false)
     }
 
     pub fn is_not_null(key: String) -> Self {
-        Self {
-            expr: SqliteSearchFilterExpr::NullCheck { key, negated: true },
-        }
+        Self::null_check(key, true)
     }
 
     /// Tests whether the value at `key` satisfies the glob pattern.
@@ -1038,13 +979,7 @@ impl SqliteSearchFilter {
     /// sqlite-vec cannot enforce `GLOB` during candidate search, so this is
     /// applied as a document-table post-filter.
     pub fn glob(key: String, pattern: impl Into<String>) -> Self {
-        Self {
-            expr: SqliteSearchFilterExpr::Pattern {
-                key,
-                op: SqlitePatternOp::Glob,
-                pattern: pattern.into(),
-            },
-        }
+        Self::pattern(key, SqlitePatternOp::Glob, pattern)
     }
 
     /// Tests whether the value at `key` satisfies the `LIKE` pattern.
@@ -1052,26 +987,11 @@ impl SqliteSearchFilter {
     /// sqlite-vec cannot enforce `LIKE` during candidate search, so this is
     /// applied as a document-table post-filter.
     pub fn like(key: String, pattern: impl Into<String>) -> Self {
-        Self {
-            expr: SqliteSearchFilterExpr::Pattern {
-                key,
-                op: SqlitePatternOp::Like,
-                pattern: pattern.into(),
-            },
-        }
+        Self::pattern(key, SqlitePatternOp::Like, pattern)
     }
 }
 
 impl SqliteSearchFilter {
-    fn raw(condition: impl Into<String>, params: Vec<serde_json::Value>) -> Self {
-        Self {
-            expr: SqliteSearchFilterExpr::Raw {
-                condition: condition.into(),
-                params,
-            },
-        }
-    }
-
     fn render_split(
         &self,
         metadata_columns: &[SqliteMetadataColumn],
@@ -1088,15 +1008,9 @@ impl SqliteSearchFilterExpr {
         metadata_columns: &[SqliteMetadataColumn],
     ) -> Result<SqliteRenderedFilters, FilterError> {
         let Some(metadata_column) = sqlite_native_metadata_column(key, metadata_columns) else {
-            return Ok(SqliteRenderedFilters {
-                native: Vec::new(),
-                post: vec![Self::render_document_comparison(
-                    key,
-                    op,
-                    value,
-                    metadata_columns,
-                )?],
-            });
+            return Ok(SqliteRenderedFilters::post_only(
+                Self::render_document_comparison(key, op, value, metadata_columns)?,
+            ));
         };
 
         if !metadata_column.metadata_type.supports_native_comparison(op) {
@@ -1143,10 +1057,9 @@ impl SqliteSearchFilterExpr {
             Self::Between { key, lo, hi } => {
                 let Some(metadata_column) = sqlite_native_metadata_column(key, metadata_columns)
                 else {
-                    return Ok(SqliteRenderedFilters {
-                        native: Vec::new(),
-                        post: vec![self.render_document(metadata_columns)?],
-                    });
+                    return Ok(SqliteRenderedFilters::post_only(
+                        self.render_document(metadata_columns)?,
+                    ));
                 };
 
                 if metadata_column.metadata_type == SqliteMetadataType::Boolean {
@@ -1166,24 +1079,11 @@ impl SqliteSearchFilterExpr {
                     post: Vec::new(),
                 })
             }
-            Self::Raw { condition, params } if condition == "1 = 1" && params.is_empty() => {
-                Ok(SqliteRenderedFilters {
-                    native: Vec::new(),
-                    post: Vec::new(),
-                })
-            }
-            Self::Or(_, _) => Ok(SqliteRenderedFilters {
-                native: Vec::new(),
-                post: vec![self.render_document(metadata_columns)?],
-            }),
+            Self::Noop => Ok(SqliteRenderedFilters::default()),
+            Self::Or(_, _) | Self::NullCheck { .. } | Self::Pattern { .. } => Ok(
+                SqliteRenderedFilters::post_only(self.render_document(metadata_columns)?),
+            ),
             Self::Not(expr) => expr.render_negated_split(metadata_columns),
-            Self::NullCheck { .. } | Self::Pattern { .. } => Ok(SqliteRenderedFilters {
-                native: Vec::new(),
-                post: vec![self.render_document(metadata_columns)?],
-            }),
-            Self::Raw { .. } => Err(sqlite_unsupported_filter(
-                "raw filters cannot be validated as sqlite-vec metadata constraints",
-            )),
         }
     }
 
@@ -1198,72 +1098,11 @@ impl SqliteSearchFilterExpr {
             Self::Not(expr) => expr.render_split(metadata_columns),
             _ => {
                 let rendered = self.render_document(metadata_columns)?;
-                Ok(SqliteRenderedFilters {
-                    native: Vec::new(),
-                    post: vec![SqliteRenderedFilter {
-                        condition: format!("NOT ({})", rendered.condition),
-                        params: rendered.params,
-                    }],
-                })
+                Ok(SqliteRenderedFilters::post_only(SqliteRenderedFilter {
+                    condition: format!("NOT ({})", rendered.condition),
+                    params: rendered.params,
+                }))
             }
-        }
-    }
-
-    fn render_vector(&self) -> Result<SqliteRenderedFilter, FilterError> {
-        match self {
-            Self::Comparison { key, op, value } => Ok(SqliteRenderedFilter {
-                condition: format!("{} {} ?", sqlite_qualify_vector_key(key), op.as_sql()),
-                params: vec![sqlite_filter_param(value.clone())?],
-            }),
-            Self::And(lhs, rhs) => {
-                let lhs = lhs.render_vector()?;
-                let rhs = rhs.render_vector()?;
-                Ok(SqliteRenderedFilter {
-                    condition: format!("({}) AND ({})", lhs.condition, rhs.condition),
-                    params: lhs.params.into_iter().chain(rhs.params).collect(),
-                })
-            }
-            Self::Or(lhs, rhs) => {
-                let lhs = lhs.render_vector()?;
-                let rhs = rhs.render_vector()?;
-                Ok(SqliteRenderedFilter {
-                    condition: format!("({}) OR ({})", lhs.condition, rhs.condition),
-                    params: lhs.params.into_iter().chain(rhs.params).collect(),
-                })
-            }
-            Self::Not(expr) => {
-                let expr = expr.render_vector()?;
-                Ok(SqliteRenderedFilter {
-                    condition: format!("NOT ({})", expr.condition),
-                    params: expr.params,
-                })
-            }
-            Self::Between { key, lo, hi } => Ok(SqliteRenderedFilter {
-                condition: format!("{} between ? and ?", sqlite_qualify_vector_key(key)),
-                params: vec![
-                    sqlite_filter_param(lo.clone())?,
-                    sqlite_filter_param(hi.clone())?,
-                ],
-            }),
-            Self::NullCheck { key, negated } => {
-                let operator = if *negated { "is not null" } else { "is null" };
-                Ok(SqliteRenderedFilter {
-                    condition: format!("{} {operator}", sqlite_qualify_vector_key(key)),
-                    params: Vec::new(),
-                })
-            }
-            Self::Pattern { key, op, pattern } => Ok(SqliteRenderedFilter {
-                condition: format!("{} {} ?", sqlite_qualify_vector_key(key), op.as_sql()),
-                params: vec![Value::Text(pattern.clone())],
-            }),
-            Self::Raw { condition, params } => Ok(SqliteRenderedFilter {
-                condition: condition.clone(),
-                params: params
-                    .iter()
-                    .cloned()
-                    .map(sqlite_filter_param)
-                    .collect::<Result<Vec<_>, _>>()?,
-            }),
         }
     }
 
@@ -1275,22 +1114,16 @@ impl SqliteSearchFilterExpr {
             Self::Comparison { key, op, value } => {
                 Self::render_document_comparison(key, *op, value.clone(), metadata_columns)
             }
-            Self::And(lhs, rhs) => {
-                let lhs = lhs.render_document(metadata_columns)?;
-                let rhs = rhs.render_document(metadata_columns)?;
-                Ok(SqliteRenderedFilter {
-                    condition: format!("({}) AND ({})", lhs.condition, rhs.condition),
-                    params: lhs.params.into_iter().chain(rhs.params).collect(),
-                })
-            }
-            Self::Or(lhs, rhs) => {
-                let lhs = lhs.render_document(metadata_columns)?;
-                let rhs = rhs.render_document(metadata_columns)?;
-                Ok(SqliteRenderedFilter {
-                    condition: format!("({}) OR ({})", lhs.condition, rhs.condition),
-                    params: lhs.params.into_iter().chain(rhs.params).collect(),
-                })
-            }
+            Self::And(lhs, rhs) => Ok(SqliteRenderedFilter::combine(
+                "AND",
+                lhs.render_document(metadata_columns)?,
+                rhs.render_document(metadata_columns)?,
+            )),
+            Self::Or(lhs, rhs) => Ok(SqliteRenderedFilter::combine(
+                "OR",
+                lhs.render_document(metadata_columns)?,
+                rhs.render_document(metadata_columns)?,
+            )),
             Self::Not(expr) => {
                 let expr = expr.render_document(metadata_columns)?;
                 Ok(SqliteRenderedFilter {
@@ -1323,9 +1156,12 @@ impl SqliteSearchFilterExpr {
                     params: vec![Value::Text(pattern.clone())],
                 })
             }
-            Self::Raw { .. } => Err(sqlite_unsupported_filter(
-                "raw filters cannot be validated as document-table constraints",
-            )),
+            // `Noop` matches every document, so it renders as a tautology when
+            // composed under `Or`/`Not`/`And` on the document path.
+            Self::Noop => Ok(SqliteRenderedFilter {
+                condition: "1 = 1".to_owned(),
+                params: Vec::new(),
+            }),
         }
     }
 }
@@ -1405,65 +1241,45 @@ fn sqlite_metadata_filter_param(
     column: &SqliteMetadataColumn,
     value: serde_json::Value,
 ) -> Result<Value, FilterError> {
-    match column.metadata_type {
-        SqliteMetadataType::Text => match value {
-            serde_json::Value::String(value) => Ok(Value::Text(value)),
-            value => Err(sqlite_metadata_filter_type_error(
-                column,
-                &value,
-                "a string filter value",
-            )),
-        },
-        SqliteMetadataType::Integer => match value {
-            serde_json::Value::Number(number) => {
-                if let Some(value) = number.as_i64() {
-                    Ok(Value::Integer(value))
-                } else if let Some(value) = number.as_u64() {
-                    i64::try_from(value).map(Value::Integer).map_err(|_| {
-                        FilterError::TypeError(format!(
-                            "SQLite integer filter value `{number}` exceeds i64::MAX"
-                        ))
-                    })
-                } else {
-                    let value = serde_json::Value::Number(number);
-                    Err(sqlite_metadata_filter_type_error(
-                        column,
-                        &value,
-                        "an integer filter value",
+    let expected = match column.metadata_type {
+        SqliteMetadataType::Text => "a string filter value",
+        SqliteMetadataType::Integer => "an integer filter value",
+        SqliteMetadataType::Float => "a finite number filter value",
+        SqliteMetadataType::Boolean => "a boolean filter value",
+    };
+
+    match (column.metadata_type, value) {
+        (SqliteMetadataType::Text, serde_json::Value::String(value)) => Ok(Value::Text(value)),
+        (SqliteMetadataType::Integer, serde_json::Value::Number(number)) => {
+            if let Some(value) = number.as_i64() {
+                Ok(Value::Integer(value))
+            } else if let Some(value) = number.as_u64() {
+                i64::try_from(value).map(Value::Integer).map_err(|_| {
+                    FilterError::TypeError(format!(
+                        "SQLite integer filter value `{number}` exceeds i64::MAX"
                     ))
-                }
-            }
-            value => Err(sqlite_metadata_filter_type_error(
-                column,
-                &value,
-                "an integer filter value",
-            )),
-        },
-        SqliteMetadataType::Float => match value {
-            serde_json::Value::Number(number) => {
-                number.as_f64().map(Value::Real).ok_or_else(|| {
-                    let value = serde_json::Value::Number(number);
-                    sqlite_metadata_filter_type_error(
-                        column,
-                        &value,
-                        "a finite number filter value",
-                    )
                 })
+            } else {
+                Err(sqlite_metadata_filter_type_error(
+                    column,
+                    &serde_json::Value::Number(number),
+                    expected,
+                ))
             }
-            value => Err(sqlite_metadata_filter_type_error(
-                column,
-                &value,
-                "a finite number filter value",
-            )),
-        },
-        SqliteMetadataType::Boolean => match value {
-            serde_json::Value::Bool(value) => Ok(Value::Integer(value as i64)),
-            value => Err(sqlite_metadata_filter_type_error(
-                column,
-                &value,
-                "a boolean filter value",
-            )),
-        },
+        }
+        (SqliteMetadataType::Float, serde_json::Value::Number(number)) => {
+            number.as_f64().map(Value::Real).ok_or_else(|| {
+                sqlite_metadata_filter_type_error(
+                    column,
+                    &serde_json::Value::Number(number),
+                    expected,
+                )
+            })
+        }
+        (SqliteMetadataType::Boolean, serde_json::Value::Bool(value)) => {
+            Ok(Value::Integer(value as i64))
+        }
+        (_, value) => Err(sqlite_metadata_filter_type_error(column, &value, expected)),
     }
 }
 
@@ -1500,18 +1316,6 @@ fn sqlite_filter_param(value: serde_json::Value) -> Result<Value, FilterError> {
 
             Ok(Value::Blob(blob))
         }
-    }
-}
-
-fn sqlite_key_is_qualified(key: &str) -> bool {
-    key.contains('.') || key.contains('(') || key.contains(' ') || key.contains('?')
-}
-
-fn sqlite_qualify_vector_key(key: &str) -> String {
-    if sqlite_key_is_qualified(key) {
-        key.to_string()
-    } else {
-        format!("e.{key}")
     }
 }
 
@@ -1764,6 +1568,78 @@ where
     }
 }
 
+impl<E, T> SqliteVectorIndex<E, T>
+where
+    E: EmbeddingModel + 'static,
+    T: SqliteVectorStoreTable + 'static,
+{
+    /// Runs the shared candidate search for `top_n`/`top_n_ids`.
+    ///
+    /// `outer_select_cols` is the outer `SELECT` list (aliases `d` for the
+    /// document table and `scored` for the ranked candidates); `map_row` maps
+    /// each result row, which ends with `scored.__rig_score`.
+    async fn search_rows<R, F>(
+        &self,
+        req: &VectorSearchRequest<SqliteSearchFilter>,
+        outer_select_cols: String,
+        map_row: F,
+    ) -> Result<Vec<R>, VectorStoreError>
+    where
+        R: Send + 'static,
+        F: Fn(&rusqlite::Row<'_>) -> rusqlite::Result<R> + Send + 'static,
+    {
+        let embedding = self.embedding_model.embed_text(req.query()).await?;
+        let query_vec: Vec<f32> = serialize_embedding(&embedding);
+        let table_name = T::name();
+        let embedding_map_table_name = format!("{table_name}_embedding_map");
+
+        let distance_metric = self.store.distance_metric;
+        let score_expression = distance_metric.score_expression("?1", "e.embedding");
+        let filters = render_search_filters(req, distance_metric, &self.store.metadata_columns)?;
+        let candidate_limit = self
+            .store
+            .candidate_limit(req.samples(), filters.has_post_filters())
+            .await?;
+        let search_query = build_search_query(query_vec, filters, candidate_limit)?;
+        let where_clause = search_query.vector_where_clause;
+        let document_filter_clause = search_query.document_filter_clause;
+        let mut params = search_query.params;
+        params.push(sqlite_limit_param(req.samples(), "result limit")?);
+
+        self.store
+            .conn
+            .call(move |conn| {
+                let mut stmt = conn.prepare(&format!(
+                    "WITH scored AS (
+                        SELECT m.document_rowid AS __rig_document_rowid,
+                            {score_expression} AS __rig_score,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY m.document_rowid
+                                ORDER BY {score_expression} DESC, e.rowid ASC
+                            ) AS __rig_rank
+                        FROM {table_name}_embeddings e
+                        JOIN {embedding_map_table_name} m ON e.rowid = m.embedding_rowid
+                        {where_clause}
+                    )
+                    SELECT {outer_select_cols}, scored.__rig_score
+                    FROM scored
+                    JOIN {table_name} d ON scored.__rig_document_rowid = d.rowid
+                    WHERE scored.__rig_rank = 1
+                        {document_filter_clause}
+                    ORDER BY scored.__rig_score DESC, d.id ASC
+                    LIMIT ?"
+                ))?;
+
+                let rows = stmt
+                    .query_map(rusqlite::params_from_iter(params), |row| map_row(row))?
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(rows)
+            })
+            .await
+            .map_err(VectorStoreError::datastore)
+    }
+}
+
 fn sqlite_distance_metric_from_schema(schema_sql: &str) -> SqliteDistanceMetric {
     let normalized = sqlite_normalized_schema(schema_sql);
 
@@ -1807,13 +1683,13 @@ fn render_search_filters(
     metadata_columns: &[SqliteMetadataColumn],
 ) -> Result<SqliteRenderedFilters, FilterError> {
     let score_expression = distance_metric.score_expression("?1", "e.embedding");
-    let threshold_filter = req.threshold().map(|threshold| {
-        SqliteSearchFilter::raw(format!("{score_expression} >= ?"), vec![threshold.into()])
-    });
 
     let mut filters = SqliteRenderedFilters::default();
-    if let Some(threshold_filter) = threshold_filter {
-        filters.native.push(threshold_filter.expr.render_vector()?);
+    if let Some(threshold) = req.threshold() {
+        filters.native.push(SqliteRenderedFilter {
+            condition: format!("{score_expression} >= ?"),
+            params: vec![Value::Real(threshold)],
+        });
     }
     if let Some(filter) = req.filter() {
         filters.extend(filter.render_split(metadata_columns)?);
@@ -1913,25 +1789,6 @@ fn sqlite_limit_param(value: u64, name: &str) -> Result<Value, FilterError> {
         .map_err(|_| FilterError::TypeError(format!("SQLite {name} `{value}` exceeds i64::MAX")))
 }
 
-#[derive(Debug)]
-struct SqliteColumnValueError {
-    column_name: &'static str,
-    column_type: &'static str,
-    message: String,
-}
-
-impl Display for SqliteColumnValueError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "could not convert SQLite column `{}` with declared type `{}`: {}",
-            self.column_name, self.column_type, self.message
-        )
-    }
-}
-
-impl std::error::Error for SqliteColumnValueError {}
-
 fn sqlite_column_value_error(
     index: usize,
     value_type: Type,
@@ -1941,7 +1798,7 @@ fn sqlite_column_value_error(
     rusqlite::Error::FromSqlConversionFailure(
         index,
         value_type,
-        Box::new(SqliteColumnValueError {
+        Box::new(SqliteInternalError::ColumnValueError {
             column_name: column.name,
             column_type: column.col_type,
             message: message.into(),
@@ -1962,20 +1819,30 @@ fn sqlite_number_value(
     Ok(serde_json::Value::Number(number))
 }
 
+fn sqlite_utf8_value<'a>(
+    index: usize,
+    value_type: Type,
+    column: &Column,
+    value: &'a [u8],
+    label: &str,
+) -> rusqlite::Result<&'a str> {
+    std::str::from_utf8(value).map_err(|e| {
+        sqlite_column_value_error(
+            index,
+            value_type,
+            column,
+            format!("invalid UTF-8 {label}: {e}"),
+        )
+    })
+}
+
 fn sqlite_text_value(
     index: usize,
     value_type: Type,
     column: &Column,
     value: &[u8],
 ) -> rusqlite::Result<serde_json::Value> {
-    let value = std::str::from_utf8(value).map_err(|e| {
-        sqlite_column_value_error(
-            index,
-            value_type,
-            column,
-            format!("invalid UTF-8 text: {e}"),
-        )
-    })?;
+    let value = sqlite_utf8_value(index, value_type, column, value, "text")?;
 
     Ok(serde_json::Value::String(value.to_string()))
 }
@@ -1993,14 +1860,7 @@ fn sqlite_json_text_value(
     column: &Column,
     value: &[u8],
 ) -> rusqlite::Result<serde_json::Value> {
-    let value = std::str::from_utf8(value).map_err(|e| {
-        sqlite_column_value_error(
-            index,
-            value_type,
-            column,
-            format!("invalid UTF-8 JSON text: {e}"),
-        )
-    })?;
+    let value = sqlite_utf8_value(index, value_type, column, value, "JSON text")?;
 
     serde_json::from_str(value).map_err(|e| {
         sqlite_column_value_error(index, value_type, column, format!("invalid JSON text: {e}"))
@@ -2054,7 +1914,7 @@ fn sqlite_id_value_to_string(index: usize, value: ValueRef<'_>) -> rusqlite::Res
                 rusqlite::Error::FromSqlConversionFailure(
                     index,
                     Type::Text,
-                    Box::new(SqliteColumnValueError {
+                    Box::new(SqliteInternalError::ColumnValueError {
                         column_name: "id",
                         column_type: "TEXT",
                         message: format!("invalid UTF-8 text: {e}"),
@@ -2064,7 +1924,7 @@ fn sqlite_id_value_to_string(index: usize, value: ValueRef<'_>) -> rusqlite::Res
         value => Err(rusqlite::Error::FromSqlConversionFailure(
             index,
             value.data_type(),
-            Box::new(SqliteColumnValueError {
+            Box::new(SqliteInternalError::ColumnValueError {
                 column_name: "id",
                 column_type: "TEXT or INTEGER",
                 message: "id cannot be NULL or BLOB".to_string(),
@@ -2090,19 +1950,14 @@ impl<E: EmbeddingModel + std::marker::Sync, T: SqliteVectorStoreTable> VectorSto
             return Ok(Vec::new());
         }
 
-        let embedding = self.embedding_model.embed_text(req.query()).await?;
-        let query_vec: Vec<f32> = serialize_embedding(&embedding);
-        let table_name = T::name();
-        let embedding_map_table_name = format!("{table_name}_embedding_map");
-
         let columns = T::schema();
         let id_column_index = columns
             .iter()
             .position(|column| column.name == "id")
             .ok_or_else(|| {
-                VectorStoreError::DatastoreError(Box::new(SqliteMissingIdColumn {
-                    table_name: table_name.to_string(),
-                }))
+                VectorStoreError::datastore(SqliteInternalError::MissingIdColumn(
+                    T::name().to_string(),
+                ))
             })?;
 
         let outer_select_cols = columns
@@ -2111,65 +1966,20 @@ impl<E: EmbeddingModel + std::marker::Sync, T: SqliteVectorStoreTable> VectorSto
             .collect::<Vec<_>>()
             .join(", ");
 
-        let distance_metric = self.store.distance_metric;
-        let score_expression = distance_metric.score_expression("?1", "e.embedding");
-        let filters = render_search_filters(&req, distance_metric, &self.store.metadata_columns)?;
-        let candidate_limit = self
-            .store
-            .candidate_limit(req.samples(), filters.has_post_filters())
-            .await?;
-        let search_query = build_search_query(query_vec, filters, candidate_limit)?;
-        let where_clause = search_query.vector_where_clause;
-        let document_filter_clause = search_query.document_filter_clause;
-        let mut params = search_query.params;
-        params.push(sqlite_limit_param(req.samples(), "result limit")?);
-
         let rows = self
-            .store
-            .conn
-            .call(move |conn| {
-                let mut stmt = conn.prepare(&format!(
-                    "WITH scored AS (
-                        SELECT m.document_rowid AS __rig_document_rowid,
-                            {score_expression} AS __rig_score,
-                            ROW_NUMBER() OVER (
-                                PARTITION BY m.document_rowid
-                                ORDER BY {score_expression} DESC, e.rowid ASC
-                            ) AS __rig_rank
-                        FROM {table_name}_embeddings e
-                        JOIN {embedding_map_table_name} m ON e.rowid = m.embedding_rowid
-                        {where_clause}
-                    )
-                    SELECT {outer_select_cols}, scored.__rig_score
-                    FROM scored
-                    JOIN {table_name} d ON scored.__rig_document_rowid = d.rowid
-                    WHERE scored.__rig_rank = 1
-                        {document_filter_clause}
-                    ORDER BY scored.__rig_score DESC, d.id ASC
-                    LIMIT ?"
-                ))?;
+            .search_rows(&req, outer_select_cols, move |row| {
+                // Create a map of column names to values
+                let mut map = serde_json::Map::new();
+                for (i, column) in columns.iter().enumerate() {
+                    let value = sqlite_column_value_to_json(i, column, row.get_ref(i)?)?;
+                    map.insert(column.name.to_string(), value);
+                }
+                let score: f64 = row.get(columns.len())?;
+                let id = sqlite_id_value_to_string(id_column_index, row.get_ref(id_column_index)?)?;
 
-                let rows = stmt
-                    .query_map(rusqlite::params_from_iter(params), |row| {
-                        // Create a map of column names to values
-                        let mut map = serde_json::Map::new();
-                        for (i, column) in columns.iter().enumerate() {
-                            let value = sqlite_column_value_to_json(i, column, row.get_ref(i)?)?;
-                            map.insert(column.name.to_string(), value);
-                        }
-                        let score: f64 = row.get(columns.len())?;
-                        let id = sqlite_id_value_to_string(
-                            id_column_index,
-                            row.get_ref(id_column_index)?,
-                        )?;
-
-                        Ok((id, serde_json::Value::Object(map), score))
-                    })?
-                    .collect::<Result<Vec<_>, _>>()?;
-                Ok(rows)
+                Ok((id, serde_json::Value::Object(map), score))
             })
-            .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            .await?;
 
         debug!("Found {} potential matches", rows.len());
         let mut top_n = Vec::new();
@@ -2201,61 +2011,14 @@ impl<E: EmbeddingModel + std::marker::Sync, T: SqliteVectorStoreTable> VectorSto
             return Ok(Vec::new());
         }
 
-        let embedding = self.embedding_model.embed_text(req.query()).await?;
-        let query_vec = serialize_embedding(&embedding);
-        let table_name = T::name();
-        let embedding_map_table_name = format!("{table_name}_embedding_map");
-
-        let distance_metric = self.store.distance_metric;
-        let score_expression = distance_metric.score_expression("?1", "e.embedding");
-        let filters = render_search_filters(&req, distance_metric, &self.store.metadata_columns)?;
-        let candidate_limit = self
-            .store
-            .candidate_limit(req.samples(), filters.has_post_filters())
-            .await?;
-        let search_query = build_search_query(query_vec, filters, candidate_limit)?;
-        let where_clause = search_query.vector_where_clause;
-        let document_filter_clause = search_query.document_filter_clause;
-        let mut params = search_query.params;
-        params.push(sqlite_limit_param(req.samples(), "result limit")?);
-
         let results = self
-            .store
-            .conn
-            .call(move |conn| {
-                let mut stmt = conn.prepare(&format!(
-                    "WITH scored AS (
-                        SELECT m.document_rowid AS __rig_document_rowid,
-                            {score_expression} AS __rig_score,
-                            ROW_NUMBER() OVER (
-                                PARTITION BY m.document_rowid
-                                ORDER BY {score_expression} DESC, e.rowid ASC
-                            ) AS __rig_rank
-                        FROM {table_name}_embeddings e
-                        JOIN {embedding_map_table_name} m ON e.rowid = m.embedding_rowid
-                        {where_clause}
-                     )
-                     SELECT d.id, scored.__rig_score
-                     FROM scored
-                     JOIN {table_name} d ON scored.__rig_document_rowid = d.rowid
-                     WHERE scored.__rig_rank = 1
-                        {document_filter_clause}
-                     ORDER BY scored.__rig_score DESC, d.id ASC
-                     LIMIT ?"
-                ))?;
-
-                let results = stmt
-                    .query_map(rusqlite::params_from_iter(params), |row| {
-                        Ok((
-                            row.get::<_, f64>(1)?,
-                            sqlite_id_value_to_string(0, row.get_ref(0)?)?,
-                        ))
-                    })?
-                    .collect::<Result<Vec<_>, _>>()?;
-                Ok(results)
+            .search_rows(&req, "d.id".to_string(), |row| {
+                Ok((
+                    row.get::<_, f64>(1)?,
+                    sqlite_id_value_to_string(0, row.get_ref(0)?)?,
+                ))
             })
-            .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            .await?;
 
         debug!("Found {} matching document IDs", results.len());
         Ok(results)
@@ -2266,74 +2029,29 @@ fn serialize_embedding(embedding: &Embedding) -> Vec<f32> {
     embedding.vec.iter().map(|x| *x as f32).collect()
 }
 
-impl ColumnValue for String {
-    fn to_sql_value(&self) -> Value {
-        Value::Text(self.clone())
-    }
+macro_rules! impl_column_value {
+    ($($ty:ty => $col_type:literal, |$value:ident| $to_sql:expr;)*) => {$(
+        impl ColumnValue for $ty {
+            fn to_sql_value(&self) -> Value {
+                let $value = self;
+                $to_sql
+            }
 
-    fn column_type(&self) -> &'static str {
-        "TEXT"
-    }
+            fn column_type(&self) -> &'static str {
+                $col_type
+            }
+        }
+    )*};
 }
 
-impl ColumnValue for i64 {
-    fn to_sql_value(&self) -> Value {
-        Value::Integer(*self)
-    }
-
-    fn column_type(&self) -> &'static str {
-        "INTEGER"
-    }
-}
-
-impl ColumnValue for i32 {
-    fn to_sql_value(&self) -> Value {
-        Value::Integer(i64::from(*self))
-    }
-
-    fn column_type(&self) -> &'static str {
-        "INTEGER"
-    }
-}
-
-impl ColumnValue for f64 {
-    fn to_sql_value(&self) -> Value {
-        Value::Real(*self)
-    }
-
-    fn column_type(&self) -> &'static str {
-        "FLOAT"
-    }
-}
-
-impl ColumnValue for f32 {
-    fn to_sql_value(&self) -> Value {
-        Value::Real(f64::from(*self))
-    }
-
-    fn column_type(&self) -> &'static str {
-        "FLOAT"
-    }
-}
-
-impl ColumnValue for bool {
-    fn to_sql_value(&self) -> Value {
-        Value::Integer(if *self { 1 } else { 0 })
-    }
-
-    fn column_type(&self) -> &'static str {
-        "BOOLEAN"
-    }
-}
-
-impl ColumnValue for serde_json::Value {
-    fn to_sql_value(&self) -> Value {
-        Value::Text(self.to_string())
-    }
-
-    fn column_type(&self) -> &'static str {
-        "JSON"
-    }
+impl_column_value! {
+    String => "TEXT", |value| Value::Text(value.clone());
+    i64 => "INTEGER", |value| Value::Integer(*value);
+    i32 => "INTEGER", |value| Value::Integer(i64::from(*value));
+    f64 => "FLOAT", |value| Value::Real(*value);
+    f32 => "FLOAT", |value| Value::Real(f64::from(*value));
+    bool => "BOOLEAN", |value| Value::Integer(if *value { 1 } else { 0 });
+    serde_json::Value => "JSON", |value| Value::Text(value.to_string());
 }
 
 #[cfg(test)]
@@ -2654,6 +2372,31 @@ mod tests {
         anyhow::ensure!(
             params.get(1) == Some(&Value::Real(0.95)),
             "threshold param should follow the query vector: {params:?}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn default_filter_composes_under_or_as_a_tautology() -> anyhow::Result<()> {
+        let filter = SqliteSearchFilter::default().or(SqliteSearchFilter::eq(
+            "category",
+            serde_json::json!("docs"),
+        ));
+
+        let req = VectorSearchRequest::<SqliteSearchFilter>::builder()
+            .query("needle")
+            .samples(5)
+            .filter(filter)
+            .build();
+
+        let filters =
+            render_search_filters(&req, SqliteDistanceMetric::Cosine, &test_metadata_columns())?;
+        let query = build_search_query(vec![1.0, 0.0], filters, 5)?;
+        anyhow::ensure!(
+            query.document_filter_clause == "AND ((1 = 1) OR (d.category = ?))",
+            "default() under OR should render as a tautology: {}",
+            query.document_filter_clause
         );
 
         Ok(())

--- a/crates/rig-surrealdb/src/lib.rs
+++ b/crates/rig-surrealdb/src/lib.rs
@@ -126,7 +126,7 @@ where
                     .create::<Option<CreateRecord>>(self.documents_table.clone())
                     .content(record)
                     .await
-                    .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+                    .map_err(VectorStoreError::datastore)?;
             }
         }
 
@@ -147,13 +147,7 @@ impl TryFrom<Filter<serde_json::Value>> for SurrealSearchFilter {
     type Error = FilterError;
 
     fn try_from(value: Filter<serde_json::Value>) -> Result<Self, Self::Error> {
-        match value {
-            Filter::Eq(key, value) => Ok(Self::eq(key, Value::from_t(value))),
-            Filter::Gt(key, value) => Ok(Self::gt(key, Value::from_t(value))),
-            Filter::Lt(key, value) => Ok(Self::lt(key, Value::from_t(value))),
-            Filter::And(lhs, rhs) => Ok(Self::try_from(*lhs)?.and(Self::try_from(*rhs)?)),
-            Filter::Or(lhs, rhs) => Ok(Self::try_from(*lhs)?.or(Self::try_from(*rhs)?)),
-        }
+        value.try_interpret(|v| Ok(Value::from_t(v)))
     }
 }
 
@@ -283,12 +277,29 @@ where
         Self::new(model, surreal, None, SurrealDistanceFunction::Cosine)
     }
 
-    fn search_query_full(&self) -> String {
-        self.search_query(true)
-    }
+    /// Embeds the query and runs the similarity-search query, returning the raw response.
+    async fn run_search_query(
+        &self,
+        req: &VectorSearchRequest<SurrealSearchFilter>,
+        with_document: bool,
+    ) -> Result<surrealdb::IndexedResults, VectorStoreError> {
+        let embedded_query: Vec<f64> = self.model.embed_text(req.query()).await?.vec;
 
-    fn search_query_only_ids(&self) -> String {
-        self.search_query(false)
+        self.surreal
+            .query(self.search_query(with_document).as_str())
+            .bind(("vec", embedded_query))
+            .bind(("tablename", self.documents_table.clone()))
+            .bind(("threshold", req.threshold().unwrap_or(0.)))
+            .bind(("limit", req.samples() as usize))
+            .bind((
+                "filter",
+                req.filter()
+                    .clone()
+                    .map(SurrealSearchFilter::inner)
+                    .unwrap_or("true".into()),
+            ))
+            .await
+            .map_err(VectorStoreError::datastore)
     }
 
     fn search_query(&self, with_document: bool) -> String {
@@ -323,28 +334,9 @@ where
         &self,
         req: VectorSearchRequest<SurrealSearchFilter>,
     ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
-        let embedded_query: Vec<f64> = self.model.embed_text(req.query()).await?.vec;
+        let mut response = self.run_search_query(&req, true).await?;
 
-        let mut response = self
-            .surreal
-            .query(self.search_query_full().as_str())
-            .bind(("vec", embedded_query))
-            .bind(("tablename", self.documents_table.clone()))
-            .bind(("threshold", req.threshold().unwrap_or(0.)))
-            .bind(("limit", req.samples() as usize))
-            .bind((
-                "filter",
-                req.filter()
-                    .clone()
-                    .map(SurrealSearchFilter::inner)
-                    .unwrap_or("true".into()),
-            ))
-            .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
-
-        let rows: Vec<SearchResult> = response
-            .take(0)
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+        let rows: Vec<SearchResult> = response.take(0).map_err(VectorStoreError::datastore)?;
 
         let rows: Vec<(f64, String, T)> = rows
             .into_iter()
@@ -359,35 +351,14 @@ where
         &self,
         req: VectorSearchRequest<SurrealSearchFilter>,
     ) -> Result<Vec<(f64, String)>, VectorStoreError> {
-        let embedded_query: Vec<f32> = self
-            .model
-            .embed_text(req.query())
-            .await?
-            .vec
-            .iter()
-            .map(|&x| x as f32)
-            .collect();
-
-        let mut response = self
-            .surreal
-            .query(self.search_query_only_ids().as_str())
-            .bind(("vec", embedded_query))
-            .bind(("tablename", self.documents_table.clone()))
-            .bind(("threshold", req.threshold().unwrap_or(0.)))
-            .bind(("limit", req.samples() as usize))
-            .bind((
-                "filter",
-                req.filter()
-                    .clone()
-                    .map(SurrealSearchFilter::inner)
-                    .unwrap_or("true".into()),
-            ))
-            .await
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+        // NOTE: this previously bound the query vector as `Vec<f32>` while
+        // `top_n` bound `Vec<f64>`; both now bind `Vec<f64>`, matching the
+        // stored `embedding: Vec<f64>` schema.
+        let mut response = self.run_search_query(&req, false).await?;
 
         let rows: Vec<SearchResultOnlyId> = response
             .take::<Vec<SearchResultOnlyId>>(0)
-            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            .map_err(VectorStoreError::datastore)?;
 
         let rows: Vec<(f64, String)> = rows
             .into_iter()

--- a/crates/rig-vectorize/src/client/mod.rs
+++ b/crates/rig-vectorize/src/client/mod.rs
@@ -15,8 +15,47 @@ pub use types::{
 };
 
 use reqwest::Client;
+use serde::de::DeserializeOwned;
 use tracing::instrument;
 use types::ApiResponse;
+
+/// Reads a Vectorize response body, logs it, and unwraps the API envelope,
+/// turning envelope errors and a missing `result` into [`VectorizeError`].
+/// `what` names the operation for the log/error messages (e.g. "upsert").
+async fn unwrap_api<T: DeserializeOwned>(
+    response: reqwest::Response,
+    what: &str,
+) -> Result<T, VectorizeError> {
+    let response_text = response.text().await?;
+    tracing::debug!("Raw Vectorize {} response: {}", what, response_text);
+
+    parse_api(&response_text, what)
+}
+
+/// Parses and unwraps a Vectorize API envelope from a raw response body.
+fn parse_api<T: DeserializeOwned>(text: &str, what: &str) -> Result<T, VectorizeError> {
+    let api_response: ApiResponse<T> = serde_json::from_str(text)?;
+
+    if !api_response.success {
+        let error = api_response
+            .errors
+            .first()
+            .map(|e| VectorizeError::ApiError {
+                code: e.code,
+                message: e.message.clone(),
+            })
+            .unwrap_or_else(|| VectorizeError::ApiError {
+                code: 0,
+                message: "Unknown error".to_string(),
+            });
+        return Err(error);
+    }
+
+    api_response.result.ok_or_else(|| VectorizeError::ApiError {
+        code: 0,
+        message: format!("No result in successful {what} response"),
+    })
+}
 
 /// Base URL for the Cloudflare API.
 const CLOUDFLARE_API_BASE_URL: &str = "https://api.cloudflare.com/client/v4";
@@ -73,30 +112,7 @@ impl VectorizeClient {
             .send()
             .await?;
 
-        let response_text = response.text().await?;
-        tracing::debug!("Raw Vectorize response: {}", response_text);
-
-        let api_response: ApiResponse<QueryResult> = serde_json::from_str(&response_text)?;
-
-        if !api_response.success {
-            let error = api_response
-                .errors
-                .first()
-                .map(|e| VectorizeError::ApiError {
-                    code: e.code,
-                    message: e.message.clone(),
-                })
-                .unwrap_or_else(|| VectorizeError::ApiError {
-                    code: 0,
-                    message: "Unknown error".to_string(),
-                });
-            return Err(error);
-        }
-
-        api_response.result.ok_or_else(|| VectorizeError::ApiError {
-            code: 0,
-            message: "No result in successful response".to_string(),
-        })
+        unwrap_api(response, "query").await
     }
 
     /// Upserts vectors (inserts or updates if ID already exists).
@@ -120,30 +136,7 @@ impl VectorizeClient {
             .send()
             .await?;
 
-        let response_text = response.text().await?;
-        tracing::debug!("Raw Vectorize upsert response: {}", response_text);
-
-        let api_response: ApiResponse<UpsertResult> = serde_json::from_str(&response_text)?;
-
-        if !api_response.success {
-            let error = api_response
-                .errors
-                .first()
-                .map(|e| VectorizeError::ApiError {
-                    code: e.code,
-                    message: e.message.clone(),
-                })
-                .unwrap_or_else(|| VectorizeError::ApiError {
-                    code: 0,
-                    message: "Unknown error".to_string(),
-                });
-            return Err(error);
-        }
-
-        api_response.result.ok_or_else(|| VectorizeError::ApiError {
-            code: 0,
-            message: "No result in successful upsert response".to_string(),
-        })
+        unwrap_api(response, "upsert").await
     }
 
     /// Deletes vectors by their IDs.
@@ -163,30 +156,7 @@ impl VectorizeClient {
             .send()
             .await?;
 
-        let response_text = response.text().await?;
-        tracing::debug!("Raw Vectorize delete response: {}", response_text);
-
-        let api_response: ApiResponse<DeleteResult> = serde_json::from_str(&response_text)?;
-
-        if !api_response.success {
-            let error = api_response
-                .errors
-                .first()
-                .map(|e| VectorizeError::ApiError {
-                    code: e.code,
-                    message: e.message.clone(),
-                })
-                .unwrap_or_else(|| VectorizeError::ApiError {
-                    code: 0,
-                    message: "Unknown error".to_string(),
-                });
-            return Err(error);
-        }
-
-        api_response.result.ok_or_else(|| VectorizeError::ApiError {
-            code: 0,
-            message: "No result in successful delete response".to_string(),
-        })
+        unwrap_api(response, "delete").await
     }
 
     /// Lists vector IDs in the index (paginated).
@@ -219,29 +189,46 @@ impl VectorizeClient {
             .send()
             .await?;
 
-        let response_text = response.text().await?;
-        tracing::debug!("Raw Vectorize list response: {}", response_text);
+        unwrap_api(response, "list").await
+    }
+}
 
-        let api_response: ApiResponse<ListVectorsResult> = serde_json::from_str(&response_text)?;
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{VectorizeError, parse_api};
 
-        if !api_response.success {
-            let error = api_response
-                .errors
-                .first()
-                .map(|e| VectorizeError::ApiError {
-                    code: e.code,
-                    message: e.message.clone(),
-                })
-                .unwrap_or_else(|| VectorizeError::ApiError {
-                    code: 0,
-                    message: "Unknown error".to_string(),
-                });
-            return Err(error);
+    #[test]
+    fn parse_api_unwraps_successful_envelope() {
+        let body = r#"{"success": true, "result": 42, "errors": [], "messages": []}"#;
+        let n: u32 = parse_api(body, "query").expect("successful envelope");
+        assert_eq!(n, 42);
+    }
+
+    #[test]
+    fn parse_api_surfaces_envelope_errors() {
+        let body = r#"{
+            "success": false,
+            "result": null,
+            "errors": [{"code": 7, "message": "index not found"}],
+            "messages": []
+        }"#;
+        match parse_api::<u32>(body, "query") {
+            Err(VectorizeError::ApiError { code: 7, message }) => {
+                assert_eq!(message, "index not found");
+            }
+            other => panic!("expected ApiError, got {other:?}"),
         }
+    }
 
-        api_response.result.ok_or_else(|| VectorizeError::ApiError {
-            code: 0,
-            message: "No result in successful list response".to_string(),
-        })
+    #[test]
+    fn parse_api_errors_on_missing_result() {
+        let body = r#"{"success": true, "result": null, "errors": [], "messages": []}"#;
+        match parse_api::<u32>(body, "upsert") {
+            Err(VectorizeError::ApiError { code: 0, message }) => {
+                assert_eq!(message, "No result in successful upsert response");
+            }
+            other => panic!("expected ApiError, got {other:?}"),
+        }
     }
 }

--- a/crates/rig-vectorize/src/lib.rs
+++ b/crates/rig-vectorize/src/lib.rs
@@ -40,7 +40,7 @@ use uuid::Uuid;
 
 impl From<VectorizeError> for VectorStoreError {
     fn from(err: VectorizeError) -> Self {
-        VectorStoreError::DatastoreError(Box::new(err))
+        VectorStoreError::datastore(err)
     }
 }
 

--- a/crates/rig-vertexai/src/completion.rs
+++ b/crates/rig-vertexai/src/completion.rs
@@ -47,13 +47,13 @@ impl CompletionModel {
         }
     }
 
-    fn model_path(&self) -> Result<String, CompletionError> {
+    fn model_path(&self) -> String {
         let project = self.client.project();
         let location = self.client.location();
-        Ok(format!(
+        format!(
             "projects/{project}/locations/{location}/publishers/google/models/{}",
             self.model
-        ))
+        )
     }
 }
 
@@ -79,7 +79,7 @@ impl CompletionModel {
         let system_instruction = vertex_request.system_instruction();
         let tools = vertex_request.tools();
         let tool_config = vertex_request.tool_config();
-        let model_path = self.model_path()?;
+        let model_path = self.model_path();
 
         let mut request_builder = self
             .client

--- a/crates/rig-vertexai/src/types/completion_request.rs
+++ b/crates/rig-vertexai/src/types/completion_request.rs
@@ -83,27 +83,20 @@ impl VertexCompletionRequest {
             return None;
         }
 
-        let function_calling_config = match self.0.tool_choice.as_ref() {
-            Some(rig_core::message::ToolChoice::Auto) => {
-                vertexai::model::FunctionCallingConfig::new()
-                    .set_mode(vertexai::model::function_calling_config::Mode::Auto)
-            }
-            Some(rig_core::message::ToolChoice::Required) => {
-                vertexai::model::FunctionCallingConfig::new()
-                    .set_mode(vertexai::model::function_calling_config::Mode::Any)
-            }
-            Some(rig_core::message::ToolChoice::None) => {
-                vertexai::model::FunctionCallingConfig::new()
-                    .set_mode(vertexai::model::function_calling_config::Mode::None)
-            }
+        use vertexai::model::function_calling_config::Mode;
+
+        let (mode, allowed_function_names) = match self.0.tool_choice.as_ref() {
+            Some(rig_core::message::ToolChoice::Auto) | None => (Mode::Auto, Vec::new()),
+            Some(rig_core::message::ToolChoice::Required) => (Mode::Any, Vec::new()),
+            Some(rig_core::message::ToolChoice::None) => (Mode::None, Vec::new()),
             Some(rig_core::message::ToolChoice::Specific { function_names }) => {
-                vertexai::model::FunctionCallingConfig::new()
-                    .set_mode(vertexai::model::function_calling_config::Mode::Any)
-                    .set_allowed_function_names(function_names.clone())
+                (Mode::Any, function_names.clone())
             }
-            None => vertexai::model::FunctionCallingConfig::new()
-                .set_mode(vertexai::model::function_calling_config::Mode::Auto),
         };
+
+        let function_calling_config = vertexai::model::FunctionCallingConfig::new()
+            .set_mode(mode)
+            .set_allowed_function_names(allowed_function_names);
 
         Some(
             vertexai::model::ToolConfig::new().set_function_calling_config(function_calling_config),

--- a/crates/rig-vertexai/src/types/message.rs
+++ b/crates/rig-vertexai/src/types/message.rs
@@ -211,40 +211,36 @@ fn vertex_tool_result_image_part(
     }
     let mime_type = media_type.to_mime_type();
 
-    match &image.data {
-        DocumentSourceKind::Base64(data) => {
-            let data = BASE64.decode(data.as_bytes()).map_err(|error| {
-                CompletionError::RequestError(
-                    format!("Invalid base64 tool-result image data: {error}").into(),
-                )
-            })?;
-            Ok(
-                vertexai::model::FunctionResponsePart::new().set_inline_data(
-                    vertexai::model::FunctionResponseBlob::new()
-                        .set_mime_type(mime_type)
-                        .set_data(data)
-                        .set_display_name(display_name),
-                ),
+    let data = match &image.data {
+        DocumentSourceKind::Base64(data) => BASE64.decode(data.as_bytes()).map_err(|error| {
+            CompletionError::RequestError(
+                format!("Invalid base64 tool-result image data: {error}").into(),
             )
-        }
-        DocumentSourceKind::Raw(data) => Ok(vertexai::model::FunctionResponsePart::new()
-            .set_inline_data(
-                vertexai::model::FunctionResponseBlob::new()
-                    .set_mime_type(mime_type)
-                    .set_data(data.clone())
-                    .set_display_name(display_name),
-            )),
-        DocumentSourceKind::Url(url) => Ok(vertexai::model::FunctionResponsePart::new()
-            .set_file_data(
+        })?,
+        DocumentSourceKind::Raw(data) => data.clone(),
+        DocumentSourceKind::Url(url) => {
+            return Ok(vertexai::model::FunctionResponsePart::new().set_file_data(
                 vertexai::model::FunctionResponseFileData::new()
                     .set_mime_type(mime_type)
                     .set_file_uri(url.clone())
                     .set_display_name(display_name),
-            )),
-        unsupported => Err(CompletionError::RequestError(
-            format!("Unsupported Vertex AI tool-result image source: {unsupported}").into(),
-        )),
-    }
+            ));
+        }
+        unsupported => {
+            return Err(CompletionError::RequestError(
+                format!("Unsupported Vertex AI tool-result image source: {unsupported}").into(),
+            ));
+        }
+    };
+
+    Ok(
+        vertexai::model::FunctionResponsePart::new().set_inline_data(
+            vertexai::model::FunctionResponseBlob::new()
+                .set_mime_type(mime_type)
+                .set_data(data)
+                .set_display_name(display_name),
+        ),
+    )
 }
 
 fn vertex_assistant_image_part(image: Image) -> Result<vertexai::model::Part, CompletionError> {


### PR DESCRIPTION
## Summary

First LOC-consolidation pass covering **all** rig crates (previous passes targeted rig-core/rig-agent only). Net **+2,383 / −5,807 = −3,424 lines** across 45 files.

### Major consolidation
- **rig-bedrock** (−2,449 prod LOC, −45% of the crate): `converse_output.rs` rewritten 3,517 → ~1,000 prod lines. The never-read Guardrail/trace/citation mirror subtree is deleted; live enum mirrors collapse into `mirror_enum!`/`mirror_union!` macros (exact error strings preserved, unit-tested); the redundant `Document` enum is replaced by `serde_json::Value` via the existing Smithy converter; four AWS error tables + five dispatch matches unified; duplicate usage normalizer and model-ID constants deduped.
- **copilot**: forked `ChatCompletionResponse`/`ChatChoice` deleted; the shared openai types now tolerate null-or-missing envelope metadata (`json_utils::null_or_default` on `object`/`created`/`index`/`finish_reason`), pinned by a test beside the shared type.
- **vector stores** (11 crates): rig-core gains `Filter::try_interpret`/`interpret_with` (with `interpret` delegating — one traversal to keep in sync) and `VectorStoreError::datastore()`; `top_n`/`top_n_ids` twin bodies merged in 9 crates; vectorize's 4× API-envelope handling → one `unwrap_api`; per-crate error-wrapper helpers and dead pub `SearchParams` (neo4j) deleted.
- **rig-candle** (−135): llama/qwen3 GGUF metadata validation share one core (llama keeps its stricter no-padding vocab rule via a flag); plain-chat rendering is table-driven with byte-identical output.
- **rig-sqlite** (−259): unreachable `Raw`/`render_vector` path removed; 7 hand-written error types → one thiserror enum (messages verbatim); search twins merged.
- **rig-memory / rig-gemini-grpc / rig-vertexai / rig-derive**: one generic in-flight guard; verbatim-duplicate prost↔JSON and base64 converters removed; misc dedup.

### Defect fixes
- **milvus**: auth header was `Authentication`; Milvus REST expects `Authorization: Bearer` — every authenticated call failed (pre-existing since #1699).
- **postgres**: `PgSearchFilter::gte`/`lte` emitted `?` placeholders the `$N` renumberer ignores — any use produced broken SQL (unit-tested).
- **surrealdb**: `top_n_ids` bound the query vector as `f32` while `top_n` used `f64`; unified to `f64` per the stored schema.
- **sqlite**: `default().or(x)` hit a misleading 'raw filters' error; `Noop` now renders as a tautology (regression test).

### Breaking changes (deliberate)
- bedrock: `trace`/`performance_config` dropped from `InternalConverseOutput` (write-only telemetry); tool payloads and `additional_model_response_fields` serialize as plain JSON instead of the tagged enum shape; `TokenUsage` omits absent cache fields.
- copilot: `raw_completion` returns the shared openai response type.
- sqlite: the private filter enum lost its `Raw` variant (previously serialized `default()` values no longer deserialize).
- openai shared type: missing/null `finish_reason` normalizes to `None` instead of erroring — consistent with the existing gateway leniency on `object`/`created`, and test-pinned.

### Verification
`cargo fmt --all`; `cargo clippy --workspace --all-targets` clean; `cargo test --workspace` — 162 suites, 0 failures (live-DB/live-API tests skipped); `cargo doc --workspace --no-deps` clean; trybuild UI fixtures unchanged; gemini-grpc streaming-conformance suite green. An independent full-diff review produced 10 findings: 6 fixed in this branch, 3 are the accepted breaking changes above, 1 refuted.

### Flagged, not changed
postgres/neo4j give opposite meanings to `threshold()` (distance vs similarity); postgres `member()`/`like()` placeholder defects; gemini system-instruction role differs across grpc/vertex/REST.