### PR TITLE
fix(rig): exclude test cassettes from the published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,16 @@ repository = "https://github.com/0xPlaygrounds/rig"
 # Examples now live in their own packages under `examples/*`; don't auto-discover
 # them as examples of this crate.
 autoexamples = false
+# This package's own `src/` is ~12 KiB of re-exports, but the manifest sits at the
+# repo root, so every sibling path is swept into the published tarball, including
+# the 1,100+ provider cassettes. They grew the crate from 6.66 MiB at 0.39.0 to
+# 9.51 MiB today, against a crates.io upload limit of 10 MiB: the next release was
+# on track to be rejected outright. That limit is enforced server-side, so no
+# amount of `cargo publish --dry-run` surfaces it. Excluding the cassettes drops
+# the tarball to 3.33 MiB. They are replay fixtures the test binaries read at
+# runtime from `CARGO_MANIFEST_DIR`, never embedded with `include_*!`, so nothing
+# in the package needs them to compile.
+exclude = ["tests/cassettes/**"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
## Description

The root manifest **is** the `rig` facade package, so every path sitting beside it gets swept into the published tarball. The facade's own `src/` is ~12 KiB of re-exports; the other 99.9% of what we ship to crates.io is repo furniture, dominated by `tests/cassettes/` (1,100+ provider replay fixtures).

That has been quietly compounding:

| version | `.crate` size |
|---|---|
| 0.39.0 | 6.66 MiB |
| 0.40.0 | 7.76 MiB |
| 0.41.0 | 7.87 MiB |
| current `main` | **9.51 MiB** |

crates.io enforces a **10 MiB upload limit**, so `main` today has 517 KiB of headroom after a cycle that added ~1.5 MiB. The next release was on track to be rejected outright.

The part that makes this worth fixing pre-emptively rather than reactively: **the limit is enforced server-side.** `cargo publish --dry-run` reports success right up until the real upload returns an error. And because a release publishes 22 crates in dependency order, a failure partway through leaves the workspace half-published on crates.io with versions that cannot be reused.

Adding `exclude = ["tests/cassettes/**"]` to the root `[package]`:

- tarball **9.51 MiB → 3.33 MiB** (below where we were at 0.39.0, 6.67 MiB of headroom restored)
- file count **1,704 → 589**
- every `cargo add rig` downloads 6.17 MiB less

This is safe because the cassettes are data the test binaries read at runtime from `CARGO_MANIFEST_DIR` (`tests/common/cassette_safety.rs:11`). They are never embedded with `include_str!`/`include_bytes!`, so nothing in the package needs them to compile. `exclude` governs packaging only, so repo-local and CI test runs are completely unaffected.

There is prior art in-repo: `crates/rig-core/Cargo.toml` already uses `exclude` for `tests/macro_hygiene.rs`.

## Type of change

- [x] Bug fix

## Testing

Verified in a throwaway worktree, no registry token required:

- [x] `cargo publish -p rig --dry-run` — **exit 0**, verification build compiles the packaged tarball with the cassettes absent, zero errors and no new warnings (notably no `warning: ignoring test ...`, which would indicate the exclude had orphaned a test target).
- [x] `cargo package -p rig --list | grep -c tests/cassettes/` — **0**, confirming the glob actually matches.
- [x] Before/after measured on the same tree: 9,968,275 B → 3,494,698 B.

Baseline for the numbers above came from a full `cargo publish --workspace --dry-run` simulation of the pending release PR (#2221), which verified all 22 crates green — so this is the only thing standing between the workspace and a clean 0.42.0.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Notes

Scoped deliberately to the cassettes, since they are 6.17 MiB of the 6.6 MiB of excludable bulk and fix the problem on their own. Worth a follow-up conversation, but **not** included here:

- `tests/providers/` (~0.48 MiB) and the root `tests/*.rs` still ship. They now ship without their fixtures, so a downstream consumer who runs `cargo test` on the unpacked crate (some distro packagers do) would see failures rather than the passes they'd have seen before. Excluding `tests/**` outright would be the more complete fix; I did not want to widen the blast radius of a release-unblocking change without a maintainer opinion.
- Nothing here prevents the *next* category of bulk from creeping in. A CI guard asserting the packaged size stays under some threshold would turn this from a fix into a fence.
