### PR TITLE
chore(deps): lower dependency floors to what rig needs and stop raising them (#2195)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,19 @@ version: 2
 updates:
   # Cargo dependencies at the workspace root.
   # archived/ is excluded from the workspace via Cargo.toml.
+  #
+  # `increase-if-necessary`: a manifest requirement is a *floor*, not a pin
+  # (`tokio = "1"` is `^1`), so a new upstream release inside the range needs
+  # only a `Cargo.lock` update. The default strategy rewrote the floor on
+  # every patch release, and every published rig release then forced
+  # downstream users to `cargo update` those crates just to take a rig point
+  # release (#2195). The manifest now moves only when a release falls outside
+  # the declared range — a major bump — which is a change worth reviewing.
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
+    versioning-strategy: increase-if-necessary
 
   # All npm package.json files live inside archived/ and should be ignored.
   # These entries exist solely to suppress Dependabot security/version PRs

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -78,6 +78,8 @@ on:
       # vector-store contract is caught by merge_group below at the latest.)
       - "Cargo.toml"
       - "Cargo.lock"
+      - "crates/*/Cargo.toml"
+      - "scripts/check-dependency-floors.py"
   # The repo merges through a merge queue (ALLGREEN, squash, batches up to
   # 5), so the commit that actually lands on main is the merge-group commit —
   # not the PR head that the `pull_request` triggers above validated. Without
@@ -156,3 +158,33 @@ jobs:
       # archived in 2023 and pins Node 20.
       - name: Test with all features
         run: cargo nextest run --locked --all-features --retries 2
+
+  # The declared dependency requirements are floors, not pins (`tokio = "1"`
+  # is `^1`), and a downstream resolves anywhere inside them — usually to
+  # whatever its own lockfile already holds. So rig has to actually build at
+  # the lowest version it declares, or the floor is a lie that surfaces as a
+  # build break in someone else's tree (#2195). Cargo's `-Zdirect-minimal-
+  # versions` is nightly-only and dead-ends in this workspace's transitive
+  # graph, so `scripts/check-dependency-floors.py` does the equivalent on
+  # stable: `cargo update --precise` every direct dependency down to the
+  # lowest version the tree admits, then `cargo check --workspace
+  # --all-features --all-targets`. It runs here rather than on the PR gate
+  # because it is a full all-features build; the `pull_request` paths above
+  # still run it on every PR that touches a manifest, the lockfile, or the
+  # script itself, which is where a floor can silently rot (a PR that starts
+  # using an API newer than the declared floor).
+  dependency-floors:
+    name: stable / dependency floors
+    runs-on: ubuntu-latest
+    if: github.repository == '0xPlaygrounds/rig'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Rust stable
+        uses: ./.github/actions/rust-setup
+        with:
+          protoc: "true"
+
+      - name: Build against the declared dependency floors
+        run: python3 scripts/check-dependency-floors.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- *(deps)* dependency requirements are now floors — the lowest version rig's own code needs (a bare major, or the version that introduced an API rig relies on) — instead of the latest patch at the time of release; Dependabot only moves `Cargo.lock` for in-range releases, and `scripts/check-dependency-floors.py` (CI `dependency-floors`) builds the workspace against the declared floors. The `deranged = "=0.5.8"` exact pin is gone. Downstream users no longer have to `cargo update` unrelated crates to take a rig release ([#2195](https://github.com/0xPlaygrounds/rig/issues/2195)) - #PR
+- *(deps)* dependency requirements are now floors — the lowest version rig's own code needs (a bare major, or the version that introduced an API rig relies on) — instead of the latest patch at the time of release; Dependabot only moves `Cargo.lock` for in-range releases, and `scripts/check-dependency-floors.py` (CI `dependency-floors`) builds the workspace against the declared floors. The `deranged = "=0.5.8"` exact pin is gone. Downstream users no longer have to `cargo update` unrelated crates to take a rig release ([#2195](https://github.com/0xPlaygrounds/rig/issues/2195)) - #2369
 
 ## [0.42.0](https://github.com/0xPlaygrounds/rig/compare/v0.41.0...v0.42.0) - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- *(deps)* dependency requirements are now floors — the lowest version rig's own code needs (a bare major, or the version that introduced an API rig relies on) — instead of the latest patch at the time of release; Dependabot only moves `Cargo.lock` for in-range releases, and `scripts/check-dependency-floors.py` (CI `dependency-floors`) builds the workspace against the declared floors. The `deranged = "=0.5.8"` exact pin is gone. Downstream users no longer have to `cargo update` unrelated crates to take a rig release ([#2195](https://github.com/0xPlaygrounds/rig/issues/2195)) - #PR
+
 ## [0.42.0](https://github.com/0xPlaygrounds/rig/compare/v0.41.0...v0.42.0) - 2026-08-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10047,7 +10047,6 @@ version = "0.42.0"
 dependencies = [
  "anyhow",
  "arrow-array",
- "deranged",
  "futures",
  "httpmock",
  "lancedb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,112 +85,139 @@ version = "0.42.0"
 edition = "2024"
 
 [workspace.dependencies]
+# Every requirement below is a FLOOR, not a pin: `tokio = "1"` means `^1`,
+# and a downstream resolves anywhere inside that range — usually to whatever
+# its own lockfile already holds. So each floor is the lowest version rig's
+# own code needs, to the best it can be verified: a bare major (or `0.minor`)
+# where rig uses only long-stable API, and `major.minor[.patch]` only where a
+# feature or API rig relies on first appeared (each such floor says which).
+# Do not raise a floor because a newer release exists — Dependabot is
+# configured (`versioning-strategy: increase-if-necessary`) to move only
+# `Cargo.lock` for in-range releases, and every rig release used to ship the
+# raised floors, forcing downstream users to `cargo update` a dozen crates
+# just to take a point release (#2195). Raise a floor when rig starts using
+# an API the old floor lacks, and say so in the changelog.
+# `scripts/check-dependency-floors.py` (CI: nightly.yaml `dependency-floors`)
+# downgrades every direct dependency to its floor and builds the workspace,
+# so a floor that has silently rotted fails there rather than downstream.
+#
 # The `rig` facade is the workspace-root package; examples depend on it via
 # `rig.workspace = true` (add per-example features at the use site).
 rig = { path = ".", version = "0.42.0" }
 rig-agent = { path = "crates/rig-agent", version = "0.42.0" }
 rig-core = { path = "crates/rig-core", version = "0.42.0" }
-anyhow = "1.0.102"
+anyhow = "1"
 arrow-array = "58"
-as-any = "0.3.2"
-assert_fs = "1.1.3"
-async-stream = "0.3.6"
-axum = "0.8.4"
-aws-config = { version = "1.8.5", default-features = false }
-aws-sdk-bedrockruntime = { version = "1.124.0", default-features = false }
-aws-smithy-eventstream = "0.60.18"
-aws-smithy-runtime-api = "1.11.3"
-aws-smithy-types = "1.3.2"
-base64 = "0.22.1"
-bytes = "1.10.1"
-candle-core = "0.11.0"
-candle-nn = "0.11.0"
-candle-transformers = "0.11.0"
+as-any = "0.3"
+assert_fs = "1"
+async-stream = "0.3"
+axum = "0.8"
+aws-config = { version = "1", default-features = false }
+# 1.124: `OutputConfig`/`ServiceTier`/citations types rig-bedrock maps.
+aws-sdk-bedrockruntime = { version = "1.124", default-features = false }
+aws-smithy-eventstream = "0.60"
+aws-smithy-runtime-api = "1"
+aws-smithy-types = "1"
+base64 = "0.22"
+bytes = "1"
+candle-core = "0.11"
+candle-nn = "0.11"
+candle-transformers = "0.11"
 chrono = "0.4"
-convert_case = "0.11.0"
-deranged = "=0.5.8"
-dotenvy = "0.15.7"
-epub = "2.1.4"
-ethers = "2.0.14"
+convert_case = "0.11"
+dotenvy = "0.15"
+epub = "2"
+ethers = "2"
+# 0.2.3: `EventStream::set_last_event_id`.
 eventsource-stream = "0.2.3"
-fastembed = { version = "4.9.1", default-features = false }
-fastrand = "2.3.0"
-futures = "0.3.32"
-futures-timer = "3.0.3"
-glob = "0.3.2"
-google-cloud-auth = "1.10"
-google-cloud-aiplatform-v1 = { version = "1.11.0", default-features = false, features = [
+# 4.5: the `hf-hub-*` feature split rig-fastembed forwards.
+fastembed = { version = "4.5", default-features = false }
+fastrand = "2"
+futures = "0.3"
+futures-timer = "3"
+glob = "0.3"
+google-cloud-auth = "1"
+# 1.7: `ThinkingLevel`, `ImageConfig`, `FunctionResponse{Blob,FileData}`.
+google-cloud-aiplatform-v1 = { version = "1.7", default-features = false, features = [
     "prediction-service",
 ] }
-http = "1.3.1"
-httpmock = "0.8.3"
-hyper-util = "0.1.14"
-indexmap = "2.14.0"
-indoc = "2.0.6"
+http = "1"
+# 0.8.2: `Recording::export_async` (cassette harness).
+httpmock = "0.8.2"
+# 0.1.2: the `service` feature.
+hyper-util = "0.1.2"
+indexmap = "2"
+indoc = "2"
 lancedb = { version = "0.30", default-features = false }
-log = "0.4.27"
-lopdf = { version = "0.44.0", default-features = false, features = ["rayon"] }
-mime = "0.3.17"
-mime_guess = "2.0.5"
-mongodb = "3.7.0"
-neo4rs = "0.8.0"
-opentelemetry = "0.32.0"
-opentelemetry-otlp = "0.32.0"
-opentelemetry_sdk = "0.32.1"
-ordered-float = "5.0.0"
+log = "0.4"
+lopdf = { version = "0.44", default-features = false, features = ["rayon"] }
+mime = "0.3"
+mime_guess = "2"
+# 3.2: 3.0/3.1 no longer build against their own `^3` macro crate.
+mongodb = "3.2"
+neo4rs = "0.8"
+opentelemetry = "0.32"
+opentelemetry-otlp = "0.32"
+opentelemetry_sdk = "0.32"
+ordered-float = "5"
+# 0.4.2: the first release whose `sqlx` feature accepts sqlx 0.9.
 pgvector = "0.4.2"
-pin-project-lite = "0.2.16"
-proc-macro2 = "1.0.95"
-qdrant-client = { version = "1.14.0", default-features = false, features = [
+pin-project-lite = "0.2"
+proc-macro2 = "1"
+# 1.10: the `Qdrant` client, `Payload`, and the query/upsert builders.
+qdrant-client = { version = "1.10", default-features = false, features = [
     "serde",
 ] }
-quick-xml = "0.41.0"
-quote = "1.0.40"
-rayon = "1.10.0"
-redis = "1.2.1"
+quick-xml = "0.41"
+quote = "1"
+rayon = "1"
+redis = "1"
 reqwest = { version = "0.13", default-features = false }
-reqwest-middleware = { version = "0.5.2", default-features = false }
+reqwest-middleware = { version = "0.5", default-features = false }
 reqwest-retry = "0.9"
-rmcp = "2.2.0"
-url = "2.5"
+rmcp = "2"
+url = "2"
 rusqlite = "0.32"
-scylla = "1.2.0"
-schemars = "1.0.4"
-serde = "1.0.219"
-serde_yaml = "0.9.34"
-serde_json = "1.0.150"
-safetensors = "0.8.0"
-sha2 = "0.10.9"
-serde_path_to_error = "0.1.17"
+scylla = "1"
+schemars = "1"
+serde = "1"
+serde_yaml = "0.9"
+# 1.0.54: the `float_roundtrip` feature.
+serde_json = "1.0.54"
+safetensors = "0.8"
+sha2 = "0.10"
+serde_path_to_error = "0.1"
 sqlite-vec = "0.1"
-sqlx = "0.9.0"
-surrealdb = "3.0.2"
-syn = "2.0.104"
-serenity = "0.12.4"
-term_size = "0.3.2"
+sqlx = "0.9"
+# 3.2: 3.0/3.1 no longer build against `surrealdb-core ^3` as published.
+surrealdb = "3.2"
+syn = "2"
+serenity = "0.12"
+term_size = "0.3"
 testcontainers = "0.27"
-textwrap = "0.16.2"
-thiserror = "2.0.12"
-tokio = "1.52.3"
-tokio-rusqlite = { version = "0.6.0", default-features = false }
-tokio-test = "0.4.4"
-tokio-stream = "0.1.17"
-tokio-tungstenite = { version = "0.29.0", default-features = false }
-tokenizers = { version = "0.22.2", default-features = false }
-tonic = "0.14.6"
-tonic-build = "0.14.6"
-tonic-prost = "0.14.5"
-tonic-prost-build = "0.14.6"
-prost = "0.14.3"
-tracing = "0.1.41"
+textwrap = "0.16"
+thiserror = "2"
+tokio = "1"
+tokio-rusqlite = { version = "0.6", default-features = false }
+tokio-test = "0.4"
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.29", default-features = false }
+tokenizers = { version = "0.22", default-features = false }
+tonic = "0.14"
+tonic-build = "0.14"
+tonic-prost = "0.14"
+tonic-prost-build = "0.14"
+prost = "0.14"
+tracing = "0.1"
+# 0.2.5: `Instrumented<S>: Stream` under `futures-03` for futures 0.3 stable.
 tracing-futures = "0.2.5"
-tracing-opentelemetry = "0.33.0"
-tracing-subscriber = "0.3.19"
-uuid = "1.17.0"
-wasm-bindgen-futures = "0.4.54"
-wasm-bindgen = "0.2.118"
-web-time = "1.1.0"
-zerocopy = "0.8.50"
+tracing-opentelemetry = "0.33"
+tracing-subscriber = "0.3"
+uuid = "1"
+wasm-bindgen-futures = "0.4"
+wasm-bindgen = "0.2"
+web-time = "1"
+zerocopy = "0.8"
 
 [workspace.metadata.cargo-autoinherit]
 # Skip cargo-autoinherit for these packages

--- a/crates/rig-agent/CHANGELOG.md
+++ b/crates/rig-agent/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- *(deps)* dependency requirements are now floors — the lowest version rig's own code needs (a bare major, or the version that introduced an API rig relies on) — instead of the latest patch at the time of release; Dependabot only moves `Cargo.lock` for in-range releases, and `scripts/check-dependency-floors.py` (CI `dependency-floors`) builds the workspace against the declared floors. The `deranged = "=0.5.8"` exact pin is gone. Downstream users no longer have to `cargo update` unrelated crates to take a rig release ([#2195](https://github.com/0xPlaygrounds/rig/issues/2195)) - #PR
+- *(deps)* dependency requirements are now floors — the lowest version rig's own code needs (a bare major, or the version that introduced an API rig relies on) — instead of the latest patch at the time of release; Dependabot only moves `Cargo.lock` for in-range releases, and `scripts/check-dependency-floors.py` (CI `dependency-floors`) builds the workspace against the declared floors. The `deranged = "=0.5.8"` exact pin is gone. Downstream users no longer have to `cargo update` unrelated crates to take a rig release ([#2195](https://github.com/0xPlaygrounds/rig/issues/2195)) - #2369
 
 
 ### Added

--- a/crates/rig-agent/CHANGELOG.md
+++ b/crates/rig-agent/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- *(deps)* dependency requirements are now floors — the lowest version rig's own code needs (a bare major, or the version that introduced an API rig relies on) — instead of the latest patch at the time of release; Dependabot only moves `Cargo.lock` for in-range releases, and `scripts/check-dependency-floors.py` (CI `dependency-floors`) builds the workspace against the declared floors. The `deranged = "=0.5.8"` exact pin is gone. Downstream users no longer have to `cargo update` unrelated crates to take a rig release ([#2195](https://github.com/0xPlaygrounds/rig/issues/2195)) - #PR
+
+
 ### Added
 
 - the provider's own response reaches agent observers on every call: `raw` on the `CompletionResponse`, `StreamResponseFinish`, and `ModelTurnFinished` hook events, `CompletionCall::raw`, `ModelTurn::raw`, and the streamed `StreamedAssistantContent::Final` terminal record — per attempt, on both surfaces ([#2366](https://github.com/0xPlaygrounds/rig/issues/2366)) - #2367

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- *(deps)* dependency requirements are now floors — the lowest version rig's own code needs (a bare major, or the version that introduced an API rig relies on) — instead of the latest patch at the time of release; Dependabot only moves `Cargo.lock` for in-range releases, and `scripts/check-dependency-floors.py` (CI `dependency-floors`) builds the workspace against the declared floors. The `deranged = "=0.5.8"` exact pin is gone. Downstream users no longer have to `cargo update` unrelated crates to take a rig release ([#2195](https://github.com/0xPlaygrounds/rig/issues/2195)) - #PR
+- *(deps)* dependency requirements are now floors — the lowest version rig's own code needs (a bare major, or the version that introduced an API rig relies on) — instead of the latest patch at the time of release; Dependabot only moves `Cargo.lock` for in-range releases, and `scripts/check-dependency-floors.py` (CI `dependency-floors`) builds the workspace against the declared floors. The `deranged = "=0.5.8"` exact pin is gone. Downstream users no longer have to `cargo update` unrelated crates to take a rig release ([#2195](https://github.com/0xPlaygrounds/rig/issues/2195)) - #2369
 
 
 ### Added

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- *(deps)* dependency requirements are now floors — the lowest version rig's own code needs (a bare major, or the version that introduced an API rig relies on) — instead of the latest patch at the time of release; Dependabot only moves `Cargo.lock` for in-range releases, and `scripts/check-dependency-floors.py` (CI `dependency-floors`) builds the workspace against the declared floors. The `deranged = "=0.5.8"` exact pin is gone. Downstream users no longer have to `cargo update` unrelated crates to take a rig release ([#2195](https://github.com/0xPlaygrounds/rig/issues/2195)) - #PR
+
+
 ### Added
 
 - the provider's own response on every completion: `raw: serde_json::Value` on `CompletionResponse` and `StreamFinal` — the value `raw_completion` / `raw_stream` would have returned, serialized — populated at every provider seam and the shared `normalize_stream` seam; `openai::GenericCompletionModel::raw_completion_with_request_id` and `copilot::CompletionModel::raw_completion_with_request_id` are public so the typed route reproduces `completion()` ([#2366](https://github.com/0xPlaygrounds/rig/issues/2366)) - #2367

--- a/crates/rig-core/Cargo.toml
+++ b/crates/rig-core/Cargo.toml
@@ -88,7 +88,8 @@ anyhow = { workspace = true }
 # downstream builds.
 rig-core = { path = ".", features = ["test-utils"] }
 # identity-leak compile-fail tests (tests/identity_leak.rs)
-trybuild = "1.0"
+# 1.0.111: the compiler-output normalization the trybuild cases were written against.
+trybuild = "1.0.111"
 # streaming identity/merge law property tests
 proptest = "1"
 assert_fs = { workspace = true }

--- a/crates/rig-derive/Cargo.toml
+++ b/crates/rig-derive/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 convert_case = { workspace = true }
 proc-macro2 = { workspace = true, features = ["proc-macro"] }
-proc-macro-crate = "3.4.0"
+proc-macro-crate = "3"
 quote = { workspace = true }
 syn = { workspace = true, features = ["full"] }
 
@@ -28,7 +28,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing-subscriber = { workspace = true }
-trybuild = "1.0"
+# 1.0.111: the compiler-output normalization the trybuild cases were written against.
+trybuild = "1.0.111"
 
 [[example]]
 name = "simple"

--- a/crates/rig-gemini-grpc/Cargo.toml
+++ b/crates/rig-gemini-grpc/Cargo.toml
@@ -27,7 +27,7 @@ tracing = { workspace = true }
 [build-dependencies]
 tonic-build = { workspace = true }
 tonic-prost-build = { workspace = true }
-protoc-bin-vendored = "3.2.0"
+protoc-bin-vendored = "3"
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/rig-lancedb/Cargo.toml
+++ b/crates/rig-lancedb/Cargo.toml
@@ -18,9 +18,6 @@ serde_json = { workspace = true }
 serde = { workspace = true }
 futures = { workspace = true }
 
-# https://github.com/jhpratt/deranged/issues/18
-deranged = { workspace = true }
-
 [dev-dependencies]
 rig-agent.workspace = true
 tokio = { workspace = true }

--- a/scripts/check-dependency-floors.py
+++ b/scripts/check-dependency-floors.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Downgrade every direct dependency to its declared floor and make sure the
+workspace still builds.
+
+A `[workspace.dependencies]` requirement is a floor, not a pin: `tokio = "1.49"`
+means "any 1.x from 1.49.0 on". Downstream users resolve inside that range,
+usually to whatever their lockfile already holds, so rig must actually compile
+against the *lowest* version it declares — otherwise the floor is a lie that
+surfaces as a build break in someone else's tree (#2195). Cargo has no stable
+switch for this: `-Zdirect-minimal-versions` is nightly-only and dead-ends in
+this workspace's transitive graph (lancedb/datafusion), so this script does the
+one thing the flag would do that matters here — for each direct dependency,
+`cargo update --precise` the lockfile entry to the lowest version that
+satisfies the declared requirement — and then runs `cargo check`.
+
+Run from the repository root:
+
+    python3 scripts/check-dependency-floors.py            # check
+    python3 scripts/check-dependency-floors.py --keep     # leave the lowered Cargo.lock in place
+
+The lockfile is restored afterwards unless `--keep` is given.
+
+When a floor is unreachable — some other dependency in this tree requires a
+newer version than rig declares — the script bisects to the *lowest version the
+tree admits* and checks against that, reporting the gap. Rig's declared floor is
+still rig's own honest requirement (a downstream with older transitives can
+resolve below what this tree can), but it can only be verified from the lowest
+reachable version up; the report says exactly which floors carry that caveat.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+LOCK = ROOT / "Cargo.lock"
+INDEX = "https://index.crates.io"
+
+
+def index_path(name: str) -> str:
+    n = len(name)
+    if n == 1:
+        return f"1/{name}"
+    if n == 2:
+        return f"2/{name}"
+    if n == 3:
+        return f"3/{name[0]}/{name}"
+    return f"{name[:2]}/{name[2:4]}/{name}"
+
+
+def parse_version(v: str) -> tuple[int, ...]:
+    core = v.split("+", 1)[0].split("-", 1)[0]
+    return tuple(int(x) for x in core.split(".")[:3])
+
+
+def satisfies(version: str, req: str) -> bool:
+    """Minimal caret/exact semver matching, enough for the requirement forms
+    this workspace uses (`"1"`, `"0.4"`, `"1.2.3"`, `"=1.2.3"`)."""
+    if "-" in version or "+" in version:
+        return False
+    if req.startswith("="):
+        return version == req[1:]
+    req = req.lstrip("^")
+    floor = parse_version(req)
+    v = parse_version(version)
+    if v < floor:
+        return False
+    # caret: same leading non-zero component
+    rp = req.split(".")
+    if rp[0] != "0":
+        return v[0] == floor[0]
+    if len(rp) == 1:
+        return v[0] == 0
+    if rp[1] != "0":
+        return v[0] == 0 and v[1] == floor[1]
+    if len(rp) == 2:
+        return v[0] == 0 and v[1] == 0
+    return v[:3] == floor[:3]
+
+
+def matching_versions(name: str, req: str) -> list[str]:
+    """Every published, non-yanked version satisfying `req`, ascending."""
+    with urllib.request.urlopen(f"{INDEX}/{index_path(name)}") as resp:
+        lines = resp.read().decode().splitlines()
+    candidates = []
+    for line in lines:
+        entry = json.loads(line)
+        if entry.get("yanked"):
+            continue
+        if satisfies(entry["vers"], req):
+            candidates.append(entry["vers"])
+    candidates.sort(key=parse_version)
+    return candidates
+
+
+def try_precise(name: str, locked: str, version: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["cargo", "update", "-p", f"{name}@{locked}", "--precise", version],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+
+def lowest_reachable(name: str, locked: str, versions: list[str]) -> str | None:
+    """Bisect `versions` (ascending, all below `locked`) for the lowest one
+    the resolver accepts. Assumes monotonicity: if a version is admitted, every
+    later one is too — true for the "a transitive needs at least X" case this
+    handles."""
+    lo, hi, found = 0, len(versions) - 1, None
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        if try_precise(name, locked, versions[mid]).returncode == 0:
+            found = versions[mid]
+            hi = mid - 1
+            # the lockfile now holds `found`; later probes update from there
+            locked = found
+        else:
+            lo = mid + 1
+    return found
+
+
+def workspace_direct_deps() -> dict[str, tuple[str, str]]:
+    """name -> (requirement, locked version) for every crates.io dependency
+    that some workspace member depends on directly."""
+    meta = json.loads(
+        subprocess.check_output(
+            ["cargo", "metadata", "--format-version", "1", "--all-features"], cwd=ROOT
+        )
+    )
+    members = set(meta["workspace_members"])
+    by_id = {p["id"]: p for p in meta["packages"]}
+    resolve = {n["id"]: n for n in meta["resolve"]["nodes"]}
+    deps: dict[str, tuple[str, str]] = {}
+    for member in members:
+        pkg = by_id[member]
+        declared = {}
+        for d in pkg["dependencies"]:
+            if d.get("source") is None or "crates.io" not in d["source"]:
+                continue
+            declared[d["name"]] = d["req"]
+        for dep in resolve[member]["deps"]:
+            dep_pkg = by_id[dep["pkg"]]
+            name = dep_pkg["name"]
+            if name in declared and "crates.io" in (dep_pkg.get("source") or ""):
+                req = declared[name]
+                # keep the tightest requirement seen across members
+                prev = deps.get(name)
+                if prev is None or parse_version(req.lstrip("^=")) > parse_version(prev[0].lstrip("^=")):
+                    deps[name] = (req, dep_pkg["version"])
+    return deps
+
+
+def main() -> int:
+    keep = "--keep" in sys.argv
+    backup = LOCK.read_bytes()
+    downgraded, skipped, unreachable = [], [], []
+    try:
+        for name, (req, locked) in sorted(workspace_direct_deps().items()):
+            versions = matching_versions(name, req)
+            if not versions:
+                print(f"?? {name}: no published version satisfies {req}")
+                continue
+            lowest = versions[0]
+            if parse_version(lowest) >= parse_version(locked):
+                skipped.append(name)
+                continue
+            result = try_precise(name, locked, lowest)
+            if result.returncode == 0:
+                downgraded.append((name, locked, lowest))
+                print(f"↓  {name}: {locked} -> {lowest}  (floor {req})")
+                continue
+            lines = result.stderr.strip().splitlines()
+            reason = next(
+                (l.strip() for l in lines if l.strip().startswith("required by package")),
+                lines[-1].strip() if lines else "?",
+            )
+            below = [v for v in versions if parse_version(v) < parse_version(locked)]
+            reachable = lowest_reachable(name, locked, below[1:]) if len(below) > 1 else None
+            if reachable:
+                downgraded.append((name, locked, reachable))
+                unreachable.append((name, req, reachable))
+                print(
+                    f"↓· {name}: {locked} -> {reachable}  (floor {req} unreachable in this "
+                    f"tree — {reason}; verified from {reachable} up)"
+                )
+            else:
+                unreachable.append((name, req, locked))
+                print(f"·  {name}: floor {req} unreachable in this tree ({reason}); stays at {locked}")
+        print(
+            f"\n{len(downgraded)} downgraded, {len(skipped)} already at floor, "
+            f"{len(unreachable)} floors below what this tree admits (verified from the lowest "
+            f"admitted version up); checking…\n"
+        )
+        check = subprocess.run(
+            ["cargo", "check", "--workspace", "--all-features", "--all-targets"], cwd=ROOT
+        )
+        if check.returncode != 0:
+            print("\nFAILED: the workspace does not build against its declared floors.")
+            print("Raise the offending floor(s) in [workspace.dependencies] to the first version that has the API in use.")
+            return check.returncode
+        print("\nOK: the workspace builds against its declared dependency floors.")
+        return 0
+    finally:
+        if not keep:
+            LOCK.write_bytes(backup)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #2195.

## The problem, precisely

Rig never pinned anything: `tokio = "1.52.3"` is `^1.52.3`. What hurt was the **floor**: Dependabot's default cargo strategy rewrites the manifest requirement on every in-range upstream release (`2816c8e59 chore(deps): bump tokio from 1.52.1 to 1.52.3` — 28 such commits on the workspace manifest), and every rig release shipped those raised floors. A downstream on tokio 1.48 with a lockfile then had to `cargo update` tokio — and a dozen other crates — just to take a rig point release. That is the "PAIN" in the issue, and it is a policy problem, not a versioning one.

## What this PR does

1. **Stops the floors from creeping.** `.github/dependabot.yml` sets `versioning-strategy: increase-if-necessary` for cargo: in-range releases become `Cargo.lock`-only PRs; the manifest moves only when a release falls outside the requirement (a major bump), which is a change worth reviewing anyway.

2. **Lowers the floors once, to what rig actually needs.** Every `[workspace.dependencies]` requirement is now the lowest version rig's own code compiles against: a bare major (`tokio = "1"`, `serde = "1"`, `futures = "0.3"`, `reqwest = "0.13"`, …) where rig uses only long-stable API, and `major.minor[.patch]` only where a feature or API rig relies on first appeared — each of those is annotated in the manifest with *why*:

   | crate | floor | because |
   |---|---|---|
   | `aws-sdk-bedrockruntime` | 1.124 | `OutputConfig`/`ServiceTier`/citations types rig-bedrock maps |
   | `google-cloud-aiplatform-v1` | 1.7 | `ThinkingLevel`, `ImageConfig`, `FunctionResponse{Blob,FileData}` |
   | `qdrant-client` | 1.10 | the `Qdrant` client, `Payload`, query/upsert builders |
   | `mongodb` | 3.2 | 3.0/3.1 no longer build against their own `^3` macro crate |
   | `surrealdb` | 3.2 | 3.0/3.1 no longer build against `surrealdb-core ^3` as published |
   | `pgvector` | 0.4.2 | first release whose `sqlx` feature accepts sqlx 0.9 |
   | `fastembed` | 4.5 | the `hf-hub-*` feature split rig-fastembed forwards |
   | `hyper-util` | 0.1.2 | the `service` feature |
   | `serde_json` | 1.0.54 | the `float_roundtrip` feature |
   | `httpmock` | 0.8.2 | `Recording::export_async` (cassette harness) |
   | `eventsource-stream` | 0.2.3 | `EventStream::set_last_event_id` |
   | `tracing-futures` | 0.2.5 | `Instrumented<S>: Stream` for futures 0.3 stable |
   | `trybuild` (rig-core, rig-derive dev) | 1.0.111 | compiler-output normalization the trybuild cases were written against |

   The `deranged = "=0.5.8"` exact pin is removed (with the `rig-lancedb` direct dependency that carried it): it was a workaround for jhpratt/deranged#18, which is closed and locked upstream, and it was the one requirement in the workspace that could make a downstream resolution *fail outright* (anyone needing `deranged 0.5.9` for another crate). If a future deranged release breaks this tree, that is a `Cargo.lock` concern here, not a constraint to impose on users. `Cargo.lock` changes only by dropping that direct edge — every locked version is unchanged, so nothing about how rig builds or tests today moves.

3. **Guards it in CI.** `scripts/check-dependency-floors.py` downgrades every direct dependency in the lockfile to the lowest version satisfying its declared floor (`cargo update --precise`), bisecting to the lowest version *the tree admits* where a transitive requires more, then runs `cargo check --workspace --all-features --all-targets`; the lockfile is restored afterwards. It is wired into `nightly.yaml` as `stable / dependency floors` (scheduled, merge-queue, `workflow_call` from cd, and on any PR touching a manifest, the lockfile, or the script). Why not `-Zdirect-minimal-versions`: it is nightly-only and dead-ends in this workspace's transitive graph (lancedb → datafusion 53.0/53.1 physical-plan conflict the flag's resolver cannot back out of), so the stable script does the equivalent.

## What the check proves, and its one honest caveat

Final run: 51 direct dependencies downgraded to their floor, 19 already at floor, 48 floors that sit *below* what this tree admits — for those the check runs from the lowest admitted version up (e.g. `tokio` floor `1`, verified from 1.52.3 because a transitive in the all-features tree needs it; `bytes` floor `1`, verified from 1.11.1 for lance). The declared floor is still rig's own honest requirement — a downstream with older transitives resolves below what this tree can — but it can only be *verified* from the lowest reachable version up, and the report says exactly which floors carry that caveat. Unit tests for `rig-core`, `rig-agent`, and `rig-derive` (including the trybuild cases) also pass at the floors.

Along the way the check surfaced that some published minimums are unbuildable on their own (`mongodb 3.0/3.1`, `surrealdb 3.0/3.1` against their current sibling crates); those floors are raised to the first buildable release and say why.

## Framing for the issue

Rig has never had an opinion on the exact tokio version; it raised the minimum too eagerly and shipped it. After this, a downstream only has to move when rig *starts using* a newer API — a deliberate, changelogged floor bump — not on every upstream patch release.
