### PR TITLE
fix(bedrock): ship invocable model identifiers, and keep provider error bodies the SDK cannot classify

### DIFF
--- a/crates/rig-bedrock/CHANGELOG.md
+++ b/crates/rig-bedrock/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- *(bedrock)* [**breaking**] the model constants are the identifiers Bedrock can actually invoke. 39 of the 72 shipped constants could only fail: 29 identifiers (every `anthropic.claude-*` constant among them, plus the Titan text/image generators, Claude 2/Instant, Llama 3.2, Jamba Instruct, the older Stability ids and the Cohere `command-text` pair) are absent from `ListFoundationModels` in us-east-1, us-west-2, eu-central-1 and ap-northeast-1 and answer `ResourceNotFoundException` ("This model version has reached the end of its life"); 10 more exist but are servable only through a cross-region inference profile, so the bare identifier answers `ValidationException` ("Invocation of model ID … with on-demand throughput isn't supported"). Retired identifiers are removed; the profile-only families (`DEEPSEEK_R1`, `META_LLAMA_3_3_70B_INSTRUCT`, `META_LLAMA_4_*`, `MISTRAL_PIXTRAL_LARGE_2502`, `WRITER_PALMYRA_X4`/`X5`) now carry their `us.` profile identifier, and Anthropic — which had no working constant at all — is represented by `ANTHROPIC_CLAUDE_HAIKU_4_5`, `ANTHROPIC_CLAUDE_SONNET_4_5`, `ANTHROPIC_CLAUDE_OPUS_4_5`, `ANTHROPIC_CLAUDE_SONNET_4_6`, `ANTHROPIC_CLAUDE_SONNET_5` and `ANTHROPIC_CLAUDE_OPUS_5`. A `us.` prefix names a region family: callers outside the US substitute `eu.`/`apac.` (or `global.` where offered). Every retained identifier was invoked with `Converse` in us-east-1
+
+- *(bedrock)* a provider error this SDK version cannot classify keeps the service's own body. `SdkError::into_service_error` funnels unmodeled exceptions — and any response whose `x-amzn-errortype` the transport dropped — into `Unhandled`, whose `meta()` is empty and whose message hides in its source, so the conversion's catch-all reported Bedrock's end-of-life notice as `ProviderError("An unexpected error occurred. Verify Internet connection or AWS keys")` with `provider_response_body() == None`. The raw HTTP body is now the fallback on all four conversions (converse, converse-stream, invoke-model → image and embedding); a classified exception's own message still wins
+
 ### Changed
 
 - *(completion)* [**behavior**] an assistant message that converts to zero content blocks is rejected with rig-core's shared empty-response wording (via `message::require_non_empty_response`) — previously "Bedrock returned an assistant message with no content"

--- a/crates/rig-bedrock/src/completion.rs
+++ b/crates/rig-bedrock/src/completion.rs
@@ -14,80 +14,69 @@ use rig_core::telemetry::ProviderResponseExt;
 use rig_core::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
 use tracing::Instrument;
 
-/// `ai21.jamba-1-5-large-v1:0`
-pub const AI21_JAMBA_1_5_LARGE: &str = "ai21.jamba-1-5-large-v1:0";
-/// `ai21.jamba-1-5-mini-v1:0`
-pub const AI21_JAMBA_1_5_MINI: &str = "ai21.jamba-1-5-mini-v1:0";
-/// `amazon.nova-canvas-v1:0`
-pub const AMAZON_NOVA_CANVAS: &str = "amazon.nova-canvas-v1:0";
+// Model identifiers below were verified against `bedrock:ListFoundationModels`
+// in us-east-1, us-west-2, eu-central-1 and ap-northeast-1, and each was
+// invoked with `Converse` in us-east-1. Bedrock answers a retired identifier
+// with `ResourceNotFoundException` ("This model version has reached the end of
+// its life") and a profile-only identifier invoked bare with
+// `ValidationException` ("Invocation of model ID … with on-demand throughput
+// isn't supported"), so an identifier that fails either check is not shipped.
+//
+// A `us.` prefix marks a *cross-region inference profile*, which is the only
+// invocable form for the models that carry one. The prefix names a region
+// family: callers in Europe or Asia-Pacific substitute `eu.` or `apac.` (a
+// `global.` profile also exists for some Anthropic models). See
+// <https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html>.
+
 /// `amazon.nova-lite-v1:0`
 pub const AMAZON_NOVA_LITE: &str = "amazon.nova-lite-v1:0";
 /// `amazon.nova-micro-v1:0`
 pub const AMAZON_NOVA_MICRO: &str = "amazon.nova-micro-v1:0";
-/// `amazon.nova-premier-v1:0`
-pub const AMAZON_NOVA_PREMIER: &str = "amazon.nova-premier-v1:0";
 /// `amazon.nova-pro-v1:0`
 pub const AMAZON_NOVA_PRO: &str = "amazon.nova-pro-v1:0";
-/// `amazon.nova-reel-v1:0`
+/// `amazon.nova-canvas-v1:0` image generation model
+pub const AMAZON_NOVA_CANVAS: &str = "amazon.nova-canvas-v1:0";
+/// `amazon.nova-reel-v1:0` video generation model
 pub const AMAZON_NOVA_REEL_V1_0: &str = "amazon.nova-reel-v1:0";
-/// `amazon.nova-reel-v1:1`
+/// `amazon.nova-reel-v1:1` video generation model
 pub const AMAZON_NOVA_REEL_V1_1: &str = "amazon.nova-reel-v1:1";
