### PR TITLE
feat(providers): implement ModelLister for groq, moonshot, and minimax

### DIFF
--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -84,6 +84,7 @@ client::impl_capabilities!(
     GroqExt,
     completion = CompletionModel<H>,
     transcription = TranscriptionModel<H>,
+    model_listing = GroqModelLister<H>,
 );
 
 impl DebugExt for GroqExt {}
@@ -106,6 +107,17 @@ pub type CompletionModel<H = reqwest::Client> =
 /// final item of the stream returned by `CompletionModel::raw_stream`. Shared
 /// with the OpenAI Chat Completions path, usage payload included.
 pub type StreamingCompletionResponse = openai::StreamingCompletionResponse;
+
+crate::providers::internal::model_listing::impl_model_lister!(
+    /// [`ModelLister`](crate::client::ModelLister) implementation for the Groq
+    /// API (`GET /models`), the same endpoint [`GroqExt::VERIFY_PATH`] already
+    /// uses to verify credentials.
+    GroqModelLister,
+    Client<H>,
+    crate::providers::internal::model_listing::ListModelEntry,
+    "Groq",
+    "/models"
+);
 
 client::impl_provider_client!(Client, input = String, api_key_env = "GROQ_API_KEY");
 
@@ -549,5 +561,89 @@ mod tests {
             Some(http::StatusCode::BAD_REQUEST)
         );
         assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    /// The lister must hit `<base>/models` — the same path `VERIFY_PATH`
+    /// already uses — and map the OpenAI-style envelope onto `Model`s.
+    #[tokio::test]
+    async fn list_models_uses_the_models_endpoint() {
+        use crate::client::ModelListingClient;
+        use crate::test_utils::RecordingHttpClient;
+
+        let http_client = RecordingHttpClient::new(
+            r#"{
+                "object": "list",
+                "data": [
+                    {"id": "llama-3.1-8b-instant", "object": "model", "created": 1693721698, "owned_by": "Meta"},
+                    {"id": "whisper-large-v3", "object": "model", "owned_by": "OpenAI"}
+                ]
+            }"#,
+        );
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client.clone())
+            .build()
+            .expect("build client");
+
+        let models = client
+            .list_models()
+            .await
+            .expect("list_models should succeed");
+
+        assert_eq!(models.len(), 2);
+        assert_eq!(models.data[0].id, "llama-3.1-8b-instant");
+        assert_eq!(models.data[0].created_at, Some(1693721698));
+        assert_eq!(models.data[0].owned_by.as_deref(), Some("Meta"));
+        assert_eq!(models.data[1].id, "whisper-large-v3");
+
+        let requests = http_client.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].uri, "https://api.groq.com/openai/v1/models");
+    }
+
+    /// A non-success listing response keeps the provider label, path, status,
+    /// and body preview instead of collapsing into a bare transport error.
+    #[tokio::test]
+    async fn list_models_preserves_api_error_context() {
+        use crate::client::ModelListingClient;
+        use crate::model::ModelListingError;
+        use crate::test_utils::RecordingHttpClient;
+
+        let http_client = RecordingHttpClient::with_error(
+            http::StatusCode::UNAUTHORIZED,
+            r#"{"error":{"message":"Invalid API Key"}}"#,
+        );
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+
+        let error = client
+            .list_models()
+            .await
+            .expect_err("list_models should fail");
+
+        match error {
+            ModelListingError::ApiError {
+                status_code,
+                message,
+            } => {
+                assert_eq!(status_code, 401);
+                assert!(
+                    message.contains("Groq"),
+                    "message should name the provider: {message}"
+                );
+                assert!(
+                    message.contains("/models"),
+                    "message should name the path: {message}"
+                );
+                assert!(
+                    message.contains("Invalid API Key"),
+                    "message should preserve the body: {message}"
+                );
+            }
+            other => panic!("expected an API error, got {other:?}"),
+        }
     }
 }

