### PR TITLE
feat(memory)!: `TemplateCompactor` caps are literal, with an explicit opt-out

### DIFF
--- a/crates/rig-memory/CHANGELOG.md
+++ b/crates/rig-memory/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- _(memory)_ `TemplateCompactor::without_max_bytes` clears a previously
+  configured size cap, restoring the default unbounded rollup. This is the
+  supported way to express "no cap" and the inverse of `with_max_bytes`,
+  which matters when a compactor is configured in layers (a shared default
+  that sets a cap, a call site that wants none).
+
+### Changed
+
+- _(memory)_ [**breaking**] `TemplateCompactor::with_max_bytes(0)` no longer
+  means "unbounded". `0` is now a literal cap of zero bytes, which collapses
+  the summary to the header line plus the `"[…truncated…]"` marker; use
+  `without_max_bytes` for unbounded behaviour. The signature is unchanged, so
+  this does not break compilation, it changes runtime behaviour for callers
+  that passed `0` as an off switch, and those callers will silently lose the
+  rolled-up carry-over rather than see an error.
+
+  The sentinel made the cap non-monotonic in its argument (`0` → unbounded,
+  `1` → header + marker, `2` → slightly more), so a cap computed
+  arithmetically — `budget.saturating_sub(overhead)`, a config field left at
+  its zero default, a token estimate that rounds down could land on the one
+  input meaning the opposite of what was asked for. Since the summary spliced
+  by `CompactingMemory` sits **outside** the wrapped `MemoryPolicy`'s budget,
+  that accidental unbounded compactor is precisely the failure the cap exists
+  to prevent; an accidental `0` now fails safe instead.
+
 ## [0.42.0](https://github.com/0xPlaygrounds/rig/compare/rig-memory-v0.41.0...rig-memory-v0.42.0) - 2026-08-16
 
 ### Other
@@ -18,11 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Contributors
 