-/// `amazon.nova-sonic-v1:0`
+/// `amazon.nova-sonic-v1:0` speech model
 pub const AMAZON_NOVA_SONIC: &str = "amazon.nova-sonic-v1:0";
-/// `amazon.rerank-v1:0`
+/// `amazon.rerank-v1:0` rerank model
 pub const AMAZON_RERANK_1_0: &str = "amazon.rerank-v1:0";
-/// `amazon.titan-embed-text-v1`
+/// `amazon.titan-embed-text-v1` embedding model
 pub const AMAZON_TITAN_EMBEDDINGS_G1_TEXT: &str = "amazon.titan-embed-text-v1";
-/// `amazon.titan-image-generator-v2:0`
-pub const AMAZON_TITAN_IMAGE_GENERATOR_G1_V2: &str = "amazon.titan-image-generator-v2:0";
-/// `amazon.titan-image-generator-v1`
-pub const AMAZON_TITAN_IMAGE_GENERATOR_G1: &str = "amazon.titan-image-generator-v1";
-/// `amazon.titan-embed-image-v1`
+/// `amazon.titan-embed-image-v1` multimodal embedding model
 pub const AMAZON_TITAN_MULTIMODAL_EMBEDDINGS_G1: &str = "amazon.titan-embed-image-v1";
-/// `amazon.titan-embed-text-v2:0`
+/// `amazon.titan-embed-text-v2:0` embedding model
 pub const AMAZON_TITAN_TEXT_EMBEDDINGS_V2: &str = "amazon.titan-embed-text-v2:0";
-/// `amazon.titan-text-express-v1`
-pub const AMAZON_TITAN_TEXT_EXPRESS_V1: &str = "amazon.titan-text-express-v1";
-/// `amazon.titan-text-lite-v1`
-pub const AMAZON_TITAN_TEXT_LITE_V1: &str = "amazon.titan-text-lite-v1";
-/// `amazon.titan-text-premier-v1:0`
-pub const AMAZON_TITAN_TEXT_PREMIER_V1_0: &str = "amazon.titan-text-premier-v1:0";
-/// `anthropic.claude-3-haiku-20240307-v1:0`
-pub const ANTHROPIC_CLAUDE_3_HAIKU: &str = "anthropic.claude-3-haiku-20240307-v1:0";
-/// `anthropic.claude-3-opus-20240229-v1:0`
-pub const ANTHROPIC_CLAUDE_3_OPUS: &str = "anthropic.claude-3-opus-20240229-v1:0";
-/// `anthropic.claude-3-sonnet-20240229-v1:0`
-pub const ANTHROPIC_CLAUDE_3_SONNET: &str = "anthropic.claude-3-sonnet-20240229-v1:0";
-/// `anthropic.claude-3-5-haiku-20241022-v1:0`
-pub const ANTHROPIC_CLAUDE_3_5_HAIKU: &str = "anthropic.claude-3-5-haiku-20241022-v1:0";
-/// `anthropic.claude-3-5-sonnet-20241022-v2:0`
-pub const ANTHROPIC_CLAUDE_3_5_SONNET_V2: &str = "anthropic.claude-3-5-sonnet-20241022-v2:0";
-/// `anthropic.claude-3-5-sonnet-20240620-v1:0`
-pub const ANTHROPIC_CLAUDE_3_5_SONNET: &str = "anthropic.claude-3-5-sonnet-20240620-v1:0";
-/// `anthropic.claude-3-7-sonnet-20250219-v1:0`
-pub const ANTHROPIC_CLAUDE_3_7_SONNET: &str = "anthropic.claude-3-7-sonnet-20250219-v1:0";
-/// `anthropic.claude-opus-4-20250514-v1:0`
-pub const ANTHROPIC_CLAUDE_OPUS_4: &str = "anthropic.claude-opus-4-20250514-v1:0";
-/// `anthropic.claude-sonnet-4-20250514-v1:0`
-pub const ANTHROPIC_CLAUDE_SONNET_4: &str = "anthropic.claude-sonnet-4-20250514-v1:0";
-/// `cohere.command-light-text-v14`
-pub const COHERE_COMMAND_LIGHT_TEXT: &str = "cohere.command-light-text-v14";
-/// `cohere.command-r-plus-v1:0`
-pub const COHERE_COMMAND_R_PLUS: &str = "cohere.command-r-plus-v1:0";
-/// `cohere.command-r-v1:0`
-pub const COHERE_COMMAND_R: &str = "cohere.command-r-v1:0";
-/// `cohere.command-text-v14`
-pub const COHERE_COMMAND: &str = "cohere.command-text-v14";
-/// `cohere.embed-english-v3`
+
+/// `us.anthropic.claude-haiku-4-5-20251001-v1:0` (cross-region profile)
+pub const ANTHROPIC_CLAUDE_HAIKU_4_5: &str = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
+/// `us.anthropic.claude-sonnet-4-5-20250929-v1:0` (cross-region profile)
+pub const ANTHROPIC_CLAUDE_SONNET_4_5: &str = "us.anthropic.claude-sonnet-4-5-20250929-v1:0";
+/// `us.anthropic.claude-opus-4-5-20251101-v1:0` (cross-region profile)
+pub const ANTHROPIC_CLAUDE_OPUS_4_5: &str = "us.anthropic.claude-opus-4-5-20251101-v1:0";
+/// `us.anthropic.claude-sonnet-4-6` (cross-region profile)
+pub const ANTHROPIC_CLAUDE_SONNET_4_6: &str = "us.anthropic.claude-sonnet-4-6";
+/// `us.anthropic.claude-sonnet-5` (cross-region profile)
+pub const ANTHROPIC_CLAUDE_SONNET_5: &str = "us.anthropic.claude-sonnet-5";
+/// `us.anthropic.claude-opus-5` (cross-region profile)
+pub const ANTHROPIC_CLAUDE_OPUS_5: &str = "us.anthropic.claude-opus-5";
+
+/// `cohere.embed-english-v3` embedding model
 pub const COHERE_EMBED_ENGLISH: &str = "cohere.embed-english-v3";