--- a/crates/rig-core/src/providers/minimax.rs
+++ b/crates/rig-core/src/providers/minimax.rs
@@ -67,6 +67,19 @@ impl_dual_dialect_provider!(
 client::impl_capabilities!(
     MiniMaxExt,
     completion = super::openai::completion::GenericCompletionModel<MiniMaxExt, H>,
+    model_listing = MiniMaxModelLister<H>,
+);
+
+crate::providers::internal::model_listing::impl_model_lister!(
+    /// [`ModelLister`](crate::client::ModelLister) implementation for
+    /// MiniMax's OpenAI-compatible API (`GET /models`). Only this dialect is
+    /// listed: MiniMax's Anthropic-compatible `/anthropic/v1/models` returns a
+    /// differently shaped payload, so [`MiniMaxAnthropicExt`] keeps no lister.
+    MiniMaxModelLister,
+    Client<H>,
+    crate::providers::internal::model_listing::ListModelEntry,
+    "MiniMax",
+    "/models"
 );
 
 impl super::openai::completion::OpenAICompatibleProvider for MiniMaxExt {
@@ -168,6 +181,71 @@ mod tests {
         assert_eq!(
             override_url.as_deref(),
             Some("https://primary.example.com/anthropic")
+        );
+    }
+
+    /// The lister must hit `<base>/models` and map MiniMax's OpenAI-style
+    /// envelope onto `Model`s.
+    #[tokio::test]
+    async fn list_models_uses_the_models_endpoint() {
+        use crate::client::ModelListingClient;
+        use crate::test_utils::RecordingHttpClient;
+
+        let http_client = RecordingHttpClient::new(
+            r#"{
+                "object": "list",
+                "data": [
+                    {"id": "MiniMax-M2.7", "object": "model", "created": 1780272000, "owned_by": "minimax"},
+                    {"id": "MiniMax-M2", "object": "model", "created": 1761782400, "owned_by": "minimax"}
+                ]
+            }"#,
+        );
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client.clone())
+            .build()
+            .expect("build client");
+
+        let models = client
+            .list_models()
+            .await
+            .expect("list_models should succeed");
+
+        assert_eq!(models.len(), 2);
+        assert_eq!(models.data[0].id, "MiniMax-M2.7");
+        assert_eq!(models.data[0].created_at, Some(1780272000));
+        assert_eq!(models.data[0].owned_by.as_deref(), Some("minimax"));
+        assert_eq!(models.data[1].id, "MiniMax-M2");
+
+        let requests = http_client.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].uri, "https://api.minimax.io/v1/models");
+    }
+
+    /// The listing path is relative to the configured base URL, so selecting
+    /// the China host moves the listing with it.
+    #[tokio::test]
+    async fn list_models_follows_the_configured_base_url() {
+        use crate::client::ModelListingClient;
+        use crate::test_utils::RecordingHttpClient;
+
+        let http_client = RecordingHttpClient::new(r#"{"object":"list","data":[]}"#);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .china()
+            .http_client(http_client.clone())
+            .build()
+            .expect("build client");
+
+        let models = client
+            .list_models()
+            .await
+            .expect("list_models should succeed");
+
+        assert!(models.data.is_empty());
+        assert_eq!(
+            http_client.requests()[0].uri,
+            "https://api.minimaxi.com/v1/models"
         );
     }
 }

--- a/crates/rig-core/src/providers/moonshot.rs
+++ b/crates/rig-core/src/providers/moonshot.rs
@@ -52,7 +52,23 @@ impl_dual_dialect_provider!(
     anthropic_base_url_env = "MOONSHOT_ANTHROPIC_API_BASE",
 );
 
