### PR TITLE
fix(bedrock): raw_completion discards provider-only response data (guardrail trace, request id, service tier)

### DIFF
--- a/crates/rig-bedrock/CHANGELOG.md
+++ b/crates/rig-bedrock/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(bedrock)* `CompletionModel::with_guardrail` attaches a [Bedrock guardrail](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) (identifier, version, trace mode) to every Converse request the model issues. Requests previously had no way to carry `guardrailConfig` at all, which also made the response-side trace unreachable
+- *(bedrock)* `types::converse_output` and `types::assistant_content` are public modules. `raw_completion` returns `AwsConverseOutput`, which wraps `InternalConverseOutput`; both lived behind `pub(crate)` modules, so a caller could not name the type the escape hatch hands back
+
 ### Fixed
+
+- *(bedrock)* `raw_completion` no longer discards provider-only response data. The conversion from the SDK's `ConverseOutput` matched five fields and swallowed the rest, so the guardrail `trace`, `performance_config`, `service_tier` and the AWS `request_id` never reached the escape hatch whose contract is that nothing the provider sent was dropped. The trace is the costly one: a blocked turn normalizes to a content-filter finish reason and nothing else, so the assessment naming the policy that fired was unrecoverable. All four are now carried — the three SDK-typed ones as the SDK's own types, `#[serde(skip)]` because they are not `Serialize`, so an in-process caller reads them in full while a serialized response omits them
 
 - *(bedrock)* [**breaking**] the model constants are the identifiers Bedrock can actually invoke. 39 of the 72 shipped constants could only fail: 29 identifiers (every `anthropic.claude-*` constant among them, plus the Titan text/image generators, Claude 2/Instant, Llama 3.2, Jamba Instruct, the older Stability ids and the Cohere `command-text` pair) are absent from `ListFoundationModels` in us-east-1, us-west-2, eu-central-1 and ap-northeast-1 and answer `ResourceNotFoundException` ("This model version has reached the end of its life"); 10 more exist but are servable only through a cross-region inference profile, so the bare identifier answers `ValidationException` ("Invocation of model ID … with on-demand throughput isn't supported"). Retired identifiers are removed; the profile-only families (`DEEPSEEK_R1`, `META_LLAMA_3_3_70B_INSTRUCT`, `META_LLAMA_4_*`, `MISTRAL_PIXTRAL_LARGE_2502`, `WRITER_PALMYRA_X4`/`X5`) now carry their `us.` profile identifier, and Anthropic — which had no working constant at all — is represented by `ANTHROPIC_CLAUDE_HAIKU_4_5`, `ANTHROPIC_CLAUDE_SONNET_4_5`, `ANTHROPIC_CLAUDE_OPUS_4_5`, `ANTHROPIC_CLAUDE_SONNET_4_6`, `ANTHROPIC_CLAUDE_SONNET_5` and `ANTHROPIC_CLAUDE_OPUS_5`. A `us.` prefix names a region family: callers outside the US substitute `eu.`/`apac.` (or `global.` where offered). Every retained identifier was invoked with `Converse` in us-east-1
 

--- a/crates/rig-bedrock/src/completion.rs
+++ b/crates/rig-bedrock/src/completion.rs
@@ -8,6 +8,7 @@ use crate::{
     },
 };
 
+use aws_sdk_bedrockruntime::types as aws_bedrock;
 use rig_core::completion::{self, CompletionError, CompletionRequest};
 use rig_core::streaming::StreamingCompletionResponse;
 use rig_core::telemetry::ProviderResponseExt;
@@ -127,6 +128,9 @@ pub struct CompletionModel {
     /// A checkpoint is placed after the system prompt and after the last message
     /// in the chat history. Disabled by default.
     pub prompt_caching: bool,
+    /// Guardrail applied to every Converse request from this model, if any.
+    /// Set through [`CompletionModel::with_guardrail`].
+    pub guardrail: Option<aws_bedrock::GuardrailConfiguration>,
 }
 
 impl CompletionModel {
@@ -135,6 +139,7 @@ impl CompletionModel {
             client,
             model: model.into(),
             prompt_caching: false,
+            guardrail: None,
         }
     }
 