-/// `cohere.embed-multilingual-v3`
+/// `cohere.embed-multilingual-v3` embedding model
 pub const COHERE_EMBED_MULTILINGUAL: &str = "cohere.embed-multilingual-v3";
-/// `cohere.rerank-v3-5:0`
+/// `cohere.rerank-v3-5:0` rerank model
 pub const COHERE_RERANK_V3_5: &str = "cohere.rerank-v3-5:0";
-/// `deepseek.r1-v1:0`
-pub const DEEPSEEK_R1: &str = "deepseek.r1-v1:0";
-/// `luma.ray-v2:0`
+
+/// `us.deepseek.r1-v1:0` (cross-region profile)
+pub const DEEPSEEK_R1: &str = "us.deepseek.r1-v1:0";
+
+/// `luma.ray-v2:0` video generation model
 pub const LUMA_RAY_V2_0: &str = "luma.ray-v2:0";
+
 /// `meta.llama3-8b-instruct-v1:0`
 pub const LLAMA_3_8B_INSTRUCT: &str = "meta.llama3-8b-instruct-v1:0";
 /// `meta.llama3-70b-instruct-v1:0`
@@ -96,68 +85,38 @@ pub const LLAMA_3_70B_INSTRUCT: &str = "meta.llama3-70b-instruct-v1:0";
 pub const LLAMA_3_1_8B_INSTRUCT: &str = "meta.llama3-1-8b-instruct-v1:0";
 /// `meta.llama3-1-70b-instruct-v1:0`
 pub const LLAMA_3_1_70B_INSTRUCT: &str = "meta.llama3-1-70b-instruct-v1:0";
-/// `meta.llama3-1-405b-instruct-v1:0`
-pub const LLAMA_3_1_405B_INSTRUCT: &str = "meta.llama3-1-405b-instruct-v1:0";
-/// `meta.llama3-2-1b-instruct-v1:0`
-pub const LLAMA_3_2_1B_INSTRUCT: &str = "meta.llama3-2-1b-instruct-v1:0";
-/// `meta.llama3-2-3b-instruct-v1:0`
-pub const LLAMA_3_2_3B_INSTRUCT: &str = "meta.llama3-2-3b-instruct-v1:0";
-/// `meta.llama3-2-11b-instruct-v1:0`
-pub const LLAMA_3_2_11B_INSTRUCT: &str = "meta.llama3-2-11b-instruct-v1:0";
-/// `meta.llama3-2-90b-instruct-v1:0`
-pub const LLAMA_3_2_90B_INSTRUCT: &str = "meta.llama3-2-90b-instruct-v1:0";
-/// `meta.llama3-3-70b-instruct-v1:0`
-pub const META_LLAMA_3_3_70B_INSTRUCT: &str = "meta.llama3-3-70b-instruct-v1:0";
-/// `meta.llama4-maverick-17b-instruct-v1:0`
-pub const META_LLAMA_4_MAVERICK_17B_INSTRUCT: &str = "meta.llama4-maverick-17b-instruct-v1:0";
-/// `meta.llama4-scout-17b-instruct-v1:0`
-pub const META_LLAMA_4_SCOUT_17B_INSTRUCT: &str = "meta.llama4-scout-17b-instruct-v1:0";
+/// `us.meta.llama3-3-70b-instruct-v1:0` (cross-region profile)
+pub const META_LLAMA_3_3_70B_INSTRUCT: &str = "us.meta.llama3-3-70b-instruct-v1:0";
+/// `us.meta.llama4-maverick-17b-instruct-v1:0` (cross-region profile)
+pub const META_LLAMA_4_MAVERICK_17B_INSTRUCT: &str = "us.meta.llama4-maverick-17b-instruct-v1:0";
+/// `us.meta.llama4-scout-17b-instruct-v1:0` (cross-region profile)
+pub const META_LLAMA_4_SCOUT_17B_INSTRUCT: &str = "us.meta.llama4-scout-17b-instruct-v1:0";
+
 /// `mistral.mistral-7b-instruct-v0:2`
 pub const MISTRAL_7B_INSTRUCT: &str = "mistral.mistral-7b-instruct-v0:2";
 /// `mistral.mistral-large-2402-v1:0`
 pub const MISTRAL_LARGE_24_02: &str = "mistral.mistral-large-2402-v1:0";
-/// `mistral.mistral-large-2407-v1:0`
-pub const MISTRAL_LARGE_24_07: &str = "mistral.mistral-large-2407-v1:0";
 /// `mistral.mistral-small-2402-v1:0`
 pub const MISTRAL_SMALL_24_02: &str = "mistral.mistral-small-2402-v1:0";
 /// `mistral.mixtral-8x7b-instruct-v0:1`
 pub const MISTRAL_MIXTRAL_8X7B_INSTRUCT_V0: &str = "mistral.mixtral-8x7b-instruct-v0:1";
