### PR TITLE
fix(openai-compatible): let llama.cpp receive an image in a tool result, plus two cassette-hygiene bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- *(openai-compatible)* [**breaking**] `openai::completion::ToolResultContent` is now an enum (`Text`/`Image`) rather than a struct with a public `text` field, `ToolResultContentType` is gone, and `OpenAIRequestParams` gained a `supports_image_tool_results` field — struct-literal construction of any of these needs updating (by [gold-silver-copper](https://github.com/gold-silver-copper))
 - *(openai-compatible)* `OpenAICompatibleProvider::SUPPORTS_IMAGE_TOOL_RESULTS`, letting a server that honours an image inside a `role:"tool"` message receive one; enabled for llamafile/llama.cpp, off everywhere else because official OpenAI refuses it on Chat Completions (by [gold-silver-copper](https://github.com/gold-silver-copper))
 - *(gemini)* explicit context caching (`cachedContents`) — create, reuse and delete a server-side cache that hits from the first request ([#2375](https://github.com/0xPlaygrounds/rig/pull/2375)) (by [gold-silver-copper](https://github.com/gold-silver-copper))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- *(openai-compatible)* `OpenAICompatibleProvider::SUPPORTS_IMAGE_TOOL_RESULTS`, letting a server that honours an image inside a `role:"tool"` message receive one; enabled for llamafile/llama.cpp, off everywhere else because official OpenAI refuses it on Chat Completions (by [gold-silver-copper](https://github.com/gold-silver-copper))
 - *(gemini)* explicit context caching (`cachedContents`) — create, reuse and delete a server-side cache that hits from the first request ([#2375](https://github.com/0xPlaygrounds/rig/pull/2375)) (by [gold-silver-copper](https://github.com/gold-silver-copper))
 
 ### Fixed

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -738,6 +738,7 @@ where
             strict_tools: self.strict_tools,
             tool_result_array_content: self.tool_result_array_content,
             supports_response_format: true,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
     }

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -431,6 +431,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: DeepSeekExt::SUPPORTS_RESPONSE_FORMAT,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
         .expect("request should convert");

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -346,6 +346,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: true,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
         .expect("Groq request should convert");
@@ -370,6 +371,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: true,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
         .expect("request should convert");
@@ -440,6 +442,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: true,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
         .expect("request should convert");
@@ -476,6 +479,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: true,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
         .expect("request should convert");

--- a/crates/rig-core/src/providers/hyperbolic.rs
+++ b/crates/rig-core/src/providers/hyperbolic.rs
@@ -351,6 +351,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: super::HyperbolicExt::SUPPORTS_RESPONSE_FORMAT,
+            supports_image_tool_results: false,
             supports_tools: false,
         })
         .expect("request should convert");

--- a/crates/rig-core/src/providers/llamafile.rs
+++ b/crates/rig-core/src/providers/llamafile.rs
@@ -66,6 +66,13 @@ impl openai::completion::OpenAICompatibleProvider for LlamafileExt {
     // llama.cpp-based servers can emit a whole tool call in one streaming chunk.
     const EMITS_COMPLETE_SINGLE_CHUNK_TOOL_CALLS: bool = true;
 
+    // llama.cpp delivers an image inside a `role:"tool"` message to the model,
+    // unlike official OpenAI. Measured against `llama-server` b1-6d05498 with
+    // Qwen3-VL-2B: a solid-colour square handed back through a tool is named
+    // correctly for magenta, green and yellow, matching a control that sends the
+    // same bytes in a `user` message.
+    const SUPPORTS_IMAGE_TOOL_RESULTS: bool = true;
+
     type Response = openai::CompletionResponse;
 }
 

--- a/crates/rig-core/src/providers/moonshot.rs
+++ b/crates/rig-core/src/providers/moonshot.rs
@@ -183,6 +183,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: MoonshotExt::SUPPORTS_RESPONSE_FORMAT,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
         .expect("request should convert");
@@ -303,6 +304,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: MoonshotExt::SUPPORTS_RESPONSE_FORMAT,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
         .expect("request should convert");

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -467,8 +467,8 @@ impl ToolResultContentValue {
     ///
     /// Lossy by construction: an image part has no textual rendering, so a
     /// caller flattening a result that carries one loses it. That is why
-    /// [`Self::normalize_for_wire`] refuses rather than flattens when a provider
-    /// cannot carry the image.
+    /// the per-provider normalization in `TryFrom<OpenAIRequestParams>` refuses
+    /// rather than flattens when a provider cannot carry the image.
     pub fn as_text(&self) -> String {
         match self {
             ToolResultContentValue::Array(arr) => arr
@@ -477,6 +477,39 @@ impl ToolResultContentValue {
                 .collect::<Vec<_>>()
                 .join("\n"),
             ToolResultContentValue::String(s) => s.clone(),
+        }
+    }
+
+    /// Convert into rig's tool-result content blocks, preserving image parts.
+    ///
+    /// The counterpart of the outbound conversion. A round trip through the
+    /// wire and back must not quietly become text-only, or a replayed history
+    /// says less than the one that produced it.
+    pub fn into_message_content(self) -> Vec<message::ToolResultContent> {
+        match self {
+            ToolResultContentValue::String(text) => vec![message::ToolResultContent::text(text)],
+            ToolResultContentValue::Array(parts) => parts
+                .into_iter()
+                .map(|part| match part {
+                    ToolResultContent::Text { text } => message::ToolResultContent::text(text),
+                    ToolResultContent::Image { image_url } => {
+                        // A base64 data URI round-trips back to its parts;
+                        // anything else stays a URL reference.
+                        match parse_image_data_uri(&image_url.url) {
+                            Some((mime, data)) => message::ToolResultContent::image_base64(
+                                data,
+                                message::ImageMediaType::from_mime_type(mime),
+                                image_url.detail,
+                            ),
+                            None => message::ToolResultContent::image_url(
+                                image_url.url,
+                                None,
+                                image_url.detail,
+                            ),
+                        }
+                    }
+                })
+                .collect(),
         }
     }
 
@@ -494,6 +527,16 @@ impl ToolResultContentValue {
             }
         }
     }
+}
+
+/// Split a base64 data URI into `(mime, base64)`, or `None` for a plain URL.
+///
+/// `rsplit_once` on the marker rather than `split_once`, so a URL that happens
+/// to contain `;base64,` earlier does not truncate the payload.
+fn parse_image_data_uri(url: &str) -> Option<(&str, &str)> {
+    let rest = url.strip_prefix("data:")?;
+    let (mime, data) = rest.rsplit_once(";base64,")?;
+    (!data.is_empty()).then_some((mime, data))
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -693,11 +736,31 @@ impl TryFrom<message::ToolResult> for Message {
                             })?;
                             format!("data:{};base64,{}", media_type.to_mime_type(), data)
                         }
-                        other => {
-                            return Err(message::MessageError::ConversionError(format!(
-                                "unsupported image source in a tool result: {other:?}; use a URL \
-                                 or base64"
-                            )));
+                        // Deliberately payload-free: `DocumentSourceKind::Raw`
+                        // Debug-formats as the entire byte vector, so `{other:?}`
+                        // would dump a whole image into an error string. The
+                        // user-image path one screen away avoids this the same way.
+                        DocumentSourceKind::Raw(_) => {
+                            return Err(message::MessageError::ConversionError(
+                                "raw image bytes are not supported in a tool result; encode as \
+                                 base64 first"
+                                    .into(),
+                            ));
+                        }
+                        // Named, never Debug-printed: `FileId` and `String`
+                        // carry caller data and `Unknown` carries nothing worth
+                        // quoting.
+                        DocumentSourceKind::FileId(_) => {
+                            return Err(message::MessageError::ConversionError(
+                                "a provider-side file id is not supported in a tool result on \
+                                 this surface; use a URL or base64"
+                                    .into(),
+                            ));
+                        }
+                        DocumentSourceKind::String(_) | DocumentSourceKind::Unknown => {
+                            return Err(message::MessageError::ConversionError(
+                                "this image carries no usable source; use a URL or base64".into(),
+                            ));
                         }
                     };
                     Ok(ToolResultContent::Image {
@@ -1100,10 +1163,16 @@ impl TryFrom<Message> for message::Message {
             } => message::Message::User {
                 // OpenAI chat tool messages carry no tool name; this
                 // conversion is lossy for name-keyed wires.
+                // Every part is carried back, images included. Flattening with
+                // `as_text()` would drop an image silently — the same loss the
+                // outbound gate refuses to commit, and worse here because it
+                // used to be impossible: before `ToolResultContent` grew an
+                // image variant, such a body failed to deserialize at all, so
+                // the loss was at least visible.
                 content: vec![message::UserContent::tool_result_from_wire(
                     tool_call_id,
                     "",
-                    vec![message::ToolResultContent::text(content.as_text())],
+                    content.into_message_content(),
                 )],
             },
 
@@ -2151,8 +2220,15 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
                         // GPT-5 family, a 200 with the image discarded — so a
                         // local error naming the constraint beats both.
                         return Err(CompletionError::RequestError(
-                            "this provider does not accept an image in a tool result. Official                              OpenAI refuses it on Chat Completions (and the GPT-5 family accepts                              the request while ignoring the image); use the Responses API, which                              carries images in `function_call_output`, or a server that sets                              `SUPPORTS_IMAGE_TOOL_RESULTS` (llama.cpp does)"
-                                .into(),
+                            concat!(
+                                "this provider does not accept an image in a tool result. ",
+                                "Official OpenAI refuses it on Chat Completions (and the GPT-5 ",
+                                "family accepts the request while ignoring the image); use the ",
+                                "Responses API, which carries images in `function_call_output`, ",
+                                "or a server that sets `SUPPORTS_IMAGE_TOOL_RESULTS` ",
+                                "(llama.cpp does)",
+                            )
+                            .into(),
                         ));
                     }
                     // An image cannot be flattened to a string, so array form is
@@ -4804,6 +4880,63 @@ mod image_tool_result_gate_tests {
             panic!("expected a tool result");
         };
         assert_eq!(content.as_text(), "ok");
+    }
+
+    /// A wire tool result carrying an image converts back into rig's types with
+    /// the image intact.
+    ///
+    /// The inbound counterpart of the gate. Flattening with `as_text()` turned
+    /// this into `Text("")` — a silent drop, and one that used to be impossible:
+    /// before the image variant existed such a body failed to deserialize, so
+    /// the loss was at least loud.
+    #[test]
+    fn an_inbound_tool_result_image_is_not_flattened_away() {
+        let wire: Message = serde_json::from_str(
+            r#"{"role":"tool","tool_call_id":"c1","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0KGgo="}}]}"#,
+        )
+        .expect("deserialize");
+
+        let converted = message::Message::try_from(wire).expect("convert back");
+        let message::Message::User { content } = converted else {
+            panic!("a tool result converts to a user message");
+        };
+        let message::UserContent::ToolResult(result) = &content[0] else {
+            panic!("expected a tool result");
+        };
+        assert!(
+            matches!(
+                result.content.first(),
+                Some(message::ToolResultContent::Image(_))
+            ),
+            "the image must survive the round trip, got {:?}",
+            result.content
+        );
+    }
+
+    /// A mixed result keeps both halves, in order.
+    #[test]
+    fn an_inbound_mixed_tool_result_keeps_text_and_image() {
+        let wire: Message = serde_json::from_str(
+            r#"{"role":"tool","tool_call_id":"c1","content":[{"type":"text","text":"here"},{"type":"image_url","image_url":{"url":"https://example.com/x.png"}}]}"#,
+        )
+        .expect("deserialize");
+
+        let converted = message::Message::try_from(wire).expect("convert back");
+        let message::Message::User { content } = converted else {
+            panic!("user message")
+        };
+        let message::UserContent::ToolResult(result) = &content[0] else {
+            panic!("tool result")
+        };
+        assert_eq!(result.content.len(), 2, "{:?}", result.content);
+        assert!(matches!(
+            result.content[0],
+            message::ToolResultContent::Text(_)
+        ));
+        assert!(matches!(
+            result.content[1],
+            message::ToolResultContent::Image(_)
+        ));
     }
 
     /// And the image shape round-trips.

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -370,18 +370,67 @@ pub struct FileData {
     pub filename: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
-pub struct ToolResultContent {
-    #[serde(default)]
-    r#type: ToolResultContentType,
-    pub text: String,
+/// One content part of a tool-result message.
+///
+/// Text is the only part official OpenAI accepts here; an image is refused with
+/// a 400 on `gpt-4o` and, worse, accepted-and-discarded on the GPT-5 family.
+/// Some OpenAI-compatible servers do honour an image — llama.cpp delivers one to
+/// the model, measured — so the variant exists and emitting it is gated on
+/// [`super::completion::OpenAICompatibleProvider::SUPPORTS_IMAGE_TOOL_RESULTS`].
+#[derive(Debug, Serialize, PartialEq, Clone)]
+#[serde(tag = "type")]
+pub enum ToolResultContent {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "image_url")]
+    Image { image_url: ImageUrl },
 }
 
-#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone)]
-#[serde(rename_all = "lowercase")]
-pub enum ToolResultContentType {
-    #[default]
-    Text,
+/// Deserialization is deliberately hand-written rather than derived from the
+/// `tag = "type"` above.
+///
+/// The struct this replaced carried `#[serde(default)] r#type`, so a stored
+/// history whose tool-result parts omit `type` still loaded. A derived
+/// internally-tagged enum makes the tag mandatory, and because
+/// [`ToolResultContentValue`] is `#[serde(untagged)]` the real cause
+/// (`missing field \`type\``) is swallowed into "data did not match any
+/// variant". `Message` is public and derives `Deserialize`, so that tolerance is
+/// load-bearing for anyone replaying a persisted conversation.
+impl<'de> Deserialize<'de> for ToolResultContent {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct Wire {
+            #[serde(default)]
+            r#type: Option<String>,
+            #[serde(default)]
+            text: Option<String>,
+            #[serde(default)]
+            image_url: Option<ImageUrl>,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        match (wire.r#type.as_deref(), wire.image_url, wire.text) {
+            (Some("image_url"), Some(image_url), _) => Ok(Self::Image { image_url }),
+            // An absent `type` is the tolerated legacy shape; so is an explicit
+            // `"text"`. Anything else with a `text` field is still text — the
+            // tag is advisory here, never a reason to fail a load.
+            (_, _, Some(text)) => Ok(Self::Text { text }),
+            (_, Some(image_url), None) => Ok(Self::Image { image_url }),
+            _ => Err(serde::de::Error::custom(
+                "tool result content part carried neither `text` nor `image_url`",
+            )),
+        }
+    }
+}
+
+impl ToolResultContent {
+    /// The text of this part, or `None` for a non-text part.
+    pub fn as_text(&self) -> Option<&str> {
+        match self {
+            Self::Text { text } => Some(text.as_str()),
+            Self::Image { .. } => None,
+        }
+    }
 }
 
 impl FromStr for ToolResultContent {
@@ -394,10 +443,7 @@ impl FromStr for ToolResultContent {
 
 impl From<String> for ToolResultContent {
     fn from(s: String) -> Self {
-        ToolResultContent {
-            r#type: ToolResultContentType::default(),
-            text: s,
-        }
+        ToolResultContent::Text { text: s }
     }
 }
 
@@ -417,15 +463,27 @@ impl ToolResultContentValue {
         }
     }
 
+    /// The text of this tool result, with any non-text parts skipped.
+    ///
+    /// Lossy by construction: an image part has no textual rendering, so a
+    /// caller flattening a result that carries one loses it. That is why
+    /// [`Self::normalize_for_wire`] refuses rather than flattens when a provider
+    /// cannot carry the image.
     pub fn as_text(&self) -> String {
         match self {
             ToolResultContentValue::Array(arr) => arr
                 .iter()
-                .map(|c| c.text.clone())
+                .filter_map(ToolResultContent::as_text)
                 .collect::<Vec<_>>()
                 .join("\n"),
             ToolResultContentValue::String(s) => s.clone(),
         }
+    }
+
+    /// Whether any part of this result is an image.
+    pub fn has_image(&self) -> bool {
+        matches!(self, ToolResultContentValue::Array(arr)
+            if arr.iter().any(|c| matches!(c, ToolResultContent::Image { .. })))
     }
 
     pub fn to_array(&self) -> Self {
@@ -607,17 +665,52 @@ impl TryFrom<message::ToolResult> for Message {
             .content
             .into_iter()
             .map(|content| match content {
-                message::ToolResultContent::Text(message::Text { text, .. }) => Ok(ToolResultContent::from(text)),
-                message::ToolResultContent::Json { value } => Ok(ToolResultContent::from(value.to_string())),
-                message::ToolResultContent::Image(_) => Err(message::MessageError::ConversionError(
-                    "OpenAI Chat Completions does not support images in tool results. Tool results must be text."
-                        .into(),
-                )),
+                message::ToolResultContent::Text(message::Text { text, .. }) => {
+                    Ok(ToolResultContent::from(text))
+                }
+                message::ToolResultContent::Json { value } => {
+                    Ok(ToolResultContent::from(value.to_string()))
+                }
+                // Represented here, refused (or not) at the wire step: whether
+                // an image may ride in a `role:"tool"` message is a per-server
+                // fact, and this conversion has no provider context. See
+                // `ToolResultContentValue::normalize_for_wire`.
+                message::ToolResultContent::Image(message::Image {
+                    data,
+                    media_type,
+                    detail,
+                    ..
+                }) => {
+                    let url = match data {
+                        DocumentSourceKind::Url(url) => url,
+                        DocumentSourceKind::Base64(data) => {
+                            let media_type = media_type.ok_or_else(|| {
+                                message::MessageError::ConversionError(
+                                    "a base64 image in a tool result needs a media type to build \
+                                     its data URI"
+                                        .into(),
+                                )
+                            })?;
+                            format!("data:{};base64,{}", media_type.to_mime_type(), data)
+                        }
+                        other => {
+                            return Err(message::MessageError::ConversionError(format!(
+                                "unsupported image source in a tool result: {other:?}; use a URL \
+                                 or base64"
+                            )));
+                        }
+                    };
+                    Ok(ToolResultContent::Image {
+                        image_url: ImageUrl { url, detail },
+                    })
+                }
             })
             .collect::<Result<Vec<_>, _>>()?;
 
+        // Only a lone *text* part flattens to a bare string; an image has no
+        // string form, so flattening it would silently discard it.
         let content = match parts.as_slice() {
-            [part] => ToolResultContentValue::String(part.text.clone()),
+            [ToolResultContent::Text { text }] => ToolResultContentValue::String(text.clone()),
             _ => ToolResultContentValue::Array(parts),
         };
 
@@ -1504,6 +1597,26 @@ pub trait OpenAICompatibleProvider: crate::client::Provider {
     /// this to false.
     const STREAM_INCLUDE_USAGE: bool = true;
 
+    /// Whether this server honours an image inside a `role:"tool"` message.
+    ///
+    /// `false` everywhere by default, because official OpenAI does not: Chat
+    /// Completions answers 400 on `gpt-4o`/`gpt-4o-mini`, and on the GPT-5
+    /// family it answers 200 with the image discarded and the model describing
+    /// something it never received. An array of *text* parts is fine on both, so
+    /// this is about the image, not about array content.
+    ///
+    /// Some OpenAI-compatible servers do honour it. Measured on llama.cpp
+    /// (`b1-6d05498`, Qwen3-VL-2B): a magenta/green/yellow square handed back
+    /// through a tool is named correctly 3/3, matching a control that sends the
+    /// same bytes in a `user` message — so the image genuinely reaches the
+    /// model. Providers whose server does that set this `true`.
+    ///
+    /// When `false`, a tool result carrying an image is refused before the
+    /// request leaves the process rather than being flattened to text (which
+    /// would silently drop it) or sent (which the provider answers with a 400,
+    /// or worse, accepts and ignores).
+    const SUPPORTS_IMAGE_TOOL_RESULTS: bool = false;
+
     /// Map a streamed terminal reason for this compatible provider.
     ///
     /// The normalized Chat Completions field is the default contract. Gateway
@@ -1601,6 +1714,7 @@ pub trait OpenAICompatibleProvider: crate::client::Provider {
             tool_result_array_content: options.tool_result_array_content,
             supports_response_format: Self::SUPPORTS_RESPONSE_FORMAT,
             supports_tools: Self::SUPPORTS_TOOLS,
+            supports_image_tool_results: Self::SUPPORTS_IMAGE_TOOL_RESULTS,
         })
     }
 
@@ -1959,6 +2073,8 @@ pub struct OpenAIRequestParams {
     pub request: CoreCompletionRequest,
     pub strict_tools: bool,
     pub tool_result_array_content: bool,
+    /// See [`OpenAICompatibleProvider::SUPPORTS_IMAGE_TOOL_RESULTS`].
+    pub supports_image_tool_results: bool,
     /// Maps `output_schema` to `response_format` when true; drops it with a
     /// warning when false (providers whose APIs reject `json_schema`).
     pub supports_response_format: bool,
@@ -1976,6 +2092,7 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
             request: req,
             strict_tools,
             tool_result_array_content,
+            supports_image_tool_results,
             supports_response_format,
             supports_tools,
         } = params;
@@ -2020,8 +2137,30 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
             ));
         }
 
+        // Per-provider normalization of tool-result content. This is the only
+        // place with both the parts and the provider's capabilities in hand —
+        // `TryFrom<message::ToolResult>` has neither.
         for msg in &mut full_history {
             if let Message::ToolResult { content, .. } = msg {
+                if content.has_image() {
+                    if !supports_image_tool_results {
+                        // Refused rather than flattened: `as_text()` would drop
+                        // the image and send a tool result that silently says
+                        // less than the caller asked for. Official OpenAI
+                        // answers this shape with a 400 on gpt-4o and, on the
+                        // GPT-5 family, a 200 with the image discarded — so a
+                        // local error naming the constraint beats both.
+                        return Err(CompletionError::RequestError(
+                            "this provider does not accept an image in a tool result. Official                              OpenAI refuses it on Chat Completions (and the GPT-5 family accepts                              the request while ignoring the image); use the Responses API, which                              carries images in `function_call_output`, or a server that sets                              `SUPPORTS_IMAGE_TOOL_RESULTS` (llama.cpp does)"
+                                .into(),
+                        ));
+                    }
+                    // An image cannot be flattened to a string, so array form is
+                    // forced regardless of `tool_result_array_content`.
+                    *content = content.to_array();
+                    continue;
+                }
+
                 let normalized = if tool_result_array_content {
                     content.to_array()
                 } else {
@@ -2163,6 +2302,7 @@ impl TryFrom<(String, CoreCompletionRequest)> for CompletionRequest {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: true,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
     }
@@ -2651,6 +2791,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: true,
             supports_response_format: true,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
         .expect("request conversion should succeed");
@@ -2686,6 +2827,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: true,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
         .expect("request conversion should succeed");
@@ -2756,6 +2898,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: true,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
         .expect("request conversion should succeed");
@@ -2787,6 +2930,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: true,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
         .expect("request conversion should succeed");
@@ -2813,6 +2957,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: true,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
         .expect("request conversion should succeed");
@@ -2872,6 +3017,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: true,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
         .expect("request conversion should succeed");
@@ -3320,6 +3466,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: true,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
         .expect("request conversion should succeed");
@@ -3352,6 +3499,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: true,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
         .expect("request conversion should succeed")
@@ -3511,6 +3659,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: true,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
         .expect("request conversion should succeed");
@@ -3565,6 +3714,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: true,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
         .expect("request conversion should succeed");
@@ -3606,6 +3756,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: true,
+            supports_image_tool_results: false,
             supports_tools: true,
         });
 
@@ -3657,6 +3808,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: true,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
         .expect("request conversion should succeed");
@@ -3728,6 +3880,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: true,
+            supports_image_tool_results: false,
             supports_tools: true,
         })
         .expect("request conversion should succeed");
@@ -4492,5 +4645,179 @@ mod tests {
             assert_eq!(reassembled.provider_request_id.as_deref(), Some(REQUEST_ID));
             assert_eq!(normalized.provider_request_id.as_deref(), Some(REQUEST_ID));
         }
+    }
+}
+
+#[cfg(test)]
+mod image_tool_result_gate_tests {
+    //! The per-provider gate on images in `role:"tool"` messages.
+    //!
+    //! Measured, not assumed. Official OpenAI Chat Completions answers 400 on
+    //! `gpt-4o`/`gpt-4o-mini` (*"Image URLs are only allowed for messages with
+    //! role 'user'"*) and, on `gpt-5` … `gpt-5.5`, answers 200 with the image
+    //! discarded and the model describing what it never received. llama.cpp
+    //! (`b1-6d05498`, Qwen3-VL-2B) delivers it: a magenta/green/yellow square
+    //! handed back through a tool is named correctly 3/3, matching a control
+    //! that sends the same bytes in a `user` message.
+    //!
+    //! These are unit tests rather than cassettes because the behaviour under
+    //! test is a *local* refusal — no request is made, so there is nothing to
+    //! record. The provider-side facts they encode are pinned by recorded cells
+    //! in the llamafile and openai suites.
+
+    use super::*;
+    use crate::message;
+
+    fn params(
+        supports_image_tool_results: bool,
+        content: Vec<message::ToolResultContent>,
+    ) -> OpenAIRequestParams {
+        OpenAIRequestParams {
+            model: "test-model".to_string(),
+            request: crate::completion::CompletionRequest {
+                model: None,
+                preamble: None,
+                chat_history: vec![message::Message::User {
+                    content: vec![message::UserContent::ToolResult(message::ToolResult {
+                        call: message::ToolCallId::new_or_mint("call_1"),
+                        provider: message::ProviderCallId::new("call_1"),
+                        name: "view_file".to_string(),
+                        content,
+                    })],
+                }],
+                documents: vec![],
+                tools: vec![],
+                temperature: None,
+                max_tokens: None,
+                tool_choice: None,
+                additional_params: None,
+                output_schema: None,
+                record_telemetry_content: false,
+            },
+            strict_tools: false,
+            tool_result_array_content: false,
+            supports_image_tool_results,
+            supports_tools: true,
+            supports_response_format: true,
+        }
+    }
+
+    fn image() -> message::ToolResultContent {
+        message::ToolResultContent::image_base64(
+            "iVBORw0KGgo=",
+            Some(message::ImageMediaType::PNG),
+            None,
+        )
+    }
+
+    /// A provider that cannot carry the image refuses locally rather than
+    /// flattening it away or letting the provider answer.
+    #[test]
+    fn an_image_tool_result_is_refused_when_the_provider_cannot_carry_it() {
+        let error = CompletionRequest::try_from(params(false, vec![image()]))
+            .expect_err("a provider without the capability must refuse");
+        let message = error.to_string();
+        assert!(
+            message.contains("does not accept an image in a tool result"),
+            "{message}"
+        );
+        assert!(
+            message.contains("Responses API"),
+            "the refusal should name the surface that works: {message}"
+        );
+    }
+
+    /// The same request is built when the provider does carry it.
+    #[test]
+    fn an_image_tool_result_is_sent_when_the_provider_supports_it() {
+        let request = CompletionRequest::try_from(params(true, vec![image()]))
+            .expect("a capable provider should accept the image");
+        let wire = serde_json::to_value(&request.messages).expect("serialize");
+        let content = &wire[0]["content"];
+        assert_eq!(content[0]["type"], "image_url", "{wire}");
+        assert!(
+            content[0]["image_url"]["url"]
+                .as_str()
+                .is_some_and(|u| u.starts_with("data:image/png;base64,")),
+            "{wire}"
+        );
+    }
+
+    /// An image forces array form even when the provider flattens text results,
+    /// because a string has nowhere to put it.
+    #[test]
+    fn an_image_forces_array_content_even_when_flattening_is_configured() {
+        let request = CompletionRequest::try_from(params(true, vec![image()])).expect("build");
+        let wire = serde_json::to_value(&request.messages).expect("serialize");
+        assert!(
+            wire[0]["content"].is_array(),
+            "image results must stay an array: {wire}"
+        );
+    }
+
+    /// Text-only results are untouched by the gate, on both settings.
+    #[test]
+    fn a_text_tool_result_is_unaffected_by_the_gate() {
+        for supports in [false, true] {
+            let request = CompletionRequest::try_from(params(
+                supports,
+                vec![message::ToolResultContent::text("ok")],
+            ))
+            .unwrap_or_else(|e| {
+                panic!("text results must always build (supports={supports}): {e}")
+            });
+            let wire = serde_json::to_value(&request.messages).expect("serialize");
+            assert_eq!(wire[0]["content"], "ok", "supports={supports}: {wire}");
+        }
+    }
+
+    /// A mixed result is refused as a whole rather than silently losing its
+    /// image half.
+    #[test]
+    fn a_mixed_text_and_image_result_is_refused_rather_than_partly_sent() {
+        let error = CompletionRequest::try_from(params(
+            false,
+            vec![
+                message::ToolResultContent::text("here is the file"),
+                image(),
+            ],
+        ))
+        .expect_err("the image half cannot be dropped silently");
+        assert!(
+            error.to_string().contains("does not accept an image"),
+            "{error}"
+        );
+    }
+
+    /// The legacy wire shape — a content part with no `type` key — still
+    /// deserializes. The struct this enum replaced carried
+    /// `#[serde(default)] r#type`, and `ToolResultContentValue` is untagged, so
+    /// a derived tagged enum would swallow the real cause into "data did not
+    /// match any variant" and break replay of stored histories.
+    #[test]
+    fn a_content_part_without_a_type_key_still_deserializes() {
+        let parsed: Message = serde_json::from_str(
+            r#"{"role":"tool","tool_call_id":"c1","content":[{"text":"ok"}]}"#,
+        )
+        .expect("a type-less text part is the tolerated legacy shape");
+        let Message::ToolResult { content, .. } = parsed else {
+            panic!("expected a tool result");
+        };
+        assert_eq!(content.as_text(), "ok");
+    }
+
+    /// And the image shape round-trips.
+    #[test]
+    fn an_image_part_round_trips_through_serde() {
+        let parsed: Message = serde_json::from_str(
+            r#"{"role":"tool","tool_call_id":"c1","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,AAAA"}}]}"#,
+        )
+        .expect("an image part should deserialize");
+        let Message::ToolResult { content, .. } = parsed else {
+            panic!("expected a tool result");
+        };
+        assert!(content.has_image());
+        let wire = serde_json::to_value(&content).expect("serialize");
+        assert_eq!(wire[0]["type"], "image_url");
     }
 }

