### PR TITLE
fix(gemini): six cachedContents defects the follow-up audit found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- *(gemini)* lift `systemInstruction` and `toolConfig` out of `additional_params`, so they reach the typed field instead of being serialized twice and walking past validation (by [gold-silver-copper](https://github.com/gold-silver-copper))
+- *(gemini)* see `systemInstruction` and `toolConfig` set through `additional_params` when validating a cached-content request, under either proto-JSON spelling; setting one of them *and* its typed counterpart is now refused rather than resolved by serialization order (by [gold-silver-copper](https://github.com/gold-silver-copper))
 - *(gemini)* triage `cachedContents` failures by status, so `Expired` is reachable on every transport, and refuse a cache handle that would retarget the request path (by [gold-silver-copper](https://github.com/gold-silver-copper))
 - *(gemini)* bound the `cachedContents` listing loop, and report when a listing was truncated (by [gold-silver-copper](https://github.com/gold-silver-copper))
 - *(gemini)* stop dropping thinking, cached and tool-use tokens on the Interactions surface ([#2375](https://github.com/0xPlaygrounds/rig/pull/2375)) (by [gold-silver-copper](https://github.com/gold-silver-copper))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- *(gemini)* lift `systemInstruction` and `toolConfig` out of `additional_params`, so they reach the typed field instead of being serialized twice and walking past validation (by [gold-silver-copper](https://github.com/gold-silver-copper))
 - *(gemini)* triage `cachedContents` failures by status, so `Expired` is reachable on every transport, and refuse a cache handle that would retarget the request path (by [gold-silver-copper](https://github.com/gold-silver-copper))
 - *(gemini)* bound the `cachedContents` listing loop, and report when a listing was truncated (by [gold-silver-copper](https://github.com/gold-silver-copper))
 - *(gemini)* stop dropping thinking, cached and tool-use tokens on the Interactions surface ([#2375](https://github.com/0xPlaygrounds/rig/pull/2375)) (by [gold-silver-copper](https://github.com/gold-silver-copper))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- *(gemini)* triage `cachedContents` failures by status, so `Expired` is reachable on every transport, and refuse a cache handle that would retarget the request path (by [gold-silver-copper](https://github.com/gold-silver-copper))
+- *(gemini)* bound the `cachedContents` listing loop, and report when a listing was truncated (by [gold-silver-copper](https://github.com/gold-silver-copper))
 - *(gemini)* stop dropping thinking, cached and tool-use tokens on the Interactions surface ([#2375](https://github.com/0xPlaygrounds/rig/pull/2375)) (by [gold-silver-copper](https://github.com/gold-silver-copper))
 - *(vertexai)* stop discarding Vertex's thinking-token count ([#2375](https://github.com/0xPlaygrounds/rig/pull/2375)) (by [gold-silver-copper](https://github.com/gold-silver-copper))
 - *(gemini)* serialize tool-schema `properties` in a stable order, so Gemini prompt caching can hit ([#2374](https://github.com/0xPlaygrounds/rig/pull/2374)) (by [gold-silver-copper](https://github.com/gold-silver-copper))

--- a/crates/rig-core/src/providers/gemini/cached_content.rs
+++ b/crates/rig-core/src/providers/gemini/cached_content.rs
@@ -74,8 +74,8 @@
 //! which is why a tool set that lives in the cache stays out of an agent's
 //! hands.
 //!
-//! An agent can therefore read from a cache only when it has no preamble, no
-//! tools and no tool choice. Native structured output is fine — the schema
+//! Leaving the allow-list aside, then, an agent reads from a cache when it has
+//! no preamble, no tools and no tool choice. Native structured output is fine — the schema
 //! rides in `generationConfig`, and the default `OutputMode::Auto` resolves
 //! there for a tool-less agent. `OutputMode::Tool` is not, because it advertises
 //! that synthetic tool *and* extends the preamble; `Extractor` pins that mode,

--- a/crates/rig-core/src/providers/gemini/cached_content.rs
+++ b/crates/rig-core/src/providers/gemini/cached_content.rs
@@ -48,6 +48,39 @@
 //! [`super::completion::gemini_api_types::GenerateContentRequest::with_cached_content`] — so the
 //! failure names the conflict instead of surfacing a provider 400.
 //!
+//! ## What that means for an `Agent`
+//!
+//! An agent does not choose which of the three it sends — it sends what it
+//! holds. A preamble becomes `systemInstruction`; every always-exposed tool is
+//! advertised on every turn (one registered through `retrieved_tools` is
+//! advertised on the turns retrieval selects it, so such an agent is refused
+//! intermittently rather than not at all); and a configured tool choice becomes
+//! `toolConfig` whether or not the agent has any tools.
+//!
+//! The agent derives the declarations it sends and the handles it dispatches
+//! through from a single registry snapshot, so it can only ever dispatch a tool
+//! it advertised — a call to a tool it never advertised is an invalid tool call,
+//! not a dispatch. The converse is representable and rig uses it:
+//! `OutputMode::Tool` advertises a synthetic output tool that is deliberately
+//! not executable. But that only ever adds declarations, never dispatch reach,
+//! which is why a tool set that lives in the cache stays out of an agent's
+//! hands.
+//!
+//! An agent can therefore read from a cache only when it has no preamble, no
+//! tools and no tool choice. Native structured output is fine — the schema
+//! rides in `generationConfig`, and the default `OutputMode::Auto` resolves
+//! there for a tool-less agent. `OutputMode::Tool` is not, because it advertises
+//! that synthetic tool *and* extends the preamble; `Extractor` pins that mode,
+//! so extractors cannot use a cache. `OutputMode::Prompted` is not either: it
+//! writes the schema into the preamble. Context documents are fine: they are
+//! appended to the chat history as user content.
+//!
+//! A cache carrying *function declarations* or `toolConfig` is consequently for
+//! the caller who drives [`super::completion::CompletionModel`] directly and
+//! runs the tool loop themselves. A provider-hosted tool is the exception:
+//! `codeExecution` runs on Gemini's side and needs no loop, so a cache carrying
+//! one is usable from an agent that declares nothing itself.
+//!
 //! # Example
 //!
 //! ```no_run
@@ -235,13 +268,32 @@ impl NewCachedContent {
     /// Attach the tool set this cache owns.
     ///
     /// Every request using the handle inherits these; a request may not send its
-    /// own (Gemini rejects that, and so does rig).
+    /// own (Gemini rejects that, and so does rig — see
+    /// [`super::completion::gemini_api_types::GenerateContentRequest::with_cached_content`]).
+    ///
+    /// Function declarations here are *declarations*, not implementations, which
+    /// is what puts them out of reach of rig's `Agent` — see the module docs
+    /// above for why. A cached function tool set is usable only when you drive
+    /// [`super::completion::CompletionModel`] yourself and run the tool loop by
+    /// hand: read the `functionCall` parts off the response and append the
+    /// matching `functionResponse` parts to the next request. A provider-hosted
+    /// tool such as `codeExecution` is different — Gemini runs it, so a cache
+    /// carrying one needs no loop and works from an agent.
     pub fn tools(mut self, tools: Vec<Tool>) -> Self {
         self.tools = Some(tools);
         self
     }
 
     /// Attach the tool choice this cache owns.
+    ///
+    /// Same reachability caveat as [`Self::tools`]: a request carrying its own
+    /// tool choice alongside the handle is refused, and rig's `Agent` sends one
+    /// whenever it is configured with one — even a tool-less agent — so this is
+    /// for callers driving [`super::completion::CompletionModel`] directly. A
+    /// tool-less agent does at least lose nothing by dropping its tool choice,
+    /// which is not true of a tool set. Gemini accepts a
+    /// `toolConfig` with no `tools` (measured; see the create matrix), which is
+    /// why the two are separate builders rather than one.
     pub fn tool_config(mut self, tool_config: ToolConfig) -> Self {
         self.tool_config = Some(tool_config);
         self

--- a/crates/rig-core/src/providers/gemini/cached_content.rs
+++ b/crates/rig-core/src/providers/gemini/cached_content.rs
@@ -50,12 +50,20 @@
 //!
 //! ## What that means for an `Agent`
 //!
-//! An agent does not choose which of the three it sends — it sends what it
-//! holds. A preamble becomes `systemInstruction`; every always-exposed tool is
-//! advertised on every turn (one registered through `retrieved_tools` is
+//! An agent mostly does not choose which of the three it sends — it sends what
+//! it holds. A preamble becomes `systemInstruction`; every always-exposed tool
+//! is advertised on every turn (one registered through `retrieved_tools` is
 //! advertised on the turns retrieval selects it, so such an agent is refused
 //! intermittently rather than not at all); and a configured tool choice becomes
 //! `toolConfig` whether or not the agent has any tools.
+//!
+//! The one lever that does exist is a per-turn `RequestPatch::active_tools`
+//! allow-list: an empty one empties the tool snapshot, so a tool-holding agent
+//! builds a request with no `tools` and the handle is accepted. That is a
+//! supported configuration, not a loophole — but it buys only the *request*,
+//! never the dispatch. The tools it suppressed are still the agent's, and the
+//! ones in the cache are still unreachable, so an agent that has to empty its
+//! allow-list to use a cache is an agent whose tools do nothing on that turn.
 //!
 //! The agent derives the declarations it sends and the handles it dispatches
 //! through from a single registry snapshot, so it can only ever dispatch a tool

--- a/crates/rig-core/src/providers/gemini/cached_content.rs
+++ b/crates/rig-core/src/providers/gemini/cached_content.rs
@@ -88,6 +88,7 @@ use serde::{Deserialize, Serialize};
 use super::client::Client;
 use super::completion::gemini_api_types::{Content, Part, Role, Tool, ToolConfig};
 use crate::http_client::{self, HttpClientExt};
+use crate::providers::internal::model_listing::MAX_LISTING_PAGES;
 use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
 
 /// The `cachedContents` collection path.
@@ -379,8 +380,14 @@ where
     ) -> Result<Vec<CachedContent>, CachedContentError> {
         let mut all = Vec::new();
         let mut page_token: Option<String> = None;
+        // Only the loop running out of iterations is a ceiling. Every `break`
+        // below is Gemini ending the listing, which is the normal path and must
+        // stay silent — inferring the ceiling from `page_token` instead would
+        // report one on any listing that fetched more than a single page, since
+        // the cursor of the *previous* page is still held when the loop breaks.
+        let mut exhausted_page_budget = true;
 
-        loop {
+        for _ in 0..MAX_LISTING_PAGES {
             // Percent-encoded through the same helper `list_models_path` uses
             // (`internal::model_listing::with_query_pairs`), which has a test
             // pinning `pageToken=weird+token%26x%3D1`. Concatenating the cursor
@@ -402,13 +409,34 @@ where
             // An empty cursor counts as absent, matching how every other
             // provider-reported cursor in rig is read: re-sending an empty
             // `pageToken` returns the same page forever.
-            let next = page.next_page_token.filter(|token| !token.is_empty());
-            match next {
-                // A cursor that does not advance is a server bug that would
-                // otherwise spin here until the process dies.
-                Some(token) if Some(&token) != page_token.as_ref() => page_token = Some(token),
-                _ => break,
+            let Some(token) = page.next_page_token.filter(|token| !token.is_empty()) else {
+                exhausted_page_budget = false;
+                break;
+            };
+            // A cursor that does not advance is a server bug: the next request
+            // would be byte-identical to the one just answered, so the same
+            // page would come back forever.
+            if page_token.as_deref() == Some(token.as_str()) {
+                tracing::warn!(
+                    provider = "Gemini",
+                    cached_contents = all.len(),
+                    "cachedContents listing repeated its pagination cursor; returning the \
+                     pages fetched so far"
+                );
+                exhausted_page_budget = false;
+                break;
             }
+            page_token = Some(token);
+        }
+
+        if exhausted_page_budget {
+            tracing::warn!(
+                provider = "Gemini",
+                cached_contents = all.len(),
+                pages = MAX_LISTING_PAGES,
+                "cachedContents listing hit its page ceiling with a cursor still advancing; \
+                 returning the pages fetched so far"
+            );
         }
 
         Ok(all)
@@ -820,6 +848,173 @@ mod tests {
         assert_eq!(
             object.get("model").and_then(|m| m.as_str()),
             Some("models/gemini-2.5-flash")
+        );
+    }
+
+    // The pagination loop, and every way its cursor can fail to advance:
+    // absent, empty, repeated, and alternating — the last of which only the
+    // page ceiling catches. `paginate_models` carries the same three rules for
+    // model listings, but this resource cannot call it (it is typed on
+    // `Model`/`ModelListingError` and fetches through `get_bytes`, which
+    // collapses the 403/404 triage `CachedContentError::Expired` exists for),
+    // so the rules are restated in `list_with_page_size` and pinned here.
+    //
+    // Only the malformed-cursor cells are unrecordable: no live response
+    // carries an empty, repeated or alternating cursor, and no live cursor
+    // carries URL-significant characters. Ordinary and multi-page listings are
+    // recorded — `prompt_caching/explicit_cache_lifecycle` for a single page,
+    // `cached_content_matrix/edge_list_pagination` for three pages at
+    // `pageSize=1`. These cells exist to pin the three termination guards,
+    // which a recording cannot exercise.
+
+    /// One page of Gemini's `cachedContents` list envelope.
+    fn cached_page(names: &[&str], next_page_token: Option<&str>) -> MockHttpResponse {
+        let cached_contents: Vec<_> = names
+            .iter()
+            .map(|name| serde_json::json!({ "name": format!("cachedContents/{name}") }))
+            .collect();
+        MockHttpResponse::success(
+            serde_json::json!({
+                "cachedContents": cached_contents,
+                "nextPageToken": next_page_token,
+            })
+            .to_string(),
+        )
+    }
+
+    /// A `cachedContents` client whose transport answers the scripted pages in
+    /// order and `NOT_IMPLEMENTED` once they run out — so a loop that fails to
+    /// terminate ends its test with an error rather than hanging the suite.
+    fn caches(
+        pages: Vec<MockHttpResponse>,
+    ) -> (
+        CachedContentClient<SequencedHttpClient>,
+        SequencedHttpClient,
+    ) {
+        let http_client = SequencedHttpClient::new(pages);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client.clone())
+            .build()
+            .expect("client should build");
+        (client.cached_contents(), http_client)
+    }
+
+    /// The ordinary single-page listing — what `list()`'s default page size
+    /// returns for any realistic collection — is unchanged by the termination
+    /// guards. Recorded live in `prompt_caching/explicit_cache_lifecycle`;
+    /// repeated here so the guards have a no-cursor baseline on the same mock
+    /// transport as the cells below.
+    #[tokio::test]
+    async fn single_page_listing_is_unchanged() {
+        let (caches, http_client) = caches(vec![cached_page(&["a", "b"], None)]);
+
+        let listed = caches.list().await.expect("listing should succeed");
+
+        let names: Vec<_> = listed.iter().map(|entry| entry.name.as_str()).collect();
+        assert_eq!(names, ["cachedContents/a", "cachedContents/b"]);
+        assert_eq!(http_client.remaining_responses(), 0);
+    }
+
+    /// An empty `nextPageToken` is as unusable as an absent one: re-sending an
+    /// empty `pageToken` returns the same page forever.
+    #[tokio::test]
+    async fn pagination_stops_on_an_empty_cursor() {
+        let (caches, http_client) = caches(vec![
+            cached_page(&["a"], Some("")),
+            cached_page(&["b"], None),
+        ]);
+
+        let listed = caches
+            .list_with_page_size(1)
+            .await
+            .expect("listing should terminate");
+
+        let names: Vec<_> = listed.iter().map(|entry| entry.name.as_str()).collect();
+        assert_eq!(names, ["cachedContents/a"]);
+        assert_eq!(http_client.remaining_responses(), 1);
+    }
+
+    /// A server that keeps echoing the same cursor cannot advance the listing
+    /// either — the next request would be byte-identical to the one just
+    /// answered, so the same page would come back forever.
+    #[tokio::test]
+    async fn pagination_stops_on_a_cursor_that_does_not_advance() {
+        let (caches, http_client) = caches(vec![
+            cached_page(&["a"], Some("stuck")),
+            cached_page(&["b"], Some("stuck")),
+            cached_page(&["c"], Some("stuck")),
+        ]);
+
+        let listed = caches
+            .list_with_page_size(1)
+            .await
+            .expect("listing should terminate");
+
+        let names: Vec<_> = listed.iter().map(|entry| entry.name.as_str()).collect();
+        assert_eq!(
+            names,
+            ["cachedContents/a", "cachedContents/b"],
+            "the repeat is only detectable on the second page, so both are kept",
+        );
+        assert_eq!(http_client.remaining_responses(), 1);
+    }
+
+    /// A cursor that keeps *changing* without making progress — a gateway
+    /// alternating between two values, or minting a fresh one per request —
+    /// defeats the repeat check, which only remembers the previous cursor. Only
+    /// the page ceiling stops it, and without one `list` never returns while
+    /// `all` grows without bound (rig#2334).
+    #[tokio::test]
+    async fn pagination_stops_at_the_page_ceiling_on_an_alternating_cursor() {
+        // Two cursors that alternate forever: every request differs from the
+        // one before, so no repeat is ever observed.
+        let pages: Vec<_> = (0..MAX_LISTING_PAGES + 10)
+            .map(|i| cached_page(&["a"], Some(if i % 2 == 0 { "ping" } else { "pong" })))
+            .collect();
+        let (caches, http_client) = caches(pages);
+
+        let listed = caches
+            .list_with_page_size(1)
+            .await
+            .expect("the ceiling ends the listing instead of looping");
+
+        assert_eq!(
+            listed.len(),
+            MAX_LISTING_PAGES,
+            "exactly the ceiling's worth of pages is fetched",
+        );
+        assert_eq!(
+            http_client.remaining_responses(),
+            10,
+            "the loop stops at the ceiling rather than draining every page",
+        );
+    }
+
+    /// A cursor carrying URL-significant characters is percent-encoded rather
+    /// than interpolated, so it cannot truncate the path or inject a query
+    /// parameter — Gemini appends `key=` to every URI, so a raw `&` in the
+    /// cursor would sit next to the credential.
+    #[tokio::test]
+    async fn pagination_percent_encodes_the_cursor() {
+        let (caches, http_client) = caches(vec![
+            cached_page(&["a"], Some("weird token&x=1")),
+            cached_page(&["b"], None),
+        ]);
+
+        caches
+            .list_with_page_size(1)
+            .await
+            .expect("listing should succeed");
+
+        let uris: Vec<_> = http_client
+            .requests()
+            .into_iter()
+            .map(|request| request.uri)
+            .collect();
+        assert!(
+            uris[1].contains("pageSize=1&pageToken=weird+token%26x%3D1&key="),
+            "the cursor must be percent-encoded: {uris:?}",
         );
     }
 }

--- a/crates/rig-core/src/providers/gemini/cached_content.rs
+++ b/crates/rig-core/src/providers/gemini/cached_content.rs
@@ -356,7 +356,7 @@ where
 
     /// Fetch one cached content by handle.
     pub async fn get(&self, name: &str) -> Result<CachedContent, CachedContentError> {
-        let http = self.client.get(resource_path(name))?.body(Vec::new())?;
+        let http = self.client.get(resource_path(name)?)?.body(Vec::new())?;
         self.send(http, Some(name)).await
     }
 
@@ -450,7 +450,10 @@ where
             ),
         };
 
-        let path = format!("{}?updateMask={mask}", resource_path(name));
+        // The `?` below is only ours because `resource_path` refuses an id that
+        // carries one: an unvalidated handle would put `updateMask` inside the
+        // caller's query string on a resource we did not mean to patch.
+        let path = format!("{}?updateMask={mask}", resource_path(name)?);
         let http = self
             .client
             .patch(&path)?
@@ -462,8 +465,13 @@ where
     ///
     /// Storage bills until this is called, so a cache created for the duration
     /// of a task should be deleted on the failure path too.
+    ///
+    /// A handle that is not a plain `cachedContents/<id>` (or a bare `<id>`) is
+    /// refused with [`CachedContentError::Invalid`] before anything is sent —
+    /// spliced into the path, a `?` or `#` would aim this delete at a different
+    /// cache and succeed.
     pub async fn delete(&self, name: &str) -> Result<(), CachedContentError> {
-        let http = self.client.delete(resource_path(name))?.body(Vec::new())?;
+        let http = self.client.delete(resource_path(name)?)?.body(Vec::new())?;
         let _: serde_json::Value = self.send_json(http, Some(name)).await?;
         Ok(())
     }
@@ -487,32 +495,46 @@ where
         let response = HttpClientExt::send::<_, Vec<u8>>(&self.client, request).await;
 
         let bytes = match response {
+            // A transport is free to hand the non-success status back as an
+            // `Ok` response rather than an error, and rig's own test double
+            // does exactly that. Without this arm the *error* body fell through
+            // to the `serde_json::from_str` below and surfaced as "missing
+            // field `name`" — a deserialization failure standing in for a 404,
+            // with `Expired` unreachable. Every other status triage in the
+            // crate checks this on the `Ok` path too (`client::Client::verify`,
+            // `internal::model_listing::decode_json_response`).
+            Ok(response) if !response.status().is_success() => {
+                let status = response.status().as_u16();
+                // A failed body read must not cancel the triage. The status is
+                // already in hand, and the `Err` arm below classifies even when
+                // the error carries no body at all — dropping to `Http` here
+                // would throw away the one thing that says the handle is gone.
+                let message = http_client::text(response)
+                    .await
+                    .unwrap_or_else(|error| format!("failed to read error response body: {error}"));
+                return Err(classify_failure(status, message, name));
+            }
             Ok(response) => http_client::text(response)
                 .await
                 .map_err(CachedContentError::Http)?,
-            Err(http_client::Error::InvalidStatusCodeWithDetails { status, body, .. }) => {
-                let message = body.to_string();
-                // 403 and 404 both mean "this handle is gone" depending on how
-                // long ago it lapsed; collapsing them spares callers from
-                // matching on a status code to answer one question.
-                if matches!(status.as_u16(), 403 | 404)
-                    && let Some(name) = name
-                {
-                    // Carry the provider's own message. A 403 also covers a
-                    // disabled key, a project without the API enabled, and quota
-                    // denial — collapsing those into "expired" without the
-                    // message would throw away the only text that says which.
-                    return Err(CachedContentError::Expired {
-                        name: name.to_owned(),
-                        message,
-                    });
-                }
-                return Err(CachedContentError::Api {
-                    status: status.as_u16(),
-                    message,
-                });
+            // Triage on the *status*, not on one error variant. The bundled
+            // reqwest transports always report a non-success status as
+            // `InvalidStatusCodeWithDetails`, but `H` is a public extension
+            // point (`ClientBuilder::http_client`) and a custom `HttpClientExt`
+            // may report `InvalidStatusCode` or `InvalidStatusCodeWithMessage`
+            // instead. Matching the one variant dropped those into `Http`
+            // below, so the recovery this module documents — recreate the cache
+            // on `Expired` — never fired outside the bundled clients.
+            Err(error) => {
+                let Some(status) = error.non_success_status() else {
+                    // No status at all: a genuine transport failure (DNS, TLS,
+                    // a dropped connection), which recreating a cache does not
+                    // answer.
+                    return Err(CachedContentError::Http(error));
+                };
+                let message = error.non_success_body().unwrap_or_default().to_owned();
+                return Err(classify_failure(status.as_u16(), message, name));
             }
-            Err(error) => return Err(CachedContentError::Http(error)),
         };
 
         // DELETE answers `{}`; `serde_json::Value` absorbs that, and a typed
@@ -533,15 +555,102 @@ fn qualify_model(model: &str) -> String {
     }
 }
 
+/// Stand-in for the provider's message when a failure carried no text.
+///
+/// [`http_client::Error::InvalidStatusCode`] carries a status and nothing else,
+/// and a non-success response can have an empty body; either way there is
+/// nothing to quote. An empty `message` would leave both [`CachedContentError`]
+/// Displays ending in a bare colon, which reads as a truncated error rather
+/// than as a silent provider.
+const NO_RESPONSE_BODY: &str = "no response body";
+
+/// Turn a non-success status and its body into the error a caller matches on.
+///
+/// Shared by both failure paths in [`CachedContentClient::send_json`] — the
+/// transport that reports the status as an error and the one that hands back
+/// the non-success response — so the two cannot drift apart.
+///
+/// `name` is `Some` only for calls that address an existing handle. `create`
+/// passes `None` deliberately: a 403 there is a disabled key, a project without
+/// the API enabled, or quota denial, and reporting it as `Expired` for a cache
+/// that was never made would send a caller into a recreate loop.
+fn classify_failure(status: u16, message: String, name: Option<&str>) -> CachedContentError {
+    let message = if message.trim().is_empty() {
+        NO_RESPONSE_BODY.to_owned()
+    } else {
+        message
+    };
+
+    // 403 and 404 both mean "this handle is gone" depending on how long ago it
+    // lapsed; collapsing them spares callers from matching on a status code to
+    // answer one question.
+    if matches!(status, 403 | 404)
+        && let Some(name) = name
+    {
+        // Carry the provider's own message. A 403 also covers a disabled key, a
+        // project without the API enabled, and quota denial — collapsing those
+        // into "expired" without the message would throw away the only text
+        // that says which.
+        return CachedContentError::Expired {
+            name: name.to_owned(),
+            message,
+        };
+    }
+
+    CachedContentError::Api { status, message }
+}
+
+/// The characters a Gemini `cachedContents` id is made of.
+///
+/// The ids Gemini hands back are twelve lowercase alphanumerics
+/// (`cachedContents/n3v1qk0nqz9k`). `-` and `_` are admitted on top of that
+/// because the cassette scrubber rewrites every recorded id to
+/// `cached-REDACTED_1` (`tests/common/cassettes.rs`), and a replayed test
+/// hands that placeholder straight back to `delete`. `.` is deliberately left
+/// out: no observed id carries one, and a `..` segment is path traversal.
+fn is_cache_id_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_')
+}
+
 /// `/v1beta/cachedContents/<id>` from either a bare id or a full handle.
-fn resource_path(name: &str) -> String {
+///
+/// Validates rather than interpolating, because this is the path `get`,
+/// `update_expiry` and — the one that matters — `delete` send. A handle
+/// carrying a `?` does not produce a malformed URL the provider rejects:
+/// `GeminiExt::build_uri` switches its key separator to `&` the moment it sees
+/// a `?` in the path, so `delete("abc?stale")` would issue a perfectly
+/// well-formed `DELETE /v1beta/cachedContents/abc?stale&key=…` and destroy the
+/// cache named `abc`. A `#` truncates the path the same way, a `/` retargets it
+/// at another resource, and an empty id aims the request at the *collection*.
+///
+/// Refusing beats percent-encoding here. The id is server-assigned and opaque,
+/// so a caller holding one that needs escaping is holding a bug; and encoding
+/// would have to escape the id while leaving the optional `cachedContents/`
+/// prefix intact — two rules for one string, in service of quietly rewriting
+/// input that is always wrong.
+///
+/// The prefix stays optional here, unlike
+/// [`super::completion::gemini_api_types::GenerateContentRequest::with_cached_content`],
+/// which requires it. That is not an inconsistency: there the handle is a wire
+/// value the API compares verbatim, here it is a path segment this function
+/// writes itself.
+fn resource_path(name: &str) -> Result<String, CachedContentError> {
     let id = name.strip_prefix("cachedContents/").unwrap_or(name);
-    format!("{CACHED_CONTENTS_PATH}/{id}")
+    if id.is_empty() || !id.chars().all(is_cache_id_char) {
+        return Err(CachedContentError::Invalid(format!(
+            "`{name}` is not a cached content handle; expected `cachedContents/<id>` or a bare \
+             `<id>` of letters, digits, `-` and `_`. The id is spliced into the request path, \
+             where a `?`, `#` or `/` silently retargets the call at a different resource — and \
+             this is the path that deletes"
+        )));
+    }
+    Ok(format!("{CACHED_CONTENTS_PATH}/{id}"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::{MockHttpResponse, SequencedHttpClient};
 
     #[test]
     fn model_is_qualified_idempotently() {
@@ -554,10 +663,112 @@ mod tests {
 
     #[test]
     fn resource_path_accepts_a_bare_id_or_a_full_handle() {
-        assert_eq!(resource_path("abc123"), "/v1beta/cachedContents/abc123");
         assert_eq!(
-            resource_path("cachedContents/abc123"),
+            resource_path("abc123").expect("a bare id is a handle"),
             "/v1beta/cachedContents/abc123"
+        );
+        assert_eq!(
+            resource_path("cachedContents/abc123").expect("a full handle is a handle"),
+            "/v1beta/cachedContents/abc123"
+        );
+    }
+
+    /// The destructive path, end to end: a handle that would mis-target must
+    /// not reach the socket at all.
+    ///
+    /// `resource_path`'s unit tests prove the string is refused; this proves the
+    /// refusal happens *before* the request is built. It matters because the
+    /// URL these handles produce is not malformed — `GeminiExt::build_uri`
+    /// appends the API key with `&` once the path contains a `?`, so
+    /// `DELETE /v1beta/cachedContents/abc?stale&key=…` is a well-formed request
+    /// that deletes cache `abc` and returns 200.
+    #[tokio::test]
+    async fn a_mis_targeting_handle_never_reaches_the_socket() {
+        for smuggled in ["abc?stale", "abc#frag", "abc/def", ""] {
+            // No scripted responses: anything that does escape fails twice, once
+            // on the error variant and once on the captured request.
+            let http_client = SequencedHttpClient::default();
+            let client = Client::builder()
+                .api_key("test-key")
+                .http_client(http_client.clone())
+                .build()
+                .expect("client should build");
+            let caches = client.cached_contents();
+
+            let outcomes = [
+                ("get", caches.get(smuggled).await.err()),
+                ("delete", caches.delete(smuggled).await.err()),
+                (
+                    "update_expiry",
+                    caches
+                        .update_expiry(smuggled, CacheExpiry::ttl(Duration::from_secs(60)))
+                        .await
+                        .err(),
+                ),
+            ];
+            for (label, error) in outcomes {
+                let error = error
+                    .unwrap_or_else(|| panic!("{label} should refuse the handle {smuggled:?}"));
+                assert!(
+                    matches!(error, CachedContentError::Invalid(_)),
+                    "{label} on {smuggled:?}: {error:?}"
+                );
+            }
+
+            assert!(
+                http_client.requests().is_empty(),
+                "handle {smuggled:?} escaped the process: {:?}",
+                http_client.requests()
+            );
+        }
+    }
+
+    /// The exact URI `update_expiry` builds, so the ordering of its three
+    /// query-string writers is pinned in one place.
+    ///
+    /// `resource_path` writes the path, the `format!` appends `?updateMask=`,
+    /// and `build_uri` follows with `&key=` because it now sees a `?`. That
+    /// layout is only stable while a handle cannot carry its own `?` — which is
+    /// what `resource_path` refuses, and what the cells above cover. This cell
+    /// pins the well-formed side: it passed before the validation existed and
+    /// exists to catch the mask being concatenated ahead of it, or the path
+    /// being escaped. The recorded PATCH in
+    /// `cached_content_matrix/edge_update_expiry_absolute` pins the same layout
+    /// against the live API; this one names it locally.
+    #[tokio::test]
+    async fn update_expiry_puts_its_update_mask_after_the_validated_path() {
+        let http_client = SequencedHttpClient::new([MockHttpResponse::success(
+            serde_json::json!({
+                "name": "cachedContents/n3v1qk0nqz9k",
+                "model": "models/gemini-2.5-flash"
+            })
+            .to_string(),
+        )]);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client.clone())
+            .build()
+            .expect("client should build");
+
+        client
+            .cached_contents()
+            .update_expiry(
+                "cachedContents/n3v1qk0nqz9k",
+                CacheExpiry::ttl(Duration::from_secs(600)),
+            )
+            .await
+            .expect("a well-formed handle should be patched");
+
+        let requests = http_client.requests();
+        let [request] = requests.as_slice() else {
+            panic!("exactly one request should have been sent: {requests:?}");
+        };
+        assert!(
+            request
+                .uri
+                .ends_with("/v1beta/cachedContents/n3v1qk0nqz9k?updateMask=ttl&key=test-key"),
+            "{}",
+            request.uri
         );
     }
 
@@ -636,20 +847,47 @@ mod exhaustive_validation_tests {
         }
     }
 
-    /// `/v1beta/cachedContents/<id>` from a bare id or a full handle, and the
-    /// prefix is stripped exactly once.
+    /// Every shape a handle can arrive in, against the path that `get`,
+    /// `update_expiry` and `delete` all build from it.
+    ///
+    /// The refusals carry the weight. `abc?stale` is not a malformed URL the
+    /// provider would reject — `build_uri` appends the API key with `&` once a
+    /// `?` is present, so it is a valid `DELETE` of cache `abc`. `#` and `/`
+    /// mis-target the same way, and an empty id aims the request at the
+    /// collection endpoint.
     #[test]
-    fn resource_path_is_total() {
+    fn resource_path_accepts_server_assigned_ids_and_refuses_everything_else() {
         for (input, expected) in [
-            ("abc", "/v1beta/cachedContents/abc"),
-            ("cachedContents/abc", "/v1beta/cachedContents/abc"),
+            // The shapes the API actually hands back, in both spellings, plus
+            // the scrubbed spelling a replayed cassette feeds back to `delete`.
+            ("n3v1qk0nqz9k", Some("/v1beta/cachedContents/n3v1qk0nqz9k")),
             (
-                "cachedContents/cachedContents/abc",
-                "/v1beta/cachedContents/cachedContents/abc",
+                "cachedContents/n3v1qk0nqz9k",
+                Some("/v1beta/cachedContents/n3v1qk0nqz9k"),
             ),
-            ("", "/v1beta/cachedContents/"),
+            (
+                "cached-REDACTED_1",
+                Some("/v1beta/cachedContents/cached-REDACTED_1"),
+            ),
+            ("abc?stale", None),
+            ("abc#frag", None),
+            ("abc/def", None),
+            ("cachedContents/cachedContents/abc", None),
+            ("abc%2Fdef", None),
+            ("abc def", None),
+            ("abc\n", None),
+            ("..", None),
+            ("", None),
+            ("cachedContents/", None),
         ] {
-            assert_eq!(resource_path(input), expected, "input {input:?}");
+            match (resource_path(input), expected) {
+                (Ok(path), Some(expected)) => assert_eq!(path, expected, "input {input:?}"),
+                (Err(CachedContentError::Invalid(message)), None) => assert!(
+                    message.contains(input),
+                    "input {input:?}: the refusal should quote the handle, got {message}"
+                ),
+                (outcome, _) => panic!("input {input:?}: unexpected {outcome:?}"),
+            }
         }
     }
 
@@ -814,5 +1052,176 @@ mod exhaustive_validation_tests {
             })
             .collect();
         assert_eq!(texts, vec!["first", "second", "third"]);
+    }
+}
+
+#[cfg(test)]
+mod status_triage_tests {
+    //! Non-success triage across every shape a transport can report one in.
+    //!
+    //! The recorded cassettes only ever exercise the bundled reqwest shape,
+    //! `http_client::Error::InvalidStatusCodeWithDetails`. But `H` is a public
+    //! extension point (`ClientBuilder::http_client`), and a custom
+    //! [`HttpClientExt`] may report the same 404 as a bare
+    //! `InvalidStatusCode`, as `InvalidStatusCodeWithMessage`, or as an `Ok`
+    //! response carrying the status — shapes rig's own test double produces.
+    //! On those the triage used to fall through to `CachedContentError::Http`
+    //! or to a bogus deserialization error, so the recovery this module
+    //! documents (`Expired { .. } => recreate the cache`) silently never fired.
+
+    use super::*;
+    use crate::test_utils::{MockHttpResponse, SequencedHttpClient};
+
+    /// A `cachedContents` client whose transport answers the next request with
+    /// `response` and nothing after it.
+    fn caches(response: MockHttpResponse) -> CachedContentClient<SequencedHttpClient> {
+        Client::builder()
+            .api_key("test-key")
+            .http_client(SequencedHttpClient::new(vec![response]))
+            .build()
+            .expect("client should build")
+            .cached_contents()
+    }
+
+    const GONE: &str =
+        r#"{"error":{"code":404,"message":"CachedContent not found (or permission denied)."}}"#;
+
+    /// A transport that reports the 404 as `InvalidStatusCodeWithMessage` —
+    /// the variant every non-bundled `HttpClientExt` in rig produces — must
+    /// still reach `Expired`.
+    ///
+    /// Before the triage moved from the variant to the status this fell into
+    /// the catch-all `Err(error) => Http(error)` arm, so a caller matching
+    /// `Expired` to recreate the cache saw an opaque transport error instead.
+    #[tokio::test]
+    async fn a_status_error_without_captured_headers_still_reports_expired() {
+        let error = caches(MockHttpResponse::error(http::StatusCode::NOT_FOUND, GONE))
+            .get("cachedContents/abc123")
+            .await
+            .expect_err("a missing handle should not resolve");
+
+        let CachedContentError::Expired { name, message } = &error else {
+            panic!("a handle that is gone should report Expired: {error:?}");
+        };
+        assert_eq!(name, "cachedContents/abc123");
+        assert!(message.contains("permission denied"), "{message}");
+    }
+
+    /// A transport that hands back the 404 as an `Ok` response instead of an
+    /// error must reach `Expired` too.
+    ///
+    /// This is the worse half of the same bug: the error body reached
+    /// `serde_json::from_str::<CachedContent>` and failed there, so the call
+    /// reported `CachedContentError::Serde` ("missing field `name`") for what
+    /// is plainly a 404 — a status-shaped failure disguised as a parse bug.
+    #[tokio::test]
+    async fn a_non_success_response_is_triaged_rather_than_deserialized() {
+        let error = caches(MockHttpResponse::ErrorResponse(
+            http::StatusCode::NOT_FOUND,
+            GONE.into(),
+        ))
+        .get("cachedContents/abc123")
+        .await
+        .expect_err("a missing handle should not resolve");
+
+        let CachedContentError::Expired { name, message } = &error else {
+            panic!("an Ok-wrapped 404 should report Expired, not a parse error: {error:?}");
+        };
+        assert_eq!(name, "cachedContents/abc123");
+        assert!(message.contains("permission denied"), "{message}");
+    }
+
+    /// Gemini answers a handle that lapsed a while ago with 403 rather than
+    /// 404, and both mean the same thing to a caller.
+    #[tokio::test]
+    async fn a_403_on_an_existing_handle_reports_expired_like_a_404() {
+        let error = caches(MockHttpResponse::error(
+            http::StatusCode::FORBIDDEN,
+            r#"{"error":{"code":403,"message":"You do not have permission to access the CachedContent."}}"#,
+        ))
+        .delete("cachedContents/abc123")
+        .await
+        .expect_err("a lapsed handle should not delete");
+
+        assert!(
+            matches!(&error, CachedContentError::Expired { name, .. } if name == "cachedContents/abc123"),
+            "{error:?}"
+        );
+    }
+
+    /// A 403 on `create` is not an expiry — there is no handle yet.
+    ///
+    /// `create` passes `name: None` for exactly this reason: a disabled key or
+    /// a project without the API enabled answers 403, and calling that
+    /// `Expired` would put a caller into a recreate loop against an API that
+    /// will keep refusing.
+    #[tokio::test]
+    async fn a_403_on_create_is_an_api_error_not_an_expiry() {
+        let error = caches(MockHttpResponse::error(
+            http::StatusCode::FORBIDDEN,
+            r#"{"error":{"code":403,"message":"Generative Language API has not been used in project 1234 before or it is disabled."}}"#,
+        ))
+        .create(NewCachedContent::new("gemini-2.5-flash").content("corpus"))
+        .await
+        .expect_err("a refused create should not succeed");
+
+        let CachedContentError::Api { status, message } = &error else {
+            panic!("a create that never made a handle cannot be Expired: {error:?}");
+        };
+        assert_eq!(*status, 403);
+        assert!(
+            message.contains("has not been used in project"),
+            "{message}"
+        );
+    }
+
+    /// Everything that is not a 403/404 on a named handle is an `Api` failure,
+    /// carrying the status a caller needs to decide whether to retry.
+    #[tokio::test]
+    async fn a_server_error_reports_the_status_rather_than_an_expiry() {
+        let error = caches(MockHttpResponse::error(
+            http::StatusCode::INTERNAL_SERVER_ERROR,
+            r#"{"error":{"code":500,"message":"Internal error encountered."}}"#,
+        ))
+        .get("cachedContents/abc123")
+        .await
+        .expect_err("a 500 should not resolve");
+
+        let CachedContentError::Api { status, message } = &error else {
+            panic!("a 500 is not an expiry: {error:?}");
+        };
+        assert_eq!(*status, 500);
+        assert!(message.contains("Internal error"), "{message}");
+    }
+
+    /// `InvalidStatusCode` carries no body, so there is no provider text to
+    /// quote. The message must still say something: an empty one leaves the
+    /// error Display ending in a bare colon, which reads as truncated output
+    /// rather than as a provider that said nothing.
+    #[tokio::test]
+    async fn a_status_error_with_no_body_still_names_why_it_has_no_message() {
+        // `SequencedHttpClient` reports `InvalidStatusCode(501)` once its
+        // scripted responses run out, which is the body-less shape.
+        let caches = Client::builder()
+            .api_key("test-key")
+            .http_client(SequencedHttpClient::new(Vec::new()))
+            .build()
+            .expect("client should build")
+            .cached_contents();
+
+        let error = caches
+            .get("cachedContents/abc123")
+            .await
+            .expect_err("an unscripted request should not resolve");
+
+        let CachedContentError::Api { status, message } = &error else {
+            panic!("a 501 is not an expiry: {error:?}");
+        };
+        assert_eq!(*status, 501);
+        assert_eq!(message, NO_RESPONSE_BODY);
+        assert!(
+            !error.to_string().ends_with(": "),
+            "the Display must not trail off: {error}"
+        );
     }
 }

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -295,6 +295,16 @@ pub(crate) fn create_request_body(
             )),
         })
         .transpose()?;
+    // `systemInstruction` and `toolConfig` are lifted for the same two reasons,
+    // and closing this for `cachedContent` alone left both of them open. They
+    // are the *other* two fields a cached content owns, so a request smuggling
+    // one past the conflict check is exactly the case the check exists for —
+    // and, cache or no cache, a flattened copy serialized beside the typed
+    // field emits the key twice, since neither carries `skip_serializing_if`.
+    let smuggled_system_instruction: Option<Content> =
+        take_typed_from_additional_params(&mut additional_params_payload, "systemInstruction")?;
+    let smuggled_tool_config: Option<ToolConfig> =
+        take_typed_from_additional_params(&mut additional_params_payload, "toolConfig")?;
 
     let AdditionalParameters {
         mut generation_config,
@@ -347,6 +357,25 @@ pub(crate) fn create_request_body(
             role: Some(Role::Model),
         })
     };
+    // A preamble and an `additional_params.systemInstruction` are two answers to
+    // one question. Before this they were both put on the wire and Gemini took
+    // the last, so the preamble the caller wrote was silently discarded; now the
+    // ambiguity is reported, matching how a doubly-set `cachedContent` is
+    // treated.
+    let system_instruction = match (system_instruction, smuggled_system_instruction) {
+        (Some(typed), Some(_)) => {
+            return Err(CompletionError::RequestError(
+                format!(
+                    "a Gemini request set the system instruction twice — once as a preamble or \
+                     system message ({} part(s)) and once through \
+                     `additional_params.systemInstruction`. Set it one way or the other",
+                    typed.parts.len()
+                )
+                .into(),
+            ));
+        }
+        (typed, smuggled) => typed.or(smuggled),
+    };
 
     let mut tools = if function_tools.is_empty() {
         Vec::new()
@@ -362,6 +391,18 @@ pub(crate) fn create_request_body(
         })
     } else {
         None
+    };
+    // Same rule as the system instruction above: `tool_choice` and
+    // `additional_params.toolConfig` are one field reached two ways.
+    let tool_config = match (tool_config, smuggled_tool_config) {
+        (Some(_), Some(_)) => {
+            return Err(CompletionError::RequestError(
+                "a Gemini request set the tool choice twice — once as `tool_choice` and once \
+                 through `additional_params.toolConfig`. Set it one way or the other"
+                    .into(),
+            ));
+        }
+        (typed, smuggled) => typed.or(smuggled),
     };
 
     let mut request = GenerateContentRequest {
@@ -404,6 +445,38 @@ pub fn split_system_messages_from_history(
     }
 
     (system, remaining)
+}
+
+/// Remove `key` from an `additional_params` object and deserialize it into the
+/// typed field it belongs in.
+///
+/// Every field of `GenerateContentRequest` that a caller can also reach through
+/// `additional_params` has to come through here, because `additional_params` is
+/// `#[serde(flatten)]` and serde emits flattened entries *after* the named
+/// ones. A copy left in the blob therefore wins on the wire while the typed
+/// field — the one every validation in this module inspects — stays empty. That
+/// is how a `cachedContent` used to overwrite the handle a caller asked for, and
+/// how a `systemInstruction` or `toolConfig` used to walk past the cached
+/// content conflict check.
+///
+/// Deserializing rather than moving the raw `Value` is what makes the lift
+/// worth doing: a malformed field is now reported here, naming the field, in
+/// place of a provider 400 that quotes a JSON path.
+fn take_typed_from_additional_params<T: serde::de::DeserializeOwned>(
+    payload: &mut Value,
+    key: &str,
+) -> Result<Option<T>, CompletionError> {
+    let Some(value) = payload
+        .as_object_mut()
+        .and_then(|object| object.remove(key))
+    else {
+        return Ok(None);
+    };
+    serde_json::from_value(value).map(Some).map_err(|error| {
+        CompletionError::RequestError(
+            format!("additional_params.{key} is not a valid Gemini {key}: {error}").into(),
+        )
+    })
 }
 
 fn extract_tools_from_additional_params(
@@ -4477,6 +4550,140 @@ mod cached_content_request_tests {
             Some("cachedContents/typed")
         );
         assert_eq!(body.get("topK").and_then(|v| v.as_u64()), Some(5));
+    }
+
+    /// The other two fields a cached content owns, smuggled the same way the
+    /// handle was.
+    ///
+    /// Lifting `cachedContent` alone left this open: the conflict check reads
+    /// the typed fields, and a `systemInstruction` or `toolConfig` sitting in
+    /// the flattened blob is not one. The handle was accepted, the request went
+    /// out, and Gemini answered the 400 the check exists to pre-empt — while
+    /// the docs promised it would not.
+    #[test]
+    fn a_system_instruction_or_tool_choice_from_additional_params_still_conflicts() {
+        for (label, smuggled) in [
+            (
+                "systemInstruction",
+                serde_json::json!({
+                    "systemInstruction": {"parts": [{"text": "you are terse"}], "role": "model"}
+                }),
+            ),
+            (
+                "toolConfig",
+                serde_json::json!({
+                    "toolConfig": {"functionCallingConfig": {"mode": "ANY"}}
+                }),
+            ),
+        ] {
+            let mut request = build_with(None, Some(smuggled)).expect("request should build");
+            let message = request
+                .with_cached_content("cachedContents/abc123")
+                .expect_err(&format!("a smuggled {label} conflicts with a cache handle"))
+                .to_string();
+            let expected = if label == "systemInstruction" {
+                "a system instruction"
+            } else {
+                "a tool choice"
+            };
+            assert!(
+                message.contains(expected),
+                "the {label} route must reach the same conflict as the typed field: {message}"
+            );
+        }
+    }
+
+    /// Whether or not a cache is involved, one field reached two ways is
+    /// ambiguous — and used to be resolved silently, in favour of whichever
+    /// serde emitted last.
+    #[test]
+    fn setting_a_field_twice_is_refused_rather_than_resolved_by_serialization_order() {
+        let message = build_with(
+            Some("you are terse"),
+            Some(serde_json::json!({
+                "systemInstruction": {"parts": [{"text": "you are verbose"}], "role": "model"}
+            })),
+        )
+        .expect_err("a preamble and a smuggled system instruction are two answers")
+        .to_string();
+        assert!(
+            message.contains("set the system instruction twice"),
+            "{message}"
+        );
+
+        let message = super::create_request_body(CompletionRequest {
+            preamble: None,
+            chat_history: vec![Message::User {
+                content: vec![UserContent::text("hi")],
+            }],
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: Some(crate::message::ToolChoice::Auto),
+            additional_params: Some(serde_json::json!({
+                "toolConfig": {"functionCallingConfig": {"mode": "ANY"}}
+            })),
+            model: None,
+            output_schema: None,
+            record_telemetry_content: false,
+        })
+        .expect_err("a tool_choice and a smuggled toolConfig are two answers")
+        .to_string();
+        assert!(message.contains("set the tool choice twice"), "{message}");
+    }
+
+    /// A lifted field lands in the typed slot rather than beside it.
+    ///
+    /// The duplicate key is the part that is a bug on its own terms: neither
+    /// `systemInstruction` nor `toolConfig` carries `skip_serializing_if`, so
+    /// before the lift both were emitted twice — once as the typed `null` and
+    /// once from the flattened blob — in every request that used them, cache or
+    /// no cache.
+    #[test]
+    fn a_lifted_field_is_serialized_once_in_the_typed_slot() {
+        let request = build_with(
+            None,
+            Some(serde_json::json!({
+                "systemInstruction": {"parts": [{"text": "you are terse"}], "role": "model"},
+                "toolConfig": {"functionCallingConfig": {"mode": "ANY"}}
+            })),
+        )
+        .expect("request should build");
+
+        let body = serde_json::to_string(&request).expect("serialize");
+        for key in ["systemInstruction", "toolConfig"] {
+            assert_eq!(
+                body.matches(&format!("\"{key}\"")).count(),
+                1,
+                "{key} should be emitted exactly once, got {body}"
+            );
+        }
+        let body: serde_json::Value = serde_json::from_str(&body).expect("valid json");
+        assert_eq!(
+            body["systemInstruction"]["parts"][0]["text"].as_str(),
+            Some("you are terse")
+        );
+        assert_eq!(
+            body["toolConfig"]["functionCallingConfig"]["mode"].as_str(),
+            Some("ANY")
+        );
+    }
+
+    /// A malformed lifted field is now reported by name here rather than as a
+    /// provider 400 quoting a JSON path.
+    #[test]
+    fn a_malformed_lifted_field_names_itself() {
+        let message = build_with(
+            None,
+            Some(serde_json::json!({"systemInstruction": "just a string"})),
+        )
+        .expect_err("a string is not a Content")
+        .to_string();
+        assert!(
+            message.contains("additional_params.systemInstruction"),
+            "{message}"
+        );
     }
 }
 

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -114,7 +114,11 @@ impl<T> CompletionModel<T> {
     ///   can only dispatch what it advertised, so an agent reading from a cache
     ///   must have no tools — and a function tool set moved into the cache is
     ///   declarations the agent could never execute (see
-    ///   [`crate::providers::gemini::cached_content::NewCachedContent::tools`]);
+    ///   [`crate::providers::gemini::cached_content::NewCachedContent::tools`]).
+    ///   An empty `RequestPatch::active_tools` allow-list does suppress the
+    ///   `tools` field for a turn, so a tool-holding agent *can* be made to pass
+    ///   this check — but it gains a request, not a dispatch: neither its own
+    ///   suppressed tools nor the cache's are callable on that turn;
     /// * a configured `tool_choice` becomes `toolConfig` even on a tool-less
     ///   agent, so it has to go too — though dropping it costs a tool-less agent
     ///   nothing;
@@ -4394,6 +4398,63 @@ mod cached_content_request_tests {
             "moving a system instruction into the cache IS the remedy; the tools caveat must not \
              leak onto it: {preamble_message}"
         );
+    }
+
+    /// The branch the `declares_functions` gate exists for, and the one neither
+    /// cell above reaches: `tools` is present but carries no function
+    /// declarations.
+    ///
+    /// A provider-hosted tool runs on Gemini's side and needs no loop, so
+    /// "you must run the tool loop yourself" is nonsense advice for it — the
+    /// code comment says as much. Without this cell the gate is free to
+    /// collapse to `self.tools.is_some()`: that mutation leaves every other
+    /// test in the workspace green, and hands a `codeExecution` caller a
+    /// paragraph about dispatching declarations they never wrote.
+    #[test]
+    fn a_provider_hosted_tool_conflicts_without_the_function_declaration_caveat() {
+        for (label, tools) in [
+            ("codeExecution", serde_json::json!([{"codeExecution": {}}])),
+            ("googleSearch", serde_json::json!([{"googleSearch": {}}])),
+            (
+                "an empty functionDeclarations list",
+                serde_json::json!([{"functionDeclarations": []}]),
+            ),
+        ] {
+            let mut request = build_with(None, Some(serde_json::json!({ "tools": tools })))
+                .expect("request should build");
+            let message = request
+                .with_cached_content("cachedContents/abc123")
+                .expect_err("tools conflict with a cache handle however they are declared")
+                .to_string();
+
+            assert!(
+                message.contains("also set tools"),
+                "{label}: the conflict must still name the tool set: {message}"
+            );
+            assert!(
+                !message.contains("declarations only"),
+                "{label}: a cache carrying a provider-hosted tool is usable from an agent, so \
+                 the function-declaration caveat must not appear: {message}"
+            );
+        }
+    }
+
+    /// The other side of the gate, through the same route: function
+    /// declarations arriving in `additional_params.tools` do earn the caveat.
+    #[test]
+    fn a_smuggled_function_declaration_still_earns_the_caveat() {
+        let mut request = build_with(
+            None,
+            Some(serde_json::json!({
+                "tools": [{"functionDeclarations": [{"name": "probe", "description": "probe"}]}]
+            })),
+        )
+        .expect("request should build");
+        let message = request
+            .with_cached_content("cachedContents/abc123")
+            .expect_err("tools conflict with a cache handle")
+            .to_string();
+        assert!(message.contains("declarations only"), "{message}");
     }
 
     #[test]

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -98,9 +98,44 @@ impl<T> CompletionModel<T> {
     /// [`crate::providers::gemini::cached_content::CachedContentClient`], and
     /// delete it when you are done — storage bills until you do.
     ///
-    /// The cache owns the system instruction and tool set, so a request built
-    /// from this model must not carry either. Rig rejects that before the
-    /// request goes out rather than letting Gemini answer 400.
+    /// # What can actually use the handle
+    ///
+    /// The cache owns the system instruction, the tool set *and* the tool
+    /// choice, so a request built from this model must carry none of the three;
+    /// rig rejects that before the request goes out rather than letting Gemini
+    /// answer 400.
+    ///
+    /// That is a tighter constraint than it looks for rig's `Agent`, because an
+    /// agent does not choose what to send — it sends what it holds:
+    ///
+    /// * a preamble becomes `systemInstruction`, so an agent reading from a
+    ///   cache must have no preamble and put those instructions in the cache;
+    /// * every always-exposed tool is advertised on every turn, and the agent
+    ///   can only dispatch what it advertised, so an agent reading from a cache
+    ///   must have no tools — and a function tool set moved into the cache is
+    ///   declarations the agent could never execute (see
+    ///   [`crate::providers::gemini::cached_content::NewCachedContent::tools`]);
+    /// * a configured `tool_choice` becomes `toolConfig` even on a tool-less
+    ///   agent, so it has to go too — though dropping it costs a tool-less agent
+    ///   nothing;
+    /// * `output_schema` is fine under the default `OutputMode::Auto`, which for
+    ///   a tool-less agent resolves to `Native` and sends the schema as a
+    ///   `generationConfig` constraint with no tool. It is not fine in `Tool`
+    ///   mode, which advertises a synthetic output tool *and* appends an
+    ///   instruction to the preamble — and `Extractor` pins `Tool` mode, so
+    ///   extractors cannot read from a cache at all. `Prompted` is out for the
+    ///   same reason: it writes the schema into the preamble, so even a
+    ///   preamble-less agent ends up sending a `systemInstruction`.
+    ///
+    /// Context documents are fine either way: they are appended to the chat
+    /// history as user content, never to the system instruction.
+    ///
+    /// So there are two supported shapes: an agent with no preamble, no tools
+    /// and no `tool_choice` (with or without native structured output), or this
+    /// model driven directly
+    /// through
+    /// [`CompletionModel::completion`](completion::CompletionModel::completion)
+    /// or [`Self::raw_completion`] with a tool loop you run yourself.
     pub fn with_cached_content(mut self, name: impl Into<String>) -> Self {
         self.cached_content = Some(name.into());
         self
@@ -2419,11 +2454,45 @@ impl gemini_api_types::GenerateContentRequest {
             conflicts.push("a tool choice");
         }
         if !conflicts.is_empty() {
+            // "Move them into the cache" is the right remedy for a system
+            // instruction — that is the feature. It is the wrong remedy for
+            // tools, and the difference is structural rather than a gap rig
+            // could close: rig's `Agent` derives the declarations it sends and
+            // the handles it dispatches through from one tool-registry snapshot,
+            // so it can only dispatch a tool it advertised, and a call to
+            // something it never advertised is always an invalid tool call. An
+            // agent therefore cannot execute a function tool set that lives in
+            // the cache, and the message must not send the reader after a
+            // configuration that does not exist.
+            //
+            // Gated on *function* declarations rather than on the field: a
+            // provider-hosted tool (`additional_params.tools = [{"codeExecution":
+            // {}}]`, lifted onto the request by
+            // `extract_tools_from_additional_params`) runs on Gemini's side and
+            // needs no loop, so moving one into the cache does work — and
+            // telling that caller to go write a tool loop would be nonsense.
+            let declares_functions = self.tools.as_ref().is_some_and(|tools| {
+                tools.iter().any(|tool| {
+                    tool.get("functionDeclarations")
+                        .and_then(Value::as_array)
+                        .is_some_and(|declarations| !declarations.is_empty())
+                })
+            });
+            let tool_caveat = if declares_functions {
+                " Note that function declarations in a cache are declarations only — rig's \
+                 `Agent` can only dispatch tools it advertised, so a cached function tool set is \
+                 never executable from an agent; it is usable only when you drive \
+                 `CompletionModel` yourself and run the tool loop. (Provider-hosted tools such \
+                 as `codeExecution` run on Gemini's side and are fine to keep in the cache.)"
+            } else {
+                ""
+            };
             return Err(CompletionError::RequestError(
                 format!(
                     "a Gemini request using cached content `{name}` also set {}. The cached \
                      content already owns the system instruction, tools and tool choice for every \
-                     request that uses it — move them into the cache, or drop the cache handle.",
+                     request that uses it — move them into the cache, or drop the cache \
+                     handle.{tool_caveat}",
                     conflicts.join(" and ")
                 )
                 .into(),
@@ -4214,6 +4283,46 @@ mod cached_content_request_tests {
         assert!(error.to_string().contains("tools"), "{error}");
     }
 
+    /// The remedy differs per conflict, and only the tools arm may say so.
+    ///
+    /// "Move them into the cache" is exactly right for a system instruction —
+    /// that is what explicit caching is for. It is wrong for tools: a cache's
+    /// tool set is declarations, and rig's `Agent` derives the declarations it
+    /// sends from the same registry it dispatches through, so it can neither
+    /// advertise nothing while executing something nor execute a tool that lives
+    /// only in the cache. A reader who follows the bare remedy ends up with a
+    /// cache no agent can use, so the caveat must appear for tools and must not
+    /// appear when only the system instruction conflicted.
+    #[test]
+    fn the_tools_conflict_says_a_cached_tool_set_is_declarations_only() {
+        let mut with_tools = request_with(None, true);
+        let tools_error = with_tools
+            .with_cached_content("cachedContents/abc123")
+            .expect_err("tools conflict with cached content");
+        let tools_message = tools_error.to_string();
+        assert!(
+            tools_message.contains("declarations only"),
+            "the tools conflict must correct the `move them into the cache` remedy: \
+             {tools_message}"
+        );
+        assert!(
+            tools_message.contains("CompletionModel"),
+            "the tools conflict must name the surface that can actually use a cached tool set: \
+             {tools_message}"
+        );
+
+        let mut with_preamble = request_with(Some("you are terse"), false);
+        let preamble_message = with_preamble
+            .with_cached_content("cachedContents/abc123")
+            .expect_err("a system instruction conflicts with cached content")
+            .to_string();
+        assert!(
+            !preamble_message.contains("declarations only"),
+            "moving a system instruction into the cache IS the remedy; the tools caveat must not \
+             leak onto it: {preamble_message}"
+        );
+    }
+
     #[test]
     fn a_clean_request_accepts_the_handle_and_puts_it_on_the_wire() {
         let mut request = request_with(None, false);
@@ -4439,16 +4548,29 @@ mod cached_content_conflict_matrix {
                             "{label}: the cache owns these fields, so this must be refused"
                         ));
                         let message = error.to_string();
-                        // The message must name every conflict, which is the
-                        // whole advantage over the provider's own 400.
+                        // Assert against the conflict clause, not the whole
+                        // message: the sentence that follows it names all three
+                        // fields unconditionally ("already owns the system
+                        // instruction, tools and tool choice"), so a naive
+                        // `message.contains("tools")` passed for every cell in
+                        // the matrix, including the ones that set no tools. The
+                        // clause is the only part that varies per cell, which is
+                        // the whole advantage over the provider's own 400.
+                        let clause = message
+                            .split_once(". The cached content")
+                            .map(|(head, _)| head)
+                            .unwrap_or(message.as_str());
                         if system {
-                            assert!(message.contains("system instruction"), "{label}: {message}");
+                            assert!(clause.contains("system instruction"), "{label}: {message}");
                         }
-                        if tools {
-                            assert!(message.contains("tools"), "{label}: {message}");
-                        }
+                        assert_eq!(
+                            clause.contains("tools"),
+                            tools,
+                            "{label}: the clause must name the tool set only when it conflicted: \
+                             {message}"
+                        );
                         if tool_choice {
-                            assert!(message.contains("tool choice"), "{label}: {message}");
+                            assert!(clause.contains("tool choice"), "{label}: {message}");
                         }
                         assert!(message.contains(HANDLE), "{label}: {message}");
                     }

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -289,16 +289,34 @@ pub(crate) fn create_request_body(
     // only inspects the typed fields. Callers reach this path whenever they set
     // the handle through `additional_params` without touching
     // `with_cached_content`, which is the plainest route there is.
-    let smuggled_cached_content = additional_params_payload
-        .as_object_mut()
-        .and_then(|object| object.remove("cachedContent"))
-        .map(|value| match value {
-            Value::String(name) => Ok(name),
-            other => Err(CompletionError::RequestError(
-                format!("additional_params.cachedContent should be a string, got {other}").into(),
-            )),
-        })
-        .transpose()?;
+    // Every spelling, not just the camelCase one. `cached_content` is a working
+    // wire spelling — measured: it reaches the cache lookup and answers
+    // `CachedContent not found` for a bogus handle — so a handle written that
+    // way used to skip the lift, and with it every check `with_cached_content`
+    // owns: the conflict refusal, the `cachedContents/<id>` shape check, the
+    // string-type check and the set-twice comparison. It still reached the wire,
+    // because the blob is flattened verbatim.
+    //
+    // Each spelling found is fed through `with_cached_content` in turn, so two
+    // spellings carrying different handles are caught by the set-twice rule that
+    // is already there.
+    let mut smuggled_cached_content = Vec::new();
+    for spelling in CACHED_CONTENT {
+        let Some(value) = additional_params_payload
+            .as_object_mut()
+            .and_then(|object| object.remove(spelling))
+        else {
+            continue;
+        };
+        match value {
+            Value::String(name) => smuggled_cached_content.push(name),
+            other => {
+                return Err(CompletionError::RequestError(
+                    format!("additional_params.{spelling} should be a string, got {other}").into(),
+                ));
+            }
+        }
+    }
     // The other two fields a cached content owns are *detected* here and left
     // exactly where the caller put them.
     //
@@ -377,8 +395,9 @@ pub(crate) fn create_request_body(
             format!(
                 "a Gemini request set the system instruction twice — once as a preamble or \
                  system message ({} part(s)) and once through `additional_params.{spelling}`. \
-                 Both reach the wire, the provider takes the last, and the preamble is the one \
-                 discarded. Set it one way or the other",
+                 Both would reach the wire, and Gemini rejects that outright: \
+                 `system_instruction` is an optional proto field, so a second one is `oneof \
+                 field '_system_instruction' is already set`. Set it one way or the other",
                 typed.parts.len()
             )
             .into(),
@@ -408,8 +427,10 @@ pub(crate) fn create_request_body(
         return Err(CompletionError::RequestError(
             format!(
                 "a Gemini request set the tool choice twice — once as `tool_choice` and once \
-                 through `additional_params.{spelling}`. Both reach the wire and the provider \
-                 takes the last. Set it one way or the other"
+                 through `additional_params.{spelling}`. Both would reach the wire, and Gemini \
+                 does not take the last — it *merges* them, so the two allowed-function lists \
+                 are unioned and the narrower `tool_choice` silently stops restricting anything. \
+                 Set it one way or the other"
             )
             .into(),
         ));
@@ -432,7 +453,7 @@ pub(crate) fn create_request_body(
         additional_params,
     };
 
-    if let Some(name) = smuggled_cached_content {
+    for name in smuggled_cached_content {
         request.with_cached_content(&name)?;
     }
 
@@ -466,6 +487,14 @@ const SYSTEM_INSTRUCTION: [&str; 2] = ["systemInstruction", "system_instruction"
 
 /// Both spellings Gemini accepts for `toolConfig`. See [`SYSTEM_INSTRUCTION`].
 const TOOL_CONFIG: [&str; 2] = ["toolConfig", "tool_config"];
+
+/// Both spellings Gemini accepts for `cachedContent`. See [`SYSTEM_INSTRUCTION`].
+const CACHED_CONTENT: [&str; 2] = ["cachedContent", "cached_content"];
+
+/// The spelling Gemini accepts for `tools`. A one-element list because the proto
+/// name and its JSON alias coincide; kept in this shape so the three lookups in
+/// `with_cached_content` read alike and a second spelling has somewhere to go.
+const TOOLS: [&str; 1] = ["tools"];
 
 /// The spelling under which one of `spellings` appears in an `additional_params`
 /// blob, if any of them does.
@@ -2526,23 +2555,27 @@ impl gemini_api_types::GenerateContentRequest {
         // `#[serde(flatten)]`, so anything left in it reaches the wire beside
         // the typed field — a conflict the provider will reject just the same,
         // and one that used to walk straight past this check because the check
-        // only looked at the typed side. `tools` needs no such lookup:
-        // `extract_tools_from_additional_params` has already moved it onto
-        // `self.tools` by the time any of this runs.
+        // only looked at the typed side.
+        //
+        // `tools` is looked up here too, even though `create_request_body` has
+        // already moved it onto `self.tools` by this point. This method is
+        // `pub`, and on a request built by hand nothing has run that lift — so
+        // without the lookup, tool declarations in the blob would sit beside a
+        // handle in one body, which is the shape this check exists to refuse.
         let blob = self.additional_params.as_ref();
-        let smuggled = |spellings: &[&str]| {
+        let smuggled = |spellings: &'static [&'static str]| {
             blob.and_then(|payload| smuggled_field(payload, spellings))
-                .is_some()
         };
 
         let mut conflicts = Vec::new();
-        if self.system_instruction.is_some() || smuggled(&SYSTEM_INSTRUCTION) {
+        if self.system_instruction.is_some() || smuggled(&SYSTEM_INSTRUCTION).is_some() {
             conflicts.push("a system instruction (preamble)");
         }
-        if self.tools.is_some() {
+        let smuggled_tools = smuggled(&TOOLS);
+        if self.tools.is_some() || smuggled_tools.is_some() {
             conflicts.push("tools");
         }
-        if self.tool_config.is_some() || smuggled(&TOOL_CONFIG) {
+        if self.tool_config.is_some() || smuggled(&TOOL_CONFIG).is_some() {
             conflicts.push("a tool choice");
         }
         if !conflicts.is_empty() {
@@ -2563,13 +2596,29 @@ impl gemini_api_types::GenerateContentRequest {
             // `extract_tools_from_additional_params`) runs on Gemini's side and
             // needs no loop, so moving one into the cache does work — and
             // telling that caller to go write a tool loop would be nonsense.
-            let declares_functions = self.tools.as_ref().is_some_and(|tools| {
-                tools.iter().any(|tool| {
-                    tool.get("functionDeclarations")
+            let declares_function = |tool: &Value| {
+                ["functionDeclarations", "function_declarations"]
+                    .iter()
+                    .any(|spelling| {
+                        tool.get(spelling)
+                            .and_then(Value::as_array)
+                            .is_some_and(|declarations| !declarations.is_empty())
+                    })
+            };
+            // The blob is scanned as well, for the same hand-built request the
+            // `tools` lookup above exists for.
+            let declares_functions = self
+                .tools
+                .iter()
+                .flatten()
+                .chain(
+                    smuggled_tools
+                        .and_then(|spelling| blob?.get(spelling))
                         .and_then(Value::as_array)
-                        .is_some_and(|declarations| !declarations.is_empty())
-                })
-            });
+                        .into_iter()
+                        .flatten(),
+                )
+                .any(declares_function);
             let tool_caveat = if declares_functions {
                 " Note that function declarations in a cache are declarations only — rig's \
                  `Agent` can only dispatch tools it advertised, so a cached function tool set is \
@@ -4739,20 +4788,35 @@ mod cached_content_request_tests {
             // The proto-original spelling, which proto3 JSON accepts alongside
             // the lowerCamelCase alias.
             serde_json::json!({"tool_config": {"function_calling_config": {"mode": "ANY"}}}),
-            // A system instruction carrying a part kind rig has no variant for.
+            // A system instruction carrying a part kind rig genuinely has no
+            // variant for. `videoMetadata` is a real Gemini `Part` field and
+            // `PartKind` does not model it, so a round-trip through `Content`
+            // would drop it. (An earlier version of this cell used `inlineData`,
+            // which rig *does* model — it failed under the reverted
+            // implementation only because `Content::role` re-serialized as an
+            // added `null`, i.e. for the wrong reason.)
             serde_json::json!({
-                "systemInstruction": {"parts": [{"inlineData": {"mimeType": "text/plain", "data": "aGk="}}]}
+                "systemInstruction": {
+                    "parts": [{"videoMetadata": {"startOffset": "0s", "endOffset": "5s"}}]
+                }
             }),
         ] {
             let request = build_with(None, Some(smuggled.clone()))
                 .unwrap_or_else(|error| panic!("{smuggled} should build, got {error}"));
-            let body = serde_json::to_value(&request).expect("serialize");
+            // `to_string`, not `to_value`: a `Value` is a map, so round-tripping
+            // through one silently deduplicates repeated members and shows only
+            // the last. The claim here is about the bytes.
+            let body = serde_json::to_string(&request).expect("serialize");
 
             for (key, expected) in smuggled.as_object().expect("object") {
-                assert_eq!(
-                    body.get(key),
-                    Some(expected),
-                    "additional_params must pass through untouched; {key} was rewritten"
+                let needle = format!(
+                    "\"{key}\":{}",
+                    serde_json::to_string(expected).expect("serialize")
+                );
+                assert!(
+                    body.contains(&needle),
+                    "additional_params must reach the wire byte for byte; expected {needle} in \
+                     {body}"
                 );
             }
         }
@@ -4778,6 +4842,149 @@ mod cached_content_request_tests {
             assert!(
                 message.contains(expected),
                 "`{spelling}` must reach the same conflict as its camelCase alias: {message}"
+            );
+        }
+    }
+
+    /// A field reached through the blob is emitted *twice* — once as the typed
+    /// `null`, once from the blob — and Gemini accepts that.
+    ///
+    /// Pinned rather than fixed, because "fixed" means `skip_serializing_if` on
+    /// `system_instruction` and `tool_config`, which would drop
+    /// `"systemInstruction":null` from every recorded Gemini request body and
+    /// invalidate the whole cassette corpus. It is worth pinning because it
+    /// looks like a bug and is not: measured against the live API,
+    /// `{"toolConfig":null,"toolConfig":{...allowedFunctionNames:["get_weather"]}}`
+    /// returns 200 *and honours the allow-list*, and the `systemInstruction`
+    /// equivalent returns 200 with the instruction applied. A `null` does not
+    /// set the proto field, so no `oneof` is claimed and nothing is overwritten.
+    ///
+    /// Two *non-null* copies are a different matter, and that is exactly what
+    /// the set-twice refusals above prevent: Gemini answers a doubled
+    /// `systemInstruction` with `oneof field '_system_instruction' is already
+    /// set`, and merges a doubled `toolConfig` into the union of both
+    /// allowed-function lists.
+    ///
+    /// So: if this cell ever fails, the fix is not to make it pass — it is to
+    /// re-record the corpus deliberately.
+    #[test]
+    fn a_blob_field_is_emitted_beside_its_typed_null_and_that_is_accepted() {
+        let request = build_with(
+            None,
+            Some(serde_json::json!({"toolConfig": {"functionCallingConfig": {"mode": "ANY"}}})),
+        )
+        .expect("request should build");
+        let body = serde_json::to_string(&request).expect("serialize");
+
+        assert_eq!(
+            body.matches("\"toolConfig\"").count(),
+            2,
+            "the typed null and the blob copy are both emitted, and the provider accepts it: \
+             {body}"
+        );
+        assert!(
+            body.find("\"toolConfig\":null") < body.find("\"toolConfig\":{"),
+            "the null must come first — serde flattens the blob after the named fields, which is \
+             what makes the caller's value the one that survives: {body}"
+        );
+    }
+
+    /// The handle's own proto-original spelling, which used to skip everything.
+    ///
+    /// `cached_content` is a working wire spelling — measured against the live
+    /// API, it reaches the cache lookup and answers `CachedContent not found`
+    /// for a bogus handle. Matching only `cachedContent` therefore meant a
+    /// handle written the other way was never lifted, `with_cached_content` was
+    /// never called, and every check it owns was skipped while the handle sailed
+    /// through the flattened blob onto the wire.
+    #[test]
+    fn the_protos_own_spelling_of_the_handle_is_validated_too() {
+        // The conflict check.
+        let message = build_with(
+            Some("you are terse"),
+            Some(serde_json::json!({"cached_content": "cachedContents/abc123"})),
+        )
+        .expect_err("a preamble conflicts with a handle however the handle is spelled")
+        .to_string();
+        assert!(message.contains("a system instruction"), "{message}");
+
+        // The handle-shape check.
+        let message = build_with(None, Some(serde_json::json!({"cached_content": "abc123"})))
+            .expect_err("a bare id is not a handle however it is spelled")
+            .to_string();
+        assert!(message.contains("cachedContents/<id>"), "{message}");
+
+        // The type check.
+        let message = build_with(None, Some(serde_json::json!({"cached_content": 7})))
+            .expect_err("a number is not a handle")
+            .to_string();
+        assert!(
+            message.contains("additional_params.cached_content"),
+            "{message}"
+        );
+
+        // The set-twice check, across the two spellings.
+        let message = build_with(
+            None,
+            Some(serde_json::json!({
+                "cachedContent": "cachedContents/one",
+                "cached_content": "cachedContents/two"
+            })),
+        )
+        .expect_err("two spellings naming different caches is still two caches")
+        .to_string();
+        assert!(message.contains("twice"), "{message}");
+
+        // And the clean case still works, under either spelling.
+        let request = build_with(
+            None,
+            Some(serde_json::json!({"cached_content": "cachedContents/ok"})),
+        )
+        .expect("a well-formed handle is accepted under the proto spelling");
+        assert_eq!(request.cached_content.as_deref(), Some("cachedContents/ok"));
+    }
+
+    /// `with_cached_content` is `pub`, and on a hand-built request nothing has
+    /// run `extract_tools_from_additional_params` — so the blob is the only
+    /// place its tools live, and the check has to look there.
+    #[test]
+    fn a_hand_built_request_conflicts_on_tools_left_in_additional_params() {
+        for (label, tools, wants_caveat) in [
+            (
+                "function declarations",
+                serde_json::json!([{"functionDeclarations": [{"name": "f", "description": "d"}]}]),
+                true,
+            ),
+            (
+                "the proto spelling of function declarations",
+                serde_json::json!([{"function_declarations": [{"name": "f", "description": "d"}]}]),
+                true,
+            ),
+            (
+                "a provider-hosted tool",
+                serde_json::json!([{"codeExecution": {}}]),
+                false,
+            ),
+        ] {
+            let mut request = GenerateContentRequest {
+                contents: vec![],
+                generation_config: None,
+                safety_settings: None,
+                tools: None,
+                tool_config: None,
+                system_instruction: None,
+                cached_content: None,
+                additional_params: Some(serde_json::json!({ "tools": tools })),
+            };
+            let message = request
+                .with_cached_content("cachedContents/abc123")
+                .expect_err("tools in the blob conflict with a handle just as typed ones do")
+                .to_string();
+            assert!(message.contains("also set tools"), "{label}: {message}");
+            assert_eq!(
+                message.contains("declarations only"),
+                wants_caveat,
+                "{label}: the caveat must track whether functions were declared: {message}"
             );
         }
     }

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -299,16 +299,22 @@ pub(crate) fn create_request_body(
             )),
         })
         .transpose()?;
-    // `systemInstruction` and `toolConfig` are lifted for the same two reasons,
-    // and closing this for `cachedContent` alone left both of them open. They
-    // are the *other* two fields a cached content owns, so a request smuggling
-    // one past the conflict check is exactly the case the check exists for —
-    // and, cache or no cache, a flattened copy serialized beside the typed
-    // field emits the key twice, since neither carries `skip_serializing_if`.
-    let smuggled_system_instruction: Option<Content> =
-        take_typed_from_additional_params(&mut additional_params_payload, "systemInstruction")?;
-    let smuggled_tool_config: Option<ToolConfig> =
-        take_typed_from_additional_params(&mut additional_params_payload, "toolConfig")?;
+    // The other two fields a cached content owns are *detected* here and left
+    // exactly where the caller put them.
+    //
+    // Deserializing them into the typed fields was tried and reverted: rig's
+    // `ToolConfig`/`FunctionCallingMode` model `mode` and a snake_case
+    // `allowed_function_names` only, so round-tripping a caller's config
+    // through them silently dropped `allowedFunctionNames` — turning a request
+    // restricted to one function into one free to call any — and hard-failed
+    // every `mode` rig does not model (`MODE_UNSPECIFIED`, `VALIDATED`, and
+    // whatever Google adds next). `Content` is narrower than the wire the same
+    // way. An `additional_params` blob is a deliberate escape hatch for shapes
+    // rig has no type for; narrowing it through a type is the one thing it must
+    // not do.
+    let smuggled_system_instruction =
+        smuggled_field(&additional_params_payload, &SYSTEM_INSTRUCTION);
+    let smuggled_tool_config = smuggled_field(&additional_params_payload, &TOOL_CONFIG);
 
     let AdditionalParameters {
         mut generation_config,
@@ -366,20 +372,18 @@ pub(crate) fn create_request_body(
     // the last, so the preamble the caller wrote was silently discarded; now the
     // ambiguity is reported, matching how a doubly-set `cachedContent` is
     // treated.
-    let system_instruction = match (system_instruction, smuggled_system_instruction) {
-        (Some(typed), Some(_)) => {
-            return Err(CompletionError::RequestError(
-                format!(
-                    "a Gemini request set the system instruction twice — once as a preamble or \
-                     system message ({} part(s)) and once through \
-                     `additional_params.systemInstruction`. Set it one way or the other",
-                    typed.parts.len()
-                )
-                .into(),
-            ));
-        }
-        (typed, smuggled) => typed.or(smuggled),
-    };
+    if let (Some(typed), Some(spelling)) = (&system_instruction, smuggled_system_instruction) {
+        return Err(CompletionError::RequestError(
+            format!(
+                "a Gemini request set the system instruction twice — once as a preamble or \
+                 system message ({} part(s)) and once through `additional_params.{spelling}`. \
+                 Both reach the wire, the provider takes the last, and the preamble is the one \
+                 discarded. Set it one way or the other",
+                typed.parts.len()
+            )
+            .into(),
+        ));
+    }
 
     let mut tools = if function_tools.is_empty() {
         Vec::new()
@@ -398,16 +402,18 @@ pub(crate) fn create_request_body(
     };
     // Same rule as the system instruction above: `tool_choice` and
     // `additional_params.toolConfig` are one field reached two ways.
-    let tool_config = match (tool_config, smuggled_tool_config) {
-        (Some(_), Some(_)) => {
-            return Err(CompletionError::RequestError(
+    if tool_config.is_some()
+        && let Some(spelling) = smuggled_tool_config
+    {
+        return Err(CompletionError::RequestError(
+            format!(
                 "a Gemini request set the tool choice twice — once as `tool_choice` and once \
-                 through `additional_params.toolConfig`. Set it one way or the other"
-                    .into(),
-            ));
-        }
-        (typed, smuggled) => typed.or(smuggled),
-    };
+                 through `additional_params.{spelling}`. Both reach the wire and the provider \
+                 takes the last. Set it one way or the other"
+            )
+            .into(),
+        ));
+    }
 
     let mut request = GenerateContentRequest {
         contents: full_history
@@ -451,36 +457,32 @@ pub fn split_system_messages_from_history(
     (system, remaining)
 }
 
-/// Remove `key` from an `additional_params` object and deserialize it into the
-/// typed field it belongs in.
+/// Both spellings Gemini accepts for `systemInstruction`.
 ///
-/// Every field of `GenerateContentRequest` that a caller can also reach through
-/// `additional_params` has to come through here, because `additional_params` is
-/// `#[serde(flatten)]` and serde emits flattened entries *after* the named
-/// ones. A copy left in the blob therefore wins on the wire while the typed
-/// field — the one every validation in this module inspects — stays empty. That
-/// is how a `cachedContent` used to overwrite the handle a caller asked for, and
-/// how a `systemInstruction` or `toolConfig` used to walk past the cached
-/// content conflict check.
+/// The API speaks proto3 JSON, which accepts a field under its lowerCamelCase
+/// alias *and* its original proto name. A check that knows only one of them is
+/// a check with a documented bypass.
+const SYSTEM_INSTRUCTION: [&str; 2] = ["systemInstruction", "system_instruction"];
+
+/// Both spellings Gemini accepts for `toolConfig`. See [`SYSTEM_INSTRUCTION`].
+const TOOL_CONFIG: [&str; 2] = ["toolConfig", "tool_config"];
+
+/// The spelling under which one of `spellings` appears in an `additional_params`
+/// blob, if any of them does.
 ///
-/// Deserializing rather than moving the raw `Value` is what makes the lift
-/// worth doing: a malformed field is now reported here, naming the field, in
-/// place of a provider 400 that quotes a JSON path.
-fn take_typed_from_additional_params<T: serde::de::DeserializeOwned>(
-    payload: &mut Value,
-    key: &str,
-) -> Result<Option<T>, CompletionError> {
-    let Some(value) = payload
-        .as_object_mut()
-        .and_then(|object| object.remove(key))
-    else {
-        return Ok(None);
-    };
-    serde_json::from_value(value).map(Some).map_err(|error| {
-        CompletionError::RequestError(
-            format!("additional_params.{key} is not a valid Gemini {key}: {error}").into(),
-        )
-    })
+/// Presence, never the value. `additional_params` is the escape hatch for wire
+/// shapes rig has no type for, so nothing on this path may narrow it by parsing:
+/// deserializing a caller's `toolConfig` into rig's own type drops every field
+/// that type does not model — `allowedFunctionNames` among them, which turns a
+/// request restricted to one function into one free to call any — and rejects
+/// every `mode` rig has not enumerated. An explicit `null` counts as absent,
+/// matching how serde treats a missing field.
+fn smuggled_field<'a>(payload: &Value, spellings: &[&'a str]) -> Option<&'a str> {
+    let object = payload.as_object()?;
+    spellings
+        .iter()
+        .find(|spelling| object.get(**spelling).is_some_and(|value| !value.is_null()))
+        .copied()
 }
 
 fn extract_tools_from_additional_params(
@@ -2520,14 +2522,27 @@ impl gemini_api_types::GenerateContentRequest {
             ));
         }
 
+        // Read `additional_params` as well as the typed fields. It is
+        // `#[serde(flatten)]`, so anything left in it reaches the wire beside
+        // the typed field — a conflict the provider will reject just the same,
+        // and one that used to walk straight past this check because the check
+        // only looked at the typed side. `tools` needs no such lookup:
+        // `extract_tools_from_additional_params` has already moved it onto
+        // `self.tools` by the time any of this runs.
+        let blob = self.additional_params.as_ref();
+        let smuggled = |spellings: &[&str]| {
+            blob.and_then(|payload| smuggled_field(payload, spellings))
+                .is_some()
+        };
+
         let mut conflicts = Vec::new();
-        if self.system_instruction.is_some() {
+        if self.system_instruction.is_some() || smuggled(&SYSTEM_INSTRUCTION) {
             conflicts.push("a system instruction (preamble)");
         }
         if self.tools.is_some() {
             conflicts.push("tools");
         }
-        if self.tool_config.is_some() {
+        if self.tool_config.is_some() || smuggled(&TOOL_CONFIG) {
             conflicts.push("a tool choice");
         }
         if !conflicts.is_empty() {
@@ -4694,60 +4709,93 @@ mod cached_content_request_tests {
         assert!(message.contains("set the tool choice twice"), "{message}");
     }
 
-    /// A lifted field lands in the typed slot rather than beside it.
+    /// Whatever the caller put in `additional_params` reaches the wire byte for
+    /// byte — including everything rig has no type for.
     ///
-    /// The duplicate key is the part that is a bug on its own terms: neither
-    /// `systemInstruction` nor `toolConfig` carries `skip_serializing_if`, so
-    /// before the lift both were emitted twice — once as the typed `null` and
-    /// once from the flattened blob — in every request that used them, cache or
-    /// no cache.
+    /// This is the cell that forbids the obvious implementation. Detecting
+    /// these fields by deserializing them into rig's own `ToolConfig` was tried,
+    /// and it silently dropped `allowedFunctionNames`: a request restricted to
+    /// one function became a request free to call any, with no error anywhere.
+    /// `additional_params` exists precisely for shapes rig does not model, so
+    /// the one thing this path must never do is narrow it.
     #[test]
-    fn a_lifted_field_is_serialized_once_in_the_typed_slot() {
-        let request = build_with(
-            None,
-            Some(serde_json::json!({
-                "systemInstruction": {"parts": [{"text": "you are terse"}], "role": "model"},
-                "toolConfig": {"functionCallingConfig": {"mode": "ANY"}}
-            })),
-        )
-        .expect("request should build");
+    fn a_smuggled_field_reaches_the_wire_exactly_as_the_caller_wrote_it() {
+        for smuggled in [
+            // The lossy case: `allowedFunctionNames` is not a field of rig's
+            // `FunctionCallingMode` (which spells it `allowed_function_names`).
+            serde_json::json!({
+                "toolConfig": {
+                    "functionCallingConfig": {
+                        "mode": "ANY",
+                        "allowedFunctionNames": ["get_weather"]
+                    }
+                }
+            }),
+            // Modes rig does not enumerate. `MODE_UNSPECIFIED` is the proto
+            // default and `VALIDATED` was added after rig's enum was written;
+            // the next one Google adds must not need a rig release either.
+            serde_json::json!({"toolConfig": {"functionCallingConfig": {"mode": "MODE_UNSPECIFIED"}}}),
+            serde_json::json!({"toolConfig": {"functionCallingConfig": {"mode": "VALIDATED"}}}),
+            // The proto-original spelling, which proto3 JSON accepts alongside
+            // the lowerCamelCase alias.
+            serde_json::json!({"tool_config": {"function_calling_config": {"mode": "ANY"}}}),
+            // A system instruction carrying a part kind rig has no variant for.
+            serde_json::json!({
+                "systemInstruction": {"parts": [{"inlineData": {"mimeType": "text/plain", "data": "aGk="}}]}
+            }),
+        ] {
+            let request = build_with(None, Some(smuggled.clone()))
+                .unwrap_or_else(|error| panic!("{smuggled} should build, got {error}"));
+            let body = serde_json::to_value(&request).expect("serialize");
 
-        let body = serde_json::to_string(&request).expect("serialize");
-        for key in ["systemInstruction", "toolConfig"] {
-            assert_eq!(
-                body.matches(&format!("\"{key}\"")).count(),
-                1,
-                "{key} should be emitted exactly once, got {body}"
+            for (key, expected) in smuggled.as_object().expect("object") {
+                assert_eq!(
+                    body.get(key),
+                    Some(expected),
+                    "additional_params must pass through untouched; {key} was rewritten"
+                );
+            }
+        }
+    }
+
+    /// The conflict check has to know both spellings, or it documents its own
+    /// bypass.
+    #[test]
+    fn the_proto_original_spelling_conflicts_too() {
+        for (spelling, expected) in [
+            ("system_instruction", "a system instruction"),
+            ("tool_config", "a tool choice"),
+        ] {
+            let mut request = build_with(
+                None,
+                Some(serde_json::json!({ spelling: {"parts": [{"text": "x"}]} })),
+            )
+            .expect("request should build");
+            let message = request
+                .with_cached_content("cachedContents/abc123")
+                .expect_err("the proto spelling is the same field")
+                .to_string();
+            assert!(
+                message.contains(expected),
+                "`{spelling}` must reach the same conflict as its camelCase alias: {message}"
             );
         }
-        let body: serde_json::Value = serde_json::from_str(&body).expect("valid json");
-        assert_eq!(
-            body["systemInstruction"]["parts"][0]["text"].as_str(),
-            Some("you are terse")
-        );
-        assert_eq!(
-            body["toolConfig"]["functionCallingConfig"]["mode"].as_str(),
-            Some("ANY")
-        );
     }
 
-    /// A malformed lifted field is now reported by name here rather than as a
-    /// provider 400 quoting a JSON path.
+    /// An explicit `null` is how serde spells "unset", so it must not be
+    /// mistaken for a value the caller set.
     #[test]
-    fn a_malformed_lifted_field_names_itself() {
-        let message = build_with(
+    fn an_explicit_null_is_not_a_conflict() {
+        let mut request = build_with(
             None,
-            Some(serde_json::json!({"systemInstruction": "just a string"})),
+            Some(serde_json::json!({"systemInstruction": null, "toolConfig": null})),
         )
-        .expect_err("a string is not a Content")
-        .to_string();
-        assert!(
-            message.contains("additional_params.systemInstruction"),
-            "{message}"
-        );
+        .expect("request should build");
+        request
+            .with_cached_content("cachedContents/abc123")
+            .expect("a null is not a value the caller set");
     }
 }
-
 #[cfg(test)]
 mod cached_content_conflict_matrix {
     //! All 2^3 combinations of the fields a cached content owns.

--- a/crates/rig-core/tests/gemini_cached_content_listing_warnings.rs
+++ b/crates/rig-core/tests/gemini_cached_content_listing_warnings.rs
@@ -1,0 +1,169 @@
+//! What a paginated `cachedContents` listing *reports*, as distinct from what
+//! it returns.
+//!
+//! `list_with_page_size` restates the three termination rules
+//! `internal::model_listing::paginate_models` carries — absent cursor, repeated
+//! cursor, page ceiling — because it cannot call it (that helper is typed on
+//! `Model`/`ModelListingError` and fetches through `get_bytes`, which collapses
+//! the 403/404 triage `CachedContentError::Expired` exists for). A restated
+//! rule is a rule that can drift, and `crates/rig-core/src/providers/gemini/
+//! cached_content.rs`'s unit tests pin only the half of it that is visible in
+//! the returned `Vec`.
+//!
+//! The other half is invisible there by construction: whether rig stopped
+//! because Gemini ended the listing or because rig ran out of pages, the caller
+//! gets the same `Vec<CachedContent>` and the same `Ok`. Only the log
+//! distinguishes a complete answer from a truncated one, so only a log
+//! assertion can hold the distinction — which is the same reason
+//! `model_listing_warnings.rs` exists for the model catalog (rig#2339: deciding
+//! the ceiling from the cursor rather than from loop exhaustion made every
+//! multi-page listing claim it had been truncated).
+//!
+//! Two of these cells assert a warning is **absent**, which is only sound while
+//! the capture is live. `common::tracing_capture` proves liveness on every
+//! call; see `rig_core::test_utils::scoped_tracing_subscriber_guard` for why
+//! this binary's isolation cannot promise that on its own.
+
+#![allow(clippy::expect_used)]
+
+#[path = "common/tracing_capture.rs"]
+mod tracing_capture;
+
+use rig_core::providers::gemini;
+use rig_core::test_utils::{MockHttpResponse, SequencedHttpClient};
+
+const CEILING_WARNING: &str = "hit its page ceiling";
+const REPEATED_CURSOR_WARNING: &str = "repeated its pagination cursor";
+
+/// `internal::model_listing::MAX_LISTING_PAGES`, which is `pub(crate)`. Pinned
+/// rather than imported: a listing that needs more than a thousand pages of
+/// caches does not exist, so this only has to be *at least* the real bound for
+/// the ceiling cells to reach it.
+const PAGE_BUDGET: usize = 1_000;
+
+/// One page of Gemini's `cachedContents` list envelope.
+fn page(names: &[&str], next_page_token: Option<&str>) -> MockHttpResponse {
+    let cached_contents: Vec<_> = names
+        .iter()
+        .map(|name| serde_json::json!({ "name": format!("cachedContents/{name}") }))
+        .collect();
+    MockHttpResponse::success(
+        serde_json::json!({
+            "cachedContents": cached_contents,
+            "nextPageToken": next_page_token,
+        })
+        .to_string(),
+    )
+}
+
+/// Pages that exhaust the loop's budget: two cursors that alternate forever, so
+/// every request differs from the one before, no repeat is ever observed, and
+/// only the bound stops it.
+fn budget_exhausting_pages() -> Vec<MockHttpResponse> {
+    (0..PAGE_BUDGET + 10)
+        .map(|i| page(&["a"], Some(if i % 2 == 0 { "ping" } else { "pong" })))
+        .collect()
+}
+
+/// Pages that stall on one cursor.
+fn repeated_cursor_pages() -> Vec<MockHttpResponse> {
+    vec![page(&["a"], Some("stuck")), page(&["b"], Some("stuck"))]
+}
+
+/// Drive one listing through a mock transport.
+///
+/// Page size 1 because that is what makes the cursor loop reachable at all:
+/// Gemini answers up to 1,000 caches per page, so a live listing is one page.
+async fn list(pages: Vec<MockHttpResponse>) {
+    let client = gemini::Client::builder()
+        .api_key("test-key")
+        .http_client(SequencedHttpClient::new(pages))
+        .build()
+        .expect("client should build");
+    client
+        .cached_contents()
+        .list_with_page_size(1)
+        .await
+        .expect("listing should succeed");
+}
+
+/// Everything `pages` logs at WARN, captured against an anchor that exercises
+/// **both** warning callsites in the listing loop — so a cell asserting either
+/// warning is absent has proof that it would have been captured if emitted.
+async fn logs_from_listing(pages: Vec<MockHttpResponse>) -> String {
+    tracing_capture::captured_logs(
+        tracing::Level::WARN,
+        || async {
+            list(budget_exhausting_pages()).await;
+            list(repeated_cursor_pages()).await;
+        },
+        &[CEILING_WARNING, REPEATED_CURSOR_WARNING],
+        || list(pages.clone()),
+    )
+    .await
+}
+
+/// A listing that ends because Gemini said so is not a ceiling, however many
+/// pages it took.
+///
+/// This is the cell that fails if the ceiling is ever inferred from the
+/// pagination cursor instead of from loop exhaustion: the loop breaks while
+/// still holding the *previous* page's cursor, so `page_token.is_some()` is
+/// true for every listing past its first page.
+#[tokio::test]
+async fn a_completed_multi_page_listing_reports_no_page_ceiling() {
+    let logs = logs_from_listing(vec![
+        page(&["a"], Some("p2")),
+        page(&["b"], Some("p3")),
+        page(&["c"], None),
+    ])
+    .await;
+
+    assert!(
+        !logs.contains(CEILING_WARNING),
+        "a completed three-page listing must not report a page ceiling; logged:\n{logs}"
+    );
+}
+
+/// A single-page listing — every real one — reports nothing at all.
+#[tokio::test]
+async fn an_ordinary_single_page_listing_reports_nothing() {
+    let logs = logs_from_listing(vec![page(&["a", "b"], None)]).await;
+
+    assert!(
+        !logs.contains(CEILING_WARNING) && !logs.contains(REPEATED_CURSOR_WARNING),
+        "the listing every caller actually makes must be silent; logged:\n{logs}"
+    );
+}
+
+/// The counterpart, so the fix cannot be "stop warning at all": a listing that
+/// genuinely runs out of its page budget still reports the ceiling.
+///
+/// Nothing else can tell the caller. `list` returns `Ok` with a `Vec` that
+/// looks like a complete answer, so an operator who is silently handed the
+/// first thousand pages of their caches has no way to know the rest exist.
+#[tokio::test]
+async fn a_listing_that_exhausts_the_page_budget_still_reports_the_ceiling() {
+    let logs = logs_from_listing(budget_exhausting_pages()).await;
+
+    assert!(
+        logs.contains(CEILING_WARNING),
+        "exhausting the page budget must still be reported; logged:\n{logs}"
+    );
+}
+
+/// A repeated cursor is its own diagnosis and ends the listing, so it reports
+/// that alone — not that *and* a page ceiling for one event.
+#[tokio::test]
+async fn a_repeated_cursor_reports_only_its_own_warning() {
+    let logs = logs_from_listing(repeated_cursor_pages()).await;
+
+    assert!(
+        logs.contains(REPEATED_CURSOR_WARNING),
+        "the repeated cursor is what ended the listing; logged:\n{logs}"
+    );
+    assert!(
+        !logs.contains(CEILING_WARNING),
+        "one event must not also be reported as a page ceiling; logged:\n{logs}"
+    );
+}

--- a/tests/cassettes/gemini/cached_content_matrix/edge_agent_active_tools_suppressed.yaml
+++ b/tests/cassettes/gemini/cached_content_matrix/edge_agent_active_tools_suppressed.yaml
@@ -1,0 +1,56 @@
+when:
+  path: /v1beta/cachedContents
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"displayName":"rig-active-tools","model":"models/gemini-2.5-flash","systemInstruction":{"parts":[{"text":"This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior.","thought":false}],"role":"model"},"ttl":"180.000000000s"}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"createTime":"2026-08-19T01:32:55.422504Z","displayName":"rig-active-tools","expireTime":"2026-08-19T01:35:54.995577631Z","model":"models/gemini-2.5-flash","name":"cachedContents/cached-REDACTED_1","updateTime":"2026-08-19T01:32:55.422504Z","usageMetadata":{"totalTokenCount":1081}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"cachedContent":"cachedContents/cached-REDACTED_1","contents":[{"parts":[{"text":"Reply with exactly: suppressed","thought":false}],"role":"user"}],"generationConfig":{"temperature":0.0},"safetySettings":null,"systemInstruction":null,"toolConfig":null}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"suppressed"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"cacheTokensDetails":[{"modality":"TEXT","tokenCount":1081}],"cachedContentTokenCount":1081,"candidatesTokenCount":2,"promptTokenCount":1087,"promptTokensDetails":[{"modality":"TEXT","tokenCount":1087}],"serviceTier":"standard","thoughtsTokenCount":21,"totalTokenCount":1110}}'
+---
+when:
+  path: /v1beta/cachedContents/cached-REDACTED_1
+  method: DELETE
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: null
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{}'

--- a/tests/cassettes/gemini/cached_content_matrix/edge_cached_code_execution.yaml
+++ b/tests/cassettes/gemini/cached_content_matrix/edge_cached_code_execution.yaml
@@ -1,0 +1,56 @@
+when:
+  path: /v1beta/cachedContents
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"displayName":"rig-cached-code-execution","model":"models/gemini-2.5-flash","systemInstruction":{"parts":[{"text":"This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior. This cache fixture paragraph is stable provider test padding about request routing, tool schemas, system instructions, and deterministic replay behavior.","thought":false}],"role":"model"},"tools":[{"codeExecution":{},"functionDeclarations":[]}],"ttl":"180.000000000s"}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"createTime":"2026-08-19T01:33:35.232330Z","displayName":"rig-cached-code-execution","expireTime":"2026-08-19T01:36:34.816474982Z","model":"models/gemini-2.5-flash","name":"cachedContents/cached-REDACTED_1","updateTime":"2026-08-19T01:33:35.232330Z","usageMetadata":{"totalTokenCount":1081}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"cachedContent":"cachedContents/cached-REDACTED_1","contents":[{"parts":[{"text":"Use the code execution tool to compute 7919 * 6841. Reply with only the number.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":null,"toolConfig":null}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"executableCode":{"code":"print(7919 * 6841)\n","language":"PYTHON"}},{"codeExecutionResult":{"outcome":"OUTCOME_OK","output":"54173879\n"}},{"text":"54173879"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"cacheTokensDetails":[{"modality":"TEXT","tokenCount":1081}],"cachedContentTokenCount":1081,"candidatesTokenCount":21,"promptTokenCount":1107,"promptTokensDetails":[{"modality":"TEXT","tokenCount":1107}],"serviceTier":"standard","thoughtsTokenCount":41,"toolUsePromptTokenCount":1171,"toolUsePromptTokensDetails":[{"modality":"TEXT","tokenCount":1171}],"totalTokenCount":2340}}'
+---
+when:
+  path: /v1beta/cachedContents/cached-REDACTED_1
+  method: DELETE
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: null
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{}'

--- a/tests/providers/gemini/cassette/cached_content_matrix.rs
+++ b/tests/providers/gemini/cassette/cached_content_matrix.rs
@@ -54,7 +54,10 @@ use rig::providers::gemini;
 use rig::providers::gemini::cached_content::{CacheExpiry, CachedContent, NewCachedContent};
 use std::time::Duration;
 
-use super::super::support::{always_deleting_cached_contents, with_gemini_prompt_caching_cassette};
+use super::super::support::{
+    always_deleting_cached_contents, assert_recorded_requests_read_from_a_cache,
+    assert_recorded_response_contains, with_gemini_prompt_caching_cassette,
+};
 
 /// Deterministic, committed timestamp for the absolute-expiry arm. A computed
 /// "now + 10 minutes" would churn the fixture on every re-record.
@@ -432,6 +435,17 @@ async fn a_cache_carrying_a_provider_hosted_tool_is_usable_from_an_agent() {
         },
     )
     .await;
+
+    // The answer alone proves nothing — a model can multiply two numbers in its
+    // head and return the same string with no tool involved at all. The cell's
+    // claim is that the tool *in the cache* ran, so it has to be read off the
+    // recorded bytes: Python generated and executed on Gemini's side, for a
+    // request that declared no tools of its own.
+    assert_recorded_response_contains(
+        "cached_content_matrix/edge_cached_code_execution",
+        &["executableCode", "codeExecutionResult"],
+    );
+    assert_recorded_requests_read_from_a_cache("cached_content_matrix/edge_cached_code_execution");
 }
 
 /// The exception to the cell above, recorded because it is the one that would
@@ -501,6 +515,12 @@ async fn an_agent_that_suppresses_its_tools_may_read_from_a_cache() {
         },
     )
     .await;
+
+    // The whole claim is about what left the process: a `tools` field
+    // suppressed and a handle sent. A passing prompt says neither.
+    assert_recorded_requests_read_from_a_cache(
+        "cached_content_matrix/edge_agent_active_tools_suppressed",
+    );
 }
 
 #[tokio::test]

--- a/tests/providers/gemini/cassette/cached_content_matrix.rs
+++ b/tests/providers/gemini/cassette/cached_content_matrix.rs
@@ -301,18 +301,24 @@ fn every_create_combination_serializes_as_expected() {
     );
 }
 
-/// An `Agent` that owns tools can never read from a cache — and the error has
-/// to say why.
+/// An `Agent` that owns tools does not get to read from a cache by default —
+/// and the error has to say why.
 ///
 /// [`NewCachedContent::tools`] reads like it makes a cached tool set usable from
 /// an agent. It does not, and the reason is structural rather than a missing
 /// feature: rig's agent derives the declarations it sends and the handles it
 /// dispatches through from one registry snapshot, so a registered tool is always
 /// advertised and a call to an unadvertised tool is an invalid tool call, never
-/// a dispatch. Every agent turn with a tool therefore carries `tools`, and
+/// a dispatch. An ordinary agent turn with a tool therefore carries `tools`, and
 /// `cachedContent` alongside `tools` is refused. The unit tests in `rig-core`
-/// cannot see this: they can build a request without tools, whereas an agent
-/// holding a tool has no way not to send it.
+/// cannot see this: they build a request directly, and so can simply leave the
+/// tools out.
+///
+/// "By default" is load-bearing. An empty `RequestPatch::active_tools`
+/// allow-list empties the snapshot for a turn, and such a request *is* accepted
+/// — see `an_agent_that_suppresses_its_tools_may_read_from_a_cache`. What it
+/// does not do is make anything callable, which is why the remedy in the message
+/// still cannot be "move them into the cache".
 ///
 /// The second assertion is the point of the finding this pins: the bare "move
 /// them into the cache" remedy is right for a system instruction and wrong here,
@@ -358,6 +364,143 @@ async fn an_agent_with_tools_cannot_read_from_a_cache() {
         "`move them into the cache` is not the remedy for tools — the message must say the \
          cached declarations are unreachable from an agent: {message}"
     );
+}
+
+/// The carve-out the `declares_functions` gate exists for, measured rather than
+/// assumed: a cache carrying a **provider-hosted** tool is usable from an agent
+/// that declares nothing itself.
+///
+/// This is the claim that makes the tools caveat conditional — "provider-hosted
+/// tools such as `codeExecution` run on Gemini's side and are fine to keep in
+/// the cache". `codeExecution` needs no tool loop, so unlike a function
+/// declaration it loses nothing by living somewhere the agent cannot dispatch
+/// from. The unit test pins that the caveat is *withheld* for this shape; only a
+/// recording can say whether the underlying claim is true, i.e. that Gemini
+/// accepts the tool in a cache and still runs it for a request that declares
+/// nothing.
+#[tokio::test]
+async fn a_cache_carrying_a_provider_hosted_tool_is_usable_from_an_agent() {
+    use rig::agent::AgentBuilder;
+    use rig::completion::Prompt as _;
+    use rig::providers::gemini::completion::gemini_api_types::{CodeExecution, Tool};
+
+    with_gemini_prompt_caching_cassette(
+        "cached_content_matrix/edge_cached_code_execution",
+        |client| async move {
+            let cache = client
+                .cached_contents()
+                .create(
+                    NewCachedContent::new(CACHE_MODEL)
+                        .system_instruction(pad())
+                        .tools(vec![Tool {
+                            function_declarations: Vec::new(),
+                            code_execution: Some(CodeExecution {}),
+                        }])
+                        .display_name("rig-cached-code-execution")
+                        .expiry(CacheExpiry::ttl(Duration::from_secs(180))),
+                )
+                .await
+                .expect("a cache carrying only a provider-hosted tool should be created");
+
+            let handles = [cache.name.clone()];
+            always_deleting_cached_contents(&client, &handles, async {
+                let agent = AgentBuilder::new(
+                    client
+                        .completion_model(CACHE_MODEL)
+                        .with_cached_content(cache.name.clone()),
+                )
+                .build();
+
+                let answer = agent
+                    .prompt(
+                        "Use the code execution tool to compute 7919 * 6841. Reply with only the \
+                         number.",
+                    )
+                    .max_turns(3)
+                    .await
+                    .expect(
+                        "an agent declaring nothing may read from a cache carrying a \
+                         provider-hosted tool",
+                    );
+
+                assert!(
+                    answer.contains("54173879"),
+                    "the cached codeExecution tool should have run on Gemini's side: {answer:?}"
+                );
+            })
+            .await;
+        },
+    )
+    .await;
+}
+
+/// The exception to the cell above, recorded because it is the one that would
+/// otherwise be an unchecked claim in the docs.
+///
+/// An empty `RequestPatch::active_tools` allow-list empties the tool snapshot
+/// for a turn, so a tool-holding agent builds a request with no `tools` and the
+/// handle is accepted — by rig, and, as this recording shows, by Gemini. The
+/// docs say so; without a cell they would be asserting a behaviour nothing
+/// exercises, and the neighbouring cell's "an agent with tools is refused"
+/// would read as absolute when it is not.
+///
+/// What it does *not* buy is dispatch: the suppressed tools are gone for the
+/// turn and the cache's are unreachable regardless, which is why the remedy in
+/// the conflict message still cannot be "move them into the cache".
+#[tokio::test]
+async fn an_agent_that_suppresses_its_tools_may_read_from_a_cache() {
+    use rig::agent::{AgentBuilder, RequestPatch};
+    use rig::completion::Prompt as _;
+
+    use super::super::hook_stress_support::ApplyPatch;
+    use super::super::tools_support::CountingPing;
+
+    with_gemini_prompt_caching_cassette(
+        "cached_content_matrix/edge_agent_active_tools_suppressed",
+        |client| async move {
+            let cache = client
+                .cached_contents()
+                .create(
+                    NewCachedContent::new(CACHE_MODEL)
+                        .system_instruction(pad())
+                        .display_name("rig-active-tools")
+                        .expiry(CacheExpiry::ttl(Duration::from_secs(180))),
+                )
+                .await
+                .expect("create should succeed");
+
+            let handles = [cache.name.clone()];
+            always_deleting_cached_contents(&client, &handles, async {
+                let agent = AgentBuilder::new(
+                    client
+                        .completion_model(CACHE_MODEL)
+                        .with_cached_content(cache.name.clone()),
+                )
+                .tool(CountingPing::default())
+                .build();
+
+                let answer = agent
+                    .prompt("Reply with exactly: suppressed")
+                    .add_hook(ApplyPatch(
+                        RequestPatch::new()
+                            .active_tools(Vec::<String>::new())
+                            .temperature(0.0),
+                    ))
+                    .await
+                    .expect(
+                        "an empty active_tools allow-list drops the tool set, so the handle is \
+                         accepted — this is the documented exception",
+                    );
+
+                assert!(
+                    answer.to_lowercase().contains("suppressed"),
+                    "the turn should have run against the cache: {answer:?}"
+                );
+            })
+            .await;
+        },
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/tests/providers/gemini/cassette/cached_content_matrix.rs
+++ b/tests/providers/gemini/cassette/cached_content_matrix.rs
@@ -297,6 +297,65 @@ fn every_create_combination_serializes_as_expected() {
     );
 }
 
+/// An `Agent` that owns tools can never read from a cache — and the error has
+/// to say why.
+///
+/// [`NewCachedContent::tools`] reads like it makes a cached tool set usable from
+/// an agent. It does not, and the reason is structural rather than a missing
+/// feature: rig's agent derives the declarations it sends and the handles it
+/// dispatches through from one registry snapshot, so a registered tool is always
+/// advertised and a call to an unadvertised tool is an invalid tool call, never
+/// a dispatch. Every agent turn with a tool therefore carries `tools`, and
+/// `cachedContent` alongside `tools` is refused. The unit tests in `rig-core`
+/// cannot see this: they can build a request without tools, whereas an agent
+/// holding a tool has no way not to send it.
+///
+/// The second assertion is the point of the finding this pins: the bare "move
+/// them into the cache" remedy is right for a system instruction and wrong here,
+/// because the cached declarations would be unreachable from the agent that was
+/// told to create them.
+///
+/// No cassette and no socket — the guard fires while the request is being built.
+/// The client still points at an unroutable address so that a regression fails
+/// as a local assertion instead of reaching the live API from a unit test.
+#[tokio::test]
+async fn an_agent_with_tools_cannot_read_from_a_cache() {
+    use rig::agent::AgentBuilder;
+    use rig::completion::Prompt as _;
+
+    use super::super::tools_support::CountingPing;
+
+    let client = gemini::Client::builder()
+        .api_key("not-a-real-key")
+        .base_url("http://127.0.0.1:1")
+        .build()
+        .expect("client should build");
+
+    let agent = AgentBuilder::new(
+        client
+            .completion_model(CACHE_MODEL)
+            .with_cached_content("cachedContents/agent-guard"),
+    )
+    .tool(CountingPing::default())
+    .build();
+
+    let message = agent
+        .prompt("hi")
+        .await
+        .expect_err("an agent that advertises tools cannot also read from a cache")
+        .to_string();
+
+    assert!(
+        message.contains("also set tools"),
+        "the failure should name the tool set as the conflict: {message}"
+    );
+    assert!(
+        message.contains("declarations only"),
+        "`move them into the cache` is not the remedy for tools — the message must say the \
+         cached declarations are unreachable from an agent: {message}"
+    );
+}
+
 #[tokio::test]
 async fn sys_notools_nocfg_noname_ttl() {
     with_gemini_prompt_caching_cassette(
@@ -656,10 +715,10 @@ async fn deleting_twice_reports_the_second_as_expired() {
             };
             assert_eq!(*name, created.name);
             assert!(
-                !message.is_empty(),
+                message.contains("not found") || message.contains("permission"),
                 "Expired should carry the provider's own message — a 403 also covers a disabled \
                  key or a project without the API enabled, and the message is the only text that \
-                 says which"
+                 says which: {message}"
             );
         },
     )

--- a/tests/providers/gemini/cassette/cached_content_matrix.rs
+++ b/tests/providers/gemini/cassette/cached_content_matrix.rs
@@ -25,7 +25,11 @@
 //! That is 164 KB instead of 1.3 MB, for strictly more coverage.
 //!
 //! Every recorded cell deletes what it created, on the failure path too, because
-//! storage bills until it does.
+//! storage bills until it does. Cells whose checks panic run them inside
+//! `always_deleting_cached_contents` (`tests/providers/gemini/support.rs`),
+//! which issues the delete even when an assertion panics; the rest get the same
+//! guarantee by hand, returning a `Result` from their checks and deleting
+//! before they panic on it.
 //!
 //! Behaviours pinned here were measured against the live API first:
 //!
@@ -50,7 +54,7 @@ use rig::providers::gemini;
 use rig::providers::gemini::cached_content::{CacheExpiry, CachedContent, NewCachedContent};
 use std::time::Duration;
 
-use super::super::support::with_gemini_prompt_caching_cassette;
+use super::super::support::{always_deleting_cached_contents, with_gemini_prompt_caching_cassette};
 
 /// Deterministic, committed timestamp for the absolute-expiry arm. A computed
 /// "now + 10 minutes" would churn the fixture on every re-record.
@@ -538,15 +542,25 @@ async fn a_cache_below_the_minimum_is_refused_by_the_provider() {
     with_gemini_prompt_caching_cassette(
         "cached_content_matrix/edge_below_minimum",
         |client| async move {
-            let error = client
+            let refusal = client
                 .cached_contents()
                 .create(
                     NewCachedContent::new(CACHE_MODEL)
                         .system_instruction(crate::cache_conformance::cache_padding(4))
                         .expiry(CacheExpiry::ttl(Duration::from_secs(120))),
                 )
-                .await
-                .expect_err("a cache under the minimum should be refused");
+                .await;
+
+            // The day Gemini lowers the floor this cell fails — but it fails
+            // having deleted the cache it just paid to create, rather than
+            // leaking one out of an `expect_err`.
+            let error = match refusal {
+                Err(error) => error,
+                Ok(created) => {
+                    let _ = client.cached_contents().delete(&created.name).await;
+                    panic!("a cache under the minimum should be refused");
+                }
+            };
 
             let message = error.to_string();
             assert!(
@@ -610,26 +624,24 @@ async fn omitting_expiry_defaults_to_one_hour() {
                 .await
                 .expect("a cache with no expiry should be created");
 
-            let (create_time, expire_time) = (
-                created.create_time.as_deref().expect("create time"),
-                created.expire_time.as_deref().expect("expire time"),
-            );
-            // Compare the hour fields rather than parsing RFC 3339: the default
-            // is one hour, and both stamps are same-day UTC.
-            let hour = |stamp: &str| stamp[11..13].parse::<i32>().expect("hour");
-            let gap = (hour(expire_time) - hour(create_time)).rem_euclid(24);
-            let failure = (gap != 1).then(|| {
-                format!(
-                    "the documented default is one hour: created {create_time}, expires \
-                     {expire_time}"
-                )
-            });
-
-            // Delete before asserting, so a failure does not leak a billed cache.
-            let _ = client.cached_contents().delete(&created.name).await;
-            if let Some(failure) = failure {
-                panic!("{failure}");
-            }
+            let handles = [created.name.clone()];
+            always_deleting_cached_contents(&client, &handles, async {
+                let (create_time, expire_time) = (
+                    created.create_time.as_deref().expect("create time"),
+                    created.expire_time.as_deref().expect("expire time"),
+                );
+                // Compare the hour fields rather than parsing RFC 3339: the default
+                // is one hour, and both stamps are same-day UTC.
+                let hour = |stamp: &str| stamp[11..13].parse::<i32>().expect("hour");
+                let gap = (hour(expire_time) - hour(create_time)).rem_euclid(24);
+                if gap != 1 {
+                    panic!(
+                        "the documented default is one hour: created {create_time}, expires \
+                         {expire_time}"
+                    );
+                }
+            })
+            .await;
         },
     )
     .await;
@@ -647,41 +659,51 @@ async fn list_follows_the_cursor_across_pages() {
         "cached_content_matrix/edge_list_pagination",
         |client| async move {
             let caches = client.cached_contents();
+            // The creates are collected rather than unwrapped: a second cache
+            // that fails to create still has to delete the first, or the very
+            // failure leaks three times the storage a passing run does.
             let mut created = Vec::new();
+            let mut create_failure = None;
             for index in 0..3 {
-                created.push(
-                    caches
-                        .create(
-                            NewCachedContent::new(CACHE_MODEL)
-                                .system_instruction(pad())
-                                .display_name(format!("rig-page-{index}"))
-                                .expiry(CacheExpiry::ttl(Duration::from_secs(180))),
-                        )
-                        .await
-                        .expect("creating a page fixture should succeed")
-                        .name,
-                );
+                match caches
+                    .create(
+                        NewCachedContent::new(CACHE_MODEL)
+                            .system_instruction(pad())
+                            .display_name(format!("rig-page-{index}"))
+                            .expiry(CacheExpiry::ttl(Duration::from_secs(180))),
+                    )
+                    .await
+                {
+                    Ok(cache) => created.push(cache.name),
+                    Err(error) => {
+                        create_failure = Some(error);
+                        break;
+                    }
+                }
             }
 
-            // Page size 1 with three caches means three pages and a cursor
-            // followed twice — the loop runs for real instead of returning
-            // everything in one response as pageSize=1000 does.
-            let listed = caches
-                .list_with_page_size(1)
-                .await
-                .expect("paginated list should succeed");
-            for name in &created {
-                assert!(
-                    listed.iter().any(|entry| entry.name == *name),
-                    "every created cache should appear in the listing: {name} missing from {} \
-                     entries",
-                    listed.len()
-                );
-            }
+            always_deleting_cached_contents(&client, &created, async {
+                if let Some(error) = create_failure {
+                    panic!("creating a page fixture should succeed: {error}");
+                }
 
-            for name in &created {
-                let _ = caches.delete(name).await;
-            }
+                // Page size 1 with three caches means three pages and a cursor
+                // followed twice — the loop runs for real instead of returning
+                // everything in one response as pageSize=1000 does.
+                let listed = caches
+                    .list_with_page_size(1)
+                    .await
+                    .expect("paginated list should succeed");
+                for name in &created {
+                    assert!(
+                        listed.iter().any(|entry| entry.name == *name),
+                        "every created cache should appear in the listing: {name} missing from \
+                         {} entries",
+                        listed.len()
+                    );
+                }
+            })
+            .await;
         },
     )
     .await;
@@ -742,15 +764,15 @@ async fn update_expiry_accepts_an_absolute_timestamp() {
                 .await
                 .expect("create should succeed");
 
-            let updated = caches
-                .update_expiry(&created.name, CacheExpiry::expire_time(ABSOLUTE_EXPIRY))
-                .await
-                .expect("updating to an absolute expiry should succeed");
-            let observed = updated.expire_time.clone();
-
-            // Delete before asserting, so a failure does not leak a billed cache.
-            let _ = caches.delete(&created.name).await;
-            assert_eq!(observed.as_deref(), Some(ABSOLUTE_EXPIRY));
+            let handles = [created.name.clone()];
+            always_deleting_cached_contents(&client, &handles, async {
+                let updated = caches
+                    .update_expiry(&created.name, CacheExpiry::expire_time(ABSOLUTE_EXPIRY))
+                    .await
+                    .expect("updating to an absolute expiry should succeed");
+                assert_eq!(updated.expire_time.as_deref(), Some(ABSOLUTE_EXPIRY));
+            })
+            .await;
         },
     )
     .await;
@@ -781,57 +803,59 @@ async fn streaming_against_a_cache_reports_the_cache_read() {
                 .await
                 .expect("create should succeed");
 
-            let model = client
-                .completion_model(CACHE_MODEL)
-                .with_cached_content(cache.name.clone());
+            let handles = [cache.name.clone()];
+            always_deleting_cached_contents(&client, &handles, async {
+                let model = client
+                    .completion_model(CACHE_MODEL)
+                    .with_cached_content(cache.name.clone());
 
-            let request = rig::completion::CompletionRequest {
-                preamble: None,
-                chat_history: vec![rig::message::Message::User {
-                    content: vec![rig::message::UserContent::text(
-                        "Reply with exactly: streamed",
-                    )],
-                }],
-                documents: vec![],
-                tools: vec![],
-                temperature: Some(0.0),
-                max_tokens: Some(16),
-                tool_choice: None,
-                additional_params: Some(serde_json::json!({
-                    "generationConfig": { "thinkingConfig": { "thinkingBudget": 0 } }
-                })),
-                model: None,
-                output_schema: None,
-                record_telemetry_content: false,
-            };
+                let request = rig::completion::CompletionRequest {
+                    preamble: None,
+                    chat_history: vec![rig::message::Message::User {
+                        content: vec![rig::message::UserContent::text(
+                            "Reply with exactly: streamed",
+                        )],
+                    }],
+                    documents: vec![],
+                    tools: vec![],
+                    temperature: Some(0.0),
+                    max_tokens: Some(16),
+                    tool_choice: None,
+                    additional_params: Some(serde_json::json!({
+                        "generationConfig": { "thinkingConfig": { "thinkingBudget": 0 } }
+                    })),
+                    model: None,
+                    output_schema: None,
+                    record_telemetry_content: false,
+                };
 
-            let mut stream = rig::completion::CompletionModel::stream(&model, request)
-                .await
-                .expect("streamed cached-content request should start");
-            let mut usage = None;
-            while let Some(item) = stream.next().await {
-                if let StreamedAssistantContent::Final(response) =
-                    item.expect("stream item should succeed")
-                {
-                    usage = Some(response.usage);
+                let mut stream = rig::completion::CompletionModel::stream(&model, request)
+                    .await
+                    .expect("streamed cached-content request should start");
+                let mut usage = None;
+                while let Some(item) = stream.next().await {
+                    if let StreamedAssistantContent::Final(response) =
+                        item.expect("stream item should succeed")
+                    {
+                        usage = Some(response.usage);
+                    }
                 }
-            }
 
-            let usage = usage.expect(
-                "the stream should carry final usage; losing it on the streaming path is the \
-                 exact bug this cell exists to catch",
-            );
-            let ratio = usage.cached_input_tokens as f64 / usage.input_tokens as f64;
-            assert!(
-                ratio >= 0.95,
-                "a streamed request against a cache handle should read essentially the whole \
-                 prefix from cache, got {} of {} ({:.1}%)",
-                usage.cached_input_tokens,
-                usage.input_tokens,
-                ratio * 100.0
-            );
-
-            let _ = client.cached_contents().delete(&cache.name).await;
+                let usage = usage.expect(
+                    "the stream should carry final usage; losing it on the streaming path is the \
+                     exact bug this cell exists to catch",
+                );
+                let ratio = usage.cached_input_tokens as f64 / usage.input_tokens as f64;
+                assert!(
+                    ratio >= 0.95,
+                    "a streamed request against a cache handle should read essentially the whole \
+                     prefix from cache, got {} of {} ({:.1}%)",
+                    usage.cached_input_tokens,
+                    usage.input_tokens,
+                    ratio * 100.0
+                );
+            })
+            .await;
         },
     )
     .await;

--- a/tests/providers/gemini/cassette/prompt_caching.rs
+++ b/tests/providers/gemini/cassette/prompt_caching.rs
@@ -61,7 +61,7 @@ use crate::cache_conformance::{
     report_and_assert_live, run_cache_probe, run_cache_probe_streaming,
 };
 
-use super::super::support::with_gemini_prompt_caching_cassette;
+use super::super::support::{always_deleting_cached_contents, with_gemini_prompt_caching_cassette};
 
 /// Gemini 2.5 Flash: implicit caching, and the cheapest model that has it.
 const CACHE_MODEL: &str = gemini::completion::GEMINI_2_5_FLASH;
@@ -236,6 +236,11 @@ async fn create_probe_cache(
 }
 
 /// The whole resource lifecycle, in one recording.
+///
+/// The delete is both the last step of the lifecycle and the cleanup that has
+/// to happen even when a step above it fails, so the guard owns it rather than
+/// the body — it still lands last on the success path, which is the order the
+/// fixture records.
 #[tokio::test]
 async fn explicit_cache_lifecycle() {
     with_gemini_prompt_caching_cassette(
@@ -244,49 +249,48 @@ async fn explicit_cache_lifecycle() {
             let caches = client.cached_contents();
             let created = create_probe_cache(&client, "rig-lifecycle").await;
 
-            assert!(
-                created.name.starts_with("cachedContents/"),
-                "a handle should be `cachedContents/<id>`, got {:?}",
-                created.name
-            );
-            assert_eq!(
-                created.model,
-                format!("models/{CACHE_MODEL}"),
-                "the cache is bound to the model it was created for"
-            );
-            let stored = created
-                .usage_metadata
-                .as_ref()
-                .map(|usage| usage.total_token_count)
-                .unwrap_or_default();
-            assert!(
-                stored >= GEMINI_CACHE_SUPPORT.min_cacheable_tokens as u64,
-                "a cache holding {stored} tokens is below the {}-token minimum and would cache \
-                 nothing",
-                GEMINI_CACHE_SUPPORT.min_cacheable_tokens
-            );
+            let handles = [created.name.clone()];
+            always_deleting_cached_contents(&client, &handles, async {
+                assert!(
+                    created.name.starts_with("cachedContents/"),
+                    "a handle should be `cachedContents/<id>`, got {:?}",
+                    created.name
+                );
+                assert_eq!(
+                    created.model,
+                    format!("models/{CACHE_MODEL}"),
+                    "the cache is bound to the model it was created for"
+                );
+                let stored = created
+                    .usage_metadata
+                    .as_ref()
+                    .map(|usage| usage.total_token_count)
+                    .unwrap_or_default();
+                assert!(
+                    stored >= GEMINI_CACHE_SUPPORT.min_cacheable_tokens as u64,
+                    "a cache holding {stored} tokens is below the {}-token minimum and would \
+                     cache nothing",
+                    GEMINI_CACHE_SUPPORT.min_cacheable_tokens
+                );
 
-            let fetched = caches.get(&created.name).await.expect("get should succeed");
-            assert_eq!(fetched.name, created.name);
+                let fetched = caches.get(&created.name).await.expect("get should succeed");
+                assert_eq!(fetched.name, created.name);
 
-            let listed = caches.list().await.expect("list should succeed");
-            assert!(
-                listed.iter().any(|entry| entry.name == created.name),
-                "the cache just created should appear in the listing"
-            );
+                let listed = caches.list().await.expect("list should succeed");
+                assert!(
+                    listed.iter().any(|entry| entry.name == created.name),
+                    "the cache just created should appear in the listing"
+                );
 
-            // Expiry is the only mutable part of the resource.
-            let extended = caches
-                .update_expiry(&created.name, CacheExpiry::ttl(Duration::from_secs(900)))
-                .await
-                .expect("update should succeed");
-            assert_eq!(extended.name, created.name);
-            assert!(extended.expire_time.is_some());
-
-            caches
-                .delete(&created.name)
-                .await
-                .expect("delete should succeed — storage bills until it lands");
+                // Expiry is the only mutable part of the resource.
+                let extended = caches
+                    .update_expiry(&created.name, CacheExpiry::ttl(Duration::from_secs(900)))
+                    .await
+                    .expect("update should succeed");
+                assert_eq!(extended.name, created.name);
+                assert!(extended.expire_time.is_some());
+            })
+            .await;
         },
     )
     .await;
@@ -299,33 +303,32 @@ async fn explicit_cache_serves_the_whole_prefix_from_the_first_turn() {
         "prompt_caching/explicit_cache_hit_ratio",
         |client| async move {
             let cache = create_probe_cache(&client, "rig-hit-ratio").await;
-            let model = client
-                .completion_model(CACHE_MODEL)
-                .with_cached_content(cache.name.clone());
 
-            // `bare()`: the cache owns the system instruction and tools, and a
-            // request that also sends its own is rejected — by rig, before it
-            // reaches Gemini.
-            let observation = run_cache_probe(&model, &probe().bare()).await;
-            assert_cache_conformance(
-                &observation,
-                &GEMINI_EXPLICIT_SUPPORT,
-                "explicit cache probe",
-            );
+            let handles = [cache.name.clone()];
+            always_deleting_cached_contents(&client, &handles, async {
+                let model = client
+                    .completion_model(CACHE_MODEL)
+                    .with_cached_content(cache.name.clone());
 
-            // Unlike implicit caching, turn 1 already hits — there is no warm-up.
-            assert!(
-                observation.turns[0].cached_input_tokens > 0,
-                "explicit caching should hit on the very first request; that is the property \
-                 implicit caching does not have.\n{}",
-                observation.report(&GEMINI_EXPLICIT_SUPPORT)
-            );
+                // `bare()`: the cache owns the system instruction and tools, and a
+                // request that also sends its own is rejected — by rig, before it
+                // reaches Gemini.
+                let observation = run_cache_probe(&model, &probe().bare()).await;
+                assert_cache_conformance(
+                    &observation,
+                    &GEMINI_EXPLICIT_SUPPORT,
+                    "explicit cache probe",
+                );
 
-            client
-                .cached_contents()
-                .delete(&cache.name)
-                .await
-                .expect("delete should succeed");
+                // Unlike implicit caching, turn 1 already hits — there is no warm-up.
+                assert!(
+                    observation.turns[0].cached_input_tokens > 0,
+                    "explicit caching should hit on the very first request; that is the property \
+                     implicit caching does not have.\n{}",
+                    observation.report(&GEMINI_EXPLICIT_SUPPORT)
+                );
+            })
+            .await;
         },
     )
     .await;
@@ -349,57 +352,56 @@ async fn explicit_cache_hits_across_unrelated_conversations() {
         "prompt_caching/explicit_cache_across_conversations",
         |client| async move {
             let cache = create_probe_cache(&client, "rig-cross-conversation").await;
-            let model = client
-                .completion_model(CACHE_MODEL)
-                .with_cached_content(cache.name.clone());
 
-            let mut reads = Vec::new();
-            for prompt in [
-                "Reply with exactly: alpha",
-                "Say only the word beta, nothing else",
-            ] {
-                let request = rig::completion::CompletionRequest {
-                    preamble: None,
-                    chat_history: vec![rig::message::Message::User {
-                        content: vec![rig::message::UserContent::text(prompt)],
-                    }],
-                    documents: vec![],
-                    tools: vec![],
-                    temperature: Some(0.0),
-                    max_tokens: Some(16),
-                    tool_choice: None,
-                    additional_params: Some(serde_json::json!({
-                        "generationConfig": { "thinkingConfig": { "thinkingBudget": 0 } }
-                    })),
-                    model: None,
-                    output_schema: None,
-                    record_telemetry_content: false,
-                };
-                let response = rig::completion::CompletionModel::completion(&model, request)
-                    .await
-                    .expect("a cached-content request should succeed");
-                reads.push((
-                    response.usage.input_tokens,
-                    response.usage.cached_input_tokens,
-                ));
-            }
+            let handles = [cache.name.clone()];
+            always_deleting_cached_contents(&client, &handles, async {
+                let model = client
+                    .completion_model(CACHE_MODEL)
+                    .with_cached_content(cache.name.clone());
 
-            for (index, (prompt_tokens, cached)) in reads.iter().enumerate() {
-                let ratio = *cached as f64 / *prompt_tokens as f64;
-                assert!(
-                    ratio >= GEMINI_EXPLICIT_SUPPORT.hit_ratio_floor,
-                    "conversation {} read {cached} of {prompt_tokens} prompt tokens ({:.1}%); a \
-                     cache handle should not care that the conversations are unrelated",
-                    index + 1,
-                    ratio * 100.0
-                );
-            }
+                let mut reads = Vec::new();
+                for prompt in [
+                    "Reply with exactly: alpha",
+                    "Say only the word beta, nothing else",
+                ] {
+                    let request = rig::completion::CompletionRequest {
+                        preamble: None,
+                        chat_history: vec![rig::message::Message::User {
+                            content: vec![rig::message::UserContent::text(prompt)],
+                        }],
+                        documents: vec![],
+                        tools: vec![],
+                        temperature: Some(0.0),
+                        max_tokens: Some(16),
+                        tool_choice: None,
+                        additional_params: Some(serde_json::json!({
+                            "generationConfig": { "thinkingConfig": { "thinkingBudget": 0 } }
+                        })),
+                        model: None,
+                        output_schema: None,
+                        record_telemetry_content: false,
+                    };
+                    let response = rig::completion::CompletionModel::completion(&model, request)
+                        .await
+                        .expect("a cached-content request should succeed");
+                    reads.push((
+                        response.usage.input_tokens,
+                        response.usage.cached_input_tokens,
+                    ));
+                }
 
-            client
-                .cached_contents()
-                .delete(&cache.name)
-                .await
-                .expect("delete should succeed");
+                for (index, (prompt_tokens, cached)) in reads.iter().enumerate() {
+                    let ratio = *cached as f64 / *prompt_tokens as f64;
+                    assert!(
+                        ratio >= GEMINI_EXPLICIT_SUPPORT.hit_ratio_floor,
+                        "conversation {} read {cached} of {prompt_tokens} prompt tokens ({:.1}%); \
+                         a cache handle should not care that the conversations are unrelated",
+                        index + 1,
+                        ratio * 100.0
+                    );
+                }
+            })
+            .await;
         },
     )
     .await;

--- a/tests/providers/gemini/support.rs
+++ b/tests/providers/gemini/support.rs
@@ -77,12 +77,20 @@ pub(super) fn recorded_request_bodies(scenario: &str) -> Vec<serde_json::Value> 
 /// The cassette's own body matching would fail a request that changed, but only
 /// as an opaque "no recorded interaction matched" — this states the guarantee,
 /// so a cell about reading from a cache cannot quietly become a cell about
-/// something else. `cachedContents` lifecycle calls (create/delete) are skipped:
-/// they carry no `contents`.
+/// something else.
+///
+/// `cachedContents` lifecycle calls are skipped, and a top-level `model` is what
+/// identifies them rather than the absence of `contents`: a cache created with
+/// `NewCachedContent::content(..)` carries `contents` too, and would otherwise
+/// be held to a rule written for completions — failing for want of a handle it
+/// is in the middle of minting. `generateContent` never carries `model` in the
+/// body; the model is in the path.
 pub(super) fn assert_recorded_requests_read_from_a_cache(scenario: &str) {
     let mut generate_requests = 0;
     for (turn, body) in recorded_request_bodies(scenario).iter().enumerate() {
-        if body.get("contents").is_none_or(serde_json::Value::is_null) {
+        let is_completion = body.get("contents").is_some_and(|c| !c.is_null())
+            && body.get("model").is_none_or(serde_json::Value::is_null);
+        if !is_completion {
             continue;
         }
         generate_requests += 1;

--- a/tests/providers/gemini/support.rs
+++ b/tests/providers/gemini/support.rs
@@ -379,6 +379,31 @@ pub(super) async fn always_deleting_cached_contents<Fut>(
 ) where
     Fut: Future<Output = ()>,
 {
+    always_deleting_cached_contents_reporting(client, handles, body, |warning| {
+        // libtest prints captured stderr under the failing test, which is
+        // exactly when someone needs this.
+        eprintln!("{warning}");
+    })
+    .await;
+}
+
+/// [`always_deleting_cached_contents`] with the leak warning routed somewhere a
+/// test can read it.
+///
+/// The warning only fires when the body panicked *and* the cleanup failed, and
+/// on that path the body's panic is re-raised — so from the outside the guard is
+/// indistinguishable from one that never warned at all. Left on `eprintln!`, the
+/// whole block could be deleted with all four cells still green, and the one
+/// path that names a still-billing handle would be gone silently.
+async fn always_deleting_cached_contents_reporting<Fut, R>(
+    client: &gemini::Client,
+    handles: &[String],
+    body: Fut,
+    report: R,
+) where
+    Fut: Future<Output = ()>,
+    R: FnOnce(String),
+{
     let outcome = AssertUnwindSafe(body).catch_unwind().await;
 
     let caches = client.cached_contents();
@@ -393,12 +418,11 @@ pub(super) async fn always_deleting_cached_contents<Fut>(
         if !failures.is_empty() {
             // The body's panic wins the cell, but a cleanup that also failed
             // leaves a billed cache behind, and this is the only place its
-            // handle is ever named — libtest prints captured stderr under the
-            // failing test, which is exactly when someone needs it.
-            eprintln!(
+            // handle is ever named.
+            report(format!(
                 "WARNING: cached contents left billing after a failed cell — delete by hand: {}",
                 failures.join("; ")
-            );
+            ));
         }
         resume_unwind(payload);
     }
@@ -568,10 +592,18 @@ mod always_deleting_cached_contents_tests {
         let (client, _stub) =
             stub_cached_contents(Arc::clone(&seen), StatusCode::INTERNAL_SERVER_ERROR).await;
 
-        let panicked = AssertUnwindSafe(always_deleting_cached_contents(
+        let warnings = Arc::new(Mutex::new(Vec::new()));
+        let collected = Arc::clone(&warnings);
+        let panicked = AssertUnwindSafe(always_deleting_cached_contents_reporting(
             &client,
             &["cachedContents/leaky".to_owned()],
             async { panic!("the assertion under test failed") },
+            move |warning| {
+                collected
+                    .lock()
+                    .expect("warning sink should not be poisoned")
+                    .push(warning)
+            },
         ))
         .catch_unwind()
         .await
@@ -588,6 +620,54 @@ mod always_deleting_cached_contents_tests {
                 .as_slice(),
             ["DELETE /v1beta/cachedContents/leaky"],
             "the delete must still be attempted, even though its failure is discarded"
+        );
+
+        // The panic is re-raised either way, so this warning is the *only*
+        // trace the still-billing cache leaves. Without this assertion the
+        // whole block can be deleted with every cell still green.
+        let warnings = warnings
+            .lock()
+            .expect("warning sink should not be poisoned");
+        let [warning] = warnings.as_slice() else {
+            panic!("a discarded cleanup failure must still be reported: {warnings:?}");
+        };
+        assert!(
+            warning.contains("cachedContents/leaky"),
+            "the warning has to name the handle — it is what someone types to delete it by hand: \
+             {warning}"
+        );
+    }
+
+    /// The converse: a cleanup that *succeeded* after a panicking body has
+    /// nothing to report, so a reader is not sent hunting for a cache that is
+    /// already gone.
+    #[tokio::test]
+    async fn a_clean_cleanup_after_a_panicking_body_reports_no_leak() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let (client, _stub) = stub_cached_contents(Arc::clone(&seen), StatusCode::OK).await;
+
+        let warnings = Arc::new(Mutex::new(Vec::new()));
+        let collected = Arc::clone(&warnings);
+        let _ = AssertUnwindSafe(always_deleting_cached_contents_reporting(
+            &client,
+            &["cachedContents/tidy".to_owned()],
+            async { panic!("the assertion under test failed") },
+            move |warning| {
+                collected
+                    .lock()
+                    .expect("warning sink should not be poisoned")
+                    .push(warning)
+            },
+        ))
+        .catch_unwind()
+        .await;
+
+        assert!(
+            warnings
+                .lock()
+                .expect("warning sink should not be poisoned")
+                .is_empty(),
+            "the cache was deleted; there is no leak to warn about"
         );
     }
 }

--- a/tests/providers/gemini/support.rs
+++ b/tests/providers/gemini/support.rs
@@ -2,7 +2,7 @@ use futures::FutureExt;
 use rig::providers::gemini;
 use serde::Deserialize;
 use std::future::Future;
-use std::panic::AssertUnwindSafe;
+use std::panic::{AssertUnwindSafe, resume_unwind};
 
 use crate::cassettes::{CassetteSpec, ProviderCassette};
 
@@ -346,4 +346,248 @@ pub(super) async fn with_gemini_prompt_caching_cassette<F, Fut>(
     Fut: Future<Output = ()>,
 {
     with_gemini_cassette(spec, test_body).await;
+}
+
+/// Run `body`, then delete `handles` — including when `body` panics.
+///
+/// Gemini bills `cachedContents` storage per token-hour from the moment
+/// `create` returns until the delete lands, so an assertion that takes a cell
+/// down between the two leaks a billed cache until its TTL lapses. That only
+/// costs money under `RIG_PROVIDER_TEST_MODE=record` — which is exactly when a
+/// newly written assertion is most likely to be the one that fails.
+///
+/// The failure is *caught* rather than threaded back as a `Result` because the
+/// checks these cells run are not all this suite's to reshape: `run_cache_probe`
+/// and `assert_cache_conformance` (`tests/common/cache_conformance.rs`) are
+/// shared by every provider's cache suite and panic from the inside, as does
+/// every `.expect()` on an intermediate `get`/`list`/`update_expiry`.
+///
+/// Delete failures are treated differently on the two paths, and the asymmetry
+/// is the point:
+///
+/// * the body panicked — the body's panic wins, because a cleanup that also
+///   failed must never overwrite the assertion actually under test;
+/// * the body passed — a delete that failed *is* the leak this exists to
+///   prevent, so it fails the cell.
+///
+/// Every handle is attempted regardless of the ones before it failing, so a
+/// cell holding three caches cannot leak two because the first delete 500'd.
+pub(super) async fn always_deleting_cached_contents<Fut>(
+    client: &gemini::Client,
+    handles: &[String],
+    body: Fut,
+) where
+    Fut: Future<Output = ()>,
+{
+    let outcome = AssertUnwindSafe(body).catch_unwind().await;
+
+    let caches = client.cached_contents();
+    let mut failures = Vec::new();
+    for handle in handles {
+        if let Err(error) = caches.delete(handle).await {
+            failures.push(format!("{handle}: {error}"));
+        }
+    }
+
+    if let Err(payload) = outcome {
+        if !failures.is_empty() {
+            // The body's panic wins the cell, but a cleanup that also failed
+            // leaves a billed cache behind, and this is the only place its
+            // handle is ever named — libtest prints captured stderr under the
+            // failing test, which is exactly when someone needs it.
+            eprintln!(
+                "WARNING: cached contents left billing after a failed cell — delete by hand: {}",
+                failures.join("; ")
+            );
+        }
+        resume_unwind(payload);
+    }
+    assert!(
+        failures.is_empty(),
+        "every cached content a cell creates must be deleted — storage bills until it lands: {}",
+        failures.join("; ")
+    );
+}
+
+#[cfg(test)]
+mod always_deleting_cached_contents_tests {
+    use super::*;
+    use axum::http::StatusCode;
+    use std::sync::{Arc, Mutex};
+
+    /// A `cachedContents` endpoint that logs every request it sees and answers
+    /// `status` with `{}` — enough for `delete`, which discards its body.
+    ///
+    /// Local rather than a cassette because the behaviour under test is the
+    /// *failure* path, and a fixture only ever records a passing run.
+    async fn stub_cached_contents(
+        seen: Arc<Mutex<Vec<String>>>,
+        status: StatusCode,
+    ) -> (gemini::Client, tokio::task::JoinHandle<()>) {
+        let app = axum::Router::new().fallback(axum::routing::any(
+            move |method: axum::http::Method, uri: axum::http::Uri| {
+                let seen = Arc::clone(&seen);
+                async move {
+                    seen.lock()
+                        .expect("stub log should not be poisoned")
+                        .push(format!("{method} {}", uri.path()));
+                    (status, "{}")
+                }
+            },
+        ));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("stub should bind");
+        let addr = listener.local_addr().expect("stub should have an address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("stub should serve");
+        });
+        let client = gemini::Client::builder()
+            .api_key("stub-key")
+            .base_url(format!("http://{addr}"))
+            .build()
+            .expect("client should build");
+
+        (client, server)
+    }
+
+    /// The guard must issue the delete when the body panics, and must let the
+    /// *body's* panic be what the runner reports.
+    ///
+    /// This is the whole reason the guard exists and the one path no fixture
+    /// covers: a regression that dropped the cleanup would keep every recorded
+    /// cell green while leaking a billed cache on every failed recording run,
+    /// and one that reported the cleanup's failure instead would hide the
+    /// assertion the cell was written to make.
+    #[tokio::test]
+    async fn a_panicking_body_still_deletes_and_still_reports_its_own_failure() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let (client, _stub) = stub_cached_contents(Arc::clone(&seen), StatusCode::OK).await;
+
+        let panicked = AssertUnwindSafe(always_deleting_cached_contents(
+            &client,
+            &["cachedContents/leaky".to_owned()],
+            async { panic!("the assertion under test failed") },
+        ))
+        .catch_unwind()
+        .await
+        .expect_err("the body's panic should propagate");
+
+        assert_eq!(
+            panicked.downcast_ref::<&str>().copied(),
+            Some("the assertion under test failed"),
+            "the guard must surface the body's failure, not the cleanup's"
+        );
+        assert_eq!(
+            seen.lock()
+                .expect("stub log should not be poisoned")
+                .as_slice(),
+            ["DELETE /v1beta/cachedContents/leaky"],
+            "the cache must be deleted even though the body panicked"
+        );
+    }
+
+    /// A cleanup delete that fails after a *passing* body is itself the leak,
+    /// so it has to fail the cell rather than pass quietly — and the failure has
+    /// to name the handle, because that is the string someone needs to delete
+    /// the cache by hand.
+    #[tokio::test]
+    async fn a_cleanup_delete_that_fails_after_a_passing_body_fails_the_cell() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let (client, _stub) =
+            stub_cached_contents(Arc::clone(&seen), StatusCode::INTERNAL_SERVER_ERROR).await;
+
+        let panicked = AssertUnwindSafe(always_deleting_cached_contents(
+            &client,
+            &["cachedContents/undeletable".to_owned()],
+            async {},
+        ))
+        .catch_unwind()
+        .await
+        .expect_err("a cleanup delete that fails should fail the cell");
+
+        let message = panicked
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .unwrap_or_default();
+        assert!(
+            message.contains("cachedContents/undeletable"),
+            "the failure should name the handle that is still being billed: {message}"
+        );
+    }
+
+    /// One handle failing to delete must not strand the handles after it.
+    ///
+    /// The pagination cell creates three caches; an early 500 that aborted the
+    /// loop would leak two of them, which is the same bug as no cleanup at all
+    /// for two thirds of the cost.
+    #[tokio::test]
+    async fn every_handle_is_deleted_even_when_an_earlier_delete_fails() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let (client, _stub) =
+            stub_cached_contents(Arc::clone(&seen), StatusCode::INTERNAL_SERVER_ERROR).await;
+
+        let _ = AssertUnwindSafe(always_deleting_cached_contents(
+            &client,
+            &[
+                "cachedContents/one".to_owned(),
+                "cachedContents/two".to_owned(),
+                "cachedContents/three".to_owned(),
+            ],
+            async {},
+        ))
+        .catch_unwind()
+        .await;
+
+        assert_eq!(
+            seen.lock()
+                .expect("stub log should not be poisoned")
+                .as_slice(),
+            [
+                "DELETE /v1beta/cachedContents/one",
+                "DELETE /v1beta/cachedContents/two",
+                "DELETE /v1beta/cachedContents/three",
+            ],
+            "a failed delete must not abandon the handles behind it"
+        );
+    }
+
+    /// The cell that decides the asymmetry: a body that panicked *and* a
+    /// cleanup that failed.
+    ///
+    /// Neither test above can see the ordering — the panicking-body case stubs
+    /// `OK`, so there is no cleanup failure to lose to, and the two 500 cases
+    /// pass a body that never panics. Swap the `resume_unwind` and the
+    /// `failures` assert and all three stay green while the assertion the cell
+    /// was written to make is replaced by the delete's 500. That is exactly
+    /// what a failed recording run looks like: the new assertion fails, and the
+    /// delete that follows it answers 403 because the cache is already gone.
+    #[tokio::test]
+    async fn a_failing_cleanup_never_overwrites_a_panicking_body() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let (client, _stub) =
+            stub_cached_contents(Arc::clone(&seen), StatusCode::INTERNAL_SERVER_ERROR).await;
+
+        let panicked = AssertUnwindSafe(always_deleting_cached_contents(
+            &client,
+            &["cachedContents/leaky".to_owned()],
+            async { panic!("the assertion under test failed") },
+        ))
+        .catch_unwind()
+        .await
+        .expect_err("the body's panic should propagate");
+
+        assert_eq!(
+            panicked.downcast_ref::<&str>().copied(),
+            Some("the assertion under test failed"),
+            "a cleanup that also failed must not overwrite the assertion under test"
+        );
+        assert_eq!(
+            seen.lock()
+                .expect("stub log should not be poisoned")
+                .as_slice(),
+            ["DELETE /v1beta/cachedContents/leaky"],
+            "the delete must still be attempted, even though its failure is discarded"
+        );
+    }
 }

--- a/tests/providers/gemini/support.rs
+++ b/tests/providers/gemini/support.rs
@@ -21,33 +21,90 @@ use crate::cassettes::{CassetteSpec, ProviderCassette};
 /// in the cassette (a response body, a JSON schema property) cannot make an
 /// absence assertion silently pass or fail.
 pub(super) fn recorded_request_generation_configs(scenario: &str) -> Vec<serde_json::Value> {
-    let path = crate::cassettes::cassette_path("gemini", scenario);
-    let contents = std::fs::read_to_string(&path)
-        .unwrap_or_else(|error| panic!("cassette {} should be readable: {error}", path.display()));
-
-    let configs: Vec<serde_json::Value> = serde_yaml::Deserializer::from_str(&contents)
-        .map(|document| {
-            let document = serde_yaml::Value::deserialize(document)
-                .unwrap_or_else(|error| panic!("cassette document should parse: {error}"));
-            let body = document
-                .get("when")
-                .and_then(|when| when.get("body"))
-                .and_then(serde_yaml::Value::as_str)
-                .expect("each recorded interaction should carry a request body")
-                .to_owned();
-            let body: serde_json::Value = serde_json::from_str(&body)
-                .unwrap_or_else(|error| panic!("recorded request body should be JSON: {error}"));
+    recorded_request_bodies(scenario)
+        .into_iter()
+        .map(|body| {
             body.get("generationConfig")
                 .cloned()
                 .unwrap_or(serde_json::Value::Null)
         })
-        .collect();
+        .collect()
+}
+
+/// Every recorded **request** body of a scenario, parsed, in recorded order.
+///
+/// The general form of [`recorded_request_generation_configs`]. A cell whose
+/// claim is about what rig *sent* — a handle present, a field absent — can only
+/// prove it here: the response says nothing about which of them the request
+/// carried, and a cassette replays regardless.
+///
+/// Bodyless interactions are skipped rather than treated as an error, because a
+/// `cachedContents` scenario records its own `GET` and `DELETE` alongside the
+/// completion, and those carry no body by construction. The non-empty assert
+/// still catches a scenario that recorded nothing to read.
+pub(super) fn recorded_request_bodies(scenario: &str) -> Vec<serde_json::Value> {
+    let path = crate::cassettes::cassette_path("gemini", scenario);
+    let contents = std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("cassette {} should be readable: {error}", path.display()));
+
+    let bodies: Vec<serde_json::Value> =
+        serde_yaml::Deserializer::from_str(&contents)
+            .filter_map(|document| {
+                let document = serde_yaml::Value::deserialize(document)
+                    .unwrap_or_else(|error| panic!("cassette document should parse: {error}"));
+                let body = document
+                    .get("when")
+                    .and_then(|when| when.get("body"))
+                    .and_then(serde_yaml::Value::as_str)
+                    .filter(|body| !body.is_empty())?
+                    .to_owned();
+                Some(serde_json::from_str(&body).unwrap_or_else(|error| {
+                    panic!("recorded request body should be JSON: {error}")
+                }))
+            })
+            .collect();
 
     assert!(
-        !configs.is_empty(),
-        "scenario {scenario} recorded no interactions, so it asserts nothing"
+        !bodies.is_empty(),
+        "scenario {scenario} recorded no request bodies, so it asserts nothing"
     );
-    configs
+    bodies
+}
+
+/// Assert that every recorded `generateContent` request in `scenario` carried
+/// `cachedContent` and none of the three fields a cached content owns.
+///
+/// The cassette's own body matching would fail a request that changed, but only
+/// as an opaque "no recorded interaction matched" — this states the guarantee,
+/// so a cell about reading from a cache cannot quietly become a cell about
+/// something else. `cachedContents` lifecycle calls (create/delete) are skipped:
+/// they carry no `contents`.
+pub(super) fn assert_recorded_requests_read_from_a_cache(scenario: &str) {
+    let mut generate_requests = 0;
+    for (turn, body) in recorded_request_bodies(scenario).iter().enumerate() {
+        if body.get("contents").is_none_or(serde_json::Value::is_null) {
+            continue;
+        }
+        generate_requests += 1;
+        assert!(
+            body.get("cachedContent")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|handle| handle.starts_with("cachedContents/")),
+            "{scenario} turn {turn}: this cell is about reading from a cache, so every \
+             generateContent request has to carry the handle: {body}"
+        );
+        for field in ["systemInstruction", "tools", "toolConfig"] {
+            assert!(
+                body.get(field).is_none_or(serde_json::Value::is_null),
+                "{scenario} turn {turn}: the cache owns {field}, so the request must not carry \
+                 its own — and the provider would reject it: {body}"
+            );
+        }
+    }
+    assert!(
+        generate_requests > 0,
+        "{scenario} recorded no generateContent request, so it proves nothing about caching"
+    );
 }
 
 /// Assert that no recorded request for `scenario` carried a `generationConfig`


### PR DESCRIPTION
Follow-up to #2375. Six defects in the `cachedContents` code that shipped there, plus the docs correction and test-infrastructure fix that found several of them.

Three independent cold-review rounds went into this. The first found four defects in the original work; the second found three in my fix for one of them; the third found three more in the fix for *that*. Each round's findings were adversarially verified before being acted on, and one was refuted with live evidence — see the last section.

## The defects

**1. `CachedContentError::Expired` was unreachable outside the bundled transports.** `send_json` matched one error *variant*, `InvalidStatusCodeWithDetails`. `ClientBuilder::http_client` is a public extension point, and a custom `HttpClientExt` reporting the same 404 as `InvalidStatusCode` fell into the catch-all `Http` arm. Worse: a transport handing the non-success response back as `Ok` (rig's own test double does) sent the *error body* into `serde_json::from_str::<CachedContent>`, so a 404 surfaced as `Serde("missing field \`name\`")`. Either way the recovery this module documents — match `Expired`, recreate the cache — silently never fired. Triage now runs on the status, through one `classify_failure` so the two paths cannot drift.

**2. A handle spliced into the request path could retarget the call.** `delete("abc?stale")` is not a malformed URL Gemini rejects: `build_uri` switches its key separator to `&` once it sees a `?`, so it issues a well-formed `DELETE /v1beta/cachedContents/abc?stale&key=…` and destroys the cache named `abc`. `#` truncates, `/` retargets, empty aims at the collection. Now refused before anything is sent — refused rather than percent-encoded, because the id is server-assigned and opaque, so one needing escapes is a bug.

**3. The `cachedContents` listing loop was unbounded.** A cursor that keeps *changing* without progressing defeats the does-not-advance guard, so `list` never returns while the accumulator grows — rig#2334 again, on the one resource that could not reuse `paginate_models` (it is typed on `Model`/`ModelListingError` and fetches through `get_bytes`, which collapses the 403/404 triage `Expired` exists for). Bounded by `MAX_LISTING_PAGES`, and both non-terminating cases now warn: `Ok(Vec)` looks identical whether it is complete or truncated, so nothing else can tell an operator they were handed the first thousand pages of their caches.

**4. `systemInstruction` / `toolConfig` / `cached_content` walked past the conflict check.** #2375 closed this for `cachedContent` only. The check reads the typed fields; anything left in `additional_params` — which is `#[serde(flatten)]` — is not one, so a request carrying a handle *and* a smuggled system instruction was accepted, dispatched, and answered by Gemini with the 400 the check exists to pre-empt.

Both proto-JSON spellings are covered, for all four fields. Gemini accepts a field under its lowerCamelCase alias *and* its proto-original name — verified live: `cached_content` reaches the cache lookup and answers `CachedContent not found` — so a check knowing only `cachedContent` documented `cached_content` as its own bypass.

The detection deliberately never parses. An earlier attempt deserialized the blob into rig's typed `ToolConfig`, which silently dropped `allowedFunctionNames` (turning a request restricted to one function into one free to call any) and hard-failed every `mode` rig does not model. `additional_params` is the escape hatch for shapes rig has no type for; narrowing it is the one thing that path must never do. `a_smuggled_field_reaches_the_wire_exactly_as_the_caller_wrote_it` forbids that implementation.

**5. Recorded cells leaked billed caches when an assertion failed.** Gemini bills storage per token-hour from `create` until `delete`. `run_cache_probe` and `assert_cache_conformance` are shared across every provider's cache suite and panic from the inside, so the hand-rolled "compute failure, delete, then panic" pattern could not cover them. `always_deleting_cached_contents` catches the unwind; the body's panic wins over a cleanup failure, but a failed cleanup after a *passing* body fails the cell.

**6. The docs were wrong about what can read from a cache.** The conflict error offered one remedy — *move them into the cache* — which is right for a system instruction and wrong for tools: an `Agent` derives what it advertises and what it dispatches from one registry snapshot, so cached function declarations are undispatchable from any agent. Following the old advice buys a cache nothing can use. The tools arm now says so, gated on *function* declarations, because a provider-hosted tool is the exception.

## Two claims that now have recordings instead of prose

- `edge_agent_active_tools_suppressed` — an empty `RequestPatch::active_tools` allow-list does let a tool-holding agent read from a cache. The docs originally claimed this was impossible; it is not, and the recorded request carries the handle and no `tools` field.
- `edge_cached_code_execution` — a cache carrying only `codeExecution`, used by an agent declaring nothing, runs the tool on Gemini's side. The recording shows `executableCode` with `print(7919 * 6841)` and `codeExecutionResult` `OUTCOME_OK` / `54173879`, for a request with no `tools` key.

Both cells assert against the recorded bytes rather than the model's answer — a model can multiply two numbers in its head and return the right string with no tool involved.

## One review finding refuted with live evidence

A reviewer held that the duplicate JSON member rig emits for a blob field (`"toolConfig":null` from the typed slot, then the caller's copy) is rejected by Google's proto-JSON parser, "so the escape hatch 400s for every caller who uses it", and that the fix was `skip_serializing_if`. That generalized from a probe using two *non-null* values. Measured directly:

- `{"toolConfig":null,"toolConfig":{…"allowedFunctionNames":["get_weather"]}}` → **200, and the allow-list is honoured**. A `null` claims no oneof.
- two *non-null* `systemInstruction` → **400, `oneof field '_system_instruction' is already set`**
- two *non-null* `toolConfig` → **200, and the two allow-lists merge** — a request allowing only `get_weather` plus a blob allowing only `get_time` called **both**.

So pass-through works, and `skip_serializing_if` — which would drop `"systemInstruction":null` from every recorded request body and invalidate the cassette corpus — is not needed. The behaviour is pinned by a test that says if it ever fails, the answer is a deliberate re-record. The last two measurements also corrected the set-twice error messages, which had claimed the provider "takes the last": it does not — it refuses one and merges the other, and merging is the more dangerous outcome, because the narrower restriction stops restricting rather than losing.

## Verification

- `cargo test --workspace` — **5,759 passed, 0 failed**
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check`, `cargo doc` with `-D rustdoc::broken-intra-doc-links`, doctests — clean
- cassette-safety scan clean; both new fixtures replay key-free with no unscrubbed handles
- **zero live caches on the account** after recording — every cell deletes what it created, including on the failure path

Every production change is mutation-verified: reverting `declares_functions` to `self.tools.is_some()`, reverting the typed round-trip, dropping `additional_params` from the guard, narrowing `CACHED_CONTENT` to one spelling, and removing the blob `tools` lookup each fail a specific cell that passes otherwise.

Note on history: `167eefec2` introduces the lossy typed lift and `b7499a8e3` reverts it. Left as a pair on purpose — the second commit's message is the explanation of why the obvious implementation is wrong, which is the part worth reading before someone tries it again.