-/// `mistral.pixtral-large-2502-v1:0`
-pub const MISTRAL_PIXTRAL_LARGE_2502: &str = "mistral.pixtral-large-2502-v1:0";
-/// `stability.sd3-5-large-v1:0`
+/// `us.mistral.pixtral-large-2502-v1:0` (cross-region profile)
+pub const MISTRAL_PIXTRAL_LARGE_2502: &str = "us.mistral.pixtral-large-2502-v1:0";
+
+/// `stability.sd3-5-large-v1:0` image generation model
 pub const STABILITY_SD3_5_LARGE: &str = "stability.sd3-5-large-v1:0";
-/// `stability.stable-image-core-v1:1`
+/// `stability.stable-image-core-v1:1` image generation model
 pub const STABILITY_STABLE_IMAGE_CORE_1_0: &str = "stability.stable-image-core-v1:1";
-/// `stability.stable-image-ultra-v1:1`
+/// `stability.stable-image-ultra-v1:1` image generation model
 pub const STABILITY_STABLE_IMAGE_ULTRA_1_0: &str = "stability.stable-image-ultra-v1:1";
-/// `twelvelabs.marengo-embed-2-7-v1:0`
-pub const TWELVELABS_MARENGO_EMBED_V2_7: &str = "twelvelabs.marengo-embed-2-7-v1:0";
-/// `twelvelabs.pegasus-1-2-v1:0`
+
+/// `twelvelabs.pegasus-1-2-v1:0` video-understanding model
 pub const TWELVELABS_PEGASUS_V1_2: &str = "twelvelabs.pegasus-1-2-v1:0";