-* [gold-silver-copper](https://github.com/gold-silver-copper)
+- [gold-silver-copper](https://github.com/gold-silver-copper)
 
 ### Changed
 
-- *(memory)* message content handled by the `MemoryPolicy` implementations is `Vec<T>` instead of `OneOrMany<T>`, transitively through rig-core's message-content change; behavior is unchanged
+- _(memory)_ message content handled by the `MemoryPolicy` implementations is `Vec<T>` instead of `OneOrMany<T>`, transitively through rig-core's message-content change; behavior is unchanged
 
 ## [0.41.0](https://github.com/0xPlaygrounds/rig/compare/rig-memory-v0.40.0...rig-memory-v0.41.0) - 2026-07-28
 
@@ -32,12 +60,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- *(client)* [**breaking**] single canonical CompletionClient + AgentClientExt ([#2205](https://github.com/0xPlaygrounds/rig/pull/2205)) (by [gold-silver-copper](https://github.com/gold-silver-copper))
+- _(client)_ [**breaking**] single canonical CompletionClient + AgentClientExt ([#2205](https://github.com/0xPlaygrounds/rig/pull/2205)) (by [gold-silver-copper](https://github.com/gold-silver-copper))
 - Simplify tool execution and hook APIs ([#2132](https://github.com/0xPlaygrounds/rig/pull/2132)) (by [gold-silver-copper](https://github.com/gold-silver-copper)) - #2132
 
 ### Contributors
 
-* [gold-silver-copper](https://github.com/gold-silver-copper)
+- [gold-silver-copper](https://github.com/gold-silver-copper)
+
 ## [0.38.1](https://github.com/0xPlaygrounds/rig/compare/rig-memory-v0.1.2...rig-memory-v0.38.1) - 2026-06-02
 
 ### Other
@@ -46,18 +75,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Contributors
 
-* @gold-silver-copper
+- @gold-silver-copper
+
 ## [0.1.2](https://github.com/0xPlaygrounds/rig/compare/rig-memory-v0.1.1...rig-memory-v0.1.2) - 2026-06-02
 
 ### Other
 
 - update Cargo.toml dependencies
+
 ## [0.1.1](https://github.com/0xPlaygrounds/rig/compare/rig-memory-v0.1.0...rig-memory-v0.1.1) - 2026-05-13
 
 ### Added
 
-- *(memory)* add Compactor trait, CompactingMemory adapter, and TemplateCompactor ([#1748](https://github.com/0xPlaygrounds/rig/pull/1748)) (by @ForeverAngry)
-- *(memory)* Rig-managed conversation memory + rig-memory companion crate ([#1702](https://github.com/0xPlaygrounds/rig/pull/1702)) (by @ForeverAngry)
+- _(memory)_ add Compactor trait, CompactingMemory adapter, and TemplateCompactor ([#1748](https://github.com/0xPlaygrounds/rig/pull/1748)) (by @ForeverAngry)
+- _(memory)_ Rig-managed conversation memory + rig-memory companion crate ([#1702](https://github.com/0xPlaygrounds/rig/pull/1702)) (by @ForeverAngry)
 
 ### Other
 
@@ -66,16 +97,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Contributors
 
-* @gold-silver-copper
-* @ForeverAngry
+- @gold-silver-copper
+- @ForeverAngry
 
 ### Added
 
 - `Compactor` trait (re-exported from `rig_core::memory`) +
   `CompactingMemory<M, P, C>` adapter and a `TemplateCompactor`
   reference implementation. Where `DemotingPolicyMemory` only
-  *observes* messages a policy truncates out of active history, a
-  `Compactor` *substitutes* them: it derives a single `Message`-shaped
+  _observes_ messages a policy truncates out of active history, a
+  `Compactor` _substitutes_ them: it derives a single `Message`-shaped
   `Artifact` from the evicted prefix (and, optionally, the previous
   summary), and `CompactingMemory` splices that artifact at the front
   of the loaded history. The resulting prompt shape is

--- a/crates/rig-memory/src/lib.rs
+++ b/crates/rig-memory/src/lib.rs
@@ -1204,7 +1204,10 @@ where
 /// cap the rolled-up text. When the cap is exceeded, the oldest portion
 /// of the body (after the header) is dropped at a UTF-8 boundary and
 /// replaced with a `"[…truncated…]"` marker, preserving the most recent
-/// context.
+/// context. The cap is taken literally — `with_max_bytes(0)` collapses the
+/// summary to the header and marker, so compute caps freely without
+/// special-casing zero. [`Self::without_max_bytes`] clears a cap that was
+/// already configured.
 ///
 /// # Example
 ///
@@ -1217,6 +1220,11 @@ where
 /// // Custom header plus a 4 KiB cap for use with token-budgeted policies.
 /// let _bounded = TemplateCompactor::with_header("Earlier context")
 ///     .with_max_bytes(4 * 1024);
+///
+/// // Opt back out of a cap inherited from a shared default.
+/// let _unbounded = TemplateCompactor::with_header("Earlier context")
+///     .with_max_bytes(4 * 1024)
+///     .without_max_bytes();
 /// ```
 #[derive(Debug, Clone)]
 pub struct TemplateCompactor {
@@ -1243,17 +1251,20 @@ impl TemplateCompactor {
     /// Cap the rolled-up summary at `max_bytes` bytes (UTF-8). When the
     /// assembled body exceeds the cap, the oldest portion after the
     /// header is dropped at a char boundary and replaced with a
-    /// `"[…truncated…]"` marker.
-    ///
-    /// `max_bytes` of `0` disables truncation (equivalent to the default
-    /// unbounded behaviour). The header line plus the marker are always
-    /// preserved even if they exceed the cap.
+    /// `"[…truncated…]"` marker. The header line plus the marker are
+    /// always preserved even if they exceed the cap, so a `max_bytes` of
+    /// `0` collapses the summary to just the header and marker rather
+    /// than disabling truncation — use [`Self::without_max_bytes`] for
+    /// unbounded behaviour.
     pub fn with_max_bytes(mut self, max_bytes: usize) -> Self {
-        self.max_bytes = if max_bytes == 0 {
-            None
-        } else {
-            Some(max_bytes)
-        };
+        self.max_bytes = Some(max_bytes);
+        self
+    }
+
+    /// Remove any configured size cap, restoring the default unbounded
+    /// behaviour.
+    pub fn without_max_bytes(mut self) -> Self {
+        self.max_bytes = None;
         self
     }
 }
@@ -2855,14 +2866,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn template_compactor_with_max_bytes_zero_is_unbounded() {
+    async fn template_compactor_with_max_bytes_zero_collapses_to_header_and_marker() {
         let compactor = TemplateCompactor::new().with_max_bytes(0);
         let mut evicted = Vec::new();
         for i in 0..200 {
             evicted.push(user(&format!("msg {i}")));
         }
         let summary = compactor.compact("c", &evicted, None).await.unwrap();
+        assert!(summary.as_str().contains("[\u{2026}truncated\u{2026}]"));
+        assert!(!summary.as_str().contains("msg 199"));
+        assert!(
+            summary
+                .as_str()
+                .starts_with("[Conversation summary so far]\n")
+        );
+    }
+
+    #[tokio::test]
+    async fn template_compactor_without_max_bytes_restores_unbounded() {
+        let compactor = TemplateCompactor::new()
+            .with_max_bytes(32)
+            .without_max_bytes();
+        let mut evicted = Vec::new();
+        for i in 0..200 {
+            evicted.push(user(&format!("msg {i}")));
+        }
+        let summary = compactor.compact("c", &evicted, None).await.unwrap();
         assert!(!summary.as_str().contains("[\u{2026}truncated\u{2026}]"));
+        assert!(summary.as_str().contains("msg 0"));
+        assert!(summary.as_str().contains("msg 199"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Problem

`TemplateCompactor::with_max_bytes(0)` previously meant **“unbounded”**. This made `0` a special value with semantics that differed from the rest of the API.

In particular, the cap was non-monotonic:

* `0` → unbounded
* `1` → header plus marker
* `2` → slightly more output

This is especially error-prone when the value is computed rather than explicitly typed. For example:

```rust
budget.saturating_sub(overhead)
```

or a configuration field left at its default value could unexpectedly produce `0`, turning a bounded compactor into an unbounded one.

This is particularly dangerous when used through `CompactingMemory`. The compactor sits outside the wrapped `MemoryPolicy`'s budget, so an accidentally unbounded compactor can cause the rollup to grow without limit: each pass embeds the previous summary verbatim.

### Changes

* `with_max_bytes(n)` now treats `n` **literally**. A value of `0` is a zero-byte cap rather than an unbounded setting.
* **New:** `without_max_cap()` explicitly opts out of the byte limit and restores unbounded rollup behavior.
* This provides a way to opt out at the call site instead of reserving `0` as a special value.
* Documentation and `CHANGELOG.md` have been updated to describe the literal-`0` behavior and the new unbounded escape hatch.

### Breaking behavior

This is a behavioral breaking change for callers that currently pass `0` as an “unbounded” switch.

The API signature remains unchanged, so existing code will still compile, but callers relying on `with_max_bytes(0)` being unbounded will now receive a zero-byte cap.

Migrate those callers to:

```rust
.without_max_cap()
```

### Verification

All checks pass:

* `cargo clippy --all-features --all-targets`
* `cargo fmt -- --check`
* `cargo test -p rig`
* `cargo test -p rig --all-features`
* `cargo test -p rig --test core`
* `cargo test -p rig-memory`
