### PR TITLE
feat(providers): add OrcaRouter provider

### DIFF
--- a/crates/rig-core/src/providers/mod.rs
+++ b/crates/rig-core/src/providers/mod.rs
@@ -17,6 +17,7 @@
 //! - Ollama
 //! - OpenAI
 //! - OpenRouter
+//! - OrcaRouter
 //! - Perplexity
 //! - Together
 //! - Venice
@@ -127,6 +128,7 @@ pub mod moonshot;
 pub mod ollama;
 pub mod openai;
 pub mod openrouter;
+pub mod orcarouter;
 pub mod perplexity;
 pub mod together;
 pub mod venice;

--- a/crates/rig-core/src/providers/orcarouter.rs
+++ b/crates/rig-core/src/providers/orcarouter.rs
@@ -1,0 +1,119 @@
+//! OrcaRouter API client and Rig integration
+//!
+//! [OrcaRouter](https://www.orcarouter.ai) is a gateway that aggregates
+//! thousands of AI models behind one OpenAI-compatible API, routing each
+//! request to the best provider and model. It also runs gateway-level,
+//! zero-trust security for AI agents on the same endpoint — screening every
+//! prompt/response and governing every tool call on a default-deny basis, with
+//! no application code changes.
+//!
+//! # Example
+//! ```no_run
+//! use rig_core::{client::CompletionClient, providers::orcarouter};
+//!
+//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = orcarouter::Client::from_env()?;
+//!
+//! let auto = client.completion_model(orcarouter::ORCAROUTER_AUTO);
+//! # Ok(())
+//! # }
+//! ```
+
+use crate::client::{self, BearerAuth, DebugExt, Provider};
+
+use super::openai;
+
+// ================================================================
+// Main OrcaRouter Client
+// ================================================================
+const ORCAROUTER_API_BASE_URL: &str = "https://api.orcarouter.ai/v1";
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct OrcaRouterExt;
+#[derive(Debug, Default, Clone, Copy)]
+pub struct OrcaRouterBuilder;
+
+type OrcaRouterApiKey = BearerAuth;
+
+impl Provider for OrcaRouterExt {
+    type Builder = OrcaRouterBuilder;
+    const VERIFY_PATH: &'static str = "/models";
+}
+
+impl openai::completion::OpenAICompatibleProvider for OrcaRouterExt {
+    const PROVIDER_NAME: &'static str = "orcarouter";
+
+    type StreamingUsage = openai::Usage;
+
+    // OrcaRouter's gateway forwards OpenAI-style requests and responses; the
+    // shared OpenAI Chat Completions path applies unchanged.
+    type Response = openai::CompletionResponse;
+}
+
+client::impl_capabilities!(
+    OrcaRouterExt,
+    completion = CompletionModel<H>,
+    model_listing = OrcaRouterModelLister<H>,
+);
+
+impl DebugExt for OrcaRouterExt {}
+
+client::impl_default_provider_builder!(
+    OrcaRouterBuilder => OrcaRouterExt,
+    api_key = OrcaRouterApiKey,
+    base_url = ORCAROUTER_API_BASE_URL,
+);
+
+crate::providers::internal::model_listing::impl_model_lister!(
+    /// [`ModelLister`](crate::client::ModelLister) implementation for the
+    /// OrcaRouter API (`GET /models`), the same path [`OrcaRouterExt::VERIFY_PATH`]
+    /// already uses.
+    OrcaRouterModelLister,
+    Client<H>,
+    crate::providers::internal::model_listing::ListModelEntry,
+    "OrcaRouter",
+    "/models"
+);
+
+pub type Client<H = reqwest::Client> = client::Client<OrcaRouterExt, H>;
+pub type ClientBuilder<H = crate::markers::Missing> =
+    client::ClientBuilder<OrcaRouterBuilder, OrcaRouterApiKey, H>;
+
+/// OrcaRouter completion model, driven by the shared OpenAI Chat Completions path.
+pub type CompletionModel<H = reqwest::Client> =
+    openai::completion::GenericCompletionModel<OrcaRouterExt, H>;
+
+/// OrcaRouter's provider-native terminal streaming record: the value carried by
+/// the final item of the stream returned by `CompletionModel::raw_stream`. Shared
+/// with the OpenAI Chat Completions path, usage payload included.
+pub type StreamingCompletionResponse = openai::StreamingCompletionResponse;
+
+client::impl_provider_client!(Client, input = String, api_key_env = "ORCAROUTER_API_KEY");
+
+// ================================================================
+// OrcaRouter Completion API
+// ================================================================
+
+/// `orcarouter/auto` — OrcaRouter's default routing model. The gateway picks
+/// the best available model for the request across its aggregated providers.
+pub const ORCAROUTER_AUTO: &str = "orcarouter/auto";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::ProviderBuilder;
+
+    #[test]
+    fn test_client_initialization() {
+        let _client = Client::new("dummy-key").expect("Client::new() failed");
+        let _client_from_builder = Client::builder()
+            .api_key("dummy-key")
+            .build()
+            .expect("Client::builder() failed");
+    }
+
+    #[test]
+    fn default_base_url_points_at_orcarouter_v1() {
+        assert_eq!(OrcaRouterBuilder::BASE_URL, "https://api.orcarouter.ai/v1");
+    }
+}