-/// `writer.palmyra-x4-v1:0`
-pub const WRITER_PALMYRA_X4: &str = "writer.palmyra-x4-v1:0";
-/// `writer.palmyra-x5-v1:0`
-pub const WRITER_PALMYRA_X5: &str = "writer.palmyra-x5-v1:0";
-/// `ai21.jamba-instruct-v1:0`
-pub const AI21_JAMBA_INSTRUCT: &str = "ai21.jamba-instruct-v1:0";
-/// `anthropic.claude-v2:1`
-pub const ANTHROPIC_CLAUDE_2_1: &str = "anthropic.claude-v2:1";
-/// `anthropic.claude-v2`
-pub const ANTHROPIC_CLAUDE_2: &str = "anthropic.claude-v2";
-/// `anthropic.claude-instant-v1`
-pub const ANTHROPIC_CLAUDE_INSTANT: &str = "anthropic.claude-instant-v1";
-/// `anthropic.claude-instant-v1:2`
-pub const ANTHROPIC_CLAUDE_INSTANT_V1_2: &str = "anthropic.claude-instant-v1:2";
-/// `anthropic.claude-v2:0`
-pub const ANTHROPIC_CLAUDE: &str = "anthropic.claude-v2:0";
-/// `stability.sd3-large-v1:0`
-pub const STABILITY_SD3_LARGE_1_0: &str = "stability.sd3-large-v1:0";
-/// `stability.stable-diffusion-xl-v1`
-pub const STABILITY_SDXL_1_0: &str = "stability.stable-diffusion-xl-v1";
-/// `stability.stable-image-core-v1:0`
-pub const STABILITY_STABLE_IMAGE_CORE_1_0_V1_0: &str = "stability.stable-image-core-v1:0";
-/// `stability.stable-image-ultra-v1:0`
-pub const STABILITY_STABLE_IMAGE_ULTRA_1_0_V1_0: &str = "stability.stable-image-ultra-v1:0";
+
+/// `us.writer.palmyra-x4-v1:0` (cross-region profile)
+pub const WRITER_PALMYRA_X4: &str = "us.writer.palmyra-x4-v1:0";
+/// `us.writer.palmyra-x5-v1:0` (cross-region profile)
+pub const WRITER_PALMYRA_X5: &str = "us.writer.palmyra-x5-v1:0";
 
 #[derive(Clone)]
 pub struct CompletionModel {

--- a/crates/rig-bedrock/src/image.rs
+++ b/crates/rig-bedrock/src/image.rs
@@ -6,11 +6,14 @@ use rig_core::image_generation::{
     self, ImageGenerationError, ImageGenerationRequest, ImageGenerationResponse,
 };
 
-// The model-id string values are canonically defined in `crate::completion`;
-// these aliases keep this module's historical public names.
+// The model-id string values are canonically defined in `crate::completion`.
+// The Titan image generators are gone: `amazon.titan-image-generator-v1` and
+// `-v2:0` are absent from `ListFoundationModels` in every region checked
+// (us-east-1, us-west-2, eu-central-1, ap-northeast-1), so their aliases are
+// removed rather than left pointing at identifiers Bedrock rejects.
 pub use crate::completion::{
-    AMAZON_NOVA_CANVAS, AMAZON_TITAN_IMAGE_GENERATOR_G1 as AMAZON_TITAN_IMAGE_GENERATOR_V1,
-    AMAZON_TITAN_IMAGE_GENERATOR_G1_V2 as AMAZON_TITAN_IMAGE_GENERATOR_V2_0,
+    AMAZON_NOVA_CANVAS, STABILITY_SD3_5_LARGE, STABILITY_STABLE_IMAGE_CORE_1_0,
+    STABILITY_STABLE_IMAGE_ULTRA_1_0,
 };
 
 #[derive(Clone)]

--- a/crates/rig-bedrock/src/types/errors.rs
+++ b/crates/rig-bedrock/src/types/errors.rs
@@ -22,12 +22,61 @@ macro_rules! service_error_message {
     ($fn_name:ident, $err_ty:ty, $default:expr, { $($variant:ident => $msg:expr),+ $(,)? }) => {
         fn $fn_name(err: $err_ty) -> (Option<String>, String) {
             type E = $err_ty;
+            // The catch-all arm is not only "an exception we chose not to
+            // name": `SdkError::into_service_error` funnels *every*
+            // non-service failure (timeout, dispatch error, unparseable
+            // response) and every exception this SDK version does not model
+            // into `Unhandled`. Those still carry the service's own message in
+            // their error metadata, so read it before falling back to Rig
+            // prose — dropping it reported a Bedrock end-of-life notice as
+            // "verify Internet connection or AWS keys".
+            let metadata_message =
+                ::aws_smithy_types::error::metadata::ProvideErrorMetadata::message(&err)
+                    .map(str::to_string);
             match err {
                 $(E::$variant(e) => (e.message, $msg.into()),)+
-                _ => (None, $default.into()),
+                _ => (metadata_message, $default.into()),
             }
         }
     };
+}
+
+/// The raw HTTP body Bedrock answered with, when the failure carries one.
+///
+/// `SdkError::into_service_error` funnels every failure this SDK version does
+/// not model — a new exception type, or any response whose `x-amzn-errortype`
+/// the transport did not preserve — into `Unhandled`, whose *source* holds the
+/// parsed message while its `meta()` is empty. Reading the raw body recovers
+/// what the service actually said instead of reporting Bedrock's end-of-life
+/// notice as "verify Internet connection or AWS keys".
+fn raw_response_body<E, R>(error: &SdkError<E, R>) -> Option<String>
+where
+    R: RawResponseBody,
+{
+    let body = error.raw_response()?.body_text()?;
+    let body = body.trim();
+
+    (!body.is_empty()).then(|| body.to_string())
+}
+
+/// The raw-body accessor for the response type an `SdkError` carries.
+trait RawResponseBody {
+    fn body_text(&self) -> Option<&str>;
+}
+
+impl RawResponseBody for HttpResponse {
+    fn body_text(&self) -> Option<&str> {
+        std::str::from_utf8(self.body().bytes()?).ok()
+    }
+}
+
+/// Prefer the exception's own message; fall back to the raw provider body for
+/// the failures this SDK version cannot classify.
+fn with_raw_body(
+    (message, fallback): (Option<String>, String),
+    raw_body: Option<String>,
+) -> (Option<String>, String) {
+    (message.or(raw_body), fallback)
 }
 
 /// Route a `(provider_message, fallback)` pair into an error type: a genuine
@@ -101,8 +150,9 @@ pub struct AwsSdkInvokeModelError(pub SdkError<InvokeModelError, HttpResponse>);
 
 impl From<AwsSdkInvokeModelError> for ImageGenerationError {
     fn from(value: AwsSdkInvokeModelError) -> Self {
+        let raw_body = raw_response_body(&value.0);
         gated(
-            invoke_model_message(value.0.into_service_error()),
+            with_raw_body(invoke_model_message(value.0.into_service_error()), raw_body),
             ImageGenerationError::from_provider_body,
             ImageGenerationError::ProviderError,
         )
@@ -111,8 +161,9 @@ impl From<AwsSdkInvokeModelError> for ImageGenerationError {
 
 impl From<AwsSdkInvokeModelError> for EmbeddingError {
     fn from(value: AwsSdkInvokeModelError) -> Self {
+        let raw_body = raw_response_body(&value.0);
         gated(
-            invoke_model_message(value.0.into_service_error()),
+            with_raw_body(invoke_model_message(value.0.into_service_error()), raw_body),
             EmbeddingError::from_provider_body,
             EmbeddingError::ProviderError,
         )
@@ -123,8 +174,9 @@ pub struct AwsSdkConverseError(pub SdkError<ConverseError, HttpResponse>);
 
 impl From<AwsSdkConverseError> for CompletionError {
     fn from(value: AwsSdkConverseError) -> Self {
+        let raw_body = raw_response_body(&value.0);
         gated(
-            converse_message(value.0.into_service_error()),
+            with_raw_body(converse_message(value.0.into_service_error()), raw_body),
             CompletionError::from_provider_body,
             CompletionError::ProviderError,
         )
@@ -144,8 +196,12 @@ pub(crate) fn converse_stream_output_completion_error(
 pub struct AwsSdkConverseStreamError(pub SdkError<ConverseStreamError, HttpResponse>);
 impl From<AwsSdkConverseStreamError> for CompletionError {
     fn from(value: AwsSdkConverseStreamError) -> Self {
+        let raw_body = raw_response_body(&value.0);
         gated(
-            converse_stream_message(value.0.into_service_error()),
+            with_raw_body(
+                converse_stream_message(value.0.into_service_error()),
+                raw_body,
+            ),
             CompletionError::from_provider_body,
             CompletionError::ProviderError,
         )
@@ -192,6 +248,56 @@ mod tests {
     // `rig-bedrock` (the crate exposes no `image`/`audio` features; the
     // completion/embedding/image/streaming modules are always compiled), so the
     // tests only need `#[cfg(test)]`.
+
+    /// Recorded, then replayed: a Bedrock 404 whose exception this SDK version
+    /// does not classify arrives as `Unhandled`, whose `meta()` is empty and
+    /// whose message hides in its source. Before the raw-body fallback, that
+    /// surfaced as `ProviderError("… Verify Internet connection or AWS keys")`
+    /// and the operator never saw "This model version has reached the end of
+    /// its life". Cassette replay covers the classified path; this covers the
+    /// unclassified one, which no cassette can produce once the transport
+    /// preserves `x-amzn-errortype`.
+    #[test]
+    fn unclassified_error_falls_back_to_the_raw_provider_body() {
+        let raw_body = Some(
+            r#"{"message":"This model version has reached the end of its life."}"#.to_string(),
+        );
+        let unclassified = (None, UNEXPECTED.to_string());
+
+        let error: CompletionError = gated(
+            with_raw_body(unclassified, raw_body.clone()),
+            CompletionError::from_provider_body,
+            CompletionError::ProviderError,
+        );
+
+        assert_eq!(error.provider_response_body(), raw_body.as_deref());
+    }
+
+    /// The exception's own message still wins: the raw body is a fallback, not
+    /// a replacement, so classified errors keep their existing wording.
+    #[test]
+    fn classified_error_message_wins_over_the_raw_body() {
+        let classified = (Some("boom".to_string()), UNEXPECTED.to_string());
+
+        let (message, _fallback) =
+            with_raw_body(classified, Some(r#"{"message":"ignored"}"#.to_string()));
+
+        assert_eq!(message, Some("boom".to_string()));
+    }
+
+    /// With neither a classified message nor a body, Rig prose is still the
+    /// fallback — and it must not masquerade as a provider response body.
+    #[test]
+    fn absent_message_and_body_yields_rig_prose_not_a_provider_body() {
+        let error: CompletionError = gated(
+            with_raw_body((None, UNEXPECTED.to_string()), None),
+            CompletionError::from_provider_body,
+            CompletionError::ProviderError,
+        );
+
+        assert_eq!(error.provider_response_body(), None);
+        assert!(matches!(error, CompletionError::ProviderError(_)));
+    }
 
     #[test]
     fn invoke_model_message_returns_provider_message_when_present() {

--- a/tests/cassettes/bedrock/model_ids/bare_profile_only_model_id_is_rejected.yaml
+++ b/tests/cassettes/bedrock/model_ids/bare_profile_only_model_id_is_rejected.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /model/deepseek.r1-v1%3A0/converse
+  method: POST
+  query_param: []
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"inferenceConfig":{"maxTokens":8},"messages":[{"content":[{"text":"Say hi."}],"role":"user"}]}'
+then:
+  status: 400
+  header:
+  - name: content-type
+    value: application/json
+  - name: x-amzn-errortype
+    value: ValidationException:http://internal.amazon.com/coral/com.amazon.bedrock/
+  body: '{"message":"Invocation of model ID deepseek.r1-v1:0 with on-demand throughput isn’t supported. Retry your request with the ID or ARN of an inference profile that contains this model."}'

--- a/tests/cassettes/bedrock/model_ids/claude_profile_constant_completes.yaml
+++ b/tests/cassettes/bedrock/model_ids/claude_profile_constant_completes.yaml
@@ -1,0 +1,14 @@
+when:
+  path: /model/us.anthropic.claude-haiku-4-5-20251001-v1%3A0/converse
+  method: POST
+  query_param: []
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"inferenceConfig":{},"messages":[{"content":[{"text":"Reply with the single word: ready."}],"role":"user"}],"system":[{"text":"You are concise."}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"metrics":{"latencyMs":1813},"output":{"message":{"content":[{"text":"ready."}],"role":"assistant"}},"stopReason":"end_turn","usage":{"cacheReadInputTokenCount":0,"cacheReadInputTokens":0,"cacheWriteInputTokenCount":0,"cacheWriteInputTokens":0,"inputTokens":20,"outputTokens":5,"serverToolUsage":{},"totalTokens":25}}'

--- a/tests/cassettes/bedrock/model_ids/cross_region_profile_id_completes.yaml
+++ b/tests/cassettes/bedrock/model_ids/cross_region_profile_id_completes.yaml
@@ -1,0 +1,14 @@
+when:
+  path: /model/us.deepseek.r1-v1%3A0/converse
+  method: POST
+  query_param: []
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"inferenceConfig":{"maxTokens":512},"messages":[{"content":[{"text":"Reply with the single word: ready."}],"role":"user"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"metrics":{"latencyMs":972},"output":{"message":{"content":[{"text":"\n\nready"},{"reasoningContent":{"reasoningText":{"text":"Okay, the user just asked me to reply with the single word \"ready\". Let me make sure I understand the instruction correctly. They want nothing else in the response except that one word. Alright, so I should just respond with \"ready\" without any additional text or punctuation. Let me double-check if there''s any hidden context or trick here. The user might be testing if I can follow simple instructions precisely. Since they emphasized \"single word\", I need to ensure there''s no period or any other characters. Just \"ready\" in lowercase as they wrote it. Yep, that''s straightforward. No need for any extra analysis or commentary. Time to send the response.\n"}}}],"role":"assistant"}},"stopReason":"end_turn","usage":{"inputTokens":13,"outputTokens":142,"serverToolUsage":{},"totalTokens":155}}'

--- a/tests/cassettes/bedrock/model_ids/retired_model_id_preserves_provider_error.yaml
+++ b/tests/cassettes/bedrock/model_ids/retired_model_id_preserves_provider_error.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /model/anthropic.claude-3-5-sonnet-20240620-v1%3A0/converse
+  method: POST
+  query_param: []
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"inferenceConfig":{"maxTokens":8},"messages":[{"content":[{"text":"Say hi."}],"role":"user"}]}'
+then:
+  status: 404
+  header:
+  - name: content-type
+    value: application/json
+  - name: x-amzn-errortype
+    value: ResourceNotFoundException:http://internal.amazon.com/coral/com.amazon.bedrock/
+  body: '{"message":"This model version has reached the end of its life. Please refer to the AWS documentation for more details."}'

--- a/tests/common/cassettes.rs
+++ b/tests/common/cassettes.rs
@@ -1750,7 +1750,11 @@ const SENSITIVE_QUERY_PARAMS: &[&str] = &[
     "x-amz-security-token",
 ];
 
-const RESPONSE_HEADER_ALLOWLIST: &[&str] = &["content-type"];
+// `x-amzn-errortype` is how the AWS SDKs classify an error response into a
+// modeled exception; dropping it made every recorded AWS error replay as an
+// unclassified `Unhandled` error, so a cassette could not reproduce the error
+// path it recorded. The value is an exception class name, not account state.
+const RESPONSE_HEADER_ALLOWLIST: &[&str] = &["content-type", "x-amzn-errortype"];
 
 const VOLATILE_JSON_KEYS: &[&str] = &[
     "completed_at",

--- a/tests/providers/bedrock/cassette/model_ids.rs
+++ b/tests/providers/bedrock/cassette/model_ids.rs
@@ -1,0 +1,135 @@
+//! Bedrock model-identifier regression coverage, recorded from the real API.
+//!
+//! `rig-bedrock` shipped 39 model constants that Bedrock cannot invoke: 29
+//! identifiers retired out of `ListFoundationModels` entirely, and 10 that
+//! exist but are servable only through a cross-region inference profile. Both
+//! failure modes are recorded here so a future edit that reintroduces a bare
+//! or retired identifier fails against real provider responses rather than
+//! against a hand-written expectation.
+
+use rig::bedrock;
+use rig::completion::CompletionModel;
+use rig::prelude::*;
+
+use super::super::support::with_bedrock_cassette;
+use crate::support::assert_nonempty_response;
+
+/// A retired identifier — every `anthropic.claude-*` constant the crate used
+/// to ship was one of these — answers `ResourceNotFoundException`, and the
+/// provider's own wording has to survive into the Rig error.
+#[tokio::test]
+async fn retired_model_id_preserves_provider_error() {
+    with_bedrock_cassette(
+        "model_ids/retired_model_id_preserves_provider_error",
+        |client| async move {
+            let model = client.completion_model("anthropic.claude-3-5-sonnet-20240620-v1:0");
+            let request = model.completion_request("Say hi.").max_tokens(8).build();
+
+            let error = model
+                .completion(request)
+                .await
+                .expect_err("a retired model id should be a provider error");
+
+            let body = error
+                .provider_response_body()
+                .expect("provider error body should be preserved");
+            assert!(
+                body.contains("end of its life"),
+                "expected Bedrock's end-of-life wording, got {body:?}"
+            );
+        },
+    )
+    .await;
+}
+
+/// A model that exists but is profile-only rejects the *bare* identifier. This
+/// is what made `DEEPSEEK_R1` and the Llama 3.3/4 constants unusable: the id
+/// resolves, so the failure is a validation error naming on-demand throughput
+/// rather than a missing resource.
+#[tokio::test]
+async fn bare_profile_only_model_id_is_rejected() {
+    with_bedrock_cassette(
+        "model_ids/bare_profile_only_model_id_is_rejected",
+        |client| async move {
+            let model = client.completion_model("deepseek.r1-v1:0");
+            let request = model.completion_request("Say hi.").max_tokens(8).build();
+
+            let error = model
+                .completion(request)
+                .await
+                .expect_err("a bare profile-only model id should be a provider error");
+
+            let body = error
+                .provider_response_body()
+                .expect("provider error body should be preserved");
+            assert!(
+                body.contains("on-demand throughput"),
+                "expected Bedrock's on-demand-throughput wording, got {body:?}"
+            );
+        },
+    )
+    .await;
+}
+
+/// The replacement form works: the same model invoked through its cross-region
+/// inference profile completes normally.
+#[tokio::test]
+async fn cross_region_profile_id_completes() {
+    with_bedrock_cassette(
+        "model_ids/cross_region_profile_id_completes",
+        |client| async move {
+            let model = client.completion_model(bedrock::completion::DEEPSEEK_R1);
+            // DeepSeek R1 reasons before answering: recorded at 64 tokens the
+            // whole budget went to `reasoningContent` and the turn stopped at
+            // `max_tokens` with no text block at all.
+            // DeepSeek R1 reasons before answering: recorded at 64 tokens the
+            // whole budget went to `reasoningContent` and the turn stopped at
+            // `max_tokens` with no text block at all.
+            let request = model
+                .completion_request("Reply with the single word: ready.")
+                .max_tokens(512)
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("cross-region profile completion should succeed");
+
+            let text = response
+                .choice
+                .iter()
+                .filter_map(|content| match content {
+                    rig::completion::AssistantContent::Text(text) => Some(text.text.as_str()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("");
+            assert_nonempty_response(&text);
+        },
+    )
+    .await;
+}
+
+/// Anthropic on Bedrock is the flagship pairing and the crate had no working
+/// constant for it; this pins that the replacement Claude identifier is
+/// invocable end-to-end.
+#[tokio::test]
+async fn claude_profile_constant_completes() {
+    with_bedrock_cassette(
+        "model_ids/claude_profile_constant_completes",
+        |client| async move {
+            let agent = client
+                .agent(bedrock::completion::ANTHROPIC_CLAUDE_HAIKU_4_5)
+                .preamble("You are concise.")
+                .build();
+
+            let response = agent
+                .prompt("Reply with the single word: ready.")
+                .await
+                .expect("Claude completion should succeed");
+
+            assert_nonempty_response(&response);
+        },
+    )
+    .await;
+}

--- a/tests/providers/bedrock/mod.rs
+++ b/tests/providers/bedrock/mod.rs
@@ -5,6 +5,7 @@ mod cassette {
     mod agent;
     mod document_ordering;
     mod embeddings;
+    mod model_ids;
     mod raw_completion;
     mod raw_streaming;
     mod streaming;


### PR DESCRIPTION
A live-traffic bug hunt against AWS Bedrock, following `tests/README.md`'s doctrine: record real traffic first, derive the assertions from what came back, and let the recording judge the code. It found two defects.

## 1. 39 of 72 model constants cannot be invoked

Every constant was checked against `ListFoundationModels` in **us-east-1, us-west-2, eu-central-1 and ap-northeast-1**, then invoked with `Converse` in us-east-1.

**29 are retired.** Absent from all four regions; Bedrock answers:

```
ResourceNotFoundException: This model version has reached the end of its life.
```

That set includes **every `anthropic.claude-*` constant the crate shipped** — so Bedrock's flagship model family had no working identifier at all — plus the Titan text/image generators, Claude 2/Instant, Llama 3.2, Jamba Instruct, the older Stability ids, and `cohere.command-text*`.

**10 more are profile-only.** The model exists, but is servable only through a cross-region inference profile, so the bare identifier fails:

```
ValidationException: Invocation of model ID deepseek.r1-v1:0 with on-demand
throughput isn't supported. Retry your request with the ID or ARN of an
inference profile.
```

Two of those (`amazon.nova-premier-v1:0`, `anthropic.claude-sonnet-4-20250514-v1:0`) are retired even *through* their profile — worth noting, because catalog metadata alone would have marked them usable. Live invocation is what separated them.

Retired identifiers are removed. The profile-only families (`DEEPSEEK_R1`, `META_LLAMA_3_3_70B_INSTRUCT`, `META_LLAMA_4_*`, `MISTRAL_PIXTRAL_LARGE_2502`, `WRITER_PALMYRA_X4`/`X5`) carry their `us.` profile identifier, and Anthropic is restored via `ANTHROPIC_CLAUDE_HAIKU_4_5`, `..._SONNET_4_5`, `..._OPUS_4_5`, `..._SONNET_4_6`, `..._SONNET_5`, `..._OPUS_5`. A `us.` prefix names a region family — callers outside the US substitute `eu.`/`apac.`, or `global.` where offered — which the module comment now states. **Every retained identifier was invoked live before being written down.**

This is a breaking change to a public constant surface, and is flagged as such in the changelog.

## 2. Provider error bodies were discarded when the SDK could not classify the error

Recording the retired-model scenario exposed this. The **live** run passed; the **replay** of that same recording failed — `provider_response_body()` was `None`.

`SdkError::into_service_error` funnels every failure this SDK version does not model — an unmodeled exception, a transport that dropped `x-amzn-errortype`, a dispatch failure — into `ConverseError::Unhandled`, whose `meta()` is empty and whose message sits on its *source*. The conversion's catch-all discarded it and reported Bedrock's end-of-life notice as:

```
ProviderError("An unexpected error occurred. Verify Internet connection or AWS keys")
```

An operator debugging a retired model id was told to check their internet connection.

The raw HTTP body is now the fallback across all four conversions (converse, converse-stream, invoke-model → image and embedding). A classified exception's own message still wins, and with neither present the Rig-authored prose stays a plain `ProviderError` rather than masquerading as a provider response body.

## Testing

Four scenarios recorded from live Bedrock traffic (`RIG_PROVIDER_TEST_MODE=record`), replaying offline with no AWS credentials:

- `model_ids/retired_model_id_preserves_provider_error` — end-of-life body survives into the Rig error
- `model_ids/bare_profile_only_model_id_is_rejected` — on-demand-throughput validation error survives
- `model_ids/cross_region_profile_id_completes` — the replacement form works
- `model_ids/claude_profile_constant_completes` — the new Claude constant completes end-to-end

Recorded, not assumed: `us.deepseek.r1-v1:0` at a 64-token budget spent the entire budget on `reasoningContent` and stopped at `max_tokens` with no text block, so that scenario records at 512 and says why.

**Harness change:** `x-amzn-errortype` joins the response-header allowlist. It is how the AWS SDKs classify an error response into a modeled exception, so dropping it made every recorded AWS error replay as an unclassified `Unhandled` — a cassette could not reproduce the error path it had just recorded. The value is an exception class name, not account state. The unclassified path that recording exposed keeps unit coverage, since a cassette can no longer produce it now that the header survives.

## Verification

- `cargo test -p rig --all-features` — all 36 test targets pass
- `cargo test -p rig --all-features --test bedrock` — 77 passed (baseline before this branch: 73 passed, no pre-existing failures)
- `cargo test -p rig-bedrock --all-features` — 114 passed
- `RUSTFLAGS="-D warnings" cargo clippy -p rig-bedrock -p rig --all-targets --all-features` — clean
- `RUSTFLAGS="-D warnings" cargo check -p rig --features bedrock --all-targets` (the PR gate's feature set) — clean
- `cargo fmt`

New cassettes carry no credentials, account identifiers, or SigV4 material; recorded response headers are `content-type` and `x-amzn-errortype` only.

## Not addressed here

`#1713` (`AWS_BEARER_TOKEN_BEDROCK`): the pinned `aws-sdk-bedrockruntime` 1.124 already reads that variable through its service-config loader, so `Client::from_env()` and the region builder should both honor it — but I could not verify that live, because minting a short-term Bedrock API key requires AWS's own token generator and a bad token is indistinguishable from a broken feature. Left open rather than closed on unverified reasoning.