-client::impl_capabilities!(MoonshotExt, completion = CompletionModel<H>);
+client::impl_capabilities!(
+    MoonshotExt,
+    completion = CompletionModel<H>,
+    model_listing = MoonshotModelLister<H>,
+);
+
+crate::providers::internal::model_listing::impl_model_lister!(
+    /// [`ModelLister`](crate::client::ModelLister) implementation for
+    /// Moonshot's OpenAI-compatible API (`GET /models`). The path is relative
+    /// to the configured base URL, so it follows the client between the global
+    /// and China hosts.
+    MoonshotModelLister,
+    Client<H>,
+    crate::providers::internal::model_listing::ListModelEntry,
+    "Moonshot",
+    "/models"
+);
 
 impl<H> ClientBuilder<H> {
     pub fn global(self) -> Self {
@@ -365,6 +381,72 @@ mod tests {
         assert_eq!(
             override_url.as_deref(),
             Some("https://primary.example.com/anthropic")
+        );
+    }
+
+    /// The lister must hit `<base>/models` and map the OpenAI-style envelope
+    /// onto `Model`s, ignoring the provider's extra per-entry fields.
+    #[tokio::test]
+    async fn list_models_uses_the_models_endpoint() {
+        use crate::client::ModelListingClient;
+        use crate::test_utils::RecordingHttpClient;
+
+        let http_client = RecordingHttpClient::new(
+            r#"{
+                "object": "list",
+                "data": [
+                    {"id": "kimi-k2-thinking", "object": "model", "created": 1745884800, "owned_by": "moonshot", "context_length": 262144},
+                    {"id": "moonshot-v1-8k", "object": "model", "owned_by": "moonshot"}
+                ]
+            }"#,
+        );
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client.clone())
+            .build()
+            .expect("build client");
+
+        let models = client
+            .list_models()
+            .await
+            .expect("list_models should succeed");
+
+        assert_eq!(models.len(), 2);
+        assert_eq!(models.data[0].id, "kimi-k2-thinking");
+        assert_eq!(models.data[0].created_at, Some(1745884800));
+        assert_eq!(models.data[0].owned_by.as_deref(), Some("moonshot"));
+        assert_eq!(models.data[1].id, "moonshot-v1-8k");
+        assert_eq!(models.data[1].created_at, None);
+
+        let requests = http_client.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].uri, "https://api.moonshot.ai/v1/models");
+    }
+
+    /// The listing path is relative to the configured base URL, so selecting
+    /// the China host moves the listing with it.
+    #[tokio::test]
+    async fn list_models_follows_the_configured_base_url() {
+        use crate::client::ModelListingClient;
+        use crate::test_utils::RecordingHttpClient;
+
+        let http_client = RecordingHttpClient::new(r#"{"object":"list","data":[]}"#);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .china()
+            .http_client(http_client.clone())
+            .build()
+            .expect("build client");
+
+        let models = client
+            .list_models()
+            .await
+            .expect("list_models should succeed");
+
+        assert!(models.data.is_empty());
+        assert_eq!(
+            http_client.requests()[0].uri,
+            "https://api.moonshot.cn/v1/models"
         );
     }
 }


### PR DESCRIPTION
Refs #2079.

## Description

Steps 1 and 2 of #2079 have landed — `providers/internal/model_listing.rs` holds the shared `list_models` path and the `impl_model_lister!` macro, and mira is migrated off its bespoke off-trait `list_models`. This is the leftover from step 3: the `ModelListing = Nothing` capability gaps.

Groq, Moonshot and MiniMax each serve an OpenAI-style `GET <base>/models`, but all three declared `ModelListing = Nothing`, so `client.list_models()` simply didn't exist on them. Each now declares `model_listing` and defines its lister through the existing macro:

```rust
crate::providers::internal::model_listing::impl_model_lister!(
    /// [`ModelLister`](crate::client::ModelLister) implementation for the Groq
    /// API (`GET /models`), the same endpoint [`GroqExt::VERIFY_PATH`] already
    /// uses to verify credentials.
    GroqModelLister,
    Client<H>,
    crate::providers::internal::model_listing::ListModelEntry,
    "Groq",
    "/models"
);
```

Two hunks per provider — a capability line and a macro call. The request, status triage, envelope decoding and error context all come from the shared path, so there is no new hand-rolled listing code. The path is relative to the configured base URL, so Moonshot and MiniMax listings follow the client between their global and China hosts instead of pinning a host.

## Type of change

- [x] New feature

## What I can and can't vouch for on the endpoints