--- a/crates/rig-core/src/providers/perplexity.rs
+++ b/crates/rig-core/src/providers/perplexity.rs
@@ -184,6 +184,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: PerplexityExt::SUPPORTS_RESPONSE_FORMAT,
+            supports_image_tool_results: false,
             supports_tools: PerplexityExt::SUPPORTS_TOOLS,
         })
         .expect("unsupported tools should be dropped, not an error");
@@ -246,6 +247,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: PerplexityExt::SUPPORTS_RESPONSE_FORMAT,
+            supports_image_tool_results: false,
             supports_tools: false,
         })
         .expect("request should convert");

--- a/crates/rig-core/src/providers/together/completion.rs
+++ b/crates/rig-core/src/providers/together/completion.rs
@@ -199,6 +199,7 @@ mod tests {
             strict_tools: false,
             tool_result_array_content: false,
             supports_response_format: false,
+            supports_image_tool_results: false,
             supports_tools: true,
         });
         assert!(matches!(result, Err(CompletionError::RequestError(_))));

--- a/tests/cassette_cache_prefix.rs
+++ b/tests/cassette_cache_prefix.rs
@@ -951,12 +951,18 @@ const NO_CACHE_SUITE: &[(&str, &str)] = &[
     ),
     (
         "llamafile",
-        "same as ollama: the local llama.cpp-compatible wire reports no cached-token field, so \
-         rig has no cache mapping for it",
+        "records against a local llama.cpp server that is not running in this environment. NOT \
+         the ollama reason: llama.cpp does report caching — measured against `llama-server` \
+         b1-6d05498, a repeated prefix comes back with `usage.prompt_tokens_details.cached_tokens` \
+         28 of 29 and `timings.cache_n` to match — and rig does map it, through \
+         `openai::Usage::to_normalized`. So this suite is worth building the day a server is \
+         available; it is absent for want of one, not for want of a field",
     ),
     (
         "llamacpp",
-        "same as ollama and llamafile: the local llama.cpp wire reports no cached-token field",
+        "same as llamafile: a local llama.cpp server is not running in this environment. The wire \
+         does report cached tokens and rig does map them, so this exemption is about the server, \
+         not the capability",
     ),
     (
         "voyageai",

--- a/tests/cassettes/llamafile/image_tool_result/a_tool_result_image_is_read_by_the_model.yaml
+++ b/tests/cassettes/llamafile/image_tool_result/a_tool_result_image_is_read_by_the_model.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/chat/completions
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"max_tokens":30,"messages":[{"role":"assistant","tool_calls":[{"function":{"arguments":"{}","name":"view_file"},"id":"call_REDACTED_1","type":"function"}]},{"content":[{"image_url":{"url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAFklEQVR4nGP4z/CfJMQwqmFUw/DVAAAg0/4QF5nKuAAAAABJRU5ErkJggg=="},"type":"image_url"}],"role":"tool","tool_call_id":"call_REDACTED_1"},{"content":"Call view_file, then reply with ONLY the dominant colour name.","role":"user"}],"model":"Qwen3-VL-2B-Instruct-Q8_0","temperature":0.0}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=utf-8
+  body: '{"choices":[{"finish_reason":"stop","index":0,"message":{"content":"Pink","role":"assistant"}}],"created":0,"id":"chatcmpl-REDACTED_1","model":"/REDACTED_PATH/Qwen3-VL-2B-Instruct-Q8_0.gguf","object":"chat.completion","system_fingerprint":"b1-6d05498","timings":{"cache_n":0,"predicted_ms":8.02,"predicted_n":2,"predicted_per_second":124.68827930174564,"predicted_per_token_ms":8.02,"prompt_ms":336.992,"prompt_n":61,"prompt_per_second":181.01319912638874,"prompt_per_token_ms":5.524459016393443},"usage":{"completion_tokens":2,"prompt_tokens":61,"prompt_tokens_details":{"cached_tokens":0},"total_tokens":63}}'

