### PR TITLE
test(rig-core): make a live tracing capture provable, not assumed

### DIFF
--- a/crates/rig-agent/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-agent/src/agent/prompt_request/streaming.rs
@@ -2458,8 +2458,10 @@ mod migrated_tests {
         max_turns: usize,
         expected_usages: &[Usage],
     ) {
-        // Scoped-subscriber tests must not run concurrently; the warm-up
-        // below explains the callsite-interest hazard this guards against.
+        // Scoped-subscriber tests must not run concurrently; the warm-up below
+        // explains the callsite-interest hazard this guards against. The
+        // guard's own docs carry that recipe plus the rule it cannot enforce:
+        // an absence assertion needs a positive anchor, or it passes vacuously.
         let _isolation = crate::test_utils::scoped_tracing_subscriber_guard().await;
         let spans = CapturedSpans::default();
         let subscriber = Registry::default().with(SpanCaptureLayer {

--- a/crates/rig-core/src/test_utils/tracing_isolation.rs
+++ b/crates/rig-core/src/test_utils/tracing_isolation.rs
@@ -7,20 +7,70 @@ static GUARD: Mutex<()> = Mutex::const_new(());
 /// Serializes tests that install scoped tracing subscribers
 /// (`tracing::subscriber::set_default` / `with_default`).
 ///
-/// `tracing` caches per-callsite interest globally, and the first thread to
+/// `tracing` caches per-callsite interest **globally**, and the first thread to
 /// hit a callsite computes that interest from its own thread's dispatcher. A
 /// test running in parallel without a subscriber can therefore cache
-/// `Interest::never` for callsites a span-asserting test relies on, and
-/// dispatcher registration churn rebuilds the cache at arbitrary times. Any
-/// test that installs a scoped subscriber and asserts on captured spans must
-/// hold this guard for the subscriber's whole lifetime (and warm/rebuild the
-/// callsites it asserts on; see `assert_stream_usage_recorded_on_chat_spans`).
+/// `Interest::never` for callsites a capturing test relies on, and dispatcher
+/// registration churn rebuilds the cache at arbitrary times.
+///
+/// Holding this guard for the subscriber's whole lifetime is necessary but
+/// **not sufficient**: it serializes the tests that *take* it, and cannot stop
+/// an unguarded sibling on another thread from re-caching `Interest::never`
+/// mid-test. Two further rules apply.
+///
+/// # 1. Warm, then rebuild — in that order
+///
+/// Under the guard, run the code path once before asserting on it, then
+/// rebuild the interest cache, then run it again for real:
+///
+/// ```ignore
+/// let _isolation = scoped_tracing_subscriber_guard().await;
+/// let _default = tracing::subscriber::set_default(subscriber);
+///
+/// // (1) Warm: first-register this path's callsites against THIS subscriber.
+/// run_the_path().await;
+/// // (2) Rebuild: heal callsites a foreign thread already poisoned.
+/// tracing::callsite::rebuild_interest_cache();
+/// captured.clear();
+///
+/// // (3) The run being asserted on.
+/// run_the_path().await;
+/// ```
+///
+/// The rebuild alone is not enough, and the difference is measurable rather
+/// than theoretical: with sibling tests hammering the same callsite, a
+/// rebuild-only capture came back empty in 3 of 52 runs, while warm-then-rebuild
+/// passed 52 of 52 (rig#2346). Both steps must sit inside the guard.
+///
+/// # 2. An absence assertion needs a positive anchor
+///
+/// The two failure directions are not equally visible. A poisoned callsite
+/// captures *nothing*, so:
+///
+/// | assertion shape | under a poisoned callsite |
+/// | --- | --- |
+/// | `assert!(logs.contains(X))` | fails loudly — flaky red |
+/// | `assert!(!logs.contains(X))` | **passes vacuously** — the test is dead |
+///
+/// So an assertion that something is **absent** from captured output is only
+/// sound where something else proves the capture was live. Assert absence
+/// beside a positive anchor, or isolate the test in its own binary.
+///
+/// # Worked examples
+///
+/// - Log capture: `crates/rig-core/tests/common/tracing_capture.rs` packages
+///   all of the above, and `crates/rig-core/tests/model_listing_warnings.rs`
+///   uses it.
+/// - Span capture: `assert_stream_usage_recorded_on_chat_spans` in
+///   `crates/rig-agent/src/agent/prompt_request/streaming.rs`.
 pub async fn scoped_tracing_subscriber_guard() -> MutexGuard<'static, ()> {
     GUARD.lock().await
 }
 
 /// Blocking variant of [`scoped_tracing_subscriber_guard`] for synchronous
 /// tests.
+///
+/// The same two rules apply — see [`scoped_tracing_subscriber_guard`].
 pub fn scoped_tracing_subscriber_guard_blocking() -> MutexGuard<'static, ()> {
     GUARD.blocking_lock()
 }

--- a/crates/rig-core/tests/common/tracing_capture.rs
+++ b/crates/rig-core/tests/common/tracing_capture.rs
@@ -1,0 +1,128 @@
+//! Capture what a code path logs, without the capture quietly going dead.
+//!
+//! Asserting on `tracing` output from a test binary has a hazard that is easy
+//! to get wrong and hard to notice: interest is cached **per callsite,
+//! globally**, computed by whichever thread reaches the callsite first, while
+//! `set_default` installs a subscriber for the current thread only. A sibling
+//! test that reaches the callsite without a subscriber can cache
+//! `Interest::never` and silence the capture mid-test.
+//!
+//! The failure is asymmetric. A silenced capture makes `assert!(contains(..))`
+//! fail loudly, but makes `assert!(!contains(..))` pass **vacuously** — the
+//! test still reports green while covering nothing.
+//!
+//! [`captured_logs`] packages the defence described on
+//! `rig_core::test_utils::scoped_tracing_subscriber_guard`, so the safe
+//! sequence is the one you get by default rather than one each caller
+//! reassembles.
+
+use std::future::Future;
+use std::io::Write;
+use std::sync::{Arc, Mutex, PoisonError};
+
+/// Shared buffer behind the subscriber's writer.
+#[derive(Clone)]
+struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+impl Write for SharedWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn drain(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
+    let mut guard = buffer.lock().unwrap_or_else(PoisonError::into_inner);
+    let bytes = std::mem::take(&mut *guard);
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+/// Run `scenario` under a scoped subscriber and return everything it logged at
+/// `level` or above.
+///
+/// `anchor` is a *different* run of the same code path, chosen so that it
+/// always logs — every string in `anchor_markers` must appear in its output.
+/// It does two jobs:
+///
+/// 1. **Warms** the callsites, so they first-register against this subscriber
+///    rather than against whichever thread happened to reach them first.
+/// 2. **Proves the capture is live** after the interest-cache rebuild, so a
+///    subsequent absence assertion over `scenario`'s output means the path
+///    stayed quiet — not that nothing was listening.
+///
+/// That second job is why this takes an anchor at all: without it, the only
+/// thing keeping an absence assertion honest is the test's own isolation, and
+/// nothing checks that isolation still holds.
+///
+/// Both closures are invoked more than once, so they must be repeatable — take
+/// a factory (`|| run(pages.clone())`), not a one-shot future.
+///
+/// # Panics
+///
+/// If the anchor's output is missing any of `anchor_markers`, which means the
+/// capture is not live and no assertion on the returned logs would be sound.
+pub async fn captured_logs<A, AFut, S, SFut>(
+    level: tracing::Level,
+    mut anchor: A,
+    anchor_markers: &[&str],
+    mut scenario: S,
+) -> String
+where
+    A: FnMut() -> AFut,
+    AFut: Future<Output = ()>,
+    S: FnMut() -> SFut,
+    SFut: Future<Output = ()>,
+{
+    assert!(
+        !anchor_markers.is_empty(),
+        "captured_logs needs at least one anchor marker; an anchor nothing is \
+         asserted about cannot prove the capture is live"
+    );
+
+    // Scoped-subscriber tests must not run concurrently.
+    let _isolation = rig_core::test_utils::scoped_tracing_subscriber_guard().await;
+
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(level)
+        .with_ansi(false)
+        .without_time()
+        .with_writer({
+            let buffer = buffer.clone();
+            move || SharedWriter(buffer.clone())
+        })
+        .finish();
+
+    let _default = tracing::subscriber::set_default(subscriber);
+
+    // (1) Warm: first-register this path's callsites against THIS subscriber.
+    anchor().await;
+    // (2) Rebuild: heal callsites a foreign thread already poisoned.
+    tracing::callsite::rebuild_interest_cache();
+    drain(&buffer);
+
+    // (3) Prove the capture survived the rebuild, at the callsites that matter.
+    let anchor_logs = {
+        anchor().await;
+        drain(&buffer)
+    };
+    for marker in anchor_markers {
+        assert!(
+            anchor_logs.contains(marker),
+            "tracing capture is not live: the anchor run did not log {marker:?}, so \
+             nothing asserted about the captured output below would be meaningful \
+             (an absence assertion would pass vacuously). Captured:\n{anchor_logs}"
+        );
+    }
+
+    // (4) The run under assertion.
+    scenario().await;
+    drain(&buffer)
+}

--- a/crates/rig-core/tests/model_listing_warnings.rs
+++ b/crates/rig-core/tests/model_listing_warnings.rs
@@ -8,23 +8,24 @@
 //! `cursor.is_some()` is true for any listing past its first page. Gemini's
 //! catalog paginates in production, so that fired on every real listing.
 //!
-//! These live in their own test binary on purpose. `tracing` caches callsite
-//! interest **globally**, computed by whichever thread reaches the callsite
-//! first, while `set_default` installs a subscriber only for the current
-//! thread. A sibling test emitting these same warnings without a subscriber
-//! therefore caches `Interest::never` and silences the capture mid-test — which
-//! is exactly what happened when these assertions lived beside the other
-//! listing tests. Alone in a binary, and serialized by
-//! `scoped_tracing_subscriber_guard`, nothing else can reach the callsites.
+//! Two of these cells assert that a warning is **absent**, which is only sound
+//! while the capture is live — a silenced callsite would make them pass while
+//! covering nothing. `common::tracing_capture` proves liveness on every call
+//! rather than leaving it to this binary's isolation; see
+//! `rig_core::test_utils::scoped_tracing_subscriber_guard` for why that is not
+//! something the isolation guard alone can promise.
 
 #![allow(clippy::expect_used)]
 
-use std::io::Write;
-use std::sync::{Arc, Mutex};
+#[path = "common/tracing_capture.rs"]
+mod tracing_capture;
 
 use rig_core::client::ModelListingClient;
 use rig_core::providers::anthropic;
 use rig_core::test_utils::{MockHttpResponse, SequencedHttpClient};
+
+const CEILING_WARNING: &str = "hit its page ceiling";
+const REPEATED_CURSOR_WARNING: &str = "repeated its pagination cursor";
 
 /// One page of Anthropic's `/v1/models` envelope.
 fn page(models: &[&str], has_more: bool, last_id: Option<&str>) -> MockHttpResponse {
@@ -37,55 +38,54 @@ fn page(models: &[&str], has_more: bool, last_id: Option<&str>) -> MockHttpRespo
     )
 }
 
-#[derive(Clone)]
-struct SharedWriter(Arc<Mutex<Vec<u8>>>);
-
-impl Write for SharedWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0.lock().expect("log buffer").extend_from_slice(buf);
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
-/// List `pages` through a mock transport and return everything it logged.
-async fn logs_from_listing(pages: Vec<MockHttpResponse>) -> String {
-    // Scoped-subscriber tests must not run concurrently; see
-    // `test_utils::scoped_tracing_subscriber_guard`.
-    let _isolation = rig_core::test_utils::scoped_tracing_subscriber_guard().await;
-    let captured = Arc::new(Mutex::new(Vec::new()));
-    let subscriber = tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::WARN)
-        .with_ansi(false)
-        .without_time()
-        .with_writer({
-            let captured = captured.clone();
-            move || SharedWriter(captured.clone())
+/// Pages that exhaust the loop's budget: two cursors that alternate forever, so
+/// every request differs from the one before, no repeat is ever observed, and
+/// only the bound stops it.
+fn budget_exhausting_pages() -> Vec<MockHttpResponse> {
+    (0..1_010)
+        .map(|i| {
+            page(
+                &["claude-a"],
+                true,
+                Some(if i % 2 == 0 { "ping" } else { "pong" }),
+            )
         })
-        .finish();
-
-    {
-        let _guard = tracing::subscriber::set_default(subscriber);
-        // Interest is cached per callsite, globally; rebuild so it is computed
-        // against the subscriber installed just above.
-        tracing::callsite::rebuild_interest_cache();
-
-        let client = anthropic::Client::builder()
-            .api_key("test-key")
-            .http_client(SequencedHttpClient::new(pages))
-            .build()
-            .expect("client should build");
-        client.list_models().await.expect("listing should succeed");
-    }
-
-    let bytes = captured.lock().expect("log buffer").clone();
-    String::from_utf8(bytes).expect("log output is utf-8")
+        .collect()
 }
 
-const CEILING_WARNING: &str = "hit its page ceiling";
+/// Pages that stall on one cursor.
+fn repeated_cursor_pages() -> Vec<MockHttpResponse> {
+    vec![
+        page(&["claude-a"], true, Some("stuck")),
+        page(&["claude-b"], true, Some("stuck")),
+    ]
+}
+
+/// Drive one listing through a mock transport.
+async fn list(pages: Vec<MockHttpResponse>) {
+    let client = anthropic::Client::builder()
+        .api_key("test-key")
+        .http_client(SequencedHttpClient::new(pages))
+        .build()
+        .expect("client should build");
+    client.list_models().await.expect("listing should succeed");
+}
+
+/// Everything `pages` logs at WARN, captured against an anchor that exercises
+/// **both** warning callsites in the listing loop — so a cell asserting either
+/// warning is absent has proof that it would have been captured if emitted.
+async fn logs_from_listing(pages: Vec<MockHttpResponse>) -> String {
+    tracing_capture::captured_logs(
+        tracing::Level::WARN,
+        || async {
+            list(budget_exhausting_pages()).await;
+            list(repeated_cursor_pages()).await;
+        },
+        &[CEILING_WARNING, REPEATED_CURSOR_WARNING],
+        || list(pages.clone()),
+    )
+    .await
+}
 
 /// A listing that ends because the provider said so is not a ceiling, however
 /// many pages it took.
@@ -108,19 +108,7 @@ async fn a_completed_multi_page_listing_reports_no_page_ceiling() {
 /// genuinely runs out of its page budget still reports the ceiling.
 #[tokio::test]
 async fn a_listing_that_exhausts_the_page_budget_still_reports_the_ceiling() {
-    // Two cursors that alternate forever: every request differs from the one
-    // before, so no repeat is ever observed and only the bound stops it.
-    let pages: Vec<_> = (0..1_010)
-        .map(|i| {
-            page(
-                &["claude-a"],
-                true,
-                Some(if i % 2 == 0 { "ping" } else { "pong" }),
-            )
-        })
-        .collect();
-
-    let logs = logs_from_listing(pages).await;
+    let logs = logs_from_listing(budget_exhausting_pages()).await;
 
     assert!(
         logs.contains(CEILING_WARNING),
@@ -132,14 +120,10 @@ async fn a_listing_that_exhausts_the_page_budget_still_reports_the_ceiling() {
 /// that alone — not that *and* a page ceiling for one event.
 #[tokio::test]
 async fn a_repeated_cursor_reports_only_its_own_warning() {
-    let logs = logs_from_listing(vec![
-        page(&["claude-a"], true, Some("stuck")),
-        page(&["claude-b"], true, Some("stuck")),
-    ])
-    .await;
+    let logs = logs_from_listing(repeated_cursor_pages()).await;
 
     assert!(
-        logs.contains("repeated its pagination cursor"),
+        logs.contains(REPEATED_CURSOR_WARNING),
         "the repeated cursor is what ended the listing; logged:\n{logs}"
     );
     assert!(


### PR DESCRIPTION
Closes #2346.

`scoped_tracing_subscriber_guard` documented the callsite-interest hazard well, then pointed at the fix:

> …and warm/rebuild the callsites it asserts on; **see `assert_stream_usage_recorded_on_chat_spans`**

That example is in **another crate**, as a private test helper (`crates/rig-agent/src/agent/prompt_request/streaming.rs`). A `rig-core` author reading the guard's own doc could not follow the pointer, and `rustdoc` could not link it. This PR does the issue's three items.

## 1. The recipe is inline now, not delegated

The guard's doc carries the two-step defence as a code block instead of compressing it to the words "warm/rebuild":

```rust
let _isolation = scoped_tracing_subscriber_guard().await;
let _default = tracing::subscriber::set_default(subscriber);

run_the_path().await;                          // (1) warm
tracing::callsite::rebuild_interest_cache();   // (2) rebuild
captured.clear();

run_the_path().await;                          // (3) the run being asserted on
```

**Order matters, and I measured it rather than restating folklore.** With sibling tests hammering the same callsite in one binary, a rebuild-only capture came back empty in **3 of 52 runs**; warm-then-rebuild passed **52 of 52**.

Worth recording, since it corrected my own model of this: the hazard does *not* reproduce sequentially. A foreign thread that poisons a callsite before any subscriber exists is fully healed by installing one, because registering a dispatcher rebuilds the interest cache. It takes genuine concurrent dispatcher churn — which is exactly what a test binary running in parallel produces, and why this only ever showed up as flakiness.

## 2. The rule the guard cannot enforce is written down

The guard serializes the tests that *take* it. It cannot stop an unguarded sibling on another thread from re-caching `Interest::never` mid-test. That matters because the two failure directions are not equally visible:

| assertion shape | under a poisoned callsite |
| --- | --- |
| `assert!(logs.contains(X))` | fails loudly — flaky red |
| `assert!(!logs.contains(X))` | **passes vacuously** — the test is dead |

So the doc now says: an absence assertion is only sound where something else proves the capture was live — assert absence beside a positive anchor, or isolate the test in its own binary.

The `rig-agent` example gets a one-line pointer back, so the author reading *it* finds the rule too. That is the whole shape of the original complaint, in reverse.

## 3. The helper — and why it is worth having

The issue left this optional, "until a third reassembly appears". Counting what is in the tree, there are already five: `CaptureLayer` in `rig-agent/src/agent/runner.rs`, `SpanCaptureLayer` in `rig-agent/.../streaming.rs`, `FieldCaptureLayer`/`WarningCaptureLayer`/`SpanCaptureLayer` in `rig-core/src/telemetry/mod.rs`, and the `SharedWriter` that #2339 added.

`crates/rig-core/tests/common/tracing_capture.rs` packages the sequence for the log-capture shape. It does one thing beyond "guard + warm + rebuild + capture": it takes an **anchor** — a different run of the same path, chosen so it always logs — and asserts the anchor's output *after* the rebuild.

```rust
tracing_capture::captured_logs(
    tracing::Level::WARN,
    || async { /* a listing that always warns */ },   // anchor
    &[CEILING_WARNING, REPEATED_CURSOR_WARNING],      // must appear
    || list(pages.clone()),                           // the run under assertion
).await
```

That converts "this binary is isolated, so its absence assertions are sound" from an unchecked property of the file layout into a per-call assertion. It is the one part of the rule a machine can check, so a machine checks it.

**Placement, deliberately not where the issue suggested.** The issue asked for `rig_core::test_utils`. That module is compiled into the library under `feature = "test-utils"`, and `tracing-subscriber` is a **dev-dependency** — so putting it there would mean adding an optional dependency to a published crate purely for test scaffolding. `tests/common/` + `#[path]` is the pattern the workspace tests already use, costs no dependency change, and is reachable by any `rig-core` integration test. If a future caller needs it from *another* crate, that is the moment to pay the dependency.

## What actually changed in behaviour

`model_listing_warnings.rs` moves onto the helper. Its two absence cells were sound only because they sit alone in a test binary — a property nothing stated or enforced. Now the proof is local to each call.

I verified both halves by mutation: silencing the capture (WARN events no longer reach the writer — the same observable a poisoned callsite produces) gives

| | `no_page_ceiling` (absence only) | `still_reports_the_ceiling` | `repeated_cursor` |
|---|---|---|---|
| on `main` | **passes — vacuous** | fails | fails |
| this PR | fails | fails | fails |

The middle and right columns fail on `main` because they carry positive assertions — which is the issue's "anchor" rule already working by accident. The left column is the one that was genuinely dead, and it is the one this fixes. The binary keeps its isolation as well; the anchor is defence in depth, not a licence to move these back beside their siblings.

## Verification

- `cargo fmt --all --check`
- `RUSTFLAGS="-D warnings" cargo clippy -p rig-core -p rig-agent --all-targets --all-features` — clean
- `cargo test -p rig-core --lib` — 1392 passed; `--doc` — 82 passed; `cargo test -p rig-agent --lib` — 520 passed
- `cargo test -p rig --all-features` — 1637 passed, 0 failed
- `cargo check -p rig-core --all-targets --all-features` — clean
- `cargo check -p rig-core --target wasm32-unknown-unknown` — clean
- `cargo test -p rig-core --test model_listing_warnings` ×15 — 15/15, and the 52-run comparison above

No `CHANGELOG.md` entry: the `Unreleased` sections are user-facing categories (Added/Fixed/Changed/Deprecated/Security) and this changes no public behaviour. Flagging the choice rather than leaving it silent.

## Not done here

The four span-capture layers are left alone. They are bespoke — one captures fields, one captures parent ids, one captures warnings — and every one already anchors on a positive expectation, so none is at risk of the vacuous-pass failure. Folding them into a shared helper is a refactor with its own risk and no defect behind it; it belongs in its own PR if it is worth doing at all.