@@ -155,6 +160,33 @@ impl CompletionModel {
     /// support table for current limits and field support.
     pub fn with_prompt_caching(mut self) -> Self {
         self.prompt_caching = true;
+        self
+    }
+
+    /// Apply a [Bedrock guardrail](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html)
+    /// to every Converse request this model issues.
+    ///
+    /// `identifier` is the guardrail id or ARN and `version` its version (or
+    /// `DRAFT`). When `trace` is enabled, Bedrock returns its assessment on
+    /// [`InternalConverseOutput::trace`](crate::types::converse_output::InternalConverseOutput::trace) —
+    /// the only place it explains *why* a turn came back with
+    /// [`StopReason::GuardrailIntervened`](crate::types::converse_output::StopReason::GuardrailIntervened),
+    /// which the normalized response reports as a content filter and nothing
+    /// more. Reach it through
+    /// [`raw_completion`](CompletionModel::raw_completion).
+    pub fn with_guardrail(
+        mut self,
+        identifier: impl Into<String>,
+        version: impl Into<String>,
+        trace: aws_bedrock::GuardrailTrace,
+    ) -> Self {
+        self.guardrail = Some(
+            aws_bedrock::GuardrailConfiguration::builder()
+                .guardrail_identifier(identifier)
+                .guardrail_version(version)
+                .trace(trace)
+                .build(),
+        );
         self
     }
 }