Groq is the solid one and it is provable in-tree: `GroqExt::VERIFY_PATH` is already `"/models"` (`groq.rs:37`), so this provider was hitting that exact path before this PR to verify credentials. With `GROQ_API_BASE_URL` at `https://api.groq.com/openai/v1`, the lister resolves `https://api.groq.com/openai/v1/models`, which is what the test asserts.

Moonshot and MiniMax are the OpenAI-compatible `/models` convention applied to base URLs already declared in this repo:

| provider | global | China |
| --- | --- | --- |
| Moonshot | `https://api.moonshot.ai/v1` | `https://api.moonshot.cn/v1` |
| MiniMax | `https://api.minimax.io/v1` | `https://api.minimaxi.com/v1` |

**I made no live API calls against any of the three**, so nothing here is verified against a running server — the tests prove the URL the client resolves and the decoding, not that the remote answers. If you want a live check before merging, that needs keys I don't have.

All three return extra per-entry fields beyond the four `ListModelEntry` reads. `ListModelEntry` doesn't set `deny_unknown_fields`, so they're ignored; the Moonshot fixture includes `context_length` to pin that.

## Testing

Six unit tests, no API keys needed. They drive the real client through `RecordingHttpClient` and assert the resolved URL rather than restating the constant, plus the mapped `Model` fields, the base-URL switch for the two dual-region providers, and that a 401 keeps provider/path/status/body in the error.

On the pinned toolchain (rustc 1.94.0), using CI's own commands, run twice end to end with identical results:

| Command | Exit | |
| --- | --- | --- |
| `cargo fmt -- --check` | 0 | |
| `cargo clippy --all-features --all-targets` | 0 | no warnings |
| `cargo nextest run --locked -p rig-core -p rig-agent --all-features --retries 2 -E 'not binary(macro_hygiene)'` | 0 | 1956 passed, 5 skipped |

The six new tests by name:

```
rig-core providers::groq::tests::list_models_uses_the_models_endpoint
rig-core providers::groq::tests::list_models_preserves_api_error_context
rig-core providers::moonshot::tests::list_models_uses_the_models_endpoint
rig-core providers::moonshot::tests::list_models_follows_the_configured_base_url
rig-core providers::minimax::tests::list_models_uses_the_models_endpoint
rig-core providers::minimax::tests::list_models_follows_the_configured_base_url
```

I also checked they can fail: changing Groq's `"/models"` to `"/modelz"` fails both Groq tests with

```
left:  "https://api.groq.com/openai/v1/modelz"
right: "https://api.groq.com/openai/v1/models"
```

which is the point of asserting the resolved URL rather than the constant.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — docstrings on each lister; no guide changes needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

## Notes

**Z.ai is deliberately left out.** #2079 lists it, but one lister on `ZAiExt` would resolve `/models` against whichever base the client was built with, and this repo declares two:

```rust
/// General-purpose OpenAI-compatible base URL.
pub const GENERAL_API_BASE_URL: &str = "https://api.z.ai/api/paas/v4";
/// Coding-focused OpenAI-compatible base URL.
pub const CODING_API_BASE_URL: &str = "https://api.z.ai/api/coding/paas/v4";
```

Those are two different product surfaces by rig's own description, so `list_models()` would mean something different depending on configuration, and I can't confirm what either returns without live calls. Say the word and I'll add it — it should probably carry a doc warning if so. (I cited a Z.ai SDK issue for this on #2079 and have since retracted that: the reference no longer resolves.)

**MiniMax's Anthropic dialect** keeps no lister — `/anthropic/v1/models` returns a different shape that `ListModelEntry` wouldn't decode correctly. Noted in the macro docstring so it doesn't read as an oversight.

**Left as `Refs` rather than `Closes`** because #2079 names z.ai and this doesn't cover it. Flip it if you'd rather the issue close on merge.

Last thing: if #2228 is expected to land first I'm happy to hold or retarget, since it removes `client/model_listing.rs` and this would need redoing on the new shape. Per provider the production surface is one capability line plus one macro call, so redoing it is cheap either way — the bulk of the diff is the tests.
