### PR TITLE
fix(rig-postgres): filtered and thresholded searches generate valid SQL

### DIFF
--- a/crates/rig-postgres/CHANGELOG.md
+++ b/crates/rig-postgres/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+
+- *(vector-store)* filtered and thresholded searches reach Postgres as valid SQL. `PgSearchFilter::member` rendered `is in`; a single-condition filter abutted the `WHERE` keyword (`WHEREprice >= $3`); and a threshold was rendered as `distance > $N` inside the inner select, where `distance` is only a select-list alias — and would have kept the least similar rows had it parsed. A threshold is now applied as a minimum similarity on the repeated distance operator (`1 - (embedding <=> $1) >= $N` for cosine and jaccard, the negated distance for the other operators), while returned scores remain raw distances in ascending order ([#2376](https://github.com/0xPlaygrounds/rig/issues/2376))
+
 ## [0.42.0](https://github.com/0xPlaygrounds/rig/compare/rig-postgres-v0.41.0...rig-postgres-v0.42.0) - 2026-08-16
 
 ### Other

--- a/crates/rig-postgres/Cargo.toml
+++ b/crates/rig-postgres/Cargo.toml
@@ -29,6 +29,10 @@ uuid = { workspace = true, features = ["v4", "serde"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+rig-core = { path = "../rig-core", version = "0.42.0", default-features = false, features = [
+  "derive",
+  "test-utils",
+] }
 log = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tokio-test = { workspace = true }

--- a/crates/rig-postgres/src/lib.rs
+++ b/crates/rig-postgres/src/lib.rs
@@ -424,8 +424,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{PgSearchFilter, SearchFilter};
+    use super::{PgSearchFilter, PgVectorDistanceFunction, PostgresVectorStore, SearchFilter};
+    use rig_core::{test_utils::MockEmbeddingModel, vector_store::request::VectorSearchRequest};
     use serde_json::json;
+    use sqlx::postgres::PgPoolOptions;
 
     /// `gte`/`lte`/`member` previously emitted `?` placeholders while
     /// `eq`/`gt`/`lt` emitted `$`; the query renumbering only rewrites `$`, so
@@ -447,5 +449,117 @@ mod tests {
         assert_eq!(cond, "(kind = $) AND (id IN ($, $))");
         assert!(!cond.contains('?'));
         assert_eq!(cond.matches('$').count(), values.len());
+    }
+
+    fn store(
+        distance_function: PgVectorDistanceFunction,
+    ) -> anyhow::Result<PostgresVectorStore<MockEmbeddingModel>> {
+        let pool = PgPoolOptions::new().connect_lazy("postgres://localhost/rig")?;
+        Ok(PostgresVectorStore::new(
+            MockEmbeddingModel,
+            pool,
+            None,
+            distance_function,
+        ))
+    }
+
+    fn where_clause(query: &str) -> anyhow::Result<&str> {
+        let start = query
+            .find("WHERE")
+            .ok_or_else(|| anyhow::anyhow!("no WHERE clause in {query}"))?;
+        let end = query
+            .find("ORDER BY id")
+            .ok_or_else(|| anyhow::anyhow!("no inner ORDER BY in {query}"))?;
+        Ok(query
+            .get(start..end)
+            .ok_or_else(|| anyhow::anyhow!("WHERE follows ORDER BY in {query}"))?
+            .trim())
+    }
+
+    #[tokio::test]
+    async fn search_without_threshold_or_filter_has_no_where_clause() -> anyhow::Result<()> {
+        let req = VectorSearchRequest::builder().query("q").samples(3).build();
+
+        let (query, params) = store(PgVectorDistanceFunction::Cosine)?.search_query(true, &req);
+
+        anyhow::ensure!(!query.contains("WHERE"), "{query}");
+        anyhow::ensure!(params.is_empty(), "{params:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn threshold_is_a_minimum_similarity_on_the_repeated_expression() -> anyhow::Result<()> {
+        let req = VectorSearchRequest::builder()
+            .query("q")
+            .samples(3)
+            .threshold(0.8)
+            .build();
+
+        let (query, params) = store(PgVectorDistanceFunction::Cosine)?.search_query(true, &req);
+
+        let clause = where_clause(&query)?;
+        anyhow::ensure!(clause == "WHERE (1 - (embedding <=> $1) >= $3)", "{clause}");
+        anyhow::ensure!(params == [json!(0.8)], "{params:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn threshold_placeholder_follows_the_filter_placeholders() -> anyhow::Result<()> {
+        let filter = PgSearchFilter::eq("kind", json!("fruit")).and(PgSearchFilter::member(
+            "id".into(),
+            vec![json!(1), json!(2)],
+        ));
+        let req = VectorSearchRequest::builder()
+            .query("q")
+            .samples(3)
+            .threshold(0.5)
+            .filter(filter)
+            .build();
+
+        let (query, params) = store(PgVectorDistanceFunction::L2)?.search_query(false, &req);
+
+        let clause = where_clause(&query)?;
+        anyhow::ensure!(
+            clause == "WHERE ((kind = $3) AND (id IN ($4, $5))) AND (-(embedding <-> $1) >= $6)",
+            "{clause}"
+        );
+        anyhow::ensure!(
+            params == [json!("fruit"), json!(1), json!(2), json!(0.5)],
+            "{params:?}"
+        );
+        anyhow::ensure!(!query.contains(", document"), "{query}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn single_condition_filter_is_separated_from_where() -> anyhow::Result<()> {
+        let req = VectorSearchRequest::builder()
+            .query("q")
+            .samples(3)
+            .filter(PgSearchFilter::gte("price".into(), json!(5)))
+            .build();
+
+        let (query, params) = store(PgVectorDistanceFunction::Cosine)?.search_query(true, &req);
+
+        let clause = where_clause(&query)?;
+        anyhow::ensure!(clause == "WHERE (price >= $3)", "{clause}");
+        anyhow::ensure!(params == [json!(5)], "{params:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn similarity_expression_inverts_each_distance_operator() {
+        let cases = [
+            (PgVectorDistanceFunction::Cosine, "1 - (e <=> q)"),
+            (PgVectorDistanceFunction::Jaccard, "1 - (e <%> q)"),
+            (PgVectorDistanceFunction::InnerProduct, "-(e <#> q)"),
+            (PgVectorDistanceFunction::L2, "-(e <-> q)"),
+            (PgVectorDistanceFunction::L1, "-(e <+> q)"),
+            (PgVectorDistanceFunction::Hamming, "-(e <~> q)"),
+        ];
+
+        for (function, expected) in cases {
+            assert_eq!(function.similarity_expression("e", "q"), expected);
+        }
     }
 }

--- a/crates/rig-postgres/src/lib.rs
+++ b/crates/rig-postgres/src/lib.rs
@@ -131,7 +131,7 @@ impl PgSearchFilter {
     }
 
     pub fn member(key: String, values: Vec<<Self as SearchFilter>::Value>) -> Self {
-        Self(SqlCondition::list(key, "is in", PLACEHOLDER, values))
+        Self(SqlCondition::list(key, "IN", PLACEHOLDER, values))
     }
 
     // String matching ops
@@ -426,7 +426,7 @@ mod tests {
         let (cond, values) = PgSearchFilter::eq("kind", json!("fruit"))
             .and(member)
             .into_clause();
-        assert_eq!(cond, "(kind = $) AND (id is in ($, $))");
+        assert_eq!(cond, "(kind = $) AND (id IN ($, $))");
         assert!(!cond.contains('?'));
         assert_eq!(cond.matches('$').count(), values.len());
     }

--- a/crates/rig-postgres/src/lib.rs
+++ b/crates/rig-postgres/src/lib.rs
@@ -47,6 +47,20 @@ pub enum PgVectorDistanceFunction {
     Jaccard,
 }
 
+impl PgVectorDistanceFunction {
+    /// Higher-is-better similarity derived from this operator's distance, so a
+    /// [`VectorSearchRequest`] threshold can be applied as a minimum similarity
+    /// while search results keep reporting the raw distance.
+    fn similarity_expression(&self, embedding: &str, query: &str) -> String {
+        match self {
+            Self::Cosine | Self::Jaccard => format!("1 - ({embedding} {self} {query})"),
+            Self::L2 | Self::InnerProduct | Self::L1 | Self::Hamming => {
+                format!("-({embedding} {self} {query})")
+            }
+        }
+    }
+}
+
 impl Display for PgVectorDistanceFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
@@ -284,27 +298,16 @@ where
     ) -> (String, Vec<serde_json::Value>) {
         let document = if with_document { ", document" } else { "" };
 
-        let thresh = req
-            .threshold()
-            .map(|t| PgSearchFilter::gt("distance", t.into()));
-        let filter = match (thresh, req.filter()) {
-            (Some(thresh), Some(filt)) => Some(thresh.and(filt.clone())),
-            (Some(thresh), _) => Some(thresh),
-            (_, Some(filt)) => Some(filt.clone()),
-            _ => None,
-        };
-        let (where_clause, params) = match filter {
-            Some(f) => {
-                let (expr, params) = f.into_clause();
-                (String::from("WHERE") + &expr, params)
-            }
-            None => (Default::default(), Default::default()),
+        let (filter_clause, mut params) = match req.filter() {
+            Some(filter) => filter.clone().into_clause(),
+            None => Default::default(),
         };
 
         let mut counter = 3;
-        let mut buf = String::with_capacity(where_clause.len() * 2);
+        let mut conditions = Vec::new();
+        let mut buf = String::with_capacity(filter_clause.len() * 2);
 
-        for c in where_clause.chars() {
+        for c in filter_clause.chars() {
             buf.push(c);
 
             if c == '$' {
@@ -312,8 +315,23 @@ where
                 counter += 1;
             }
         }
+        if !buf.is_empty() {
+            conditions.push(buf);
+        }
 
-        let where_clause = buf;
+        if let Some(threshold) = req.threshold() {
+            let similarity = self
+                .distance_function
+                .similarity_expression("embedding", "$1");
+            conditions.push(format!("{similarity} >= ${counter}"));
+            params.push(threshold.into());
+        }
+
+        let where_clause = if conditions.is_empty() {
+            String::new()
+        } else {
+            format!("WHERE ({})", conditions.join(") AND ("))
+        };
 
         let query = format!(
             "

--- a/tests/integrations/postgres.rs
+++ b/tests/integrations/postgres.rs
@@ -7,7 +7,7 @@
 )]
 
 use rig::client::EmbeddingsClient;
-use rig::postgres::PostgresVectorStore;
+use rig::postgres::{PgSearchFilter, PostgresVectorStore};
 use rig::providers::openai;
 use rig::vector_store::request::VectorSearchRequest;
 use rig::{
@@ -163,6 +163,54 @@ async fn vector_search_test() {
     println!("Distance: {distance}, id: {id}");
 
     assert_eq!(id, full_query_id);
+
+    // A threshold is a minimum similarity: cutting just below the best match's
+    // similarity keeps only that match out of the whole table.
+    let all = vector_store
+        .top_n_ids(
+            VectorSearchRequest::builder()
+                .query(query)
+                .samples(3)
+                .build(),
+        )
+        .await
+        .expect("Failed to search without a threshold");
+    assert_eq!(all.len(), 3);
+    let (best_distance, best_id) = all[0].clone();
+    let (runner_up_distance, _) = all[1].clone();
+    assert!(best_distance < runner_up_distance);
+
+    let thresholded = vector_store
+        .top_n_ids(
+            VectorSearchRequest::builder()
+                .query(query)
+                .samples(3)
+                .threshold(1.0 - (best_distance + runner_up_distance) / 2.0)
+                .build(),
+        )
+        .await
+        .expect("Failed to search with a threshold");
+    assert_eq!(thresholded, vec![(best_distance, best_id)]);
+
+    let filtered = vector_store
+        .top_n::<Word>(
+            VectorSearchRequest::builder()
+                .query(query)
+                .samples(3)
+                .filter(PgSearchFilter::member(
+                    "document->>'name'".into(),
+                    vec![json!("flurbo"), json!("linglingdong")],
+                ))
+                .build(),
+        )
+        .await
+        .expect("Failed to search with a member filter");
+    let mut names: Vec<_> = filtered
+        .iter()
+        .map(|(_, _, doc)| doc.name.as_str())
+        .collect();
+    names.sort_unstable();
+    assert_eq!(names, ["flurbo", "linglingdong"]);
 }
 
 async fn start_container() -> ContainerAsync<GenericImage> {


### PR DESCRIPTION
Fixes #2376

`rig-postgres` produced SQL that Postgres rejects for any `VectorSearchRequest` that carries a `member` filter, a single-condition filter, or a `threshold`; and the threshold compared in the wrong direction. Found by auditing the vector-store crates against `rig-sqlite`, which gets all of this right.

| # | bug | severity |
|---|---|---|
| 1 | `PgSearchFilter::member` renders `id is in ($3, $4)` — not a Postgres operator | high (hard error) |
| 2 | threshold rendered as `distance > $N` in the inner `WHERE`, where `distance` is only a select-list alias → `column "distance" does not exist` | high (hard error) |
| 3 | `>` on a pgvector *distance* while `threshold` is documented as a minimum similarity → would keep the *worst* rows | high |
| 4 | `"WHERE" + condition` with no separator → `WHEREprice >= $3` for any single-condition filter | high (hard error) |

Generated SQL on `origin/main`, as printed by the new tests when run there:

```
WHEREprice >= $3
WHEREdistance > $3
WHERE(distance > $3) AND ((kind = $4) AND (id is in ($5, $6)))
```

and on this branch:

```
WHERE (price >= $3)
WHERE (1 - (embedding <=> $1) >= $3)
WHERE ((kind = $3) AND (id IN ($4, $5))) AND (-(embedding <-> $1) >= $6)
```

## Fix

- `member` renders `IN`.
- The threshold is applied as a **minimum similarity** on a per-operator expression that repeats the distance operator rather than naming the alias: `1 - (embedding <=> $1)` for cosine and jaccard, the negated distance for inner product / L2 / L1 / hamming (pgvector's `<#>` is already the negative inner product). This is the approach `rig-sqlite` takes. It is composed *after* the `$` renumbering pass so the `$1` inside the expression survives, and its bind value is appended after the filter's.
- `WHERE` is separated from its first condition.

**Non-breaking**: returned scores are still raw pgvector distances in ascending order; only requests that previously errored change behavior.

## Tests

- **4 unit tests fail on `origin/main` and pass here** (`threshold_is_a_minimum_similarity_on_the_repeated_expression`, `threshold_placeholder_follows_the_filter_placeholders`, `single_condition_filter_is_separated_from_where`, plus the existing `every_parameterised_operator_uses_dollar_placeholders`, whose assertion pinned `is in`). They call the private `search_query` on a store built with a lazy pool and `rig_core::test_utils::MockEmbeddingModel`, so no database is needed. `similarity_expression_inverts_each_distance_operator` covers all six operators.


Verified locally: `cargo fmt --all -- --check`, `cargo clippy -p rig-postgres --all-targets --all-features`, `cargo test -p rig-postgres`.