--- a/tests/cassettes/llamafile/image_tool_result/the_same_image_in_a_user_message_is_read_too.yaml
+++ b/tests/cassettes/llamafile/image_tool_result/the_same_image_in_a_user_message_is_read_too.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/chat/completions
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"max_tokens":30,"messages":[{"content":[{"text":"Reply with ONLY the dominant colour name.","type":"text"},{"image_url":{"detail":"auto","url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAFklEQVR4nGP4z/CfJMQwqmFUw/DVAAAg0/4QF5nKuAAAAABJRU5ErkJggg=="},"type":"image_url"}],"role":"user"}],"model":"Qwen3-VL-2B-Instruct-Q8_0","temperature":0.0}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=utf-8
+  body: '{"choices":[{"finish_reason":"stop","index":0,"message":{"content":"Pink","role":"assistant"}}],"created":0,"id":"chatcmpl-REDACTED_1","model":"/REDACTED_PATH/Qwen3-VL-2B-Instruct-Q8_0.gguf","object":"chat.completion","system_fingerprint":"b1-6d05498","timings":{"cache_n":0,"predicted_ms":7.983,"predicted_n":2,"predicted_per_second":125.26619065514218,"predicted_per_token_ms":7.983,"prompt_ms":78.662,"prompt_n":27,"prompt_per_second":343.2407007195342,"prompt_per_token_ms":2.9134074074074077},"usage":{"completion_tokens":2,"prompt_tokens":27,"prompt_tokens_details":{"cached_tokens":0},"total_tokens":29}}'