--- a/tests/cassette_cache_prefix.rs
+++ b/tests/cassette_cache_prefix.rs
@@ -963,6 +963,12 @@ const NO_CACHE_SUITE: &[(&str, &str)] = &[
     ("minimax", "no MINIMAX_API_KEY in this environment"),
     ("mira", "no MIRA_API_KEY in this environment"),
     ("moonshot", "no MOONSHOT_API_KEY in this environment"),
+    (
+        "orcarouter",
+        "new OpenAI-compatible gateway provider whose prompt-cache suite has not yet been \
+         recorded. OrcaRouter forwards OpenAI-style Chat Completions requests, so its cache \
+         semantics mirror the shared OpenAI path already covered by the direct OpenAI cache suite",
+    ),
     ("together", "no TOGETHER_API_KEY in this environment"),
     ("xiaomimimo", "no XIAOMIMIMO_API_KEY in this environment"),
     ("zai", "no ZAI_API_KEY in this environment"),

--- a/tests/core/provider_layout.rs
+++ b/tests/core/provider_layout.rs
@@ -153,6 +153,14 @@ const PROVIDER_WIRES: &[(&str, WireCoverage)] = &[
     ("mistral", Exempt(OPENAI_CHAT_GATEWAY)),
     ("moonshot", Exempt(OPENAI_CHAT_GATEWAY)),
     (
+        "orcarouter",
+        Exempt(
+            "OrcaRouter — an OpenAI-compatible gateway that implements `OpenAICompatibleProvider`, \
+             forwarding the OpenAI Chat Completions wire verbatim (covered by the `openai_chat` \
+             suite)",
+        ),
+    ),
+    (
         "openrouter",
         SharedWireOwnSemantics {
             wire: OPENAI_CHAT_GATEWAY,

--- a/tests/orcarouter.rs
+++ b/tests/orcarouter.rs
@@ -1,0 +1,15 @@
+#![allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::unreachable
+)]
+
+#[path = "common/reasoning.rs"]
+mod reasoning;
+#[path = "common/support.rs"]
+mod support;
+
+#[path = "providers/orcarouter/mod.rs"]
+mod orcarouter;

--- a/tests/providers/orcarouter/agent.rs
+++ b/tests/providers/orcarouter/agent.rs
@@ -1,0 +1,24 @@
+//! OrcaRouter agent completion smoke test.
+
+use rig::completion::Prompt;
+use rig::prelude::*;
+use rig::providers::orcarouter;
+
+use crate::support::{BASIC_PREAMBLE, BASIC_PROMPT, assert_nonempty_response};
+
+#[tokio::test]
+#[ignore = "requires ORCAROUTER_API_KEY"]
+async fn completion_smoke() {
+    let client = orcarouter::Client::from_env().expect("client should build");
+    let agent = client
+        .agent(orcarouter::ORCAROUTER_AUTO)
+        .preamble(BASIC_PREAMBLE)
+        .build();
+
+    let response = agent
+        .prompt(BASIC_PROMPT)
+        .await
+        .expect("completion should succeed");
+
+    assert_nonempty_response(&response);
+}

--- a/tests/providers/orcarouter/mod.rs
+++ b/tests/providers/orcarouter/mod.rs
@@ -1,0 +1,4 @@
+mod agent;
+mod models;
+mod streaming;
+mod tools;

--- a/tests/providers/orcarouter/models.rs
+++ b/tests/providers/orcarouter/models.rs
@@ -1,0 +1,21 @@
+//! OrcaRouter model listing smoke test.
+
+use rig::client::{ModelListingClient, ProviderClient};
+use rig::providers::orcarouter;
+
+#[tokio::test]
+#[ignore = "requires ORCAROUTER_API_KEY"]
+async fn list_models_smoke() {
+    let client = orcarouter::Client::from_env().expect("client should build");
+    let models = match client.list_models().await {
+        Ok(models) => models,
+        Err(error) => {
+            panic!("listing OrcaRouter models should succeed\nDisplay: {error}\nDebug: {error:#?}")
+        }
+    };
+
+    assert!(
+        !models.is_empty(),
+        "expected OrcaRouter to return at least one model\nModel list: {models:#?}"
+    );
+}

--- a/tests/providers/orcarouter/streaming.rs
+++ b/tests/providers/orcarouter/streaming.rs
@@ -1,0 +1,58 @@
+//! OrcaRouter streaming smoke tests.
+
+use rig::prelude::*;
+use rig::providers::orcarouter;
+use rig::streaming::{StreamingChat, StreamingPrompt};
+
+use crate::support::{
+    STREAMING_PREAMBLE, STREAMING_PROMPT, STREAMING_TOOLS_PREAMBLE, STREAMING_TOOLS_PROMPT,
+    collect_stream_final_response, collect_stream_observation,
+};
+
+#[tokio::test]
+#[ignore = "requires ORCAROUTER_API_KEY"]
+async fn streaming_smoke() {
+    let client = orcarouter::Client::from_env().expect("client should build");
+    let agent = client
+        .agent(orcarouter::ORCAROUTER_AUTO)
+        .preamble(STREAMING_PREAMBLE)
+        .build();
+
+    let mut stream = agent.stream_prompt(STREAMING_PROMPT).await;
+    let response = collect_stream_final_response(&mut stream)
+        .await
+        .expect("streaming prompt should succeed");
+
+    assert!(!response.trim().is_empty(), "streamed response was empty");
+}
+
+#[tokio::test]
+#[ignore = "requires ORCAROUTER_API_KEY"]
+async fn streaming_tools_smoke() {
+    let client = orcarouter::Client::from_env().expect("client should build");
+    let agent = client
+        .agent(orcarouter::ORCAROUTER_AUTO)
+        .preamble(STREAMING_TOOLS_PREAMBLE)
+        .default_max_turns(2)
+        .tool(crate::support::Adder)
+        .tool(crate::support::Subtract)
+        .build();
+
+    let mut stream = agent
+        .stream_chat(
+            STREAMING_TOOLS_PROMPT,
+            Vec::<rig::completion::Message>::new(),
+        )
+        .await;
+
+    let observation = collect_stream_observation(&mut stream).await;
+    assert!(
+        observation.errors.is_empty(),
+        "stream should not emit errors: {:?}",
+        observation.errors
+    );
+    assert!(
+        observation.got_final_response,
+        "stream should emit a final response"
+    );
+}

--- a/tests/providers/orcarouter/tools.rs
+++ b/tests/providers/orcarouter/tools.rs
@@ -1,0 +1,27 @@
+//! OrcaRouter tools smoke test.
+
+use rig::completion::Prompt;
+use rig::prelude::*;
+use rig::providers::orcarouter;
+
+use crate::support::{TOOLS_PREAMBLE, TOOLS_PROMPT, assert_mentions_expected_number};
+
+#[tokio::test]
+#[ignore = "requires ORCAROUTER_API_KEY"]
+async fn tools_smoke() {
+    let client = orcarouter::Client::from_env().expect("client should build");
+    let agent = client
+        .agent(orcarouter::ORCAROUTER_AUTO)
+        .preamble(TOOLS_PREAMBLE)
+        .default_max_turns(2)
+        .tool(crate::support::Adder)
+        .tool(crate::support::Subtract)
+        .build();
+
+    let response = agent
+        .prompt(TOOLS_PROMPT)
+        .await
+        .expect("tool prompt should succeed");
+
+    assert_mentions_expected_number(&response, -3);
+}


### PR DESCRIPTION
## Summary

Adds a named [OrcaRouter](https://www.orcarouter.ai) provider to rig-core, mirroring the existing OpenAI-compatible gateway providers (`groq`, `together`, `venice`). OrcaRouter is an OpenAI-compatible gateway that aggregates thousands of AI models behind one endpoint at `https://api.orcarouter.ai/v1`. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- `crates/rig-core/src/providers/orcarouter.rs` — new provider module implementing `OpenAICompatibleProvider`:
  - base URL `https://api.orcarouter.ai/v1`, default model `orcarouter/auto`
  - completions through the shared `GenericCompletionModel` / OpenAI Chat Completions path
  - `GET /models` model listing via the shared lister
  - `ORCAROUTER_API_KEY` env var for `Client::from_env()`
- `crates/rig-core/src/providers/mod.rs` — register the module and list it in the provider doc
- `tests/orcarouter.rs` + `tests/providers/orcarouter/` — live smoke tests (ignored, require `ORCAROUTER_API_KEY`) for completion, streaming, tools, and model listing
- `tests/cassette_cache_prefix.rs` / `tests/core/provider_layout.rs` — register the provider with the layout guards (OpenAI Chat Completions wire family; cache suite not yet recorded)

## Verification

- `cargo test -p rig-core --lib` — 1552 passed, 0 failed
- `cargo test -p rig` — 203 passed; the only failure is the pre-existing environment-dependent `llamacpp::cassette::loaders::loaders_smoke` (reproduces on a clean tree; its cassette scrubs `REDACTED_PATH` which cannot match a local checkout path)
- `cargo clippy -p rig-core --all-targets` — clean
- `cargo fmt --check` — clean
- Live smoke tests against the real OrcaRouter API — all 5 pass (completion, streaming, streaming tools, tools roundtrip, model listing) on the pinned 1.94.0 toolchain

## Related

Closes #2383

Disclosure: I'm an engineer on the OrcaRouter team.