@@ -210,7 +242,8 @@ impl CompletionModel {
             .set_tool_config(tool_config)
             .set_system(request.system_prompt()?)
             .set_messages(Some(messages))
-            .set_output_config(output_config);
+            .set_output_config(output_config)
+            .set_guardrail_config(self.guardrail.clone());
 
         async move {
             let response = converse_builder.send().await.map_err(|sdk_error| {

--- a/crates/rig-bedrock/src/types/converse_output.rs
+++ b/crates/rig-bedrock/src/types/converse_output.rs
@@ -1,11 +1,21 @@
 //! Types that replace the AWS Bedrock Runtime SDK's `ConverseOutput` type.
 //! This is required so that we can impl Serialize and Deserialize.
 //!
-//! Only the parts of the Converse response that rig actually reads are
-//! mirrored as typed structs. Model-specific extras
+//! Rig's normalized [`CompletionResponse`](rig_core::completion::CompletionResponse)
+//! reads only part of the Converse response, but this type is what
+//! `raw_completion` hands back — the escape hatch whose whole purpose is that
+//! nothing the provider sent has been thrown away. Model-specific extras
 //! (`additional_model_response_fields`) are carried as plain
-//! [`serde_json::Value`]; the guardrail-assessment trace and performance
-//! configuration (telemetry-only, never read) are not mirrored.
+//! [`serde_json::Value`].
+//!
+//! The guardrail trace, performance configuration and service tier keep the
+//! SDK's own types rather than gaining hand-written mirrors: they are deeply
+//! nested (a guardrail assessment alone is a dozen types), and a mirror that
+//! drifts from the SDK would reintroduce exactly the silent loss this exists
+//! to prevent. Those three are `#[serde(skip)]` because the SDK types are not
+//! `Serialize`, so a serialized `InternalConverseOutput` — a cassette fixture,
+//! a persisted response — omits them while an in-process caller reads them in
+//! full.
 use std::fmt;
 
 use aws_sdk_bedrockruntime::types as aws_bedrock;
@@ -28,11 +38,41 @@ pub struct InternalConverseOutput {
     pub metrics: Option<ConverseMetrics>,
     /// <p>Additional fields in the response that are unique to the model.</p>
     pub additional_model_response_fields: Option<serde_json::Value>,
+    /// The AWS request id, taken from the response's `x-amzn-RequestId`
+    /// header. Always present on a successful call, and the identifier AWS
+    /// support asks for.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    /// <p>A trace object that contains information about the Guardrail behavior.</p>
+    ///
+    /// Populated when the request carried a guardrail configuration with
+    /// tracing enabled (see
+    /// [`CompletionModel::with_guardrail`](crate::completion::CompletionModel::with_guardrail));
+    /// it is the only place Bedrock explains *why* a turn stopped with
+    /// [`StopReason::GuardrailIntervened`].
+    #[serde(skip)]
+    pub trace: Option<aws_bedrock::ConverseTrace>,
+    /// <p>Model performance settings for the request.</p>
+    #[serde(skip)]
+    pub performance_config: Option<aws_bedrock::PerformanceConfiguration>,
+    /// <p>The processing tier used to serve the request.</p>
+    #[serde(skip)]
+    pub service_tier: Option<aws_bedrock::ServiceTier>,
 }
 
 impl InternalConverseOutput {
     pub fn usage(&self) -> Option<&TokenUsage> {
         self.usage.as_ref()
+    }
+
+    /// Bedrock's guardrail trace for this turn, when one was requested.
+    pub fn trace(&self) -> Option<&aws_bedrock::ConverseTrace> {
+        self.trace.as_ref()
+    }
+
+    /// The AWS request id for this call.
+    pub fn request_id(&self) -> Option<&str> {
+        self.request_id.as_deref()
     }
 }
 
@@ -44,12 +84,27 @@ impl TryFrom<aws_sdk_bedrockruntime::operation::converse::ConverseOutput>
     fn try_from(
         value: aws_sdk_bedrockruntime::operation::converse::ConverseOutput,
     ) -> Result<Self, Self::Error> {
+        // The request id is only reachable through the trait, and only before
+        // the struct is destructured.
+        let request_id =
+            aws_sdk_bedrockruntime::operation::RequestId::request_id(&value).map(str::to_string);
+
+        // `ConverseOutput` is `#[non_exhaustive]` and hides `_request_id`, so
+        // the rest pattern is mandatory and cannot be traded for a
+        // compile-time guard: every field the SDK adds arrives here silently.
+        // That is how the guardrail trace, performance config and service tier
+        // came to be dropped, so the list below is checked against the SDK
+        // type when the dependency moves, and `converse_output_carries_every_
+        // sdk_field` pins the ones known today.
         let aws_sdk_bedrockruntime::operation::converse::ConverseOutput {
             output,
             stop_reason,
             usage,
             metrics,
             additional_model_response_fields,
+            trace,
+            performance_config,
+            service_tier,
             ..
         } = value;
 
@@ -60,6 +115,10 @@ impl TryFrom<aws_sdk_bedrockruntime::operation::converse::ConverseOutput>
             metrics: metrics.map(|x| x.try_into()).transpose()?,
             additional_model_response_fields: additional_model_response_fields
                 .map(|doc| AwsDocument(doc).into()),
+            request_id,
+            trace,
+            performance_config,
+            service_tier,
         })
     }
 }
@@ -1129,6 +1188,101 @@ impl TryFrom<ToolUseBlock> for aws_bedrock::ToolUseBlock {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// The escape hatch's contract is that nothing the provider sent was
+    /// dropped, and the SDK's output type is `#[non_exhaustive]`, so the
+    /// conversion's rest pattern hides every field added upstream. This pins
+    /// the ones known today — `trace`, `performance_config` and `service_tier`
+    /// were all silently discarded before.
+    #[test]
+    fn converse_output_carries_every_sdk_field() {
+        let sdk_output = aws_sdk_bedrockruntime::operation::converse::ConverseOutput::builder()
+            .stop_reason(aws_bedrock::StopReason::GuardrailIntervened)
+            .output(aws_bedrock::ConverseOutput::Message(
+                aws_bedrock::Message::builder()
+                    .role(aws_bedrock::ConversationRole::Assistant)
+                    .content(aws_bedrock::ContentBlock::Text("blocked".into()))
+                    .build()
+                    .unwrap(),
+            ))
+            .usage(
+                aws_bedrock::TokenUsage::builder()
+                    .input_tokens(1)
+                    .output_tokens(2)
+                    .total_tokens(3)
+                    .build()
+                    .unwrap(),
+            )
+            .metrics(
+                aws_bedrock::ConverseMetrics::builder()
+                    .latency_ms(4)
+                    .build()
+                    .unwrap(),
+            )
+            .trace(
+                aws_bedrock::ConverseTrace::builder()
+                    .guardrail(aws_bedrock::GuardrailTraceAssessment::builder().build())
+                    .build(),
+            )
+            .performance_config(
+                aws_bedrock::PerformanceConfiguration::builder()
+                    .latency(aws_bedrock::PerformanceConfigLatency::Standard)
+                    .build(),
+            )
+            .service_tier(
+                aws_bedrock::ServiceTier::builder()
+                    .r#type(aws_bedrock::ServiceTierType::Default)
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        let mirrored = InternalConverseOutput::try_from(sdk_output).unwrap();
+
+        assert!(mirrored.output.is_some());
+        assert_eq!(mirrored.stop_reason, StopReason::GuardrailIntervened);
+        assert!(mirrored.usage.is_some());
+        assert!(mirrored.metrics.is_some());
+        assert!(
+            mirrored.trace().is_some(),
+            "the guardrail trace must survive the conversion"
+        );
+        assert!(
+            mirrored.performance_config.is_some(),
+            "the performance configuration must survive the conversion"
+        );
+        assert!(
+            mirrored.service_tier.is_some(),
+            "the service tier must survive the conversion"
+        );
+    }
+
+    /// The SDK types behind `trace`, `performance_config` and `service_tier`
+    /// are not `Serialize`, so they are `#[serde(skip)]`: serializing must
+    /// still succeed and must not invent values on the way back.
+    #[test]
+    fn skipped_provider_fields_round_trip_as_absent() {
+        let output = InternalConverseOutput {
+            output: None,
+            stop_reason: StopReason::EndTurn,
+            usage: None,
+            metrics: None,
+            additional_model_response_fields: None,
+            request_id: Some("req-1".to_string()),
+            trace: None,
+            performance_config: None,
+            service_tier: None,
+        };
+
+        let json = serde_json::to_string(&output).unwrap();
+        let restored: InternalConverseOutput = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(restored.request_id(), Some("req-1"));
+        assert!(restored.trace().is_none());
+        assert!(restored.performance_config.is_none());
+        assert!(restored.service_tier.is_none());
+    }
 
     #[test]
     fn mirror_enum_converts_known_variants_both_ways() {

--- a/crates/rig-bedrock/src/types/mod.rs
+++ b/crates/rig-bedrock/src/types/mod.rs
@@ -1,6 +1,16 @@
-pub(crate) mod assistant_content;
+//! Bedrock wire types.
+//!
+//! `converse_output` and `assistant_content` are public because
+//! [`CompletionModel::raw_completion`](crate::completion::CompletionModel::raw_completion)
+//! returns `assistant_content::AwsConverseOutput`, which wraps
+//! `converse_output::InternalConverseOutput`: an escape hatch whose type a
+//! caller cannot name is only half an escape hatch. The remaining modules are
+//! request-side conversions with no public return type.
+
+pub mod assistant_content;
+pub mod converse_output;
+
 pub(crate) mod completion_request;
-pub(crate) mod converse_output;
 pub(crate) mod document;
 pub(crate) mod errors;
 pub(crate) mod image;

--- a/tests/cassettes/bedrock/raw_provider_data/guardrail_trace_survives_into_raw_completion.yaml
+++ b/tests/cassettes/bedrock/raw_provider_data/guardrail_trace_survives_into_raw_completion.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /model/amazon.nova-lite-v1%3A0/converse
+  method: POST
+  query_param: []
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"guardrailConfig":{"guardrailIdentifier":"fytaiyvapuzp","guardrailVersion":"DRAFT","trace":"enabled"},"inferenceConfig":{"maxTokens":64},"messages":[{"content":[{"text":"Explain a gravitational singularity in one sentence."}],"role":"user"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: x-amzn-requestid
+    value: req_REDACTED_1
+  body: '{"metrics":{"latencyMs":271},"output":{"message":{"content":[{"text":"Blocked by guardrail."}],"role":"assistant"}},"stopReason":"guardrail_intervened","trace":{"guardrail":{"actionReason":"Guardrail blocked.","inputAssessment":{"fytaiyvapuzp":{"appliedGuardrailDetails":{"guardrailArn":"arn:aws:bedrock:us-east-1:account_REDACTED_1:guardrail/fytaiyvapuzp","guardrailId":"fytaiyvapuzp","guardrailOrigin":["REQUEST"],"guardrailOwnership":"SELF","guardrailVersion":"DRAFT"},"invocationMetrics":{"guardrailCoverage":{"textCharacters":{"guarded":52,"total":52}},"guardrailProcessingLatency":114,"usage":{"automatedReasoningPolicies":0,"automatedReasoningPolicyUnits":0,"contentPolicyImageUnits":0,"contentPolicyUnits":0,"contextualGroundingPolicyUnits":0,"sensitiveInformationPolicyFreeUnits":0,"sensitiveInformationPolicyUnits":0,"topicPolicyUnits":0,"wordPolicyUnits":1}},"wordPolicy":{"customWords":[{"action":"BLOCKED","detected":true,"match":"gravitational singularity"}]}}}}},"usage":{"inputTokens":0,"outputTokens":0,"serverToolUsage":{},"totalTokens":0}}'

--- a/tests/cassettes/bedrock/raw_provider_data/request_id_survives_into_raw_completion.yaml
+++ b/tests/cassettes/bedrock/raw_provider_data/request_id_survives_into_raw_completion.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /model/amazon.nova-lite-v1%3A0/converse
+  method: POST
+  query_param: []
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"inferenceConfig":{"maxTokens":16},"messages":[{"content":[{"text":"Reply with the single word: ready."}],"role":"user"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: x-amzn-requestid
+    value: req_REDACTED_1
+  body: '{"metrics":{"latencyMs":378},"output":{"message":{"content":[{"text":"Ready."}],"role":"assistant"}},"stopReason":"end_turn","usage":{"inputTokens":8,"outputTokens":3,"serverToolUsage":{},"totalTokens":11}}'

--- a/tests/common/cassettes.rs
+++ b/tests/common/cassettes.rs
@@ -1754,7 +1754,12 @@ const SENSITIVE_QUERY_PARAMS: &[&str] = &[
 // modeled exception; dropping it made every recorded AWS error replay as an
 // unclassified `Unhandled` error, so a cassette could not reproduce the error
 // path it recorded. The value is an exception class name, not account state.
-const RESPONSE_HEADER_ALLOWLIST: &[&str] = &["content-type", "x-amzn-errortype"];
+// `x-amzn-requestid` is the only place the AWS request id appears — the SDK
+// reads it off the header, not the body — so a cassette that drops it cannot
+// replay any behavior that reads the id. It is a per-call opaque identifier,
+// not account state, and the scrubber placeholders its value.
+const RESPONSE_HEADER_ALLOWLIST: &[&str] =
+    &["content-type", "x-amzn-errortype", "x-amzn-requestid"];
 
 const VOLATILE_JSON_KEYS: &[&str] = &[
     "completed_at",
@@ -1773,6 +1778,9 @@ const SENSITIVE_STRING_KEYS: &[&str] = &[
     "signature",
     "thoughtsignature",
 ];
+
+/// Allowlisted response headers whose value is a generated per-call id.
+const GENERATED_ID_HEADERS: &[&str] = &["x-amzn-requestid"];
 
 const GENERATED_ID_KEYS: &[&str] = &[
     "call_id",
@@ -1840,6 +1848,15 @@ impl CassetteScrubber {
 
     fn scrub_response(&mut self, response: &mut CassetteResponse) {
         scrub_headers(self.policy, &mut response.header, HeaderMode::Response);
+
+        // An allowlisted header is kept for its *shape*, not its value: the
+        // request id is a per-call generated token and gets the same
+        // placeholder treatment as one carried in a body.
+        for header in response.header.iter_mut() {
+            if contains_case_insensitive(GENERATED_ID_HEADERS, &header.name) {
+                header.value = self.placeholder(&header.value, "req_");
+            }
+        }
 
         if let Some(body) = &mut response.body {
             *body = self.scrub_encoded_body(body, response.body_encoding);
@@ -2092,7 +2109,53 @@ impl CassetteScrubber {
             scrubbed = scrub_query_param(&scrubbed, key, REDACTED);
         }
         let scrubbed = self.scrub_grounding_redirects(&scrubbed);
+        let scrubbed = self.scrub_aws_account_ids(&scrubbed);
         self.scrub_generated_tokens(&scrubbed)
+    }
+
+    /// Replace the account-id segment of every ARN.
+    ///
+    /// A Bedrock guardrail assessment echoes the guardrail's ARN, which
+    /// carries the caller's 12-digit AWS account id — a provider account
+    /// identifier, which cassettes must not commit. The rest of the ARN
+    /// (partition, service, region, resource) stays readable so the fixture
+    /// still shows which resource answered.
+    fn scrub_aws_account_ids(&mut self, text: &str) -> String {
+        const PREFIX: &str = "arn:";
+        const ACCOUNT_FIELD: usize = 4;
+        const ACCOUNT_LEN: usize = 12;
+
+        let mut output = String::with_capacity(text.len());
+        let mut rest = text;
+
+        while let Some(start) = rest.find(PREFIX) {
+            output.push_str(&rest[..start]);
+            let arn = &rest[start..];
+            // An ARN ends at the first character that cannot appear in one;
+            // the surrounding JSON quote or comma is the usual terminator.
+            let end = arn
+                .find(['"', ',', ' ', '\n', '}', ']'])
+                .unwrap_or(arn.len());
+            let (arn, tail) = arn.split_at(end);
+
+            let mut fields = arn.split(':').map(str::to_string).collect::<Vec<_>>();
+            match fields.get(ACCOUNT_FIELD) {
+                Some(account)
+                    if account.len() == ACCOUNT_LEN
+                        && account.chars().all(|ch| ch.is_ascii_digit()) =>
+                {
+                    let placeholder = self.placeholder(account, "account_");
+                    fields[ACCOUNT_FIELD] = placeholder;
+                    output.push_str(&fields.join(":"));
+                }
+                _ => output.push_str(arn),
+            }
+
+            rest = tail;
+        }
+
+        output.push_str(rest);
+        output
     }
 
     fn scrub_grounding_redirects(&mut self, text: &str) -> String {
@@ -2902,8 +2965,23 @@ mod tests {
             .expect("interaction should be recorded");
         assert_eq!(interaction.when.header.len(), 1);
         assert_eq!(interaction.when.header[0].name, "content-type");
-        assert_eq!(interaction.then.header.len(), 1);
-        assert_eq!(interaction.then.header[0].name, "content-type");
+
+        // The response keeps `x-amzn-requestid` — the SDK reads the AWS
+        // request id off that header and nowhere else — with its value
+        // placeholdered, and still drops everything outside the allowlist.
+        let response_headers = interaction
+            .then
+            .header
+            .iter()
+            .map(|header| (header.name.as_str(), header.value.as_str()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            response_headers,
+            vec![
+                ("content-type", "application/json"),
+                ("x-amzn-requestid", "req_REDACTED_1"),
+            ]
+        );
     }
 
     #[test]

--- a/tests/providers/bedrock/cassette/raw_provider_data.rs
+++ b/tests/providers/bedrock/cassette/raw_provider_data.rs
@@ -1,0 +1,105 @@
+//! `raw_completion` is the escape hatch for everything rig does not
+//! normalize, so what Bedrock sends has to survive the trip through
+//! `InternalConverseOutput`. It did not: the conversion's rest pattern
+//! discarded the guardrail trace, the performance configuration, the service
+//! tier and the AWS request id.
+//!
+//! The guardrail trace is the one that costs a caller real information. A
+//! blocked turn normalizes to `FinishReason::ContentFilter` and nothing else;
+//! only the trace says which policy fired and on what text.
+
+use rig::bedrock;
+use rig::completion::CompletionModel;
+use rig::prelude::*;
+
+use super::super::support::with_bedrock_cassette;
+
+/// The guardrail this scenario was recorded against. It is an account-scoped
+/// resource name, not a credential, and the guardrail itself was deleted after
+/// recording; replay only has to send the same identifier the cassette saw.
+const GUARDRAIL_ID: &str = "fytaiyvapuzp";
+const GUARDRAIL_VERSION: &str = "DRAFT";
+
+/// Recorded against a guardrail that blocks a specific phrase: Bedrock stops
+/// the turn with `guardrail_intervened` and explains itself in `trace`.
+#[tokio::test]
+async fn guardrail_trace_survives_into_raw_completion() {
+    with_bedrock_cassette(
+        "raw_provider_data/guardrail_trace_survives_into_raw_completion",
+        |client| async move {
+            let model = client
+                .completion_model(bedrock::completion::AMAZON_NOVA_LITE)
+                .with_guardrail(
+                    GUARDRAIL_ID,
+                    GUARDRAIL_VERSION,
+                    aws_sdk_bedrockruntime::types::GuardrailTrace::Enabled,
+                );
+
+            let request = model
+                .completion_request("Explain a gravitational singularity in one sentence.")
+                .max_tokens(64)
+                .build();
+
+            let response = model
+                .raw_completion(request)
+                .await
+                .expect("guardrail-intervened completion should still return a response");
+
+            let output = &response.0;
+            assert!(
+                matches!(
+                    output.stop_reason,
+                    bedrock::types::converse_output::StopReason::GuardrailIntervened
+                ),
+                "expected the guardrail to intervene, got {:?}",
+                output.stop_reason
+            );
+
+            let trace = output
+                .trace()
+                .expect("the guardrail trace must reach raw_completion");
+            let guardrail = trace
+                .guardrail()
+                .expect("a guardrail-intervened turn carries a guardrail assessment");
+            let input_assessment = guardrail
+                .input_assessment()
+                .expect("the blocked input carries an assessment");
+            assert!(
+                !input_assessment.is_empty(),
+                "expected the input assessment naming the policy that fired"
+            );
+        },
+    )
+    .await;
+}
+
+/// The AWS request id rides an HTTP header, so it is present on every call —
+/// including the ordinary ones — and it is what AWS support asks for.
+#[tokio::test]
+async fn request_id_survives_into_raw_completion() {
+    with_bedrock_cassette(
+        "raw_provider_data/request_id_survives_into_raw_completion",
+        |client| async move {
+            let model = client.completion_model(bedrock::completion::AMAZON_NOVA_LITE);
+            let request = model
+                .completion_request("Reply with the single word: ready.")
+                .max_tokens(16)
+                .build();
+
+            let response = model
+                .raw_completion(request)
+                .await
+                .expect("completion should succeed");
+
+            let request_id = response
+                .0
+                .request_id()
+                .expect("the AWS request id must reach raw_completion");
+            assert!(
+                !request_id.trim().is_empty(),
+                "expected a non-empty AWS request id"
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/bedrock/mod.rs
+++ b/tests/providers/bedrock/mod.rs
@@ -7,6 +7,7 @@ mod cassette {
     mod embeddings;
     mod model_ids;
     mod raw_completion;
+    mod raw_provider_data;
     mod raw_streaming;
     mod streaming;
     mod tool_choice;


### PR DESCRIPTION
`raw_completion` is rig-bedrock's escape hatch: the reason it exists is that nothing the provider sent has been thrown away. It was throwing four things away.

## What was lost

The conversion from the SDK's `ConverseOutput` matched five fields and swallowed the rest with `..`:

| dropped | why it matters |
| --- | --- |
| `trace` | the guardrail assessment |
| `performance_config` | latency tier the request ran under |
| `service_tier` | processing tier that served the request |
| `request_id` | rides `x-amzn-RequestId`; what AWS support asks for |

The trace is the expensive one. A guardrail-blocked turn normalizes to a content-filter finish reason **and nothing else** — so *which* policy fired, on *what* text, was unrecoverable from rig. Recorded live, Bedrock says plenty:

```json
"trace": {"guardrail": {"inputAssessment": {"…": {"wordPolicy": {"customWords": [
  {"match": "gravitational singularity", "action": "BLOCKED", "detected": true}
]}}}}}
```

All four are carried now. The three SDK-typed fields keep the SDK's own types rather than gaining hand-written mirrors — a guardrail assessment alone is a dozen types, and a mirror that drifts from the SDK reintroduces exactly the silent loss this exists to prevent. They are `#[serde(skip)]` because those types are not `Serialize`: an in-process caller reads them in full, a serialized response omits them.

## Two things found on the way

**The escape hatch's type could not be named.** `types::converse_output` and `types::assistant_content` were `pub(crate)`, so `AwsConverseOutput`/`InternalConverseOutput` — what `raw_completion` returns — could not be named by a caller, only used through inference. My own test hit that wall first. Both modules are public now.

**Requests could not carry a guardrail at all**, so the preserved trace had no way to be populated for a rig caller: Bedrock only returns an assessment when the request asked for one. `CompletionModel::with_guardrail(identifier, version, trace)` sets `guardrailConfig`, following the existing `with_prompt_caching` shape.

The SDK's output type is `#[non_exhaustive]` with a private field, so the rest pattern is mandatory and can't be traded for a compile-time guard. `converse_output_carries_every_sdk_field` pins the fields known today.

## Testing

Two scenarios recorded from live Bedrock traffic, replaying offline with no AWS credentials — recorded against a guardrail created for the recording and **deleted afterwards**:

- `raw_provider_data/guardrail_trace_survives_into_raw_completion` — blocked turn, assessment reaches the caller
- `raw_provider_data/request_id_survives_into_raw_completion` — ordinary turn, AWS request id reaches the caller

Plus unit coverage for the field-by-field mirror and for the `#[serde(skip)]` round trip.

### Harness changes, both driven by what the recording needed

- **ARN account ids are placeholdered.** A guardrail assessment echoes the guardrail ARN, which embeds the caller's 12-digit AWS account id — a provider account identifier, which cassettes must not commit. The rest of the ARN stays readable: `arn:aws:bedrock:us-east-1:account_REDACTED_1:guardrail/…`.
- **`x-amzn-requestid` joins the response allowlist**, value placeholdered. The SDK reads the request id off that header and nowhere else, so a cassette that dropped it could not replay behavior that reads it — the scenario passed live and failed on replay until the header survived.

`direct_recorder_omits_sigv4_headers` had incidentally pinned the old allowlist; its assertion is updated to the new intended behavior while still proving no SigV4 material is recorded.

## Verification

- `cargo test -p rig --all-features` — all 36 test targets pass
- `cargo test -p rig --all-features --test bedrock` — 79 passed
- `cargo test -p rig-bedrock --all-features` — 116 passed
- `RUSTFLAGS="-D warnings" cargo clippy -p rig-bedrock -p rig --all-targets --all-features` — clean
- `cargo fmt`

Staged diff scanned for credentials, session tokens and the account id: clean. The one remaining account-scoped string is the guardrail's resource id, which names a guardrail that no longer exists and grants nothing without credentials — flagging it explicitly in case you'd rather it were scrubbed too.