--- a/tests/common/cassettes.rs
+++ b/tests/common/cassettes.rs
@@ -1374,11 +1374,14 @@ fn scrub_local_filesystem_paths(text: &str) -> String {
 
         output.push_str(&rest[..at]);
         let path = &rest[at..];
-        // A path ends at the first character that cannot appear in one. Quotes
-        // and whitespace are the practical terminators inside a JSON string.
-        let end = path
-            .find(|c: char| c == '"' || c == '\\' || c.is_whitespace())
-            .unwrap_or(path.len());
+        // A path ends at the closing quote of its JSON string, and at nothing
+        // else. Whitespace is emphatically *not* a terminator: macOS home
+        // directories created from a full account name routinely contain a
+        // space, and ending the path at it would keep the first word as the
+        // "basename" and copy `Smith/models/m.gguf` through verbatim — writing
+        // the operator's name into the fixture while leaving output the rule
+        // considers already-scrubbed, so nothing downstream would notice.
+        let end = path.find(['"', '\\', '\n', '\r']).unwrap_or(path.len());
         let (path, tail) = path.split_at(end);
 
         // Keep the basename; replace everything before it.
@@ -4119,6 +4122,21 @@ mod local_path_scrub_tests {
             scrubbed.contains("one.gguf") && scrubbed.contains("two.gguf"),
             "{scrubbed}"
         );
+    }
+
+    /// A home directory containing a space is the case that makes whitespace a
+    /// forbidden terminator.
+    ///
+    /// macOS creates `/Users/John Smith` from a full account name. Ending the
+    /// path at the space kept `John` as the basename and copied `Smith/...`
+    /// through untouched — the operator's name in the fixture, in output the
+    /// rule then considers already-scrubbed, so the safety scan reports nothing.
+    #[test]
+    fn a_home_directory_containing_a_space_is_fully_replaced() {
+        let scrubbed = scrub(r#"{"model":"/Users/John Smith/models/m.gguf"}"#);
+        assert_eq!(scrubbed, r#"{"model":"/REDACTED_PATH/m.gguf"}"#);
+        assert!(!scrubbed.contains("John"), "{scrubbed}");
+        assert!(!scrubbed.contains("Smith"), "{scrubbed}");
     }
 
     /// Re-scrubbing scrubbed output must not change it — the cassette safety

--- a/tests/common/cassettes.rs
+++ b/tests/common/cassettes.rs
@@ -1320,6 +1320,86 @@ fn scrub_body_for_diagnostics(policy: CassettePolicy, body: &str) -> String {
     CassetteScrubber::new(policy).scrub_body(body)
 }
 
+/// Replace the directory part of an absolute home-directory path, keeping the
+/// final component.
+///
+/// Locally-hosted providers echo the path they were launched with. `llama-server`
+/// puts it in `model` on **every** chat response — the whole
+/// `/Users/<name>/.cache/huggingface/hub/models--<org>--<repo>/snapshots/<sha>/<file>.gguf`
+/// — so recording one turn against it writes the operator's username, their
+/// cache layout and a snapshot hash into a fixture that is then committed to a
+/// public repository. Nothing else in the scrubber reaches this: it is not a
+/// token, not a header, not a query parameter, and it trips no
+/// `FORBIDDEN_CASSETTE_PATTERNS` entry, so the safety scan passes it.
+///
+/// The final component survives because it is the useful, non-identifying part
+/// — which model the fixture was recorded against — and because a cell may
+/// legitimately assert on it. Everything to its left is replaced.
+///
+/// The match is anchored to the **start of a JSON string value**, which is what
+/// separates a local path from a URL that merely contains one of these
+/// segments. Anthropic's recorded web-search results cite
+/// `https://math.ucr.edu/home/baez/physics/...`; an unanchored rule rewrites
+/// that public URL and corrupts the fixture, which the safety scan catches as
+/// "not in scrubbed cassette form". A real local path occupies the entire value
+/// (`"model":"/Users/…"`), so requiring a `"` immediately before it keeps the
+/// rule precise.
+fn scrub_local_filesystem_paths(text: &str) -> String {
+    const HOME_PREFIXES: &[&str] = &["/Users/", "/home/", "/root/"];
+
+    let mut output = String::with_capacity(text.len());
+    let mut rest = text;
+    let mut consumed = 0usize;
+
+    'outer: loop {
+        let Some((prefix, at)) = HOME_PREFIXES
+            .iter()
+            .filter_map(|p| rest.find(*p).map(|i| (*p, i)))
+            .min_by_key(|(_, i)| *i)
+        else {
+            break;
+        };
+
+        // Anchored: the value must begin here. Anything else is a path segment
+        // inside a larger string (a URL, prose) and is not ours to rewrite.
+        let absolute = consumed + at;
+        let starts_value = absolute == 0 || text.as_bytes().get(absolute - 1) == Some(&b'"');
+        if !starts_value {
+            let skip = at + prefix.len();
+            output.push_str(&rest[..skip]);
+            rest = &rest[skip..];
+            consumed = absolute + prefix.len();
+            continue;
+        }
+
+        output.push_str(&rest[..at]);
+        let path = &rest[at..];
+        // A path ends at the first character that cannot appear in one. Quotes
+        // and whitespace are the practical terminators inside a JSON string.
+        let end = path
+            .find(|c: char| c == '"' || c == '\\' || c.is_whitespace())
+            .unwrap_or(path.len());
+        let (path, tail) = path.split_at(end);
+
+        // Keep the basename; replace everything before it.
+        match path.rsplit_once('/') {
+            Some((_, base)) if !base.is_empty() => {
+                output.push_str("/REDACTED_PATH/");
+                output.push_str(base);
+            }
+            _ => output.push_str("/REDACTED_PATH"),
+        }
+        consumed = absolute + path.len();
+        rest = tail;
+        if rest.is_empty() {
+            break 'outer;
+        }
+    }
+
+    output.push_str(rest);
+    output
+}
+
 fn scrub_text_for_diagnostics(policy: CassettePolicy, text: &str) -> String {
     CassetteScrubber::new(policy).scrub_text(text)
 }
@@ -2248,6 +2328,7 @@ impl CassetteScrubber {
         let scrubbed = self.scrub_grounding_redirects(&scrubbed);
         let scrubbed = self.scrub_aws_account_ids(&scrubbed);
         let scrubbed = self.scrub_resource_names(&scrubbed);
+        let scrubbed = scrub_local_filesystem_paths(&scrubbed);
         self.scrub_generated_tokens(&scrubbed)
     }
 
@@ -3981,5 +4062,109 @@ mod pagination_cursor_scrub_tests {
             "the same cursor must map to the same placeholder, or the request that \
              replays it stops matching the response that issued it"
         );
+    }
+}
+
+#[cfg(test)]
+mod local_path_scrub_tests {
+    //! Absolute home-directory paths must not reach a committed fixture.
+    //!
+    //! A locally-hosted provider echoes the path it was launched with:
+    //! `llama-server` puts the full GGUF path in `model` on every chat
+    //! response. Nothing else in the scrubber reaches it, and no
+    //! `FORBIDDEN_CASSETTE_PATTERNS` entry trips on it, so without this rule the
+    //! safety scan passes a fixture carrying the operator's username.
+
+    use super::scrub_local_filesystem_paths as scrub;
+
+    #[test]
+    fn a_home_path_keeps_only_its_basename() {
+        let scrubbed = scrub(
+            "/Users/someone/.cache/huggingface/hub/models--org--repo/snapshots/abc123/Model-Q8_0.gguf",
+        );
+        assert_eq!(scrubbed, "/REDACTED_PATH/Model-Q8_0.gguf");
+        assert!(
+            !scrubbed.contains("someone"),
+            "the username must not survive"
+        );
+        assert!(
+            !scrubbed.contains("abc123"),
+            "the snapshot hash must not survive"
+        );
+    }
+
+    #[test]
+    fn linux_and_root_homes_are_covered_too() {
+        assert_eq!(scrub("/home/dev/models/m.gguf"), "/REDACTED_PATH/m.gguf");
+        assert_eq!(scrub("/root/m.gguf"), "/REDACTED_PATH/m.gguf");
+    }
+
+    /// The path sits inside a JSON string in practice, so the rule has to stop
+    /// at the closing quote rather than swallowing the rest of the body.
+    #[test]
+    fn a_path_inside_json_stops_at_the_quote() {
+        let scrubbed = scrub(r#"{"model":"/Users/a/b/m.gguf","object":"chat.completion"}"#);
+        assert_eq!(
+            scrubbed,
+            r#"{"model":"/REDACTED_PATH/m.gguf","object":"chat.completion"}"#
+        );
+    }
+
+    /// Several paths in one body are all replaced.
+    #[test]
+    fn every_occurrence_is_replaced() {
+        let scrubbed = scrub(r#"{"a":"/Users/x/one.gguf","b":"/Users/y/two.gguf"}"#);
+        assert!(!scrubbed.contains("/Users/"), "{scrubbed}");
+        assert!(
+            scrubbed.contains("one.gguf") && scrubbed.contains("two.gguf"),
+            "{scrubbed}"
+        );
+    }
+
+    /// Re-scrubbing scrubbed output must not change it — the cassette safety
+    /// check re-scrubs its own output, so a non-idempotent rule fails there.
+    #[test]
+    fn the_rule_is_idempotent() {
+        let once = scrub("/Users/a/.cache/m.gguf");
+        assert_eq!(scrub(&once), once);
+    }
+
+    /// A URL that merely *contains* one of these segments is not a local path
+    /// and must survive verbatim.
+    ///
+    /// This is not hypothetical: anthropic's recorded web-search fixtures cite
+    /// `https://math.ucr.edu/home/baez/physics/...`, and an unanchored rule
+    /// rewrote it — corrupting three committed fixtures and failing the safety
+    /// scan with "not in scrubbed cassette form".
+    #[test]
+    fn a_url_containing_a_home_segment_is_not_a_local_path() {
+        let body =
+            r#"{"url":"https://math.ucr.edu/home/baez/physics/General/BlueSky/blue_sky.html"}"#;
+        assert_eq!(scrub(body), body);
+        let body = r#"{"url":"https://example.com/Users/profile.html"}"#;
+        assert_eq!(scrub(body), body);
+    }
+
+    /// The anchored rule still catches the real case sitting next to a URL.
+    #[test]
+    fn a_local_path_beside_a_url_is_still_scrubbed() {
+        let scrubbed =
+            scrub(r#"{"url":"https://math.ucr.edu/home/baez/x.html","model":"/Users/me/m.gguf"}"#);
+        assert!(
+            scrubbed.contains("math.ucr.edu/home/baez/x.html"),
+            "{scrubbed}"
+        );
+        assert!(
+            scrubbed.contains(r#""model":"/REDACTED_PATH/m.gguf""#),
+            "{scrubbed}"
+        );
+    }
+
+    /// Text carrying no path is untouched, so the rule cannot churn unrelated
+    /// fixtures.
+    #[test]
+    fn unrelated_text_is_untouched() {
+        let body = r#"{"model":"gpt-4o-mini","choices":[]}"#;
+        assert_eq!(scrub(body), body);
     }
 }

--- a/tests/providers/llamafile/cassette/image_tool_result.rs
+++ b/tests/providers/llamafile/cassette/image_tool_result.rs
@@ -1,0 +1,152 @@
+//! Handing an image *back* to the model through a tool result.
+//!
+//! Official OpenAI cannot do this on Chat Completions: `gpt-4o` answers 400
+//! (*"Image URLs are only allowed for messages with role 'user'"*) and the
+//! GPT-5 family answers 200 with the image discarded, the model then describing
+//! what it never received. llama.cpp does honour it, which is why
+//! `LlamafileExt::SUPPORTS_IMAGE_TOOL_RESULTS` is `true` and the shared
+//! conversion is gated rather than hard-coded.
+//!
+//! Recorded against `llama-server` built from source at commit `6d05498`
+//! (`build_info` `b1-6d05498`) running `ggml-org/Qwen3-VL-2B-Instruct-GGUF`
+//! Q8_0 with its `mmproj`, `--jinja --seed 42 --temp 0 -c 4096`. The subject
+//! and its control were recorded in one run so the negative half cannot be
+//! explained away by a bad image or a blind model.
+//!
+//! Run cassette tests in replay mode by default, or set
+//! `RIG_PROVIDER_TEST_MODE=record` to record against a local llama.cpp server.
+
+use rig::client::CompletionClient as _;
+use rig::completion::CompletionModel as _;
+use rig::message::{ImageMediaType, ProviderCallId, ToolCallId, ToolResult, ToolResultContent};
+
+use super::super::cassette_support::with_llamafile_cassette;
+
+/// 16x16 solid magenta. Distinctive on purpose: "red" and "blue" are plausible
+/// blind guesses for "what colour is this image", so a cell using them could
+/// pass without the model ever receiving the bytes.
+const MAGENTA_PNG_BASE64: &str = "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAFklEQVR4nGP4z/CfJMQwqmFUw/DVAAAg0/4QF5nKuAAAAABJRU5ErkJggg==";
+
+/// The vision model the fixture was recorded against.
+const VISION_MODEL: &str = "Qwen3-VL-2B-Instruct-Q8_0";
+
+fn image_tool_result() -> ToolResult {
+    ToolResult {
+        call: ToolCallId::new_or_mint("call_1"),
+        provider: ProviderCallId::new("call_1"),
+        name: "view_file".to_string(),
+        content: vec![ToolResultContent::image_base64(
+            MAGENTA_PNG_BASE64,
+            Some(ImageMediaType::PNG),
+            None,
+        )],
+    }
+}
+
+fn tool_call_turn() -> rig::message::Message {
+    rig::message::Message::Assistant {
+        id: None,
+        content: vec![rig::message::AssistantContent::tool_call(
+            "call_1",
+            "view_file",
+            serde_json::json!({}),
+        )],
+    }
+}
+
+fn assistant_text(response: &rig::completion::CompletionResponse) -> String {
+    response
+        .choice
+        .iter()
+        .filter_map(|c| match c {
+            rig::message::AssistantContent::Text(t) => Some(t.text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+/// The image reaches the model through a `role:"tool"` message.
+///
+/// The assertion is the colour, not a 200. A cell that only checked the request
+/// was accepted would pass against a server that took the image and dropped it
+/// — which is exactly what the GPT-5 family does, and exactly the failure worth
+/// catching.
+#[tokio::test]
+async fn a_tool_result_image_is_read_by_the_model() {
+    with_llamafile_cassette(
+        "image_tool_result/a_tool_result_image_is_read_by_the_model",
+        |client| async move {
+            let model = client.completion_model(VISION_MODEL);
+            let request = model
+                .completion_request(
+                    "Call view_file, then reply with ONLY the dominant colour name.",
+                )
+                .max_tokens(30)
+                .temperature(0.0)
+                .messages(vec![
+                    tool_call_turn(),
+                    rig::message::Message::User {
+                        content: vec![rig::message::UserContent::ToolResult(image_tool_result())],
+                    },
+                ])
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("llama.cpp accepts an image in a tool result");
+
+            let said = assistant_text(&response);
+            assert!(
+                said.contains("pink") || said.contains("magenta"),
+                "the model has to have seen the image to name its colour; said: {said:?}"
+            );
+        },
+    )
+    .await;
+}
+
+/// The control: identical bytes in a `user` message.
+///
+/// Without this the cell above proves only that *something* produced a colour
+/// word. With it, the image, the model and the run are all held constant and
+/// the only variable is the message role.
+#[tokio::test]
+async fn the_same_image_in_a_user_message_is_read_too() {
+    with_llamafile_cassette(
+        "image_tool_result/the_same_image_in_a_user_message_is_read_too",
+        |client| async move {
+            let model = client.completion_model(VISION_MODEL);
+            let request = model
+                .completion_request(rig::message::Message::User {
+                    content: vec![
+                        rig::message::UserContent::text(
+                            "Reply with ONLY the dominant colour name.",
+                        ),
+                        rig::message::UserContent::image_base64(
+                            MAGENTA_PNG_BASE64,
+                            Some(ImageMediaType::PNG),
+                            None,
+                        ),
+                    ],
+                })
+                .max_tokens(30)
+                .temperature(0.0)
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("an image in a user message is ordinary and must work");
+
+            let said = assistant_text(&response);
+            assert!(
+                said.contains("pink") || said.contains("magenta"),
+                "the control must succeed or the subject cell proves nothing: {said:?}"
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/llamafile/mod.rs
+++ b/tests/providers/llamafile/mod.rs
@@ -18,6 +18,7 @@ mod typed_prompt_tools;
 mod cassette {
     mod agent;
     mod embeddings;
+    mod image_tool_result;
     mod raw_capture_matrix;
     mod raw_stream_capture_matrix;
     mod streaming;


### PR DESCRIPTION
Hunted bugs in rig's llama.cpp support by recording against a real `llama-server`, built from source at commit `6d05498` and driven with `ggml-org/Qwen3-VL-2B-Instruct-GGUF` Q8_0 + mmproj and `unsloth/Qwen3-1.7B-GGUF` Q4_K_M, `--jinja --seed 42 --temp 0`.

Three bugs, each confirmed against the live server before being fixed. A cold review of the result then found six more defects in my own work, three of them major; those are fixed too and described at the end.

## Bug 1 — rig cannot send an image in a tool result to a server that honours one

`TryFrom<message::ToolResult>` refused unconditionally:

```
message::ToolResultContent::Image(_) => Err(ConversionError(
  "OpenAI Chat Completions does not support images in tool results…"))
```

Right for OpenAI, wrong as a universal rule, and living in a conversion nine providers share — so a llama.cpp user was denied a feature their server has and told about a different vendor's limitation.

**On-main failure**, from a worktree at `80cdde136`:

```
ON-MAIN FAILURE: Message conversion error: OpenAI Chat Completions does not
support images in tool results. Tool results must be text.
```

**llama.cpp honours it.** A solid-colour square handed back through a `role:"tool"` message is named correctly 3/3, against a same-run control sending the identical bytes in a `user` message:

| actual | via tool message | via user message (control) |
|---|---|---|
| magenta | "…is pink" | Pink |
| green | "…is green" | Green |
| yellow | "…is yellow" | Yellow |

**Official OpenAI does not**, which is why the default stays `false` — measured separately: 400 on `gpt-4o`/`gpt-4o-mini` (*"Image URLs are only allowed for messages with role 'user'"*), and on `gpt-5` … `gpt-5.5` a **200 with the image silently discarded**, the model then describing what it never received. The second is the dangerous one: a caller checking status codes concludes it works.

**Fix:** `OpenAICompatibleProvider::SUPPORTS_IMAGE_TOOL_RESULTS`, default `false`, `true` for llamafile — a per-provider constant beside `SUPPORTS_TOOLS`, `SUPPORTS_RESPONSE_FORMAT` and `EMITS_COMPLETE_SINGLE_CHUNK_TOOL_CALLS`. `providers/mod.rs` asks for exactly this: dialect differences go in the trait's hooks, never the shared conversion. The refusal moves to the per-provider normalization pass, which is the only place holding both the parts and the provider's capabilities — `TryFrom<ToolResult>` has neither, which is why the old guard had to be unconditional.

Three things the obvious refactor gets wrong, avoided here: `to_array()` still lifts a `String`, so `with_tool_result_array_content()` keeps working for the common single-text case; `Deserialize` is hand-written so a stored history whose parts omit `type` still loads (a derived tagged enum makes the tag mandatory and the untagged wrapper swallows the cause); and `detail` and the media type survive the round trip.

This is the capability [#2378](https://github.com/0xPlaygrounds/rig/pull/2378) was reaching for. It delivers that PR's goal for the provider that actually supports it, and declines it for OpenAI with the measurement above rather than an opinion.

## Bug 2 — recorded fixtures leak the operator's home directory

`llama-server` echoes the full GGUF path in `model` on **every** response:

```
"model":"/Users/<name>/.cache/huggingface/hub/models--<org>--<repo>/snapshots/<sha>/<file>.gguf"
```

Username, cache layout and a snapshot hash, headed for a public repo. Nothing in the scrubber reached it — not a token, header or query parameter — and no `FORBIDDEN_CASSETTE_PATTERNS` entry trips, so the safety scan passed a fixture carrying it. Verified by recording one and grepping.

**Fix:** `scrub_local_filesystem_paths`, keeping the basename (which model — useful, non-identifying) and replacing everything left of it.

## Bug 3 — two cache exemptions false on both counts

`NO_CACHE_SUITE` excused llamafile and llamacpp because "the local llama.cpp wire reports no cached-token field, so rig has no cache mapping for it". The wire reports it — a repeated prefix returns `usage.prompt_tokens_details.cached_tokens` at **28 of 29**, with `timings.cache_n` agreeing — and rig maps it, through `openai::Usage::to_normalized`. The exemptions stay (no server runs in CI, same as `mistralrs`) but now say so, because a stale justification answers the question that would otherwise get asked.

## What the cold review then found in my own work

| Severity | Defect |
|---|---|
| major | Broken intra-doc link `Self::normalize_for_wire` — CI runs `cargo doc -D warnings`, and `cargo doc` was the one check missing from my list |
| major | The scrub rule ended paths at whitespace, so `/Users/John Smith/…` kept `John Smith` — and the output is a fixed point, so re-scrubbing reports nothing |
| major | The inbound conversion flattened tool-result images to `Text("")` — the same silent loss the outbound gate refuses, and previously a loud deserialize error |
| minor | Refusal message had ~30-space runs from a wrapped literal |
| minor | Error arms Debug-printed `DocumentSourceKind`, dumping a whole `Raw(Vec<u8>)` image |
| minor | The enum change is breaking and the changelog filed it only under `Added` |

## Coverage

18 unit cells (9 gate, 9 scrubber) and 2 recorded cassette cells. The recorded pair is subject + control in one fixture directory: the subject alone would prove only that something produced a colour word, and the pair holds the image, model and run constant so the only variable is the message role. Both assert the **colour**, not a 200 — a cell checking acceptance would pass against a server that took the image and dropped it, which is precisely what GPT-5 does.

Determinism: `--seed 42 --temp 0`, model and quantisation stated in the module docs. Replay is server-free.

## Verification

- `cargo test --workspace --all-features` — **6,090 passed, 0 failed suites**
- `RUSTFLAGS="-D warnings" cargo clippy -p rig-core -p rig -p rig-agent --all-targets --all-features` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc` — clean (the check that caught defect 1)
- `cargo fmt --all --check`, `cargo check -p rig-core --target wasm32-unknown-unknown` — clean
- cassette safety scan clean; **0 fixtures contain a home directory**
- llamafile suite replays with the server stopped

## Not done

The 53 `#[ignore]`d llama.cpp tests (23 in `tests/providers/llamacpp/`, 30 in the llamafile suite) remain ignored. Running them live surfaced 5 failures: 2 need `--embeddings` on the server, and 3 are `MaxTurnsError { max_turns: 1 }` from tests that call a tool under `stream_prompt`'s default single turn — test-authoring issues in never-run tests, not rig bugs. Converting that suite to cassettes is a larger piece of work and deliberately out of scope here.
