### PR TITLE
fix(rig-core): build all features on browser WASM

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,10 +79,10 @@ jobs:
   #
   # The runtime split adds wasm-sensitive code to rig-agent, feature forwarding
   # in the `rig` facade, and explicit feature wiring in the Candle runtime and
-  # browser example, so check each on the wasm target too. These are plain
-  # checks with no feature flags: the relaxed async bounds now follow from the
-  # target alone, so building for `wasm32-unknown-unknown` is the whole opt-in.
-  # None of them download a model.
+  # browser example, so check each on the wasm target too. The baseline checks
+  # use default features; rig-core also gets an all-feature pass so optional
+  # loaders cannot introduce browser-incompatible transitive dependencies.
+  # None of these checks download a model.
   #
   # Each package must be checked **on its own**: cargo unifies features across
   # packages built in one invocation, so a workspace-wide `--all-features` build
@@ -117,6 +117,10 @@ jobs:
 
       - name: Run cargo check wasm target
         run: cargo check --package ${{ matrix.package }} --target wasm32-unknown-unknown
+
+      - name: Run rig-core all-features wasm check
+        if: matrix.package == 'rig-core'
+        run: cargo check --package rig-core --all-features --target wasm32-unknown-unknown
 
   # `rmcp` is native-only: rmcp's `ClientHandler` requires `Send + Sync`
   # unconditionally, which rig's wasm tool registry cannot satisfy. Asking for it

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4738,11 +4738,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/rig-core/Cargo.toml
+++ b/crates/rig-core/Cargo.toml
@@ -75,6 +75,10 @@ tokio-tungstenite = { workspace = true, optional = true }
 # would be wrong-by-construction on WASI.
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 futures-timer = { workspace = true, features = ["wasm-bindgen"] }
+# `lopdf` pulls `getrandom` through its PDF encryption support. Browser WASM
+# cannot select a randomness backend from the target triple alone, so opt in to
+# lopdf's Web Crypto backend only for Rig's supported browser target.
+lopdf = { workspace = true, optional = true, features = ["wasm_js"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/rig-core/README.md
+++ b/crates/rig-core/README.md
@@ -8,6 +8,7 @@ More information about this crate can be found in the [crate documentation](http
   - [Table of contents](#table-of-contents)
   - [Features](#features)
   - [Installation](#installation)
+  - [WASM target support](#wasm-target-support)
   - [Simple example:](#simple-example)
   - [Integrations](#integrations)
   - [Who is using Rig?](#who-is-using-rig)
@@ -26,6 +27,13 @@ More information about this crate can be found in the [crate documentation](http
 ```bash
 cargo add rig-core
 ```
+
+## WASM target support
+
+`rig-core` supports the browser-oriented `wasm32-unknown-unknown` target. When
+the `pdf` feature is enabled, the host must provide the Web Crypto API's
+`Crypto.getRandomValues` implementation, as modern browsers, Web Workers, and
+Node.js 19 or later do. WASI targets are not supported.
 
 ## Simple example
 ```rust


### PR DESCRIPTION
## Description

Make `rig-core --all-features` compile for `wasm32-unknown-unknown` by enabling `lopdf`'s `wasm_js` randomness backend only on the supported browser WASM target. Native builds keep the existing Rayon-backed PDF configuration without the JS backend.

This also adds the exact all-features WASM command to CI and documents the Web Crypto runtime requirement for PDF-enabled browser builds.

Fixes #2318

## Type of change

- [x] Bug fix
- [x] Documentation update

## Testing

- [x] `cargo check --locked -p rig-core --all-features --target wasm32-unknown-unknown`
- [x] `cargo check -p rig-core --target wasm32-unknown-unknown`
- [x] `cargo check -p rig-core --no-default-features --target wasm32-unknown-unknown`
- [x] `cargo check -p rig-core --no-default-features --features image,audio --target wasm32-unknown-unknown`
- [x] `cargo check -p rig-core --no-default-features --features pdf --target wasm32-unknown-unknown`
- [x] `cargo test -p rig-core --features pdf loaders::pdf::tests`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`
- [x] `cargo test`
- [x] `cargo doc --workspace --no-deps`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented the target-specific dependency configuration
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added CI coverage that proves the fix is effective
- [x] New and existing tests pass locally with my changes

## Notes

An independent review of the complete merge-base diff found no correctness, regression, security, or missing-test issues.