### PR TITLE
chore(release): publish v0.42.0 from main, including everything merged since the release PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-### Changed
-
-- *(deps)* dependency requirements are now floors — the lowest version rig's own code needs (a bare major, or the version that introduced an API rig relies on) — instead of the latest patch at the time of release; Dependabot only moves `Cargo.lock` for in-range releases, and `scripts/check-dependency-floors.py` (CI `dependency-floors`) builds the workspace against the declared floors. The `deranged = "=0.5.8"` exact pin is gone. Downstream users no longer have to `cargo update` unrelated crates to take a rig release ([#2195](https://github.com/0xPlaygrounds/rig/issues/2195)) - #2369
-
-## [0.42.0](https://github.com/0xPlaygrounds/rig/compare/v0.41.0...v0.42.0) - 2026-08-16
+## [0.42.0](https://github.com/0xPlaygrounds/rig/compare/v0.41.0...v0.42.0) - 2026-08-17
 
 ### Added
 
@@ -197,6 +192,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- *(deps)* dependency requirements are now floors — the lowest version rig's own code needs (a bare major, or the version that introduced an API rig relies on) — instead of the latest patch at the time of release; Dependabot only moves `Cargo.lock` for in-range releases, and `scripts/check-dependency-floors.py` (CI `dependency-floors`) builds the workspace against the declared floors. The `deranged = "=0.5.8"` exact pin is gone. Downstream users no longer have to `cargo update` unrelated crates to take a rig release ([#2195](https://github.com/0xPlaygrounds/rig/issues/2195)) - #2369
 - *(providers)* the cursor-paginated model listers (Anthropic, Gemini) share one loop. Each had hand-rolled its own and each shipped the same unbounded-loop bug in [#2334](https://github.com/0xPlaygrounds/rig/pull/2334); the termination rules — no next cursor ends the listing, a repeated cursor ends it, and a hard page ceiling ends it — now live once in `internal::model_listing::paginate_models`, with each provider supplying only how it spells a cursor and how it reads one out of a page. The ceiling is the new rule: both listers were bare `loop`s, so a cursor that keeps *changing* without advancing — a gateway alternating `c1, c2, c1, …`, or minting a fresh one per request — never terminated, where the shared loop now stops after `MAX_LISTING_PAGES` (1000), warns, and returns the pages fetched so far. Venice's lister, which was the shared macro's output written by hand, uses the macro. No public type changed ([#2079](https://github.com/0xPlaygrounds/rig/issues/2079))
 - *(workspace)* remove `#[non_exhaustive]` from every type in the workspace — 53 attributes across `rig-core`, `rig-agent`, `rig-bedrock` and `rig-candle`. Struct literals, functional update (`..Default::default()`) and exhaustive `match` now work from any crate, which is the point: these types read as plain data again. This is a permissive change, so it is **not** breaking and nothing stops compiling because of it. Two consequences to know about. First, downstream `match` arms that exist only to satisfy a previously non-exhaustive enum may now warn `unreachable_patterns`, which is an error under `-D warnings` — delete the wildcard (two in-tree matches over `ReasoningContent` needed this). Second, the reverse of the old bargain now applies: adding a field to any of these structs, or a variant to any of these enums, is a breaking change from here on, so it must wait for a breaking window. `#[non_exhaustive]` cannot be reintroduced outside one either. See `MIGRATING.md` for the superseded guidance and the one invariant this widens ([#2335](https://github.com/0xPlaygrounds/rig/pull/2335))
 - *(agent)* [**breaking**] `ToolSetBuilder` and `ToolSet::builder()` are removed, and the `rig` facade drops `ToolSetBuilder` from its `rig::tool` re-export. A tool set is populated in place instead: `ToolSet::default()` (or `from_tools`/`from_dynamic_tools`) plus `add_tool`, `add_dynamic_tool`, `add_portable_dynamic_tool` and the new `add_retrieved_tool`, so `ToolSet::builder().retrieved_tool(t).build()` becomes `let mut set = ToolSet::default(); set.add_retrieved_tool(t);` ([#2320](https://github.com/0xPlaygrounds/rig/pull/2320))

--- a/crates/rig-agent/CHANGELOG.md
+++ b/crates/rig-agent/CHANGELOG.md
@@ -6,20 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-### Changed
-
-- *(deps)* dependency requirements are now floors — the lowest version rig's own code needs (a bare major, or the version that introduced an API rig relies on) — instead of the latest patch at the time of release; Dependabot only moves `Cargo.lock` for in-range releases, and `scripts/check-dependency-floors.py` (CI `dependency-floors`) builds the workspace against the declared floors. The `deranged = "=0.5.8"` exact pin is gone. Downstream users no longer have to `cargo update` unrelated crates to take a rig release ([#2195](https://github.com/0xPlaygrounds/rig/issues/2195)) - #2369
-
+## [0.42.0](https://github.com/0xPlaygrounds/rig/compare/rig-agent-v0.41.0...rig-agent-v0.42.0) - 2026-08-17
 
 ### Added
 
 - the provider's own response reaches agent observers on every call: `raw` on the `CompletionResponse`, `StreamResponseFinish`, and `ModelTurnFinished` hook events, `CompletionCall::raw`, `ModelTurn::raw`, and the streamed `StreamedAssistantContent::Final` terminal record — per attempt, on both surfaces ([#2366](https://github.com/0xPlaygrounds/rig/issues/2366)) - #2367
-
-## [0.42.0](https://github.com/0xPlaygrounds/rig/compare/rig-agent-v0.41.0...rig-agent-v0.42.0) - 2026-08-16
-
-### Added
-
 - *(agent)* [**breaking**] expose portable model-turn termination metadata to hooks ([#2341](https://github.com/0xPlaygrounds/rig/pull/2341)) (by [gold-silver-copper](https://github.com/gold-silver-copper))
 - carry the provider transport request id on completion errors ([#2314](https://github.com/0xPlaygrounds/rig/pull/2314)) ([#2315](https://github.com/0xPlaygrounds/rig/pull/2315)) (by [gold-silver-copper](https://github.com/gold-silver-copper)) - #2315
 - response identity metadata — native response id + provider transport request id, to every completion observer ([#2265](https://github.com/0xPlaygrounds/rig/pull/2265)) ([#2313](https://github.com/0xPlaygrounds/rig/pull/2313)) (by [gold-silver-copper](https://github.com/gold-silver-copper)) - #2313
@@ -70,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- *(deps)* dependency requirements are now floors — the lowest version rig's own code needs (a bare major, or the version that introduced an API rig relies on) — instead of the latest patch at the time of release; Dependabot only moves `Cargo.lock` for in-range releases, and `scripts/check-dependency-floors.py` (CI `dependency-floors`) builds the workspace against the declared floors. The `deranged = "=0.5.8"` exact pin is gone. Downstream users no longer have to `cargo update` unrelated crates to take a rig release ([#2195](https://github.com/0xPlaygrounds/rig/issues/2195)) - #2369
 - *(agent)* `AgentBuilder`, `Agent`, and `AgentRunner` now share one private `AgentConfig`; `AgentRunner::from_agent` clones it as a single unit instead of copying 15 settings field by field, so a new agent setting can no longer compile while silently failing to propagate to execution (#2326). Per-run overrides mutate only the runner's cloned config, never the source agent. Internal renames within the private config: `default_max_turns` is now a resolved `max_turns: usize` (default `1`, preserving the one-call budget) and `default_conversation_id` is now `conversation_id`. No public API change
 
 - *(tool)* [**breaking**] `ToolSetBuilder` and `ToolSet::builder()` are removed; a tool set is populated in place with `ToolSet::default()` (or `from_tools`/`from_dynamic_tools`) plus `add_tool`, `add_dynamic_tool`, `add_portable_dynamic_tool` and the new `add_retrieved_tool` — `ToolSet::builder().retrieved_tool(t).build()` becomes `let mut set = ToolSet::default(); set.add_retrieved_tool(t);`

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -6,20 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-### Changed
-
-- *(deps)* dependency requirements are now floors — the lowest version rig's own code needs (a bare major, or the version that introduced an API rig relies on) — instead of the latest patch at the time of release; Dependabot only moves `Cargo.lock` for in-range releases, and `scripts/check-dependency-floors.py` (CI `dependency-floors`) builds the workspace against the declared floors. The `deranged = "=0.5.8"` exact pin is gone. Downstream users no longer have to `cargo update` unrelated crates to take a rig release ([#2195](https://github.com/0xPlaygrounds/rig/issues/2195)) - #2369
-
+## [0.42.0](https://github.com/0xPlaygrounds/rig/compare/rig-core-v0.41.0...rig-core-v0.42.0) - 2026-08-17
 
 ### Added
 
 - the provider's own response on every completion: `raw: serde_json::Value` on `CompletionResponse` and `StreamFinal` — the value `raw_completion` / `raw_stream` would have returned, serialized — populated at every provider seam and the shared `normalize_stream` seam; `openai::GenericCompletionModel::raw_completion_with_request_id` and `copilot::CompletionModel::raw_completion_with_request_id` are public so the typed route reproduces `completion()` ([#2366](https://github.com/0xPlaygrounds/rig/issues/2366)) - #2367
-
-## [0.42.0](https://github.com/0xPlaygrounds/rig/compare/rig-core-v0.41.0...rig-core-v0.42.0) - 2026-08-16
-
-### Added
-
 - *(voyageai)* expose embedding request options ([#2343](https://github.com/0xPlaygrounds/rig/pull/2343)) (by [sergiomeneses](https://github.com/sergiomeneses))
 - carry the provider transport request id on completion errors ([#2314](https://github.com/0xPlaygrounds/rig/pull/2314)) ([#2315](https://github.com/0xPlaygrounds/rig/pull/2315)) (by [gold-silver-copper](https://github.com/gold-silver-copper)) - #2315
 - response identity metadata — native response id + provider transport request id, to every completion observer ([#2265](https://github.com/0xPlaygrounds/rig/pull/2265)) ([#2313](https://github.com/0xPlaygrounds/rig/pull/2313)) (by [gold-silver-copper](https://github.com/gold-silver-copper)) - #2313
@@ -87,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- *(deps)* dependency requirements are now floors — the lowest version rig's own code needs (a bare major, or the version that introduced an API rig relies on) — instead of the latest patch at the time of release; Dependabot only moves `Cargo.lock` for in-range releases, and `scripts/check-dependency-floors.py` (CI `dependency-floors`) builds the workspace against the declared floors. The `deranged = "=0.5.8"` exact pin is gone. Downstream users no longer have to `cargo update` unrelated crates to take a rig release ([#2195](https://github.com/0xPlaygrounds/rig/issues/2195)) - #2369
 - *(anthropic)* [**breaking**] `completion::Citation`'s five locator variants become newtypes over five new public payload structs: `CharLocation(CharLocationCitation)`, `PageLocation(PageLocationCitation)`, `ContentBlockLocation(ContentBlockLocationCitation)`, `SearchResultLocation(SearchResultLocationCitation)`, `WebSearchResultLocation(WebSearchResultLocationCitation)` — the crate-private `*CitationFields` DTOs the hand-written `Deserialize` already decoded into, made public as the variant payload itself and renamed without the `Fields` suffix. Field names, types and optionality are carried over verbatim and the `type`-tagged wire shape is untouched (including `web_search_result_location`'s `title`, still written even when absent), so persisted citations load and a serialized one carries the same keys and values; only source that spells the fields breaks — `Citation::CharLocation { cited_text, .. }` becomes `Citation::CharLocation(CharLocationCitation { cited_text, .. })`. `Citation::Unknown(serde_json::Value)` is unchanged. Both routes to the type are provider-native: `Content::Text { citations, .. }` and `streaming::ContentDelta::CitationsDelta`
 
 - *(image, audio)* `image_generation::ImageGenerationModel` and `audio_generation::AudioGenerationModel` state their bounds as `WasmCompatSend`/`WasmCompatSync` rather than `Send`/`Sync`: `ImageGenerationModel`'s own supertraits, plus the associated `Response` and the returned future on both. That is the shape `CompletionModel`, `EmbeddingModel` and `TranscriptionModel` already had. On native targets nothing changes — `WasmCompatSend: Send`, `WasmCompatSync: Sync`, blanket-implemented for every qualifying type — so existing implementors compile unchanged and generic code still gets `Send`/`Sync` from the bound; on `wasm32-unknown-unknown` both markers are empty, so a model whose HTTP future is not `Send` can implement either trait, which the old `+ Send` future bound ruled out

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,7 +2,15 @@
 git_release_body = """{{ changelog }}"""
 git_release_enable = false
 git_tag_enable = false
-release_always = false
+# Publish whenever a crate's manifest version is ahead of crates.io, on any
+# push to main — not only on the release-PR merge commit. With `false`, a
+# publish that fails for a reason unrelated to the code (v0.42.0: an empty
+# `CARGO_REGISTRY_TOKEN`) is stranded: every later push logs "current commit
+# is not from a release PR" and nothing ever retries, while the queued run
+# from the previous push opens a stale duplicate release PR (#2360). With
+# `true` the next push simply publishes the version main already declares,
+# and a version whose crates are all on crates.io is a no-op.
+release_always = true
 
 [[package]]
 name = "rig"


### PR DESCRIPTION
**Merging this PR publishes v0.42.0 to crates.io from `main` as of the merge commit** — with #2367, #2361, #2369 and anything else merged before it. Read that sentence twice before pressing the button.

## Why this exists

The release-PR merge commit for v0.42.0 (`2da030332`, #2221) ran `release-plz release` at 01:47 UTC and failed on the very first `cargo publish` (`rig-derive`): *"please provide a non-empty token"* — `CARGO_REGISTRY_TOKEN` was empty. Nothing was published (crates.io is still at 0.41.0 for every crate) and no `v0.42.0` tag exists. The secret has since been set (12:39 UTC), but `release-plz.toml` had `release_always = false`, so every push since logs *"skipping release: current commit is not from a release PR"* — a stranded release that nothing will ever retry.

Meanwhile the cd run queued behind the release (for `57b4ad2bb`) ran its release-plz step at 01:32 on a checkout that predates the merge, found no open release PR, and opened #2360 — a stale "0.41.0 → 0.42.0" duplicate that conflicts with `main` on every manifest because `main` already contains those bumps. #2360 should be **closed**, not refreshed.

## What this changes

- `release-plz.toml`: `release_always = true` (release-plz's default). Publish whenever a crate's manifest version is ahead of crates.io, on any push to `main`. That both recovers v0.42.0 now and makes a future token/network failure self-heal on the next push; once every crate for a version is on crates.io it's a no-op.
- Changelogs: the `[Unreleased]` entries from #2367 (raw provider responses on every completion) and #2369 (dependency floors) are folded into the `0.42.0` sections of the root, `rig-core`, and `rig-agent` changelogs — that text is the GitHub release body — and the section date becomes 2026-08-17.

No manifest version changes: `main` already says 0.42.0 everywhere.

## What happens on merge

`cd.yaml` runs the gates (~40 min), then `release-plz release` publishes the 22 crates in dependency order, creates the `v0.42.0` tag and the GitHub release for `rig`. The next push after that makes release-plz open the "chore: release v0.43.0" PR for whatever comes next (#2367 is breaking, so a minor bump pre-1.0).

Verify afterwards: `curl -s https://index.crates.io/ri/g-/rig-core | tail -1` → `0.42.0`; `git ls-remote --tags origin v0.42.0`.
