### PR TITLE
feat!: finish the type-erasure sweep — normalize transcription/image/audio responses, move construction off every model trait, erase the embedding model in vector stores

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -2146,6 +2146,163 @@ merged `RequestPatch` and the previous model, and may pick a different handle
 per model call). `CompletionModel::capabilities()` is captured by value when
 the handle is created.
 
+### Transcription, image-generation and audio-generation responses are concrete and normalized
+
+The same argument #2257 applied to completions now applies to the three
+remaining response-bearing model traits. `TranscriptionModel`,
+`ImageGenerationModel` and `AudioGenerationModel` lose `type Response`, and
+`TranscriptionResponse<T>`, `ImageGenerationResponse<T>` and
+`AudioGenerationResponse<T>` lose their parameter. Each is now a concrete
+struct carrying the payload plus the metadata every provider can report:
+
+```rust
+pub struct TranscriptionResponse {
+    pub text: String,                    // ImageGenerationResponse: image: Vec<u8>
+    pub usage: Usage,                    // AudioGenerationResponse: audio: Vec<u8>
+    pub provider: String,                // stable descriptor name, always set
+    pub model: Option<String>,           // provider-reported model, when any
+    pub response_id: Option<String>,
+    pub provider_request_id: Option<String>,
+    pub raw: serde_json::Value,          // the provider's own payload, serialized
+}
+```
+
+plus `identity() -> ResponseIdentity`. Delete the type argument from your
+annotations — `TranscriptionResponse<openai::TranscriptionResponse>` becomes
+`TranscriptionResponse` — and the parameter from
+`TranscriptionRequestBuilder<M, D>` / `ImageGenerationRequestBuilder<M, P>` /
+`AudioGenerationRequestBuilder<M, T, V>` callers, whose `send()` now returns
+the concrete type.
+
+**The `response` field is gone.** Everything a caller used to read off it has
+a named home or lives behind the raw route:
+
+| 0.42 read                                    | now                                                          |
+| -------------------------------------------- | ------------------------------------------------------------ |
+| `r.response.text` (OpenAI / OpenRouter)      | `r.text`                                                     |
+| `r.response.usage` token counts              | `r.usage` (`Usage`, zero when the provider reports none)     |
+| `r.response.usage` duration-billed seconds   | `raw_transcription(..)` / `r.raw["usage"]["seconds"]`        |
+| `r.response.model` (Mistral) / `model_version` (Gemini) | `r.model`                                         |
+| `r.response.response_id` (Gemini)            | `r.response_id`                                              |
+| `r.response.id` (Venice image)               | `r.raw["id"]`, or `raw_image_generation(..).id`              |
+| anything else provider-specific              | `r.raw` (deserialize it into the provider type), or `raw_*`  |
+
+Every concrete provider model gains inherent `raw_transcription`,
+`raw_image_generation` or `raw_audio_generation` returning the provider's
+native type from the same request, transport, parser and error path as the
+normalized call — the same escape hatch `raw_completion` is for completions,
+designed in up front this time rather than restored by a follow-up. For
+providers whose endpoint answers with bytes and no JSON envelope (Hugging Face
+images, every OpenAI-style text-to-speech endpoint) the native type is the
+bytes and `raw` on the normalized response stays `Null`; `raw_*` is the typed
+route.
+
+Normalization is a trait, implementable out of tree: replace
+`impl TryFrom<MyPayload> for TranscriptionResponse<MyPayload>` with
+
+```rust
+impl NormalizeTranscriptionResponse for MyPayload {
+    fn normalize(self, provider: &str) -> Result<TranscriptionResponse, TranscriptionError> {
+        Ok(TranscriptionResponse::new(self.text, provider).with_usage(..))
+    }
+}
+```
+
+(`NormalizeImageGenerationResponse` / `NormalizeAudioGenerationResponse`
+likewise). The provider name is an *input*: several providers share one wire
+shape, and a conversion that hardcoded a name would mislabel every provider
+but one. Custom models implement only the operation:
+
+```rust
+impl TranscriptionModel for MyModel {
+    async fn transcription(&self, req: TranscriptionRequest)
+        -> Result<TranscriptionResponse, TranscriptionError> { /* ... */ }
+}
+```
+
+The three traits also drop `Clone` from their supertraits (and
+`AudioGenerationModel` drops `Sized`), exactly as `CompletionModel` did:
+`transcription_request()` / `image_generation_request()` /
+`audio_generation_request()` gate on `where Self: Sized + Clone`, and each
+trait is implemented for `Arc<M>` by forwarding, so wrapping a non-`Clone`
+model in an `Arc` works through every generic API. Generic code that cloned a
+model through one of these traits must bound `M: …Model + Clone` explicitly.
+
+The shared OpenAI-style drivers now read the provider's transport request-id
+header onto `provider_request_id` where the provider has one (OpenAI, Groq:
+`x-request-id`; Mistral: `mistral-correlation-id`; Bedrock: the SDK's
+`x-amzn-RequestId`). Gemini, Hugging Face, Azure, Venice, xAI and OpenRouter
+report none on these endpoints; `None` is the documented outcome.
+
+### Construction moved off every model trait
+
+`EmbeddingModel`, `RerankModel`, `TranscriptionModel`, `ImageGenerationModel`
+and `AudioGenerationModel` lose `type Client` and `fn make`, matching
+`CompletionModel`. Delete both from your impls. `EmbeddingModel::MAX_DOCUMENTS`
+is now `fn max_documents(&self) -> usize` (a constant cannot survive type
+erasure — see the next section); `RerankModel::MAX_DOCUMENTS` and
+`ImageEmbeddingModel::MAX_DOCUMENTS` are unchanged.
+
+The capability client traits construct models themselves:
+`EmbeddingsClient::embedding_model` / `embedding_model_with_ndims`,
+`RerankingClient::rerank_model`, `TranscriptionClient::transcription_model`,
+`ImageGenerationClient::image_generation_model` and
+`AudioGenerationClient::audio_generation_model` (which loses its default body)
+are required methods that call your model's own constructor. Call sites —
+`client.embedding_model(..)`, `client.transcription_model(..)` — are
+unchanged.
+
+A provider extension built on the generic `rig::client::Client<Ext, H>`
+implements the new public hooks instead: `ConstructEmbeddingModel<C>`
+(`construct(client, model, ndims: Option<usize>)`), `ConstructRerankModel<C>`,
+`ConstructTranscriptionModel<C>`, `ConstructImageGenerationModel<C>`,
+`ConstructAudioGenerationModel<C>` (`construct(client, model)`), all beside
+`ConstructCompletionModel`. The blanket capability-client impls over
+`Client<Ext, H>` bound on them, so an out-of-tree extension reaches
+`embedding_model`/`transcription_model`/… through public API only — the
+orphan rule that forced `ConstructCompletionModel` to be public applies to
+every modality, and this closes the hole. `rig-core` ships a compile probe of
+exactly that (`client::external_modality_extension_probe`).
+
+Tests that called `Model::make(&client, ..)` directly should go through the
+client: `client.embedding_model(..)`.
+
+`ImageEmbeddingModel` also drops `Clone` from its supertraits.
+
+### Vector stores erase the embedding model at construction
+
+Every vector store and index lost its embedding-model type parameter — the
+structural twin of `Agent<M>` losing its model:
+
+```rust
+// 0.42
+let index: QdrantVectorStore<openai::EmbeddingModel> = QdrantVectorStore::new(client, model, ..);
+let index: InMemoryVectorIndex<openai::EmbeddingModel, Doc> = store.index(model);
+// now
+let index: QdrantVectorStore = QdrantVectorStore::new(client, model, ..);
+let index: InMemoryVectorIndex<Doc> = store.index(model);
+```
+
+Constructors take `impl EmbeddingModel + 'static` and erase it once into
+`rig::embeddings::EmbeddingModelHandle`, a cloneable handle that itself
+implements `EmbeddingModel`; `ndims()` and `max_documents()` are captured by
+value at erasure. Affected: `InMemoryVectorIndex<M, D>` → `<D>`,
+`QdrantVectorStore<M>`, `LanceDbVectorIndex<M>`, `ScyllaDbVectorStore<M>`,
+`MongoDbVectorIndex<C, M>` → `<C>`, `MilvusVectorStore<M>`,
+`VectorizeVectorStore<M>`, `Neo4jVectorIndex<M>`, `S3VectorsVectorStore<M>`,
+`PostgresVectorStore<M>`, `SqliteVectorStore<E, T>` / `SqliteVectorIndex<E, T>`
+→ `<T>`, `SurrealVectorStore<C, M>` → `<C>`, `HelixDBVectorStore<C, E>` →
+`<C>`. Construction call sites are unchanged; delete the parameter from type
+annotations. Heterogeneous collections of indexes (`Vec<Box<dyn
+VectorStoreIndex<Filter = _>>>`) no longer need a provider name per element.
+
+Unlike `Agent`, this is **not** a swapping mechanism and there is no
+`set_model`: an index populated under one model is only meaningful under that
+model, so the handle a store holds is fixed for its lifetime. The payoff is
+type ergonomics and dyn-storability, nothing more. `EmbeddingsBuilder<M, T>`
+keeps its parameter: it is transient and dropped at `build()`, like
+`CompletionRequestBuilder`.
+
 ### Assistant content is tagged and provider extras are a named field
 
 `AssistantContent` serializes with a `"type"` tag, exactly like `UserContent`

--- a/crates/rig-bedrock/src/embedding.rs
+++ b/crates/rig-bedrock/src/embedding.rs
@@ -78,7 +78,9 @@ impl EmbeddingModel {
 }
 
 impl embeddings::EmbeddingModel for EmbeddingModel {
-    const MAX_DOCUMENTS: usize = 1024;
+    fn max_documents(&self) -> usize {
+        1024
+    }
 
     fn ndims(&self) -> usize {
         self.ndims.unwrap_or_default()

--- a/crates/rig-bedrock/src/embedding.rs
+++ b/crates/rig-bedrock/src/embedding.rs
@@ -80,12 +80,6 @@ impl EmbeddingModel {
 impl embeddings::EmbeddingModel for EmbeddingModel {
     const MAX_DOCUMENTS: usize = 1024;
 
-    type Client = Client;
-
-    fn make(client: &Self::Client, model: impl Into<String>, dims: Option<usize>) -> Self {
-        Self::new(client.clone(), model, dims)
-    }
-
     fn ndims(&self) -> usize {
         self.ndims.unwrap_or_default()
     }
@@ -121,5 +115,11 @@ impl embeddings::EmbeddingModel for EmbeddingModel {
             None => Ok(results),
             Some(err) => Err(EmbeddingError::ResponseError(err.to_string())),
         }
+    }
+}
+
+impl rig_core::client::ConstructEmbeddingModel<Client> for EmbeddingModel {
+    fn construct(client: &Client, model: String, dims: Option<usize>) -> Self {
+        Self::new(client.clone(), model, dims)
     }
 }

--- a/crates/rig-bedrock/src/image.rs
+++ b/crates/rig-bedrock/src/image.rs
@@ -1,9 +1,11 @@
 use crate::client::Client;
+use crate::types::assistant_content::PROVIDER_NAME;
 use crate::types::errors::AwsSdkInvokeModelError;
 use crate::types::text_to_image::{TextToImageGeneration, TextToImageResponse};
 use aws_smithy_types::Blob;
 use rig_core::image_generation::{
     self, ImageGenerationError, ImageGenerationRequest, ImageGenerationResponse,
+    NormalizeImageGenerationResponse,
 };
 
 // The model-id string values are canonically defined in `crate::completion`.
@@ -31,19 +33,26 @@ impl ImageGenerationModel {
     }
 }
 
-impl image_generation::ImageGenerationModel for ImageGenerationModel {
-    type Response = TextToImageResponse;
-
-    type Client = Client;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
-
-    async fn image_generation(
+impl ImageGenerationModel {
+    /// Perform the generation and return Bedrock's native
+    /// [`TextToImageResponse`] instead of the normalized
+    /// [`ImageGenerationResponse`]. Same request, transport, parser, and error
+    /// path as [`image_generation::ImageGenerationModel::image_generation`].
+    pub async fn raw_image_generation(
         &self,
         generation_request: ImageGenerationRequest,
-    ) -> Result<ImageGenerationResponse<Self::Response>, ImageGenerationError> {
+    ) -> Result<TextToImageResponse, ImageGenerationError> {
+        self.raw_image_generation_with_request_id(generation_request)
+            .await
+            .map(|(response, _)| response)
+    }
+
+    /// [`Self::raw_image_generation`] plus the AWS request id
+    /// (`x-amzn-RequestId`) from the SDK's response metadata, when present.
+    pub async fn raw_image_generation_with_request_id(
+        &self,
+        generation_request: ImageGenerationRequest,
+    ) -> Result<(TextToImageResponse, Option<String>), ImageGenerationError> {
         let mut request = TextToImageGeneration::new(generation_request.prompt);
         request.width(generation_request.width);
         request.height(generation_request.height);
@@ -64,12 +73,38 @@ impl image_generation::ImageGenerationModel for ImageGenerationModel {
                 Into::<ImageGenerationError>::into(AwsSdkInvokeModelError(sdk_error))
             })?;
 
+        let provider_request_id =
+            aws_sdk_bedrockruntime::operation::RequestId::request_id(&model_response)
+                .map(str::to_string);
+
         let response_str = String::from_utf8(model_response.body.into_inner())
             .map_err(|e| ImageGenerationError::ResponseError(e.to_string()))?;
 
         let result: TextToImageResponse = serde_json::from_str(&response_str)
             .map_err(|e| ImageGenerationError::ResponseError(e.to_string()))?;
 
-        result.try_into()
+        Ok((result, provider_request_id))
+    }
+}
+
+impl image_generation::ImageGenerationModel for ImageGenerationModel {
+    async fn image_generation(
+        &self,
+        generation_request: ImageGenerationRequest,
+    ) -> Result<ImageGenerationResponse, ImageGenerationError> {
+        let (response, provider_request_id) = self
+            .raw_image_generation_with_request_id(generation_request)
+            .await?;
+        let captured = serde_json::to_value(&response)?;
+        Ok(response
+            .normalize(PROVIDER_NAME)?
+            .with_optional_provider_request_id(provider_request_id)
+            .with_raw(captured))
+    }
+}
+
+impl rig_core::client::ConstructImageGenerationModel<Client> for ImageGenerationModel {
+    fn construct(client: &Client, model: String) -> Self {
+        Self::new(client.clone(), model)
     }
 }

--- a/crates/rig-bedrock/src/types/mod.rs
+++ b/crates/rig-bedrock/src/types/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod image;
 pub(crate) mod json;
 pub(crate) mod media_types;
 pub(crate) mod message;
-pub(crate) mod text_to_image;
+/// Bedrock's text-to-image request and response wire types; [`TextToImageResponse`](text_to_image::TextToImageResponse) is what [`crate::image::ImageGenerationModel::raw_image_generation`] returns.
+pub mod text_to_image;
 pub(crate) mod tool;
 pub(crate) mod user_content;

--- a/crates/rig-bedrock/src/types/text_to_image.rs
+++ b/crates/rig-bedrock/src/types/text_to_image.rs
@@ -1,7 +1,7 @@
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
 use rig_core::image_generation;
-use rig_core::image_generation::ImageGenerationError;
+use rig_core::image_generation::{ImageGenerationError, NormalizeImageGenerationResponse};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -94,24 +94,23 @@ impl TextToImageGeneration {
     }
 }
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct TextToImageResponse {
     pub images: Option<Vec<String>>,
     pub error: Option<String>,
 }
 
-impl TryFrom<TextToImageResponse>
-    for image_generation::ImageGenerationResponse<TextToImageResponse>
-{
-    type Error = ImageGenerationError;
-
-    fn try_from(value: TextToImageResponse) -> Result<Self, Self::Error> {
-        if let Some(error) = value.error {
+impl NormalizeImageGenerationResponse for TextToImageResponse {
+    fn normalize(
+        self,
+        provider: &str,
+    ) -> Result<image_generation::ImageGenerationResponse, ImageGenerationError> {
+        if let Some(error) = self.error {
             return Err(ImageGenerationError::ResponseError(error));
         }
 
-        if let Some(images) = value.to_owned().images {
+        if let Some(images) = self.images {
             let image = images.first().ok_or_else(|| {
                 ImageGenerationError::ResponseError("Bedrock image response was empty".into())
             })?;
@@ -119,10 +118,9 @@ impl TryFrom<TextToImageResponse>
                 .decode(image)
                 .map_err(|err| ImageGenerationError::ResponseError(err.to_string()))?;
 
-            return Ok(Self {
-                image: data,
-                response: value,
-            });
+            return Ok(image_generation::ImageGenerationResponse::new(
+                data, provider,
+            ));
         }
 
         Err(ImageGenerationError::ResponseError(

--- a/crates/rig-core/src/audio_generation.rs
+++ b/crates/rig-core/src/audio_generation.rs
@@ -1,8 +1,11 @@
 //! Everything related to audio generation (ie, Text To Speech).
 //! Rig abstracts over a number of different providers using the [AudioGenerationModel] trait.
+use crate::completion::{ResponseIdentity, Usage};
 use crate::markers::{Missing, Provided};
 use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::sync::Arc;
 
 crate::provider_response::provider_error_enum!(
     ///
@@ -17,29 +20,123 @@ crate::provider_response::provider_error_enum!(
     }
 );
 
-pub struct AudioGenerationResponse<T> {
+/// The normalized audio generation response: the audio plus the metadata
+/// every provider can report, attributed to the provider that produced it.
+///
+/// This type is concrete — it carries no provider type parameter — so the
+/// provider does not leak into the request builder or into any caller holding
+/// a model. The provider's own payload stays reachable through a model's
+/// inherent `raw_audio_generation` method, which performs the same request and
+/// returns the provider's native type, and through [`Self::raw`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AudioGenerationResponse {
+    /// The generated audio bytes.
     pub audio: Vec<u8>,
-    pub response: T,
+    /// Usage as the provider reported it. Zero-valued when the provider
+    /// reported none — the same sentinel [`Usage`] documents for completions.
+    #[serde(default)]
+    pub usage: Usage,
+    /// Stable descriptor name of the provider that produced this response,
+    /// for example `"openai"`. Always populated.
+    pub provider: String,
+    /// Provider-reported model identifier, when the wire response named one.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Provider-assigned response-scoped identifier, when reported.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_id: Option<String>,
+    /// The provider's transport-level request identifier, taken from the HTTP
+    /// response headers — the id provider support asks for. `None` means the
+    /// provider reported none; that is a documented outcome, never an error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_request_id: Option<String>,
+    /// The provider's own response for this call: the value the model's
+    /// inherent `raw_audio_generation` would have returned, serialized.
+    /// Most text-to-speech endpoints answer with the audio bytes directly and
+    /// no JSON envelope; those providers leave this `Null` and
+    /// `raw_audio_generation` returns the bytes.
+    /// `Value::Null` otherwise means the value was built without a provider
+    /// behind it (a test double), never that the provider sent nothing.
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub raw: serde_json::Value,
 }
 
-pub trait AudioGenerationModel: Sized + Clone + WasmCompatSend + WasmCompatSync {
-    type Response: WasmCompatSend + WasmCompatSync;
+impl AudioGenerationResponse {
+    /// Create a response from its required parts; optional metadata starts
+    /// unset and is filled in with the `with_*` helpers.
+    pub fn new(audio: Vec<u8>, provider: impl Into<String>) -> Self {
+        Self {
+            audio,
+            usage: Usage::new(),
+            provider: provider.into(),
+            model: None,
+            response_id: None,
+            provider_request_id: None,
+            raw: serde_json::Value::Null,
+        }
+    }
 
-    type Client;
+    /// This response's identity metadata as one [`ResponseIdentity`] carrier.
+    /// `message_id` is always `None`: nothing here is replayed as an
+    /// assistant message.
+    pub fn identity(&self) -> ResponseIdentity {
+        ResponseIdentity {
+            message_id: None,
+            response_id: self.response_id.clone(),
+            provider_request_id: self.provider_request_id.clone(),
+        }
+    }
+}
 
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self;
+crate::provider_response::modality_response_metadata_setters!(AudioGenerationResponse);
 
+/// Convert a provider's own audio generation payload into the normalized
+/// [`AudioGenerationResponse`].
+///
+/// The provider descriptor name is an *input*, never something the conversion
+/// knows — several providers share one wire shape, and a hardcoded name would
+/// mislabel every provider but one. A trait rather than `TryFrom<(&str, T)>`
+/// so that out-of-tree provider extensions can implement it on their own
+/// response type without tripping the orphan rule.
+pub trait NormalizeAudioGenerationResponse {
+    /// Normalize this payload, attributing it to `provider`.
+    fn normalize(self, provider: &str) -> Result<AudioGenerationResponse, AudioGenerationError>;
+}
+
+/// Trait defining an audio generation (text-to-speech) model.
+///
+/// The trait describes only what a model *does*: it has no associated types.
+/// Construction lives on the capability client trait, and `Clone` is required
+/// only by [`AudioGenerationModel::audio_generation_request`], which hands the builder its own
+/// copy. The trait is implemented for `Arc<M>` by forwarding.
+pub trait AudioGenerationModel: WasmCompatSend + WasmCompatSync {
     fn audio_generation(
         &self,
         request: AudioGenerationRequest,
-    ) -> impl std::future::Future<
-        Output = Result<AudioGenerationResponse<Self::Response>, AudioGenerationError>,
-    > + WasmCompatSend;
+    ) -> impl std::future::Future<Output = Result<AudioGenerationResponse, AudioGenerationError>>
+    + WasmCompatSend;
 
-    fn audio_generation_request(&self) -> AudioGenerationRequestBuilder<Self, Missing, Missing> {
+    fn audio_generation_request(&self) -> AudioGenerationRequestBuilder<Self, Missing, Missing>
+    where
+        Self: Sized + Clone,
+    {
         AudioGenerationRequestBuilder::new(self.clone())
     }
 }
+
+impl<M> AudioGenerationModel for Arc<M>
+where
+    M: AudioGenerationModel,
+{
+    fn audio_generation(
+        &self,
+        request: AudioGenerationRequest,
+    ) -> impl std::future::Future<Output = Result<AudioGenerationResponse, AudioGenerationError>>
+    + WasmCompatSend {
+        (**self).audio_generation(request)
+    }
+}
+
 pub struct AudioGenerationRequest {
     pub text: String,
     pub voice: String,
@@ -117,18 +214,31 @@ where
     M: AudioGenerationModel,
 {
     pub fn build(self) -> AudioGenerationRequest {
-        AudioGenerationRequest {
-            text: self.text.0,
-            voice: self.voice.0,
-            speed: self.speed,
-            additional_params: self.additional_params,
-        }
+        self.into_parts().1
     }
 
-    pub async fn send(self) -> Result<AudioGenerationResponse<M::Response>, AudioGenerationError> {
-        let model = self.model.clone();
+    fn into_parts(self) -> (M, AudioGenerationRequest) {
+        let Self {
+            model,
+            text,
+            voice,
+            speed,
+            additional_params,
+        } = self;
+        (
+            model,
+            AudioGenerationRequest {
+                text: text.0,
+                voice: voice.0,
+                speed,
+                additional_params,
+            },
+        )
+    }
 
-        model.audio_generation(self.build()).await
+    pub async fn send(self) -> Result<AudioGenerationResponse, AudioGenerationError> {
+        let (model, request) = self.into_parts();
+        model.audio_generation(request).await
     }
 }
 

--- a/crates/rig-core/src/client/audio_generation.rs
+++ b/crates/rig-core/src/client/audio_generation.rs
@@ -6,7 +6,7 @@ mod audio {
     /// Clone is required for conversions between client types.
     pub trait AudioGenerationClient {
         /// The AudioGenerationModel used by the Client
-        type AudioGenerationModel: AudioGenerationModel<Client = Self>;
+        type AudioGenerationModel: AudioGenerationModel;
 
         /// Create an audio generation model with the given name.
         ///
@@ -23,9 +23,21 @@ mod audio {
         /// # Ok(())
         /// # }
         /// ```
-        fn audio_generation_model(&self, model: impl Into<String>) -> Self::AudioGenerationModel {
-            Self::AudioGenerationModel::make(self, model)
-        }
+        fn audio_generation_model(&self, model: impl Into<String>) -> Self::AudioGenerationModel;
+    }
+
+    /// Construction hook for the blanket [`AudioGenerationClient`] implementation over
+    /// [`crate::client::Client`] — the audio generation twin of
+    /// [`crate::client::ConstructCompletionModel`].
+    ///
+    /// Public for the same reason: an out-of-tree provider extension built on the
+    /// generic `Client<Ext, H>` cannot implement [`AudioGenerationClient`] for that foreign
+    /// type (orphan rule), so it implements this trait on its own model type and
+    /// the blanket implementation supplies the constructor. Providers with their
+    /// own client type implement [`AudioGenerationClient`] directly and never need this.
+    pub trait ConstructAudioGenerationModel<C>: Sized {
+        /// Build this model from its provider client and a model identifier.
+        fn construct(client: &C, model: String) -> Self;
     }
 }
 

--- a/crates/rig-core/src/client/embeddings.rs
+++ b/crates/rig-core/src/client/embeddings.rs
@@ -98,3 +98,21 @@ pub trait EmbeddingsClient {
         EmbeddingsBuilder::new(self.embedding_model_with_ndims(model, ndims))
     }
 }
+
+/// Construction hook for the blanket [`EmbeddingsClient`] implementation over
+/// [`crate::client::Client`] — the embedding twin of
+/// [`crate::client::ConstructCompletionModel`].
+///
+/// Public for the same reason: an out-of-tree provider extension built on the
+/// generic `Client<Ext, H>` cannot implement [`EmbeddingsClient`] for that foreign
+/// type (orphan rule), so it implements this trait on its own model type and
+/// the blanket implementation supplies the constructor. Providers with their
+/// own client type implement [`EmbeddingsClient`] directly and never need this.
+pub trait ConstructEmbeddingModel<C>: Sized {
+    /// Build this model from its provider client and a model identifier.
+    ///
+    /// `ndims` is the caller-requested dimension count from
+    /// [`EmbeddingsClient::embedding_model_with_ndims`], or `None` for the
+    /// model's default.
+    fn construct(client: &C, model: String, ndims: Option<usize>) -> Self;
+}

--- a/crates/rig-core/src/client/image_generation.rs
+++ b/crates/rig-core/src/client/image_generation.rs
@@ -6,7 +6,7 @@ mod image {
     /// Clone is required for conversions between client types.
     pub trait ImageGenerationClient {
         /// The ImageGenerationModel used by the Client
-        type ImageGenerationModel: ImageGenerationModel<Client = Self>;
+        type ImageGenerationModel: ImageGenerationModel;
 
         /// Create an image generation model with the given name.
         ///
@@ -24,6 +24,20 @@ mod image {
         /// # }
         /// ```
         fn image_generation_model(&self, model: impl Into<String>) -> Self::ImageGenerationModel;
+    }
+
+    /// Construction hook for the blanket [`ImageGenerationClient`] implementation over
+    /// [`crate::client::Client`] — the image generation twin of
+    /// [`crate::client::ConstructCompletionModel`].
+    ///
+    /// Public for the same reason: an out-of-tree provider extension built on the
+    /// generic `Client<Ext, H>` cannot implement [`ImageGenerationClient`] for that foreign
+    /// type (orphan rule), so it implements this trait on its own model type and
+    /// the blanket implementation supplies the constructor. Providers with their
+    /// own client type implement [`ImageGenerationClient`] directly and never need this.
+    pub trait ConstructImageGenerationModel<C>: Sized {
+        /// Build this model from its provider client and a model identifier.
+        fn construct(client: &C, model: String) -> Self;
     }
 }
 

--- a/crates/rig-core/src/client/mod.rs
+++ b/crates/rig-core/src/client/mod.rs
@@ -1288,7 +1288,9 @@ mod external_modality_extension_probe {
     where
         H: Send + Sync + 'static,
     {
-        const MAX_DOCUMENTS: usize = 1;
+        fn max_documents(&self) -> usize {
+            1
+        }
 
         fn ndims(&self) -> usize {
             self.ndims.unwrap_or(3)

--- a/crates/rig-core/src/client/mod.rs
+++ b/crates/rig-core/src/client/mod.rs
@@ -12,23 +12,24 @@ pub mod verify;
 
 use bytes::Bytes;
 pub use completion::{CompletionClient, ConstructCompletionModel};
-pub use embeddings::EmbeddingsClient;
+pub use embeddings::{ConstructEmbeddingModel, EmbeddingsClient};
 use http::{HeaderMap, HeaderName, HeaderValue};
 pub use model_listing::{ModelLister, ModelListingClient};
-pub use rerank::RerankingClient;
+pub use rerank::{ConstructRerankModel, RerankingClient};
 use std::{env::VarError, fmt::Debug, marker::PhantomData, sync::Arc};
 use thiserror::Error;
+pub use transcription::ConstructTranscriptionModel;
 pub use verify::{VerifyClient, VerifyError};
 
 #[cfg(feature = "image")]
 use crate::image_generation::ImageGenerationModel;
 #[cfg(feature = "image")]
-use image_generation::ImageGenerationClient;
+pub use image_generation::{ConstructImageGenerationModel, ImageGenerationClient};
 
 #[cfg(feature = "audio")]
 use crate::audio_generation::*;
 #[cfg(feature = "audio")]
-use audio_generation::*;
+pub use audio_generation::{AudioGenerationClient, ConstructAudioGenerationModel};
 
 use crate::{
     completion::CompletionModel,
@@ -964,52 +965,48 @@ where
 
 // Every single-model capability client impl on `Client<Ext, H>` shares the
 // same shape: gate on the matching `Capabilities` slot, name the model type,
-// and construct it with `M::make`. The macro keeps the per-capability
-// variation (trait, slot, associated type, method, extra model bounds, and
-// feature gate) in one invocation each. `CompletionClient` (different
-// constructor protocol) and `EmbeddingsClient` (extra `_with_ndims` method)
-// stay hand-written below.
+// and construct it through the capability's public `Construct*Model` hook.
+// The macro keeps the per-capability variation (trait, slot, associated type,
+// method, hook, and feature gate) in one invocation each. `EmbeddingsClient`
+// (extra `_with_ndims` method and a `dims` argument on its hook) stays
+// hand-written below.
 macro_rules! impl_capability_client {
     (
         $(#[cfg(feature = $feature:literal)])?
-        $client_trait:ident { $slot:ident, $assoc:ident, $method:ident, $model_trait:ident $(+ $extra:path)* }
+        $client_trait:ident { $slot:ident, $assoc:ident, $method:ident, $model_trait:ident, $construct:ident }
     ) => {
         $(#[cfg(feature = $feature)])?
         impl<M, Ext, H> $client_trait for Client<Ext, H>
         where
             Ext: Capabilities<H, $slot = Capable<M>>,
-            M: $model_trait<Client = Self> $(+ $extra)*,
+            M: $model_trait + $construct<Self>,
         {
             type $assoc = M;
 
             fn $method(&self, model: impl Into<String>) -> Self::$assoc {
-                M::make(self, model)
+                M::construct(self, model.into())
             }
         }
     };
 }
 
-impl<M, Ext, H> CompletionClient for Client<Ext, H>
-where
-    Ext: Capabilities<H, Completion = Capable<M>>,
-    M: CompletionModel + ConstructCompletionModel<Self>,
-{
-    type CompletionModel = M;
-
-    fn completion_model(&self, model: impl Into<String>) -> Self::CompletionModel {
-        M::construct(self, model.into())
-    }
-}
+impl_capability_client!(CompletionClient {
+    Completion,
+    CompletionModel,
+    completion_model,
+    CompletionModel,
+    ConstructCompletionModel
+});
 
 impl<M, Ext, H> EmbeddingsClient for Client<Ext, H>
 where
     Ext: Capabilities<H, Embeddings = Capable<M>>,
-    M: EmbeddingModel<Client = Self>,
+    M: EmbeddingModel + ConstructEmbeddingModel<Self>,
 {
     type EmbeddingModel = M;
 
     fn embedding_model(&self, model: impl Into<String>) -> Self::EmbeddingModel {
-        M::make(self, model, None)
+        M::construct(self, model.into(), None)
     }
 
     fn embedding_model_with_ndims(
@@ -1017,7 +1014,7 @@ where
         model: impl Into<String>,
         ndims: usize,
     ) -> Self::EmbeddingModel {
-        M::make(self, model, Some(ndims))
+        M::construct(self, model.into(), Some(ndims))
     }
 }
 
@@ -1025,14 +1022,16 @@ impl_capability_client!(RerankingClient {
     Rerank,
     RerankModel,
     rerank_model,
-    RerankModel
+    RerankModel,
+    ConstructRerankModel
 });
 
 impl_capability_client!(TranscriptionClient {
     Transcription,
     TranscriptionModel,
     transcription_model,
-    TranscriptionModel + WasmCompatSend
+    TranscriptionModel,
+    ConstructTranscriptionModel
 });
 
 impl_capability_client!(
@@ -1041,7 +1040,8 @@ impl_capability_client!(
         ImageGeneration,
         ImageGenerationModel,
         image_generation_model,
-        ImageGenerationModel
+        ImageGenerationModel,
+        ConstructImageGenerationModel
     }
 );
 
@@ -1051,7 +1051,8 @@ impl_capability_client!(
         AudioGeneration,
         AudioGenerationModel,
         audio_generation_model,
-        AudioGenerationModel
+        AudioGenerationModel,
+        ConstructAudioGenerationModel
     }
 );
 
@@ -1189,5 +1190,260 @@ mod tests {
             .api_key("Foo")
             .build()
             .unwrap();
+    }
+}
+
+/// Compile coverage for an out-of-tree provider extension built on the generic
+/// [`Client`] that offers every non-completion modality: implementing the
+/// public `Construct*Model` hooks is all it takes for the blanket capability
+/// client impls to apply. Everything here uses only public API, mirroring what
+/// a downstream crate can write — the same probe [`completion`] ships for
+/// [`ConstructCompletionModel`].
+#[cfg(test)]
+mod external_modality_extension_probe {
+    use super::*;
+    use crate::embeddings::{Embedding, EmbeddingError, EmbeddingModel};
+    use crate::rerank::{RerankError, RerankModel, RerankResponse};
+    use crate::transcription::{
+        TranscriptionError, TranscriptionModel, TranscriptionRequest, TranscriptionResponse,
+    };
+
+    #[derive(Debug, Default, Clone, Copy)]
+    struct ExternalExt;
+    #[derive(Debug, Default, Clone, Copy)]
+    struct ExternalExtBuilder;
+
+    impl Provider for ExternalExt {
+        type Builder = ExternalExtBuilder;
+        const VERIFY_PATH: &'static str = "/";
+    }
+
+    impl ProviderBuilder for ExternalExtBuilder {
+        type Extension<H>
+            = ExternalExt
+        where
+            H: HttpClientExt;
+        type ApiKey = BearerAuth;
+
+        const BASE_URL: &'static str = "https://external.invalid";
+
+        fn build<H>(
+            _builder: &ClientBuilder<Self, Self::ApiKey, H>,
+        ) -> http_client::Result<Self::Extension<H>>
+        where
+            H: HttpClientExt,
+        {
+            Ok(ExternalExt)
+        }
+    }
+
+    impl<H> Capabilities<H> for ExternalExt {
+        type Completion = Nothing;
+        type Embeddings = Capable<ExternalModel<H>>;
+        type Transcription = Capable<ExternalModel<H>>;
+        type ModelListing = Nothing;
+        #[cfg(feature = "image")]
+        type ImageGeneration = Capable<ExternalModel<H>>;
+        #[cfg(feature = "audio")]
+        type AudioGeneration = Capable<ExternalModel<H>>;
+        type Rerank = Capable<ExternalModel<H>>;
+    }
+
+    impl DebugExt for ExternalExt {}
+
+    /// One model type standing in for every modality; deliberately not
+    /// `Clone`, which the relaxed supertraits no longer require.
+    struct ExternalModel<H> {
+        _client: Client<ExternalExt, H>,
+        model: String,
+        ndims: Option<usize>,
+    }
+
+    impl<H> TranscriptionModel for ExternalModel<H>
+    where
+        H: Send + Sync + 'static,
+    {
+        async fn transcription(
+            &self,
+            _request: TranscriptionRequest,
+        ) -> Result<TranscriptionResponse, TranscriptionError> {
+            Err(TranscriptionError::ResponseError(self.model.clone()))
+        }
+    }
+
+    impl<H> ConstructTranscriptionModel<Client<ExternalExt, H>> for ExternalModel<H>
+    where
+        H: Clone,
+    {
+        fn construct(client: &Client<ExternalExt, H>, model: String) -> Self {
+            Self {
+                _client: client.clone(),
+                model,
+                ndims: None,
+            }
+        }
+    }
+
+    impl<H> EmbeddingModel for ExternalModel<H>
+    where
+        H: Send + Sync + 'static,
+    {
+        const MAX_DOCUMENTS: usize = 1;
+
+        fn ndims(&self) -> usize {
+            self.ndims.unwrap_or(3)
+        }
+
+        async fn embed_texts(
+            &self,
+            _texts: impl IntoIterator<Item = String> + Send,
+        ) -> Result<Vec<Embedding>, EmbeddingError> {
+            Err(EmbeddingError::ResponseError(self.model.clone()))
+        }
+    }
+
+    impl<H> ConstructEmbeddingModel<Client<ExternalExt, H>> for ExternalModel<H>
+    where
+        H: Clone,
+    {
+        fn construct(client: &Client<ExternalExt, H>, model: String, ndims: Option<usize>) -> Self {
+            Self {
+                _client: client.clone(),
+                model,
+                ndims,
+            }
+        }
+    }
+
+    impl<H> RerankModel for ExternalModel<H>
+    where
+        H: Send + Sync + 'static,
+    {
+        const MAX_DOCUMENTS: usize = 1;
+
+        async fn rerank(
+            &self,
+            _query: &str,
+            _documents: Vec<String>,
+        ) -> Result<RerankResponse, RerankError> {
+            Err(RerankError::ResponseError(self.model.clone()))
+        }
+    }
+
+    impl<H> ConstructRerankModel<Client<ExternalExt, H>> for ExternalModel<H>
+    where
+        H: Clone,
+    {
+        fn construct(client: &Client<ExternalExt, H>, model: String) -> Self {
+            Self {
+                _client: client.clone(),
+                model,
+                ndims: None,
+            }
+        }
+    }
+
+    #[cfg(feature = "image")]
+    impl<H> ImageGenerationModel for ExternalModel<H>
+    where
+        H: Send + Sync + 'static,
+    {
+        async fn image_generation(
+            &self,
+            _request: crate::image_generation::ImageGenerationRequest,
+        ) -> Result<
+            crate::image_generation::ImageGenerationResponse,
+            crate::image_generation::ImageGenerationError,
+        > {
+            Err(crate::image_generation::ImageGenerationError::ResponseError(self.model.clone()))
+        }
+    }
+
+    #[cfg(feature = "image")]
+    impl<H> ConstructImageGenerationModel<Client<ExternalExt, H>> for ExternalModel<H>
+    where
+        H: Clone,
+    {
+        fn construct(client: &Client<ExternalExt, H>, model: String) -> Self {
+            Self {
+                _client: client.clone(),
+                model,
+                ndims: None,
+            }
+        }
+    }
+
+    #[cfg(feature = "audio")]
+    impl<H> AudioGenerationModel for ExternalModel<H>
+    where
+        H: Send + Sync + 'static,
+    {
+        async fn audio_generation(
+            &self,
+            _request: AudioGenerationRequest,
+        ) -> Result<AudioGenerationResponse, AudioGenerationError> {
+            Err(AudioGenerationError::ResponseError(self.model.clone()))
+        }
+    }
+
+    #[cfg(feature = "audio")]
+    impl<H> ConstructAudioGenerationModel<Client<ExternalExt, H>> for ExternalModel<H>
+    where
+        H: Clone,
+    {
+        fn construct(client: &Client<ExternalExt, H>, model: String) -> Self {
+            Self {
+                _client: client.clone(),
+                model,
+                ndims: None,
+            }
+        }
+    }
+
+    #[test]
+    fn external_extension_reaches_every_blanket_capability_client_impl() {
+        fn assert_transcription<C: TranscriptionClient>() {}
+        fn assert_embeddings<C: EmbeddingsClient>() {}
+        fn assert_rerank<C: RerankingClient>() {}
+        #[cfg(feature = "image")]
+        fn assert_image<C: ImageGenerationClient>() {}
+        #[cfg(feature = "audio")]
+        fn assert_audio<C: AudioGenerationClient>() {}
+
+        type ExternalClient = Client<ExternalExt, reqwest::Client>;
+        assert_transcription::<ExternalClient>();
+        assert_embeddings::<ExternalClient>();
+        assert_rerank::<ExternalClient>();
+        #[cfg(feature = "image")]
+        assert_image::<ExternalClient>();
+        #[cfg(feature = "audio")]
+        assert_audio::<ExternalClient>();
+    }
+
+    #[test]
+    fn embedding_hook_receives_the_requested_dims() {
+        let client: Client<ExternalExt, reqwest::Client> = Client::<ExternalExt>::builder()
+            .api_key("key")
+            .build()
+            .expect("client should build");
+        assert_eq!(client.embedding_model("m").ndims(), 3);
+        assert_eq!(client.embedding_model_with_ndims("m", 7).ndims(), 7);
+    }
+
+    /// `Arc<M>` is a model: the relaxed supertraits make "wrap it in an Arc"
+    /// real through the generic APIs, as for `CompletionModel`.
+    #[test]
+    fn arc_wrapped_models_satisfy_the_modality_traits() {
+        fn assert_transcription_model<M: TranscriptionModel>() {}
+        #[cfg(feature = "image")]
+        fn assert_image_model<M: ImageGenerationModel>() {}
+        #[cfg(feature = "audio")]
+        fn assert_audio_model<M: AudioGenerationModel>() {}
+
+        assert_transcription_model::<Arc<ExternalModel<reqwest::Client>>>();
+        #[cfg(feature = "image")]
+        assert_image_model::<Arc<ExternalModel<reqwest::Client>>>();
+        #[cfg(feature = "audio")]
+        assert_audio_model::<Arc<ExternalModel<reqwest::Client>>>();
     }
 }

--- a/crates/rig-core/src/client/rerank.rs
+++ b/crates/rig-core/src/client/rerank.rs
@@ -8,3 +8,17 @@ pub trait RerankingClient {
     /// Create a reranking model with the given model identifier.
     fn rerank_model(&self, model: impl Into<String>) -> Self::RerankModel;
 }
+
+/// Construction hook for the blanket [`RerankingClient`] implementation over
+/// [`crate::client::Client`] — the rerank twin of
+/// [`crate::client::ConstructCompletionModel`].
+///
+/// Public for the same reason: an out-of-tree provider extension built on the
+/// generic `Client<Ext, H>` cannot implement [`RerankingClient`] for that foreign
+/// type (orphan rule), so it implements this trait on its own model type and
+/// the blanket implementation supplies the constructor. Providers with their
+/// own client type implement [`RerankingClient`] directly and never need this.
+pub trait ConstructRerankModel<C>: Sized {
+    /// Build this model from its provider client and a model identifier.
+    fn construct(client: &C, model: String) -> Self;
+}

--- a/crates/rig-core/src/client/transcription.rs
+++ b/crates/rig-core/src/client/transcription.rs
@@ -23,3 +23,17 @@ pub trait TranscriptionClient {
     /// ```
     fn transcription_model(&self, model: impl Into<String>) -> Self::TranscriptionModel;
 }
+
+/// Construction hook for the blanket [`TranscriptionClient`] implementation over
+/// [`crate::client::Client`] — the transcription twin of
+/// [`crate::client::ConstructCompletionModel`].
+///
+/// Public for the same reason: an out-of-tree provider extension built on the
+/// generic `Client<Ext, H>` cannot implement [`TranscriptionClient`] for that foreign
+/// type (orphan rule), so it implements this trait on its own model type and
+/// the blanket implementation supplies the constructor. Providers with their
+/// own client type implement [`TranscriptionClient`] directly and never need this.
+pub trait ConstructTranscriptionModel<C>: Sized {
+    /// Build this model from its provider client and a model identifier.
+    fn construct(client: &C, model: String) -> Self;
+}

--- a/crates/rig-core/src/embeddings/builder.rs
+++ b/crates/rig-core/src/embeddings/builder.rs
@@ -489,12 +489,6 @@ mod tests {
     impl EmbeddingModel for SlowFirstBatchModel {
         const MAX_DOCUMENTS: usize = 5;
 
-        type Client = crate::client::Nothing;
-
-        fn make(_: &Self::Client, _: impl Into<String>, _: Option<usize>) -> Self {
-            Self::new()
-        }
-
         fn ndims(&self) -> usize {
             10
         }
@@ -514,6 +508,12 @@ mod tests {
                     vec: vec![0.0; 10],
                 })
                 .collect())
+        }
+    }
+
+    impl crate::client::ConstructEmbeddingModel<crate::client::Nothing> for SlowFirstBatchModel {
+        fn construct(_: &crate::client::Nothing, _: String, _: Option<usize>) -> Self {
+            Self::new()
         }
     }
 
@@ -539,12 +539,6 @@ mod tests {
     impl EmbeddingModel for DescendingLatencyModel {
         const MAX_DOCUMENTS: usize = 5;
 
-        type Client = crate::client::Nothing;
-
-        fn make(_: &Self::Client, _: impl Into<String>, _: Option<usize>) -> Self {
-            Self::new()
-        }
-
         fn ndims(&self) -> usize {
             10
         }
@@ -567,6 +561,12 @@ mod tests {
                     vec: vec![0.0; 10],
                 })
                 .collect())
+        }
+    }
+
+    impl crate::client::ConstructEmbeddingModel<crate::client::Nothing> for DescendingLatencyModel {
+        fn construct(_: &crate::client::Nothing, _: String, _: Option<usize>) -> Self {
+            Self::new()
         }
     }
 
@@ -723,12 +723,6 @@ mod tests {
     impl EmbeddingModel for OneAtATimeReversedLatency {
         const MAX_DOCUMENTS: usize = 1;
 
-        type Client = crate::client::Nothing;
-
-        fn make(_: &Self::Client, _: impl Into<String>, _: Option<usize>) -> Self {
-            Self
-        }
-
         fn ndims(&self) -> usize {
             10
         }
@@ -762,6 +756,12 @@ mod tests {
                     vec: vec![0.0; 10],
                 })
                 .collect())
+        }
+    }
+
+    impl crate::client::ConstructEmbeddingModel<crate::client::Nothing> for OneAtATimeReversedLatency {
+        fn construct(_: &crate::client::Nothing, _: String, _: Option<usize>) -> Self {
+            Self
         }
     }
 

--- a/crates/rig-core/src/embeddings/builder.rs
+++ b/crates/rig-core/src/embeddings/builder.rs
@@ -178,11 +178,12 @@ where
         }
 
         let total_texts = texts.len();
+        let max_documents = max(1, self.model.max_documents());
 
         // Compute the embeddings.
         let (slots, usage) = stream::iter(texts.into_iter().enumerate())
             // Chunk them into batches. Each batch size is at most the embedding API limit per request.
-            .chunks(M::MAX_DOCUMENTS)
+            .chunks(max_documents)
             // Generate the embeddings for each batch with usage tracking.
             .map(|chunk| async {
                 let (slots, batch): (Vec<usize>, Vec<String>) = chunk.into_iter().unzip();
@@ -197,7 +198,7 @@ where
                 ))
             })
             // Parallelize the embeddings generation over 10 concurrent requests
-            .buffer_unordered(max(1, 1024 / M::MAX_DOCUMENTS))
+            .buffer_unordered(max(1, 1024 / max_documents))
             // Write each embedding into the slot its text came from, and
             // accumulate usage.
             .try_fold(
@@ -487,7 +488,9 @@ mod tests {
     }
 
     impl EmbeddingModel for SlowFirstBatchModel {
-        const MAX_DOCUMENTS: usize = 5;
+        fn max_documents(&self) -> usize {
+            5
+        }
 
         fn ndims(&self) -> usize {
             10
@@ -537,7 +540,9 @@ mod tests {
     }
 
     impl EmbeddingModel for DescendingLatencyModel {
-        const MAX_DOCUMENTS: usize = 5;
+        fn max_documents(&self) -> usize {
+            5
+        }
 
         fn ndims(&self) -> usize {
             10
@@ -721,7 +726,9 @@ mod tests {
     struct OneAtATimeReversedLatency;
 
     impl EmbeddingModel for OneAtATimeReversedLatency {
-        const MAX_DOCUMENTS: usize = 1;
+        fn max_documents(&self) -> usize {
+            1
+        }
 
         fn ndims(&self) -> usize {
             10

--- a/crates/rig-core/src/embeddings/embedding.rs
+++ b/crates/rig-core/src/embeddings/embedding.rs
@@ -101,12 +101,6 @@ pub trait EmbeddingModel: WasmCompatSend + WasmCompatSync {
     /// The maximum number of documents that can be embedded in a single request.
     const MAX_DOCUMENTS: usize;
 
-    /// Provider client type used to construct this embedding model.
-    type Client;
-
-    /// Construct a model handle from a provider client, model identifier, and optional dimensions.
-    fn make(client: &Self::Client, model: impl Into<String>, dims: Option<usize>) -> Self;
-
     /// The number of dimensions in the embedding vector.
     fn ndims(&self) -> usize;
 
@@ -182,7 +176,7 @@ pub struct EmbeddingResponse {
 }
 
 /// Trait for embedding models that can generate embeddings for images.
-pub trait ImageEmbeddingModel: Clone + WasmCompatSend + WasmCompatSync {
+pub trait ImageEmbeddingModel: WasmCompatSend + WasmCompatSync {
     /// The maximum number of images the provider accepts in one request.
     const MAX_DOCUMENTS: usize;
 

--- a/crates/rig-core/src/embeddings/embedding.rs
+++ b/crates/rig-core/src/embeddings/embedding.rs
@@ -98,8 +98,13 @@ crate::provider_response::provider_error_enum!(
 
 /// Trait for embedding models that can generate embeddings for documents.
 pub trait EmbeddingModel: WasmCompatSend + WasmCompatSync {
-    /// The maximum number of documents that can be embedded in a single request.
-    const MAX_DOCUMENTS: usize;
+    /// The maximum number of documents that can be embedded in a single
+    /// request.
+    ///
+    /// A method rather than an associated constant so the value survives type
+    /// erasure: [`EmbeddingModelHandle`](super::EmbeddingModelHandle) captures
+    /// it by value at construction.
+    fn max_documents(&self) -> usize;
 
     /// The number of dimensions in the embedding vector.
     fn ndims(&self) -> usize;

--- a/crates/rig-core/src/embeddings/handle.rs
+++ b/crates/rig-core/src/embeddings/handle.rs
@@ -1,0 +1,306 @@
+//! A runtime handle that erases an [`EmbeddingModel`]'s concrete type.
+//!
+//! Provider authors implement [`EmbeddingModel`] as usual. [`EmbeddingModelHandle`]
+//! erases that implementation once, when it enters a long-lived consumer such as
+//! a vector store, so the store's Rust type no longer names the provider. The
+//! handle is itself an [`EmbeddingModel`] with the same behavior — erasure is
+//! lossless, because [`Embedding`] is already provider-neutral.
+//!
+//! This is the embedding twin of `rig_agent::ModelHandle`, and follows its
+//! shape deliberately: a private object-safe mirror trait with a blanket impl,
+//! one `Arc` allocation holding snapshot data plus the unsized erased model,
+//! and construction-time data ([`EmbeddingModel::ndims`],
+//! [`EmbeddingModel::max_documents`]) captured **by value** at erasure so the
+//! handle never calls back into the provider for them.
+//!
+//! It is *not* a runtime-swapping mechanism. Swapping the embedding model
+//! under a populated vector index changes the vector space and usually breaks
+//! `ndims`; the handle exists for type ergonomics and dyn-storability
+//! (heterogeneous collections of indexes, no provider name in every downstream
+//! signature), and offers no way to replace the model it holds.
+
+use std::{fmt, sync::Arc};
+
+use crate::wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync};
+
+use super::{Embedding, EmbeddingError, EmbeddingModel, EmbeddingResponse};
+
+/// Private object-safe mirror of [`EmbeddingModel`]: the public trait stays
+/// generic (RPITIT futures, `impl IntoIterator` arguments); this dyn-safe twin
+/// exists only so [`EmbeddingModelHandle`] can store one vtable.
+///
+/// The `WasmCompat*` supertraits carry the cfg fork (no-op markers on browser
+/// wasm). `ndims` and `max_documents` are deliberately absent: they are
+/// construction-time data captured alongside the erased model.
+trait ErasedEmbeddingModel: WasmCompatSend + WasmCompatSync {
+    fn embed_texts(
+        &self,
+        texts: Vec<String>,
+    ) -> WasmBoxedFuture<'_, Result<Vec<Embedding>, EmbeddingError>>;
+
+    fn embed_texts_with_usage(
+        &self,
+        texts: Vec<String>,
+    ) -> WasmBoxedFuture<'_, Result<EmbeddingResponse, EmbeddingError>>;
+}
+
+/// Every embedding model erases; the borrowed futures delegate straight to the
+/// RPITIT methods, so erasure adds one `Box::pin` per call and never clones
+/// the model.
+impl<M> ErasedEmbeddingModel for M
+where
+    M: EmbeddingModel + 'static,
+{
+    fn embed_texts(
+        &self,
+        texts: Vec<String>,
+    ) -> WasmBoxedFuture<'_, Result<Vec<Embedding>, EmbeddingError>> {
+        Box::pin(EmbeddingModel::embed_texts(self, texts))
+    }
+
+    fn embed_texts_with_usage(
+        &self,
+        texts: Vec<String>,
+    ) -> WasmBoxedFuture<'_, Result<EmbeddingResponse, EmbeddingError>> {
+        Box::pin(EmbeddingModel::embed_texts_with_usage(self, texts))
+    }
+}
+
+/// The handle's single allocation: snapshot data first, the unsized erased
+/// model last, so `Arc<EmbeddingDriver<M>>` unsize-coerces to
+/// `Arc<EmbeddingDriver<dyn ErasedEmbeddingModel>>` without a second box.
+struct EmbeddingDriver<M: ?Sized> {
+    ndims: usize,
+    max_documents: usize,
+    label: Option<String>,
+    model: M,
+}
+
+/// A cloneable, opaque handle to live embedding-model behavior.
+///
+/// Cloning is cheap and shares the retained model through an [`Arc`]; every
+/// call runs against the same instance, so interior-mutable model state
+/// persists and the model itself is never cloned. The handle is intentionally
+/// not serializable: captured clients and credentials are live process state.
+#[derive(Clone)]
+pub struct EmbeddingModelHandle {
+    inner: Arc<EmbeddingDriver<dyn ErasedEmbeddingModel>>,
+}
+
+impl EmbeddingModelHandle {
+    /// Erase a typed embedding model into a runtime handle.
+    pub fn new<M>(model: M) -> Self
+    where
+        M: EmbeddingModel + 'static,
+    {
+        Self::from_parts(None, model)
+    }
+
+    /// Erase a typed embedding model and attach a diagnostic label.
+    ///
+    /// Labels are for logs and diagnostics only; they are not stable provider
+    /// identities and are not serialized.
+    pub fn named<M>(label: impl Into<String>, model: M) -> Self
+    where
+        M: EmbeddingModel + 'static,
+    {
+        Self::from_parts(Some(label.into()), model)
+    }
+
+    fn from_parts<M>(label: Option<String>, model: M) -> Self
+    where
+        M: EmbeddingModel + 'static,
+    {
+        // Capture the snapshot once, at erasure time; the model is consumed
+        // by value and never cloned again (pinned by the
+        // `erasure_never_clones_the_model` test below).
+        let ndims = model.ndims();
+        let max_documents = model.max_documents();
+        Self {
+            inner: Arc::new(EmbeddingDriver {
+                ndims,
+                max_documents,
+                label,
+                model,
+            }),
+        }
+    }
+
+    /// Returns the optional diagnostic label attached to this handle.
+    pub fn label(&self) -> Option<&str> {
+        self.inner.label.as_deref()
+    }
+}
+
+/// A handle behaves exactly like the model it erased, with `ndims` and
+/// `max_documents` served from the snapshot captured at erasure time.
+impl EmbeddingModel for EmbeddingModelHandle {
+    fn max_documents(&self) -> usize {
+        self.inner.max_documents
+    }
+
+    fn ndims(&self) -> usize {
+        self.inner.ndims
+    }
+
+    fn embed_texts(
+        &self,
+        texts: impl IntoIterator<Item = String> + WasmCompatSend,
+    ) -> impl std::future::Future<Output = Result<Vec<Embedding>, EmbeddingError>> + WasmCompatSend
+    {
+        self.inner.model.embed_texts(texts.into_iter().collect())
+    }
+
+    fn embed_texts_with_usage(
+        &self,
+        texts: impl IntoIterator<Item = String> + WasmCompatSend,
+    ) -> impl std::future::Future<Output = Result<EmbeddingResponse, EmbeddingError>> + WasmCompatSend
+    {
+        self.inner
+            .model
+            .embed_texts_with_usage(texts.into_iter().collect())
+    }
+}
+
+impl fmt::Debug for EmbeddingModelHandle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EmbeddingModelHandle")
+            .field("label", &self.label())
+            .field("ndims", &self.inner.ndims)
+            .field("max_documents", &self.inner.max_documents)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    /// A minimal model that counts every `Clone` of itself.
+    #[derive(Clone)]
+    struct CountingInner {
+        ndims: usize,
+    }
+
+    struct CloneCountingModel {
+        inner: CountingInner,
+        clones: Arc<AtomicUsize>,
+    }
+
+    impl Clone for CloneCountingModel {
+        fn clone(&self) -> Self {
+            self.clones.fetch_add(1, Ordering::SeqCst);
+            Self {
+                inner: self.inner.clone(),
+                clones: Arc::clone(&self.clones),
+            }
+        }
+    }
+
+    impl EmbeddingModel for CloneCountingModel {
+        fn max_documents(&self) -> usize {
+            4
+        }
+
+        fn ndims(&self) -> usize {
+            self.inner.ndims
+        }
+
+        async fn embed_texts(
+            &self,
+            texts: impl IntoIterator<Item = String> + WasmCompatSend,
+        ) -> Result<Vec<Embedding>, EmbeddingError> {
+            Ok(texts
+                .into_iter()
+                .map(|document| Embedding {
+                    document,
+                    vec: vec![0.0; self.inner.ndims],
+                })
+                .collect())
+        }
+    }
+
+    /// Erasure consumes the model by value: no code path may ever clone it,
+    /// no matter how many calls run through the handle. This pins the
+    /// shared-instance semantics structurally, not just in prose.
+    #[tokio::test]
+    async fn erasure_never_clones_the_model() {
+        let clones = Arc::new(AtomicUsize::new(0));
+        let handle = EmbeddingModelHandle::new(CloneCountingModel {
+            inner: CountingInner { ndims: 3 },
+            clones: Arc::clone(&clones),
+        });
+
+        for _ in 0..3 {
+            EmbeddingModel::embed_texts(&handle, vec!["a".to_owned(), "b".to_owned()])
+                .await
+                .expect("embed");
+            EmbeddingModel::embed_text(&handle, "c")
+                .await
+                .expect("embed one");
+            EmbeddingModel::embed_texts_with_usage(&handle, vec!["d".to_owned()])
+                .await
+                .expect("embed with usage");
+        }
+        let second = handle.clone();
+        EmbeddingModel::embed_text(&second, "e")
+            .await
+            .expect("embed via clone");
+
+        assert_eq!(
+            clones.load(Ordering::SeqCst),
+            0,
+            "erasure and calls through the handle must never clone the model"
+        );
+    }
+
+    /// `ndims` and `max_documents` are snapshots, not callbacks.
+    #[test]
+    fn snapshot_is_captured_by_value() {
+        let handle = EmbeddingModelHandle::named(
+            "probe",
+            CloneCountingModel {
+                inner: CountingInner { ndims: 5 },
+                clones: Arc::new(AtomicUsize::new(0)),
+            },
+        );
+        assert_eq!(handle.ndims(), 5);
+        assert_eq!(handle.max_documents(), 4);
+        assert_eq!(handle.label(), Some("probe"));
+        assert_eq!(
+            format!("{handle:?}"),
+            "EmbeddingModelHandle { label: Some(\"probe\"), ndims: 5, max_documents: 4, .. }"
+        );
+    }
+
+    /// A model without any `Clone` impl passes through the erasure seam; the
+    /// bound is the test.
+    struct NonCloneModel;
+
+    impl EmbeddingModel for NonCloneModel {
+        fn max_documents(&self) -> usize {
+            1
+        }
+
+        fn ndims(&self) -> usize {
+            1
+        }
+
+        async fn embed_texts(
+            &self,
+            _texts: impl IntoIterator<Item = String> + WasmCompatSend,
+        ) -> Result<Vec<Embedding>, EmbeddingError> {
+            Err(EmbeddingError::ResponseError("probe".to_owned()))
+        }
+    }
+
+    #[test]
+    fn non_clone_models_erase() {
+        fn assert_embedding_model<M: EmbeddingModel>() {}
+        assert_embedding_model::<EmbeddingModelHandle>();
+        let _ = || EmbeddingModelHandle::new(NonCloneModel);
+    }
+}

--- a/crates/rig-core/src/embeddings/mod.rs
+++ b/crates/rig-core/src/embeddings/mod.rs
@@ -8,10 +8,12 @@
 pub mod builder;
 pub mod embed;
 pub mod embedding;
+pub mod handle;
 pub mod tool;
 
 pub mod distance;
 pub use builder::EmbeddingsBuilder;
 pub use embed::{Embed, EmbedError, TextEmbedder, to_texts};
 pub use embedding::*;
+pub use handle::EmbeddingModelHandle;
 pub use tool::ToolSchema;

--- a/crates/rig-core/src/image_generation.rs
+++ b/crates/rig-core/src/image_generation.rs
@@ -1,8 +1,11 @@
 //! Everything related to core image generation abstractions in Rig.
 //! Rig allows calling a number of different providers (that support image generation) using the [ImageGenerationModel] trait.
+use crate::completion::{ResponseIdentity, Usage};
 use crate::markers::{Missing, Provided};
 use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::sync::Arc;
 
 crate::provider_response::provider_error_enum!(
     ImageGenerationError, "image generation" {
@@ -12,32 +15,123 @@ crate::provider_response::provider_error_enum!(
     }
 );
 
-/// A unified response for a model image generation, returning both the image and the raw response.
-#[derive(Debug)]
-pub struct ImageGenerationResponse<T> {
+/// The normalized image generation response: the image plus the metadata
+/// every provider can report, attributed to the provider that produced it.
+///
+/// This type is concrete — it carries no provider type parameter — so the
+/// provider does not leak into the request builder or into any caller holding
+/// a model. The provider's own payload stays reachable through a model's
+/// inherent `raw_image_generation` method, which performs the same request and
+/// returns the provider's native type, and through [`Self::raw`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImageGenerationResponse {
+    /// The generated image, decoded to bytes.
     pub image: Vec<u8>,
-    pub response: T,
+    /// Usage as the provider reported it. Zero-valued when the provider
+    /// reported none — the same sentinel [`Usage`] documents for completions.
+    #[serde(default)]
+    pub usage: Usage,
+    /// Stable descriptor name of the provider that produced this response,
+    /// for example `"openai"`. Always populated.
+    pub provider: String,
+    /// Provider-reported model identifier, when the wire response named one.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Provider-assigned response-scoped identifier, when reported.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_id: Option<String>,
+    /// The provider's transport-level request identifier, taken from the HTTP
+    /// response headers — the id provider support asks for. `None` means the
+    /// provider reported none; that is a documented outcome, never an error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_request_id: Option<String>,
+    /// The provider's own response for this call: the value the model's
+    /// inherent `raw_image_generation` would have returned, serialized.
+    /// Providers whose endpoint answers with the image bytes directly (no
+    /// JSON envelope) have nothing to serialize here and leave it `Null`;
+    /// their `raw_image_generation` returns the bytes.
+    /// `Value::Null` otherwise means the value was built without a provider
+    /// behind it (a test double), never that the provider sent nothing.
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub raw: serde_json::Value,
 }
 
-pub trait ImageGenerationModel: Clone + WasmCompatSend + WasmCompatSync {
-    type Response: WasmCompatSend + WasmCompatSync;
+impl ImageGenerationResponse {
+    /// Create a response from its required parts; optional metadata starts
+    /// unset and is filled in with the `with_*` helpers.
+    pub fn new(image: Vec<u8>, provider: impl Into<String>) -> Self {
+        Self {
+            image,
+            usage: Usage::new(),
+            provider: provider.into(),
+            model: None,
+            response_id: None,
+            provider_request_id: None,
+            raw: serde_json::Value::Null,
+        }
+    }
 
-    type Client;
+    /// This response's identity metadata as one [`ResponseIdentity`] carrier.
+    /// `message_id` is always `None`: nothing here is replayed as an
+    /// assistant message.
+    pub fn identity(&self) -> ResponseIdentity {
+        ResponseIdentity {
+            message_id: None,
+            response_id: self.response_id.clone(),
+            provider_request_id: self.provider_request_id.clone(),
+        }
+    }
+}
 
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self;
+crate::provider_response::modality_response_metadata_setters!(ImageGenerationResponse);
 
+/// Convert a provider's own image generation payload into the normalized
+/// [`ImageGenerationResponse`].
+///
+/// The provider descriptor name is an *input*, never something the conversion
+/// knows — several providers share one wire shape, and a hardcoded name would
+/// mislabel every provider but one. A trait rather than `TryFrom<(&str, T)>`
+/// so that out-of-tree provider extensions can implement it on their own
+/// response type without tripping the orphan rule.
+pub trait NormalizeImageGenerationResponse {
+    /// Normalize this payload, attributing it to `provider`.
+    fn normalize(self, provider: &str) -> Result<ImageGenerationResponse, ImageGenerationError>;
+}
+
+/// Trait defining an image generation model.
+///
+/// The trait describes only what a model *does*: it has no associated types.
+/// Construction lives on the capability client trait, and `Clone` is required
+/// only by [`ImageGenerationModel::image_generation_request`], which hands the builder its own
+/// copy. The trait is implemented for `Arc<M>` by forwarding.
+pub trait ImageGenerationModel: WasmCompatSend + WasmCompatSync {
     fn image_generation(
         &self,
         request: ImageGenerationRequest,
-    ) -> impl std::future::Future<
-        Output = Result<ImageGenerationResponse<Self::Response>, ImageGenerationError>,
-    > + WasmCompatSend;
+    ) -> impl std::future::Future<Output = Result<ImageGenerationResponse, ImageGenerationError>>
+    + WasmCompatSend;
 
-    fn image_generation_request(&self) -> ImageGenerationRequestBuilder<Self, Missing> {
+    fn image_generation_request(&self) -> ImageGenerationRequestBuilder<Self, Missing>
+    where
+        Self: Sized + Clone,
+    {
         ImageGenerationRequestBuilder::new(self.clone())
     }
 }
-/// An image generation request.
+
+impl<M> ImageGenerationModel for Arc<M>
+where
+    M: ImageGenerationModel,
+{
+    fn image_generation(
+        &self,
+        request: ImageGenerationRequest,
+    ) -> impl std::future::Future<Output = Result<ImageGenerationResponse, ImageGenerationError>>
+    + WasmCompatSend {
+        (**self).image_generation(request)
+    }
+}
+
 pub struct ImageGenerationRequest {
     pub prompt: String,
     pub width: u32,
@@ -112,18 +206,31 @@ where
     M: ImageGenerationModel,
 {
     pub fn build(self) -> ImageGenerationRequest {
-        ImageGenerationRequest {
-            prompt: self.prompt.0,
-            width: self.width,
-            height: self.height,
-            additional_params: self.additional_params,
-        }
+        self.into_parts().1
     }
 
-    pub async fn send(self) -> Result<ImageGenerationResponse<M::Response>, ImageGenerationError> {
-        let model = self.model.clone();
+    fn into_parts(self) -> (M, ImageGenerationRequest) {
+        let Self {
+            model,
+            prompt,
+            width,
+            height,
+            additional_params,
+        } = self;
+        (
+            model,
+            ImageGenerationRequest {
+                prompt: prompt.0,
+                width,
+                height,
+                additional_params,
+            },
+        )
+    }
 
-        model.image_generation(self.build()).await
+    pub async fn send(self) -> Result<ImageGenerationResponse, ImageGenerationError> {
+        let (model, request) = self.into_parts();
+        model.image_generation(request).await
     }
 }
 

--- a/crates/rig-core/src/provider_response.rs
+++ b/crates/rig-core/src/provider_response.rs
@@ -423,6 +423,72 @@ macro_rules! response_metadata_setters {
 }
 
 pub(crate) use response_metadata_setters;
+/// Metadata setters for the normalized non-completion modality responses
+/// (transcription, image generation, audio generation). Same empty-string
+/// filtering rule as [`response_metadata_setters`]; these responses carry no
+/// message-scoped ID because nothing they produce is ever replayed as an
+/// assistant message.
+macro_rules! modality_response_metadata_setters {
+    ($ty:ty) => {
+        impl $ty {
+            /// Attach the provider-assigned response-scoped ID.
+            pub fn with_response_id(self, response_id: impl Into<String>) -> Self {
+                self.with_optional_response_id(Some(response_id.into()))
+            }
+
+            /// Attach the provider-assigned response-scoped ID when the
+            /// provider reported one. An empty string is treated as absent.
+            pub fn with_optional_response_id(
+                mut self,
+                response_id: Option<impl Into<String>>,
+            ) -> Self {
+                self.response_id = response_id.map(Into::into).filter(|id| !id.is_empty());
+                self
+            }
+
+            /// Attach the provider's transport-level request identifier.
+            pub fn with_provider_request_id(self, request_id: impl Into<String>) -> Self {
+                self.with_optional_provider_request_id(Some(request_id.into()))
+            }
+
+            /// Attach the provider's transport-level request identifier when
+            /// the provider reported one. An empty string is treated as absent.
+            pub fn with_optional_provider_request_id(
+                mut self,
+                request_id: Option<impl Into<String>>,
+            ) -> Self {
+                self.provider_request_id = request_id.map(Into::into).filter(|id| !id.is_empty());
+                self
+            }
+
+            /// Attach the provider-reported model identifier.
+            pub fn with_model(self, model: impl Into<String>) -> Self {
+                self.with_optional_model(Some(model.into()))
+            }
+
+            /// Attach the provider-reported model identifier when the
+            /// response carried one. An empty string is treated as absent.
+            pub fn with_optional_model(mut self, model: Option<impl Into<String>>) -> Self {
+                self.model = model.map(Into::into).filter(|model| !model.is_empty());
+                self
+            }
+
+            /// Attach the usage the provider reported.
+            pub fn with_usage(mut self, usage: $crate::completion::Usage) -> Self {
+                self.usage = usage;
+                self
+            }
+
+            /// Attach the provider's own response, serialized — the value the
+            /// model's inherent raw method would have returned.
+            pub fn with_raw(mut self, raw: impl Into<serde_json::Value>) -> Self {
+                self.raw = raw.into();
+                self
+            }
+        }
+    };
+}
+pub(crate) use modality_response_metadata_setters;
 
 /// Declares a capability error enum with the shared core variants
 /// (`HttpError`, `JsonError`, `ResponseError`, `ProviderError`,

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -427,6 +427,8 @@ where
     T: HttpClientExt + Clone + 'static,
 {
     const MODEL_IN_FORM: bool = false;
+    const PROVIDER_NAME: &'static str = "azure.openai";
+    const REQUEST_ID_HEADER: Option<&'static str> = None;
 
     fn transcription_request(
         &self,
@@ -458,6 +460,7 @@ mod image_generation {
 
     impl JsonImageGenerationProvider for AzureExt {
         const IMAGE_GENERATION_PATH: &'static str = "";
+        const PROVIDER_NAME: &'static str = "azure.openai";
         type Response = ImageGenerationResponse;
 
         fn image_generation_request_builder<H>(
@@ -506,6 +509,7 @@ mod audio_generation {
 
     impl RawAudioGenerationProvider for AzureExt {
         const AUDIO_GENERATION_PATH: &'static str = "";
+        const PROVIDER_NAME: &'static str = "azure.openai";
 
         fn audio_generation_request_builder<H>(
             client: &crate::client::Client<Self, H>,
@@ -588,6 +592,7 @@ mod azure_tests {
     #[cfg(feature = "image")]
     #[tokio::test]
     async fn image_generation_non_success_response_preserves_status_and_body() {
+        use crate::client::image_generation::ImageGenerationClient;
         use crate::image_generation::{
             ImageGenerationError, ImageGenerationModel as ImageGenerationModelTrait,
             ImageGenerationRequest,
@@ -597,7 +602,7 @@ mod azure_tests {
         let body = r#"{"error":{"message":"invalid image request"}}"#;
         let http_client =
             RecordingHttpClient::with_error_response(http::StatusCode::BAD_REQUEST, body);
-        let model = ImageGenerationModel::make(&test_client(http_client), "dall-e-3");
+        let model = test_client(http_client).image_generation_model("dall-e-3");
 
         let error = model
             .image_generation(ImageGenerationRequest {
@@ -794,7 +799,7 @@ mod azure_tests {
             .http_client(http_client)
             .build()
             .expect("build client");
-        let model = super::EmbeddingModel::make(&client, TEXT_EMBEDDING_3_SMALL, None);
+        let model = client.embedding_model(TEXT_EMBEDDING_3_SMALL);
 
         let error = match model.embed_texts(vec!["Hello, world!".to_string()]).await {
             Err(error) => error,
@@ -827,7 +832,7 @@ mod azure_tests {
             .http_client(http_client.clone())
             .build()
             .expect("build client");
-        let model = super::EmbeddingModel::make(&client, TEXT_EMBEDDING_3_SMALL, None);
+        let model = client.embedding_model(TEXT_EMBEDDING_3_SMALL);
 
         let response = model
             .embed_texts_with_usage(vec!["Hello, world!".to_string()])

--- a/crates/rig-core/src/providers/cohere/embeddings.rs
+++ b/crates/rig-core/src/providers/cohere/embeddings.rs
@@ -148,7 +148,9 @@ impl<T> embeddings::EmbeddingModel for EmbeddingModel<T>
 where
     T: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
-    const MAX_DOCUMENTS: usize = 96;
+    fn max_documents(&self) -> usize {
+        96
+    }
     fn ndims(&self) -> usize {
         self.ndims
     }

--- a/crates/rig-core/src/providers/cohere/embeddings.rs
+++ b/crates/rig-core/src/providers/cohere/embeddings.rs
@@ -149,17 +149,6 @@ where
     T: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     const MAX_DOCUMENTS: usize = 96;
-    type Client = Client<T>;
-
-    fn make(client: &Self::Client, model: impl Into<String>, dims: Option<usize>) -> Self {
-        let model = model.into();
-        let dims = dims
-            .or(super::model_dimensions_from_identifier(&model))
-            .unwrap_or_default();
-
-        Self::new(client.clone(), model, "search_document", dims)
-    }
-
     fn ndims(&self) -> usize {
         self.ndims
     }
@@ -246,6 +235,19 @@ where
                 String::from_utf8_lossy(&raw_body),
             ))
         }
+    }
+}
+
+impl<T> crate::client::ConstructEmbeddingModel<Client<T>> for EmbeddingModel<T>
+where
+    T: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
+{
+    fn construct(client: &Client<T>, model: String, dims: Option<usize>) -> Self {
+        let dims = dims
+            .or(super::model_dimensions_from_identifier(&model))
+            .unwrap_or_default();
+
+        Self::new(client.clone(), model, "search_document", dims)
     }
 }
 

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -1135,18 +1135,6 @@ where
     H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
 {
     const MAX_DOCUMENTS: usize = 1024;
-    type Client = Client<H>;
-
-    fn make(client: &Self::Client, model: impl Into<String>, ndims: Option<usize>) -> Self {
-        let model = model.into();
-        let dims = ndims.unwrap_or(match model.as_str() {
-            TEXT_EMBEDDING_3_LARGE => 3072,
-            TEXT_EMBEDDING_3_SMALL | TEXT_EMBEDDING_ADA_002 => 1536,
-            _ => 0,
-        });
-        Self::new(client.clone(), model, dims)
-    }
-
     fn ndims(&self) -> usize {
         self.ndims
     }
@@ -1265,6 +1253,21 @@ where
             let text = http_client::text(response).await?;
             Err(EmbeddingError::from_http_response(status, text))
         }
+    }
+}
+
+impl<H> crate::client::ConstructEmbeddingModel<Client<H>> for EmbeddingModel<H>
+where
+    Client<H>: HttpClientExt + Clone + Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
+{
+    fn construct(client: &Client<H>, model: String, ndims: Option<usize>) -> Self {
+        let dims = ndims.unwrap_or(match model.as_str() {
+            TEXT_EMBEDDING_3_LARGE => 3072,
+            TEXT_EMBEDDING_3_SMALL | TEXT_EMBEDDING_ADA_002 => 1536,
+            _ => 0,
+        });
+        Self::new(client.clone(), model, dims)
     }
 }
 

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -1134,7 +1134,9 @@ where
     Client<H>: HttpClientExt + Clone + Debug + WasmCompatSend + WasmCompatSync + 'static,
     H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
 {
-    const MAX_DOCUMENTS: usize = 1024;
+    fn max_documents(&self) -> usize {
+        1024
+    }
     fn ndims(&self) -> usize {
         self.ndims
     }

--- a/crates/rig-core/src/providers/gemini/embedding.rs
+++ b/crates/rig-core/src/providers/gemini/embedding.rs
@@ -57,15 +57,7 @@ impl<T> embeddings::EmbeddingModel for EmbeddingModel<T>
 where
     T: Clone + HttpClientExt + 'static,
 {
-    type Client = Client<T>;
-
     const MAX_DOCUMENTS: usize = 1024;
-
-    fn make(client: &Self::Client, model: impl Into<String>, dims: Option<usize>) -> Self {
-        let model = model.into();
-        let ndims = dims.or_else(|| model_default_ndims(&model)).unwrap_or(768);
-        Self::new(client.clone(), model, ndims)
-    }
 
     fn ndims(&self) -> usize {
         self.ndims
@@ -152,6 +144,16 @@ where
     }
 }
 
+impl<T> crate::client::ConstructEmbeddingModel<Client<T>> for EmbeddingModel<T>
+where
+    T: Clone + HttpClientExt + 'static,
+{
+    fn construct(client: &Client<T>, model: String, dims: Option<usize>) -> Self {
+        let ndims = dims.or_else(|| model_default_ndims(&model)).unwrap_or(768);
+        Self::new(client.clone(), model, ndims)
+    }
+}
+
 // =================================================================
 // Gemini API Types
 // =================================================================
@@ -174,6 +176,7 @@ mod gemini_api_types {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client::EmbeddingsClient;
 
     #[test]
     fn test_embedding_values_deserializes_without_empty_values_field() {
@@ -194,21 +197,15 @@ mod tests {
         let client = Client::new("test_key").unwrap();
 
         // EMBEDDING_001 defaults to 3072
-        let model =
-            <EmbeddingModel as embeddings::EmbeddingModel>::make(&client, EMBEDDING_001, None);
+        let model = client.embedding_model(EMBEDDING_001);
         assert_eq!(embeddings::EmbeddingModel::ndims(&model), 3072);
 
         // EMBEDDING_004 defaults to 768
-        let model =
-            <EmbeddingModel as embeddings::EmbeddingModel>::make(&client, EMBEDDING_004, None);
+        let model = client.embedding_model(EMBEDDING_004);
         assert_eq!(embeddings::EmbeddingModel::ndims(&model), 768);
 
         // Unknown model falls back to 768
-        let model = <EmbeddingModel as embeddings::EmbeddingModel>::make(
-            &client,
-            "some-future-model",
-            None,
-        );
+        let model = client.embedding_model("some-future-model");
         assert_eq!(embeddings::EmbeddingModel::ndims(&model), 768);
     }
 
@@ -216,8 +213,7 @@ mod tests {
     fn test_make_respects_explicit_dims() {
         let client = Client::new("test_key").unwrap();
 
-        let model =
-            <EmbeddingModel as embeddings::EmbeddingModel>::make(&client, EMBEDDING_001, Some(256));
+        let model = client.embedding_model_with_ndims(EMBEDDING_001, 256);
         assert_eq!(embeddings::EmbeddingModel::ndims(&model), 256);
     }
 

--- a/crates/rig-core/src/providers/gemini/embedding.rs
+++ b/crates/rig-core/src/providers/gemini/embedding.rs
@@ -57,7 +57,9 @@ impl<T> embeddings::EmbeddingModel for EmbeddingModel<T>
 where
     T: Clone + HttpClientExt + 'static,
 {
-    const MAX_DOCUMENTS: usize = 1024;
+    fn max_documents(&self) -> usize {
+        1024
+    }
 
     fn ndims(&self) -> usize {
         self.ndims

--- a/crates/rig-core/src/providers/gemini/image_generation.rs
+++ b/crates/rig-core/src/providers/gemini/image_generation.rs
@@ -5,8 +5,11 @@ use super::completion::gemini_api_types::{
     Content, GenerateContentRequest, GenerateContentResponse, GenerationConfig, ImageConfig, Part,
     PartKind, ResponseModality, Role,
 };
+use crate::completion::Usage;
 use crate::http_client::HttpClientExt;
-use crate::image_generation::{ImageGenerationError, ImageGenerationRequest};
+use crate::image_generation::{
+    ImageGenerationError, ImageGenerationRequest, NormalizeImageGenerationResponse,
+};
 use crate::{http_client, image_generation};
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
@@ -32,38 +35,40 @@ impl<T> ImageGenerationModel<T> {
     }
 }
 
-impl TryFrom<GenerateContentResponse>
-    for image_generation::ImageGenerationResponse<GenerateContentResponse>
-{
-    type Error = ImageGenerationError;
+impl NormalizeImageGenerationResponse for GenerateContentResponse {
+    fn normalize(
+        self,
+        provider: &str,
+    ) -> Result<image_generation::ImageGenerationResponse, ImageGenerationError> {
+        let image = first_image_bytes(&self)?;
+        let usage = self
+            .usage_metadata
+            .as_ref()
+            .map(Usage::from)
+            .unwrap_or_default();
 
-    fn try_from(value: GenerateContentResponse) -> Result<Self, Self::Error> {
-        let image = first_image_bytes(&value)?;
-
-        Ok(image_generation::ImageGenerationResponse {
-            image,
-            response: value,
-        })
+        Ok(
+            image_generation::ImageGenerationResponse::new(image, provider)
+                .with_optional_model(self.model_version)
+                .with_response_id(self.response_id)
+                .with_usage(usage),
+        )
     }
 }
 
-impl<T> image_generation::ImageGenerationModel for ImageGenerationModel<T>
+impl<T> ImageGenerationModel<T>
 where
     T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
 {
-    type Response = GenerateContentResponse;
-
-    type Client = Client<T>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
-
-    async fn image_generation(
+    /// Perform the generation and return Gemini's native
+    /// [`GenerateContentResponse`] instead of the normalized
+    /// [`image_generation::ImageGenerationResponse`]. Same request, transport,
+    /// parser, and error path as
+    /// [`image_generation::ImageGenerationModel::image_generation`].
+    pub async fn raw_image_generation(
         &self,
         generation_request: ImageGenerationRequest,
-    ) -> Result<image_generation::ImageGenerationResponse<Self::Response>, ImageGenerationError>
-    {
+    ) -> Result<GenerateContentResponse, ImageGenerationError> {
         let body = serde_json::to_vec(&create_request_body(generation_request)?)?;
 
         let request = self
@@ -82,12 +87,37 @@ where
         }
 
         match serde_json::from_str::<ApiResponse<GenerateContentResponse>>(&text)? {
-            ApiResponse::Ok(response) => response.try_into(),
+            ApiResponse::Ok(response) => Ok(response),
             ApiResponse::Err(err) => {
                 tracing::warn!(message = %err.error.message, "provider returned an error response");
                 Err(ImageGenerationError::from_http_response(status, text))
             }
         }
+    }
+}
+
+impl<T> image_generation::ImageGenerationModel for ImageGenerationModel<T>
+where
+    T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+{
+    async fn image_generation(
+        &self,
+        generation_request: ImageGenerationRequest,
+    ) -> Result<image_generation::ImageGenerationResponse, ImageGenerationError> {
+        let response = self.raw_image_generation(generation_request).await?;
+        let captured = serde_json::to_value(&response)?;
+        Ok(response
+            .normalize(super::completion::PROVIDER_NAME)?
+            .with_raw(captured))
+    }
+}
+
+impl<T> crate::client::ConstructImageGenerationModel<Client<T>> for ImageGenerationModel<T>
+where
+    T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+{
+    fn construct(client: &Client<T>, model: String) -> Self {
+        Self::new(client.clone(), model)
     }
 }
 
@@ -316,8 +346,8 @@ mod tests {
             response_id: "response-id".to_string(),
         };
 
-        let parsed: image_generation::ImageGenerationResponse<GenerateContentResponse> = response
-            .try_into()
+        let parsed = response
+            .normalize(super::super::completion::PROVIDER_NAME)
             .expect("response should contain an image");
 
         assert_eq!(parsed.image, b"final image");
@@ -351,10 +381,9 @@ mod tests {
             response_id: "response-id".to_string(),
         };
 
-        let err = image_generation::ImageGenerationResponse::<GenerateContentResponse>::try_from(
-            response,
-        )
-        .expect_err("text-only responses should fail");
+        let err = response
+            .normalize(super::super::completion::PROVIDER_NAME)
+            .expect_err("text-only responses should fail");
 
         assert!(err.to_string().contains("did not include image data"));
     }

--- a/crates/rig-core/src/providers/gemini/transcription.rs
+++ b/crates/rig-core/src/providers/gemini/transcription.rs
@@ -5,17 +5,18 @@ use mime_guess;
 use serde_json::{Map, Value};
 
 use crate::{
+    completion::Usage,
     http_client::HttpClientExt,
     providers::gemini::completion::gemini_api_types::{
         Blob, Content, GenerateContentRequest, GenerationConfig, Part, PartKind, Role,
         visible_text_parts,
     },
     providers::internal::transcription::send_json_transcription,
-    transcription::{self, TranscriptionError},
+    transcription::{self, NormalizeTranscriptionResponse, TranscriptionError},
     wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
 
-use super::{Client, completion::gemini_api_types::GenerateContentResponse};
+use super::completion::gemini_api_types::GenerateContentResponse;
 
 const TRANSCRIPTION_PREAMBLE: &str =
     "Translate the provided audio exactly. Do not add additional information.";
@@ -26,25 +27,19 @@ pub type TranscriptionModel<T = reqwest::Client> =
         T,
     >;
 
-impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
+impl<T> TranscriptionModel<T>
 where
     T: HttpClientExt + WasmCompatSend + WasmCompatSync + Clone + 'static,
 {
-    type Response = GenerateContentResponse;
-    type Client = Client<T>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        TranscriptionModel::new(client.clone(), model)
-    }
-
-    async fn transcription(
+    /// Perform the transcription and return Gemini's native
+    /// [`GenerateContentResponse`] instead of the normalized
+    /// [`transcription::TranscriptionResponse`]. Same request, transport,
+    /// parser, and error path as
+    /// [`transcription::TranscriptionModel::transcription`].
+    pub async fn raw_transcription(
         &self,
         request: transcription::TranscriptionRequest,
-    ) -> Result<
-        transcription::TranscriptionResponse<Self::Response>,
-        transcription::TranscriptionError,
-    > {
-        // Handle Gemini specific parameters
+    ) -> Result<GenerateContentResponse, TranscriptionError> {
         let additional_params = request
             .additional_params
             .unwrap_or_else(|| Value::Object(Map::new()));
@@ -97,11 +92,13 @@ where
 
         let body = serde_json::to_vec(&request)?;
 
+        // Gemini sends no transport request-id header.
         send_json_transcription(
             &self.client,
             self.client
                 .post(format!("/v1beta/models/{}:generateContent", self.model))?,
             body,
+            None,
             |_, body| {
                 let body: GenerateContentResponse = serde_json::from_slice(body)?;
 
@@ -117,37 +114,48 @@ where
 
                 tracing::debug!("Received response");
 
-                transcription::TranscriptionResponse::try_from(body)
+                Ok(body)
             },
         )
         .await
+        .map(|(response, _)| response)
     }
 }
 
-impl TryFrom<GenerateContentResponse>
-    for transcription::TranscriptionResponse<GenerateContentResponse>
+impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
+where
+    T: HttpClientExt + WasmCompatSend + WasmCompatSync + Clone + 'static,
 {
-    type Error = TranscriptionError;
+    async fn transcription(
+        &self,
+        request: transcription::TranscriptionRequest,
+    ) -> Result<transcription::TranscriptionResponse, TranscriptionError> {
+        let response = self.raw_transcription(request).await?;
+        let captured = serde_json::to_value(&response)?;
+        Ok(response
+            .normalize(super::completion::PROVIDER_NAME)?
+            .with_raw(captured))
+    }
+}
 
-    fn try_from(response: GenerateContentResponse) -> Result<Self, Self::Error> {
-        let candidate = response.candidates.first().ok_or_else(|| {
+impl<T> crate::client::ConstructTranscriptionModel<super::Client<T>> for TranscriptionModel<T>
+where
+    T: HttpClientExt + WasmCompatSend + WasmCompatSync + Clone + 'static,
+{
+    fn construct(client: &super::Client<T>, model: String) -> Self {
+        TranscriptionModel::new(client.clone(), model)
+    }
+}
+
+impl NormalizeTranscriptionResponse for GenerateContentResponse {
+    fn normalize(
+        self,
+        provider: &str,
+    ) -> Result<transcription::TranscriptionResponse, TranscriptionError> {
+        let candidate = self.candidates.first().ok_or_else(|| {
             TranscriptionError::ResponseError("No response candidates in response".into())
         })?;
 
-        // The transcript is *every* visible text part, concatenated. Reading
-        // only `parts.first()` mistook the two shapes Gemini routinely
-        // returns here: a thinking model answers with its chain-of-thought in
-        // parts[0] (`thought: true`) and the transcript after it, so the
-        // reasoning was returned as the transcript and the transcript was
-        // dropped; and a transcript split across several text parts kept only
-        // the first. `visible_text_parts` is the shared skip-the-thoughts rule
-        // — no separator is invented between parts, because Gemini's split
-        // points are not sentence boundaries.
-        //
-        // "No text" stays a *structural* question — are there visible text
-        // parts at all — rather than "is the joined string empty". A turn
-        // whose text part is genuinely empty still converted before this
-        // change, and still does.
         let mut parts = candidate
             .content
             .as_ref()
@@ -162,7 +170,16 @@ impl TryFrom<GenerateContentResponse>
         }
         let text = parts.collect::<String>();
 
-        Ok(transcription::TranscriptionResponse { text, response })
+        let usage = self
+            .usage_metadata
+            .as_ref()
+            .map(Usage::from)
+            .unwrap_or_default();
+
+        Ok(transcription::TranscriptionResponse::new(text, provider)
+            .with_optional_model(self.model_version)
+            .with_response_id(self.response_id)
+            .with_usage(usage))
     }
 }
 
@@ -201,8 +218,7 @@ mod tests {
         let error = model
             .transcription(transcription_request())
             .await
-            .err()
-            .expect("should fail with non-success status");
+            .expect_err("should fail with non-success status");
 
         assert!(matches!(error, TranscriptionError::HttpError(_)));
         assert_eq!(

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -281,6 +281,8 @@ where
     T: HttpClientExt + Clone + 'static,
 {
     const MODEL_IN_FORM: bool = true;
+    const PROVIDER_NAME: &'static str = "groq";
+    const REQUEST_ID_HEADER: Option<&'static str> = Some("x-request-id");
 
     fn transcription_request(
         &self,

--- a/crates/rig-core/src/providers/huggingface/image_generation.rs
+++ b/crates/rig-core/src/providers/huggingface/image_generation.rs
@@ -1,7 +1,9 @@
 use super::client::Client;
 use crate::http_client::HttpClientExt;
 use crate::image_generation;
-use crate::image_generation::{ImageGenerationError, ImageGenerationRequest};
+use crate::image_generation::{
+    ImageGenerationError, ImageGenerationRequest, NormalizeImageGenerationResponse,
+};
 use serde_json::json;
 
 #[allow(non_upper_case_globals)]
@@ -12,21 +14,21 @@ pub mod image_generation_models {
 }
 pub use image_generation_models::*;
 
-#[derive(Debug)]
+/// Hugging Face's image endpoint answers with the image bytes directly — no
+/// JSON envelope — so the provider's native response *is* the bytes.
+#[derive(Debug, Clone)]
 pub struct ImageGenerationResponse {
-    data: Vec<u8>,
+    pub data: Vec<u8>,
 }
 
-impl TryFrom<ImageGenerationResponse>
-    for image_generation::ImageGenerationResponse<ImageGenerationResponse>
-{
-    type Error = ImageGenerationError;
-
-    fn try_from(value: ImageGenerationResponse) -> Result<Self, Self::Error> {
-        Ok(image_generation::ImageGenerationResponse {
-            image: value.data.clone(),
-            response: value,
-        })
+impl NormalizeImageGenerationResponse for ImageGenerationResponse {
+    fn normalize(
+        self,
+        provider: &str,
+    ) -> Result<image_generation::ImageGenerationResponse, ImageGenerationError> {
+        Ok(image_generation::ImageGenerationResponse::new(
+            self.data, provider,
+        ))
     }
 }
 
@@ -45,23 +47,19 @@ impl<T> ImageGenerationModel<T> {
     }
 }
 
-impl<T> image_generation::ImageGenerationModel for ImageGenerationModel<T>
+impl<T> ImageGenerationModel<T>
 where
     T: HttpClientExt + Send + Clone + 'static,
 {
-    type Response = ImageGenerationResponse;
-
-    type Client = Client<T>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
-
-    async fn image_generation(
+    /// Perform the generation and return the provider's native response (the
+    /// image bytes) instead of the normalized
+    /// [`image_generation::ImageGenerationResponse`]. Same request, transport,
+    /// and error path as
+    /// [`image_generation::ImageGenerationModel::image_generation`].
+    pub async fn raw_image_generation(
         &self,
         request: ImageGenerationRequest,
-    ) -> Result<image_generation::ImageGenerationResponse<Self::Response>, ImageGenerationError>
-    {
+    ) -> Result<ImageGenerationResponse, ImageGenerationError> {
         let request = json!({
             "inputs": request.prompt,
             "parameters": {
@@ -98,7 +96,32 @@ where
 
         let data: Vec<u8> = response.into_body().await?;
 
-        ImageGenerationResponse { data }.try_into()
+        Ok(ImageGenerationResponse { data })
+    }
+}
+
+impl<T> image_generation::ImageGenerationModel for ImageGenerationModel<T>
+where
+    T: HttpClientExt + Send + Clone + 'static,
+{
+    async fn image_generation(
+        &self,
+        request: ImageGenerationRequest,
+    ) -> Result<image_generation::ImageGenerationResponse, ImageGenerationError> {
+        // The native response is bytes, not JSON: `raw` stays `Null` and the
+        // typed route is `raw_image_generation`.
+        self.raw_image_generation(request)
+            .await?
+            .normalize("huggingface")
+    }
+}
+
+impl<T> crate::client::ConstructImageGenerationModel<Client<T>> for ImageGenerationModel<T>
+where
+    T: HttpClientExt + Send + Clone + 'static,
+{
+    fn construct(client: &Client<T>, model: String) -> Self {
+        Self::new(client.clone(), model)
     }
 }
 

--- a/crates/rig-core/src/providers/huggingface/transcription.rs
+++ b/crates/rig-core/src/providers/huggingface/transcription.rs
@@ -3,7 +3,7 @@ use crate::providers::huggingface::Client;
 use crate::providers::huggingface::completion::ApiResponse;
 use crate::providers::internal::transcription::send_json_transcription;
 use crate::transcription;
-use crate::transcription::TranscriptionError;
+use crate::transcription::{NormalizeTranscriptionResponse, TranscriptionError};
 use crate::wasm_compat::WasmCompatSync;
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
@@ -22,22 +22,19 @@ pub type TranscriptionModel<T = reqwest::Client> =
         T,
     >;
 
-impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
+impl<T> TranscriptionModel<T>
 where
     T: HttpClientExt + Clone + WasmCompatSync + 'static,
 {
-    type Response = TranscriptionResponse;
-
-    type Client = Client<T>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        TranscriptionModel::new(client.clone(), model)
-    }
-
-    async fn transcription(
+    /// Perform the transcription and return the provider's native response
+    /// (the OpenAI-shaped `{ text }` payload Hugging Face answers with)
+    /// instead of the normalized [`transcription::TranscriptionResponse`].
+    /// Same request, transport, parser, and error path as
+    /// [`transcription::TranscriptionModel::transcription`].
+    pub async fn raw_transcription(
         &self,
         request: transcription::TranscriptionRequest,
-    ) -> Result<transcription::TranscriptionResponse<Self::Response>, TranscriptionError> {
+    ) -> Result<TranscriptionResponse, TranscriptionError> {
         let data = request.data;
         let data = BASE64_STANDARD.encode(data);
 
@@ -52,15 +49,17 @@ where
 
         let request = serde_json::to_vec(&request)?;
 
+        // Hugging Face reports no transport request-id header.
         send_json_transcription(
             &self.client,
             self.client
                 .post(&route)?
                 .header("Content-Type", "application/json"),
             request,
+            None,
             |status, body| match serde_json::from_slice::<ApiResponse<TranscriptionResponse>>(body)?
             {
-                ApiResponse::Ok(response) => response.try_into(),
+                ApiResponse::Ok(response) => Ok(response),
                 ApiResponse::Err(err) => {
                     let message = err
                         .get("error")
@@ -79,6 +78,30 @@ where
             },
         )
         .await
+        .map(|(response, _)| response)
+    }
+}
+
+impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
+where
+    T: HttpClientExt + Clone + WasmCompatSync + 'static,
+{
+    async fn transcription(
+        &self,
+        request: transcription::TranscriptionRequest,
+    ) -> Result<transcription::TranscriptionResponse, TranscriptionError> {
+        let response = self.raw_transcription(request).await?;
+        let captured = serde_json::to_value(&response)?;
+        Ok(response.normalize("huggingface")?.with_raw(captured))
+    }
+}
+
+impl<T> crate::client::ConstructTranscriptionModel<Client<T>> for TranscriptionModel<T>
+where
+    T: HttpClientExt + Clone + WasmCompatSync + 'static,
+{
+    fn construct(client: &Client<T>, model: String) -> Self {
+        TranscriptionModel::new(client.clone(), model)
     }
 }
 
@@ -106,8 +129,7 @@ mod tests {
         let error = model
             .transcription(request)
             .await
-            .err()
-            .expect("should fail with non-success status");
+            .expect_err("should fail with non-success status");
 
         assert!(matches!(error, TranscriptionError::HttpError(_)));
         assert_eq!(
@@ -136,8 +158,7 @@ mod tests {
         let error = model
             .transcription(request)
             .await
-            .err()
-            .expect("should fail with provider error envelope");
+            .expect_err("should fail with provider error envelope");
 
         match &error {
             TranscriptionError::ProviderResponse(stored) => {

--- a/crates/rig-core/src/providers/hyperbolic.rs
+++ b/crates/rig-core/src/providers/hyperbolic.rs
@@ -149,12 +149,14 @@ pub use image_generation::*;
 mod image_generation {
     use super::HyperbolicExt;
     use crate::image_generation;
-    use crate::image_generation::{ImageGenerationError, ImageGenerationRequest};
+    use crate::image_generation::{
+        ImageGenerationError, ImageGenerationRequest, NormalizeImageGenerationResponse,
+    };
     use crate::json_utils::merge_inplace;
     use crate::providers::internal::image_generation::{
         GenericImageGenerationModel, JsonImageGenerationProvider, decode_base64_image,
     };
-    use serde::Deserialize;
+    use serde::{Deserialize, Serialize};
     use serde_json::json;
 
     pub const SDXL1_0_BASE: &str = "SDXL1.0-base";
@@ -168,33 +170,36 @@ mod image_generation {
     /// Hyperbolic image generation model.
     pub type ImageGenerationModel<T> = GenericImageGenerationModel<HyperbolicExt, T>;
 
-    #[derive(Clone, Deserialize)]
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Image {
-        image: String,
+        pub image: String,
     }
 
-    #[derive(Clone, Deserialize)]
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct ImageGenerationResponse {
-        images: Vec<Image>,
+        pub images: Vec<Image>,
     }
 
-    impl TryFrom<ImageGenerationResponse>
-        for image_generation::ImageGenerationResponse<ImageGenerationResponse>
-    {
-        type Error = ImageGenerationError;
-
-        fn try_from(value: ImageGenerationResponse) -> Result<Self, Self::Error> {
-            decode_base64_image(
-                value,
+    impl NormalizeImageGenerationResponse for ImageGenerationResponse {
+        fn normalize(
+            self,
+            provider: &str,
+        ) -> Result<image_generation::ImageGenerationResponse, ImageGenerationError> {
+            let image = decode_base64_image(
+                &self,
                 |response| response.images.first().map(|image| image.image.as_str()),
                 "missing image data",
                 None,
-            )
+            )?;
+            Ok(image_generation::ImageGenerationResponse::new(
+                image, provider,
+            ))
         }
     }
 
     impl JsonImageGenerationProvider for HyperbolicExt {
         const IMAGE_GENERATION_PATH: &'static str = "/v1/image/generation";
+        const PROVIDER_NAME: &'static str = "hyperbolic";
         type Response = ImageGenerationResponse;
 
         fn image_generation_request_body(
@@ -228,12 +233,14 @@ pub use audio_generation::*;
 mod audio_generation {
     use super::{ApiResponse, Client};
     use crate::audio_generation;
-    use crate::audio_generation::{AudioGenerationError, AudioGenerationRequest};
+    use crate::audio_generation::{
+        AudioGenerationError, AudioGenerationRequest, NormalizeAudioGenerationResponse,
+    };
     use crate::http_client::{self, HttpClientExt};
     use base64::Engine;
     use base64::prelude::BASE64_STANDARD;
     use bytes::Bytes;
-    use serde::Deserialize;
+    use serde::{Deserialize, Serialize};
     use serde_json::json;
 
     #[derive(Clone)]
@@ -242,47 +249,39 @@ mod audio_generation {
         pub language: String,
     }
 
-    #[derive(Clone, Deserialize)]
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct AudioGenerationResponse {
-        audio: String,
+        pub audio: String,
     }
 
-    impl TryFrom<AudioGenerationResponse>
-        for audio_generation::AudioGenerationResponse<AudioGenerationResponse>
-    {
-        type Error = AudioGenerationError;
-
-        fn try_from(value: AudioGenerationResponse) -> Result<Self, Self::Error> {
+    impl NormalizeAudioGenerationResponse for AudioGenerationResponse {
+        fn normalize(
+            self,
+            provider: &str,
+        ) -> Result<audio_generation::AudioGenerationResponse, AudioGenerationError> {
             let data = BASE64_STANDARD
-                .decode(&value.audio)
+                .decode(&self.audio)
                 .map_err(|err| AudioGenerationError::ResponseError(err.to_string()))?;
 
-            Ok(Self {
-                audio: data,
-                response: value,
-            })
+            Ok(audio_generation::AudioGenerationResponse::new(
+                data, provider,
+            ))
         }
     }
 
-    impl<T> audio_generation::AudioGenerationModel for AudioGenerationModel<T>
+    impl<T> AudioGenerationModel<T>
     where
         T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
     {
-        type Response = AudioGenerationResponse;
-        type Client = Client<T>;
-
-        fn make(client: &Self::Client, language: impl Into<String>) -> Self {
-            Self {
-                client: client.clone(),
-                language: language.into(),
-            }
-        }
-
-        async fn audio_generation(
+        /// Perform the generation and return Hyperbolic's native response
+        /// (base64 audio) instead of the normalized
+        /// [`audio_generation::AudioGenerationResponse`]. Same request,
+        /// transport, parser, and error path as
+        /// [`audio_generation::AudioGenerationModel::audio_generation`].
+        pub async fn raw_audio_generation(
             &self,
             request: AudioGenerationRequest,
-        ) -> Result<audio_generation::AudioGenerationResponse<Self::Response>, AudioGenerationError>
-        {
+        ) -> Result<AudioGenerationResponse, AudioGenerationError> {
             let request = json!({
                 "language": self.language,
                 "speaker": request.voice,
@@ -310,7 +309,7 @@ mod audio_generation {
             }
 
             match serde_json::from_slice::<ApiResponse<AudioGenerationResponse>>(&response_body)? {
-                ApiResponse::Ok(response) => response.try_into(),
+                ApiResponse::Ok(response) => Ok(response),
                 ApiResponse::Err(err) => {
                     tracing::warn!(message = %err.message, "provider returned an error response");
                     Err(AudioGenerationError::from_http_response(
@@ -318,6 +317,32 @@ mod audio_generation {
                         String::from_utf8_lossy(&response_body),
                     ))
                 }
+            }
+        }
+    }
+
+    impl<T> audio_generation::AudioGenerationModel for AudioGenerationModel<T>
+    where
+        T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+    {
+        async fn audio_generation(
+            &self,
+            request: AudioGenerationRequest,
+        ) -> Result<audio_generation::AudioGenerationResponse, AudioGenerationError> {
+            let response = self.raw_audio_generation(request).await?;
+            let captured = serde_json::to_value(&response)?;
+            Ok(response.normalize("hyperbolic")?.with_raw(captured))
+        }
+    }
+
+    impl<T> crate::client::ConstructAudioGenerationModel<Client<T>> for AudioGenerationModel<T>
+    where
+        T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+    {
+        fn construct(client: &Client<T>, language: String) -> Self {
+            Self {
+                client: client.clone(),
+                language,
             }
         }
     }
@@ -463,8 +488,7 @@ mod tests {
         let error = model
             .image_generation(request)
             .await
-            .err()
-            .expect("image generation should fail with non-success status");
+            .expect_err("image generation should fail with non-success status");
 
         assert!(matches!(error, ImageGenerationError::HttpError(_)));
         assert_eq!(
@@ -502,8 +526,7 @@ mod tests {
         let error = model
             .image_generation(request)
             .await
-            .err()
-            .expect("image generation should fail with provider error envelope");
+            .expect_err("image generation should fail with provider error envelope");
 
         match &error {
             ImageGenerationError::ProviderResponse(stored) => {
@@ -543,8 +566,7 @@ mod tests {
         let error = model
             .audio_generation(request)
             .await
-            .err()
-            .expect("audio generation should fail with non-success status");
+            .expect_err("audio generation should fail with non-success status");
 
         assert!(matches!(error, AudioGenerationError::HttpError(_)));
         assert_eq!(
@@ -582,8 +604,7 @@ mod tests {
         let error = model
             .audio_generation(request)
             .await
-            .err()
-            .expect("audio generation should fail with provider error envelope");
+            .expect_err("audio generation should fail with provider error envelope");
 
         match &error {
             AudioGenerationError::ProviderResponse(stored) => {

--- a/crates/rig-core/src/providers/internal/audio_generation.rs
+++ b/crates/rig-core/src/providers/internal/audio_generation.rs
@@ -13,9 +13,17 @@ use crate::http_client::{self, HttpClientExt};
 use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
 
 /// Provider-specific request construction for the shared raw-audio model.
-pub(crate) trait RawAudioGenerationProvider: Provider {
+#[doc(hidden)]
+pub trait RawAudioGenerationProvider: Provider {
     const AUDIO_GENERATION_PATH: &'static str;
     const EXPLICIT_JSON_CONTENT_TYPE: bool = false;
+
+    /// Stable descriptor name of the provider, stamped on every normalized
+    /// response — an input to normalization, never hardcoded in the driver.
+    const PROVIDER_NAME: &'static str;
+
+    /// The provider's transport request-id response header, when it has one.
+    const REQUEST_ID_HEADER: Option<&'static str> = None;
 
     fn audio_generation_request_builder<H>(
         client: &Client<Self, H>,
@@ -81,29 +89,71 @@ impl<Ext, H> GenericAudioGenerationModel<Ext, H> {
     }
 }
 
+impl<Ext, H> GenericAudioGenerationModel<Ext, H>
+where
+    Ext: RawAudioGenerationProvider + Clone + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
+{
+    /// Perform the generation and return the provider's native response —
+    /// the audio bytes as sent, these endpoints answer with no JSON envelope
+    /// — instead of the normalized [`AudioGenerationResponse`]. Same request,
+    /// transport, and error path as
+    /// [`audio_generation::AudioGenerationModel::audio_generation`].
+    pub async fn raw_audio_generation(
+        &self,
+        request: AudioGenerationRequest,
+    ) -> Result<Bytes, AudioGenerationError> {
+        self.raw_audio_generation_with_request_id(request)
+            .await
+            .map(|(bytes, _)| bytes)
+    }
+
+    /// [`Self::raw_audio_generation`] plus the transport request id from the
+    /// provider's request-id response header, when it carries one.
+    pub async fn raw_audio_generation_with_request_id(
+        &self,
+        request: AudioGenerationRequest,
+    ) -> Result<(Bytes, Option<String>), AudioGenerationError> {
+        let builder = Ext::audio_generation_request_builder(&self.client, &self.model)?;
+        let body = Ext::audio_generation_request_body(&self.model, request)?;
+        send_audio_generation(&self.client, builder, body, Ext::REQUEST_ID_HEADER).await
+    }
+}
+
 impl<Ext, H> audio_generation::AudioGenerationModel for GenericAudioGenerationModel<Ext, H>
 where
     Ext: RawAudioGenerationProvider + Clone + WasmCompatSend + WasmCompatSync + 'static,
     H: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
-    type Response = Bytes;
-    type Client = Client<Ext, H>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
-
     async fn audio_generation(
         &self,
         request: AudioGenerationRequest,
-    ) -> Result<AudioGenerationResponse<Self::Response>, AudioGenerationError> {
-        let builder = Ext::audio_generation_request_builder(&self.client, &self.model)?;
-        let body = Ext::audio_generation_request_body(&self.model, request)?;
-        send_audio_generation(&self.client, builder, body).await
+    ) -> Result<AudioGenerationResponse, AudioGenerationError> {
+        let (bytes, provider_request_id) =
+            self.raw_audio_generation_with_request_id(request).await?;
+        // The native response is bytes, not JSON: `raw` stays `Null` and the
+        // typed route is `raw_audio_generation`.
+        Ok(
+            AudioGenerationResponse::new(bytes.to_vec(), Ext::PROVIDER_NAME)
+                .with_optional_provider_request_id(provider_request_id),
+        )
     }
 }
 
-/// Sends an audio generation request and returns the raw audio bytes.
+impl<Ext, H> crate::client::ConstructAudioGenerationModel<Client<Ext, H>>
+    for GenericAudioGenerationModel<Ext, H>
+where
+    Ext: RawAudioGenerationProvider + Clone + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
+{
+    fn construct(client: &Client<Ext, H>, model: String) -> Self {
+        Self::new(client.clone(), model)
+    }
+}
+
+/// Sends an audio generation request and returns the raw audio bytes plus the
+/// transport request id read from `request_id_header`, when the provider has
+/// one and the response carried it.
 ///
 /// `builder` is the provider's already-path-built POST request; `body` is the
 /// provider's JSON request body. Provider error bodies are preserved raw via
@@ -112,7 +162,8 @@ pub(crate) async fn send_audio_generation<C>(
     client: &C,
     builder: http_client::Builder,
     body: serde_json::Value,
-) -> Result<AudioGenerationResponse<Bytes>, AudioGenerationError>
+    request_id_header: Option<&str>,
+) -> Result<(Bytes, Option<String>), AudioGenerationError>
 where
     C: HttpClientExt,
 {
@@ -129,6 +180,8 @@ where
     // (rig#2210).
     let (parts, body) = response.into_parts();
     let status = parts.status;
+    let provider_request_id =
+        super::transcription::request_id_from_headers(&parts.headers, request_id_header);
     let bytes: Bytes = body.await?;
 
     if !status.is_success() {
@@ -139,10 +192,7 @@ where
         .with_response_headers(Some(Box::new(parts.headers))));
     }
 
-    Ok(AudioGenerationResponse {
-        audio: bytes.to_vec(),
-        response: bytes,
-    })
+    Ok((bytes, provider_request_id))
 }
 
 #[cfg(test)]
@@ -160,6 +210,7 @@ mod tests {
 
     impl RawAudioGenerationProvider for DefaultAudioExt {
         const AUDIO_GENERATION_PATH: &'static str = "/audio/speech";
+        const PROVIDER_NAME: &'static str = "test";
     }
 
     fn body(additional_params: Option<serde_json::Value>) -> serde_json::Value {
@@ -240,10 +291,10 @@ mod header_preservation_tests {
                 .method(http::Method::POST)
                 .uri("https://example.test/v1/audio/speech"),
             serde_json::json!({}),
+            None,
         )
         .await
-        .err()
-        .expect("a 429 should fail");
+        .expect_err("a 429 should fail");
 
         assert_eq!(
             error

--- a/crates/rig-core/src/providers/internal/image_generation.rs
+++ b/crates/rig-core/src/providers/internal/image_generation.rs
@@ -14,41 +14,52 @@ use serde::de::DeserializeOwned;
 use super::envelope::ProviderEnvelope;
 use crate::client::{Client, Provider};
 use crate::http_client::{self, HttpClientExt};
-use crate::image_generation::{self, ImageGenerationError, ImageGenerationRequest};
+use crate::image_generation::{
+    self, ImageGenerationError, ImageGenerationRequest, NormalizeImageGenerationResponse,
+};
 use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
 
 /// Decodes the first base64 image selected from a provider response while
 /// retaining that response in Rig's normalized wrapper.
+/// Decodes the base64 image `select` picks out of a provider payload, with
+/// the provider's own wording for the missing-image and decode-failure
+/// errors preserved.
 pub(crate) fn decode_base64_image<T>(
-    response: T,
+    response: &T,
     select: fn(&T) -> Option<&str>,
     missing_message: &'static str,
     decode_error_prefix: Option<&'static str>,
-) -> Result<image_generation::ImageGenerationResponse<T>, ImageGenerationError> {
-    let encoded = select(&response)
+) -> Result<Vec<u8>, ImageGenerationError> {
+    let encoded = select(response)
         .ok_or_else(|| ImageGenerationError::ResponseError(missing_message.to_owned()))?;
-    let image = BASE64_STANDARD.decode(encoded).map_err(|error| {
+    BASE64_STANDARD.decode(encoded).map_err(|error| {
         ImageGenerationError::ResponseError(match decode_error_prefix {
             Some(prefix) => format!("{prefix}{error}"),
             None => error.to_string(),
         })
-    })?;
-    Ok(image_generation::ImageGenerationResponse { image, response })
+    })
 }
 
-/// Provider-specific request and response types for the shared OpenAI-envelope
-/// image generation model.
 #[doc(hidden)]
 pub trait JsonImageGenerationProvider: Provider {
     const IMAGE_GENERATION_PATH: &'static str;
 
+    /// Stable descriptor name of the provider, stamped on every normalized
+    /// response — an input to normalization, never hardcoded in the shared
+    /// conversion.
+    const PROVIDER_NAME: &'static str;
+
+    /// The provider's transport request-id response header, when it has one.
+    const REQUEST_ID_HEADER: Option<&'static str> = None;
+
+    /// The provider's own image-generation payload: what the model's inherent
+    /// `raw_image_generation` returns, and what normalizes onto
+    /// [`image_generation::ImageGenerationResponse`].
     type Response: DeserializeOwned
+        + serde::Serialize
         + WasmCompatSend
         + WasmCompatSync
-        + TryInto<
-            image_generation::ImageGenerationResponse<Self::Response>,
-            Error = ImageGenerationError,
-        >;
+        + NormalizeImageGenerationResponse;
     fn image_generation_request_builder<H>(
         client: &Client<Self, H>,
         _model: &str,
@@ -65,7 +76,6 @@ pub trait JsonImageGenerationProvider: Provider {
     ) -> Result<serde_json::Value, ImageGenerationError>;
 }
 
-/// Shared model shell for JSON image-generation endpoints.
 #[doc(hidden)]
 #[derive(Clone)]
 pub struct GenericImageGenerationModel<Ext, H = reqwest::Client> {
@@ -89,50 +99,81 @@ impl<Ext, H> GenericImageGenerationModel<Ext, H> {
     }
 }
 
-impl<Ext, H> image_generation::ImageGenerationModel for GenericImageGenerationModel<Ext, H>
+impl<Ext, H> GenericImageGenerationModel<Ext, H>
 where
     Ext: JsonImageGenerationProvider + Clone + WasmCompatSend + WasmCompatSync + 'static,
     H: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
-    type Response = Ext::Response;
-    type Client = Client<Ext, H>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
-
-    async fn image_generation(
+    /// Perform the generation and return the provider's native response
+    /// instead of the normalized [`image_generation::ImageGenerationResponse`].
+    /// Same request, transport, parser, and error path as
+    /// [`image_generation::ImageGenerationModel::image_generation`].
+    pub async fn raw_image_generation(
         &self,
         request: ImageGenerationRequest,
-    ) -> Result<image_generation::ImageGenerationResponse<Self::Response>, ImageGenerationError>
-    {
+    ) -> Result<Ext::Response, ImageGenerationError> {
+        self.raw_image_generation_with_request_id(request)
+            .await
+            .map(|(response, _)| response)
+    }
+
+    /// [`Self::raw_image_generation`] plus the transport request id from the
+    /// provider's request-id response header, when it carries one.
+    pub async fn raw_image_generation_with_request_id(
+        &self,
+        request: ImageGenerationRequest,
+    ) -> Result<(Ext::Response, Option<String>), ImageGenerationError> {
         let builder = Ext::image_generation_request_builder(&self.client, &self.model)?;
         let body = Ext::image_generation_request_body(&self.model, request)?;
         send_image_generation::<_, crate::providers::openai::client::ApiResponse<Ext::Response>>(
             &self.client,
             builder,
             body,
+            Ext::REQUEST_ID_HEADER,
         )
         .await
     }
 }
 
-/// Sends an image generation request and decodes the shared success-or-error
-/// envelope.
-///
-/// `builder` is the provider's already-path-built POST request; `body` is the
-/// provider's JSON request body; `A` is the provider's own response envelope
-/// so error-body classification is unchanged. Provider error bodies are
-/// preserved raw via [`ImageGenerationError::from_http_response`].
+impl<Ext, H> image_generation::ImageGenerationModel for GenericImageGenerationModel<Ext, H>
+where
+    Ext: JsonImageGenerationProvider + Clone + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
+{
+    async fn image_generation(
+        &self,
+        request: ImageGenerationRequest,
+    ) -> Result<image_generation::ImageGenerationResponse, ImageGenerationError> {
+        let (response, provider_request_id) =
+            self.raw_image_generation_with_request_id(request).await?;
+        let captured = serde_json::to_value(&response)?;
+        Ok(response
+            .normalize(Ext::PROVIDER_NAME)?
+            .with_optional_provider_request_id(provider_request_id)
+            .with_raw(captured))
+    }
+}
+
+impl<Ext, H> crate::client::ConstructImageGenerationModel<Client<Ext, H>>
+    for GenericImageGenerationModel<Ext, H>
+where
+    Ext: JsonImageGenerationProvider + Clone + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
+{
+    fn construct(client: &Client<Ext, H>, model: String) -> Self {
+        Self::new(client.clone(), model)
+    }
+}
+
 pub(crate) async fn send_image_generation<C, A>(
     client: &C,
     builder: http_client::Builder,
     body: serde_json::Value,
-) -> Result<image_generation::ImageGenerationResponse<A::Payload>, ImageGenerationError>
+    request_id_header: Option<&str>,
+) -> Result<(A::Payload, Option<String>), ImageGenerationError>
 where
     C: HttpClientExt,
     A: DeserializeOwned + ProviderEnvelope,
-    A::Payload: TryInto<image_generation::ImageGenerationResponse<A::Payload>, Error = ImageGenerationError>,
 {
     let body = serde_json::to_vec(&body)?;
 
@@ -147,6 +188,8 @@ where
     // path (rig#2210).
     let (parts, body) = response.into_parts();
     let status = parts.status;
+    let provider_request_id =
+        super::transcription::request_id_from_headers(&parts.headers, request_id_header);
     let headers = Box::new(parts.headers);
     let response_body = body.into_future().await?;
 
@@ -159,7 +202,7 @@ where
     }
 
     match serde_json::from_slice::<A>(&response_body)?.into_payload() {
-        Ok(response) => response.try_into(),
+        Ok(response) => Ok((response, provider_request_id)),
         Err(message) => {
             tracing::warn!(message = %message, "provider returned an error response");
             Err(ImageGenerationError::from_http_response(
@@ -171,9 +214,6 @@ where
     }
 }
 
-/// rig#2210: a failed image-generation response keeps its headers, so the
-/// capability error's `provider_response_headers()` is not a promise the
-/// driver quietly breaks.
 #[cfg(test)]
 mod header_preservation_tests {
     use super::*;
@@ -184,14 +224,6 @@ mod header_preservation_tests {
     /// returns before any decoding, so its conversion is never reached.
     #[derive(serde::Deserialize)]
     struct Payload;
-
-    impl TryFrom<Payload> for image_generation::ImageGenerationResponse<Payload> {
-        type Error = ImageGenerationError;
-
-        fn try_from(_: Payload) -> Result<Self, Self::Error> {
-            unreachable!("a 429 never reaches payload conversion")
-        }
-    }
 
     #[tokio::test]
     async fn non_success_response_preserves_headers() {
@@ -209,6 +241,7 @@ mod header_preservation_tests {
                 .method(http::Method::POST)
                 .uri("https://example.test/v1/images/generations"),
             serde_json::json!({}),
+            None,
         )
         .await
         .err()

--- a/crates/rig-core/src/providers/internal/rerank.rs
+++ b/crates/rig-core/src/providers/internal/rerank.rs
@@ -120,12 +120,6 @@ where
 {
     const MAX_DOCUMENTS: usize = Ext::MAX_DOCUMENTS;
 
-    type Client = Client<Ext, H>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
-
     async fn rerank(
         &self,
         query: &str,
@@ -187,5 +181,16 @@ where
                 tool_use_prompt_tokens: 0,
             },
         })
+    }
+}
+
+impl<Ext, H> crate::client::ConstructRerankModel<Client<Ext, H>> for GenericRerankModel<Ext, H>
+where
+    Client<Ext, H>: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
+    Ext: JinaCompatibleRerank + Clone + WasmCompatSend + WasmCompatSync + 'static,
+    H: WasmCompatSend + WasmCompatSync,
+{
+    fn construct(client: &Client<Ext, H>, model: String) -> Self {
+        Self::new(client.clone(), model)
     }
 }

--- a/crates/rig-core/src/providers/internal/transcription.rs
+++ b/crates/rig-core/src/providers/internal/transcription.rs
@@ -14,13 +14,25 @@ use super::envelope::ProviderEnvelope;
 use crate::client::Client;
 use crate::http_client::multipart::Part;
 use crate::http_client::{self, HttpClientExt, MultipartForm};
-use crate::transcription::{self, TranscriptionError, TranscriptionRequest};
+use crate::transcription::{
+    self, NormalizeTranscriptionResponse, TranscriptionError, TranscriptionRequest,
+};
 
 /// Provider-specific request routing for the shared OpenAI-style model.
-pub(crate) trait OpenAiTranscriptionClient: HttpClientExt + Clone {
+#[doc(hidden)]
+pub trait OpenAiTranscriptionClient: HttpClientExt + Clone {
     /// Whether the model is a multipart form field. Azure addresses the model
     /// as a deployment in the request URL instead.
     const MODEL_IN_FORM: bool;
+
+    /// Stable descriptor name of the provider, stamped on every normalized
+    /// response. An input to normalization, never hardcoded in the shared
+    /// conversion: this wire shape is shared by several providers.
+    const PROVIDER_NAME: &'static str;
+
+    /// The provider's transport request-id response header, when it has one
+    /// (OpenAI `x-request-id`). `None` means the provider reports none.
+    const REQUEST_ID_HEADER: Option<&'static str>;
 
     fn transcription_request(&self, model: &str) -> http_client::Result<http_client::Builder>;
 }
@@ -45,21 +57,35 @@ impl<C> OpenAiTranscriptionModel<C> {
     }
 }
 
-impl<C> transcription::TranscriptionModel for OpenAiTranscriptionModel<C>
+impl<C> OpenAiTranscriptionModel<C>
 where
     C: OpenAiTranscriptionClient + 'static,
 {
-    type Response = crate::providers::openai::TranscriptionResponse;
-    type Client = C;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
-
-    async fn transcription(
+    /// Perform the transcription and return the provider's native response
+    /// instead of the normalized [`transcription::TranscriptionResponse`].
+    /// Same request, transport, parser, and error path as
+    /// [`transcription::TranscriptionModel::transcription`].
+    pub async fn raw_transcription(
         &self,
         request: TranscriptionRequest,
-    ) -> Result<transcription::TranscriptionResponse<Self::Response>, TranscriptionError> {
+    ) -> Result<crate::providers::openai::TranscriptionResponse, TranscriptionError> {
+        self.raw_transcription_with_request_id(request)
+            .await
+            .map(|(response, _)| response)
+    }
+
+    /// [`Self::raw_transcription`] plus the transport request id from the
+    /// provider's request-id response header, when it carries one.
+    pub async fn raw_transcription_with_request_id(
+        &self,
+        request: TranscriptionRequest,
+    ) -> Result<
+        (
+            crate::providers::openai::TranscriptionResponse,
+            Option<String>,
+        ),
+        TranscriptionError,
+    > {
         let form = transcription_form(
             request,
             TranscriptionFields {
@@ -76,8 +102,36 @@ where
             &self.client,
             self.client.transcription_request(&self.model)?,
             form,
+            C::REQUEST_ID_HEADER,
         )
         .await
+    }
+}
+
+impl<C> transcription::TranscriptionModel for OpenAiTranscriptionModel<C>
+where
+    C: OpenAiTranscriptionClient + 'static,
+{
+    async fn transcription(
+        &self,
+        request: TranscriptionRequest,
+    ) -> Result<transcription::TranscriptionResponse, TranscriptionError> {
+        let (response, provider_request_id) =
+            self.raw_transcription_with_request_id(request).await?;
+        let captured = serde_json::to_value(&response)?;
+        Ok(response
+            .normalize(C::PROVIDER_NAME)?
+            .with_optional_provider_request_id(provider_request_id)
+            .with_raw(captured))
+    }
+}
+
+impl<C> crate::client::ConstructTranscriptionModel<C> for OpenAiTranscriptionModel<C>
+where
+    C: OpenAiTranscriptionClient + 'static,
+{
+    fn construct(client: &C, model: String) -> Self {
+        Self::new(client.clone(), model)
     }
 }
 
@@ -163,7 +217,9 @@ pub(crate) fn transcription_form(
 }
 
 /// Sends an OpenAI-style transcription request and decodes the shared
-/// success-or-error envelope.
+/// success-or-error envelope, returning the provider's typed payload plus the
+/// transport request id read from `request_id_header`, when the provider has
+/// one and the response carried it.
 ///
 /// `builder` is the provider's already-path-built POST request; `A` is the
 /// provider's own response envelope so error-body classification is unchanged.
@@ -173,12 +229,11 @@ pub(crate) async fn send_transcription<C, A>(
     client: &C,
     builder: http_client::Builder,
     form: MultipartForm,
-) -> Result<transcription::TranscriptionResponse<A::Payload>, TranscriptionError>
+    request_id_header: Option<&str>,
+) -> Result<(A::Payload, Option<String>), TranscriptionError>
 where
     C: HttpClientExt,
     A: DeserializeOwned + ProviderEnvelope,
-    A::Payload:
-        TryInto<transcription::TranscriptionResponse<A::Payload>, Error = TranscriptionError>,
 {
     let req = builder
         .body(form)
@@ -191,12 +246,13 @@ where
     // path (rig#2210).
     let (parts, body) = response.into_parts();
     let status = parts.status;
+    let provider_request_id = request_id_from_headers(&parts.headers, request_id_header);
     let headers = Box::new(parts.headers);
     let response_body = body.into_future().await?;
 
     if status.is_success() {
         match serde_json::from_slice::<A>(&response_body)?.into_payload() {
-            Ok(response) => response.try_into(),
+            Ok(response) => Ok((response, provider_request_id)),
             Err(message) => {
                 tracing::warn!(message = %message, "provider returned an error response");
                 Err(TranscriptionError::from_http_response(
@@ -215,6 +271,22 @@ where
     }
 }
 
+/// Reads the provider's transport request id off a response's headers, when
+/// the provider names such a header and the response carries a non-empty
+/// value. `None` is the documented "not reported" outcome.
+pub(crate) fn request_id_from_headers(
+    headers: &http::HeaderMap,
+    request_id_header: Option<&str>,
+) -> Option<String> {
+    request_id_header.and_then(|header| {
+        headers
+            .get(header)
+            .and_then(|value| value.to_str().ok())
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    })
+}
+
 /// Sends a JSON-bodied transcription request and splits the response on
 /// status, mirroring [`send_transcription`] for providers whose transcription
 /// endpoint takes JSON instead of multipart.
@@ -223,17 +295,16 @@ where
 /// provider-specific headers) and `body` the serialized JSON payload. On a
 /// 2xx status the raw body is handed to `decode` together with the status so
 /// each provider keeps its own payload decoding, logging and error-envelope
-/// classification; non-2xx statuses preserve the raw body via
-/// [`TranscriptionError::from_http_response`].
+/// classification; the decoded payload is returned with the transport request
+/// id read from `request_id_header`. Non-2xx statuses preserve the raw body
+/// via [`TranscriptionError::from_http_response`].
 pub(crate) async fn send_json_transcription<C, R>(
     client: &C,
     builder: http_client::Builder,
     body: Vec<u8>,
-    decode: impl FnOnce(
-        http::StatusCode,
-        &[u8],
-    ) -> Result<transcription::TranscriptionResponse<R>, TranscriptionError>,
-) -> Result<transcription::TranscriptionResponse<R>, TranscriptionError>
+    request_id_header: Option<&str>,
+    decode: impl FnOnce(http::StatusCode, &[u8]) -> Result<R, TranscriptionError>,
+) -> Result<(R, Option<String>), TranscriptionError>
 where
     C: HttpClientExt,
 {
@@ -244,11 +315,12 @@ where
     let response = client.send::<_, Vec<u8>>(req).await?;
     let (parts, body) = response.into_parts();
     let status = parts.status;
+    let provider_request_id = request_id_from_headers(&parts.headers, request_id_header);
     let headers = Box::new(parts.headers);
     let body = body.await?;
 
     if status.is_success() {
-        decode(status, &body)
+        Ok((decode(status, &body)?, provider_request_id))
     } else {
         Err(TranscriptionError::from_http_response(
             status,
@@ -450,11 +522,11 @@ mod header_preservation_tests {
                 .method(http::Method::POST)
                 .uri("https://example.test/v1/audio/transcriptions"),
             b"{}".to_vec(),
+            None,
             |_, _| unreachable!("a 429 never reaches the decoder"),
         )
         .await
-        .err()
-        .expect("a 429 should fail");
+        .expect_err("a 429 should fail");
 
         assert_retry_after(&error, "send_json_transcription");
     }
@@ -472,10 +544,10 @@ mod header_preservation_tests {
                 .method(http::Method::POST)
                 .uri("https://example.test/v1/audio/transcriptions"),
             MultipartForm::default(),
+            None,
         )
         .await
-        .err()
-        .expect("a 429 should fail");
+        .expect_err("a 429 should fail");
 
         assert_retry_after(&error, "send_transcription");
     }

--- a/crates/rig-core/src/providers/mistral/embedding.rs
+++ b/crates/rig-core/src/providers/mistral/embedding.rs
@@ -238,9 +238,12 @@ mod batch_tests {
     /// `tests/providers/mistral/capability_edges.rs`.
     #[test]
     fn builder_chunks_at_mistrals_cap_not_openais() {
+        use crate::client::EmbeddingsClient;
+        use crate::embeddings::EmbeddingModel as _;
         assert_eq!(MAX_DOCUMENTS, 256);
+        let client = super::super::Client::new("key").expect("client");
         assert_eq!(
-            <super::super::EmbeddingModel as crate::embeddings::EmbeddingModel>::MAX_DOCUMENTS,
+            client.embedding_model(super::MISTRAL_EMBED).max_documents(),
             256,
             "the generic model must take the provider's cap; the shared default is OpenAI's 1024, \
              which Mistral rejects"

--- a/crates/rig-core/src/providers/mistral/transcription.rs
+++ b/crates/rig-core/src/providers/mistral/transcription.rs
@@ -1,11 +1,13 @@
 //! Implements Mistral (basic) transcription API
 use bytes::Bytes;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
+use crate::completion::Usage;
 use crate::http_client::HttpClientExt;
+use crate::providers::internal::transcription::request_id_from_headers;
 use crate::providers::internal::transcription::{TranscriptionFields, transcription_form};
 use crate::providers::mistral::Client;
-use crate::transcription::{self, TranscriptionError};
+use crate::transcription::{self, NormalizeTranscriptionResponse, TranscriptionError};
 use crate::wasm_compat::WasmCompatSend;
 
 // ================================================================
@@ -18,7 +20,7 @@ pub const VOXTRAL_MINI: &str = "voxtral-mini-latest";
 pub const VOXTRAL_SMALL: &str = "voxtral-small-latest";
 
 /// Request usage statistics
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TranscriptionUsage {
     pub prompt_audio_seconds: Option<i32>,
     pub prompt_tokens: i32,
@@ -48,7 +50,7 @@ impl std::fmt::Display for TranscriptionUsage {
 }
 
 /// Diarization information, tells when each speaker started and ended talking plus what they said.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SegmentChunk {
     /// Start time in seconds
     pub start: f32,
@@ -63,7 +65,7 @@ pub struct SegmentChunk {
     pub segment_type: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MistralTranscriptionResponse {
     /// Audio language
     pub language: Option<String>,
@@ -77,16 +79,22 @@ pub struct MistralTranscriptionResponse {
     pub usage: TranscriptionUsage,
 }
 
-impl TryFrom<MistralTranscriptionResponse>
-    for transcription::TranscriptionResponse<MistralTranscriptionResponse>
-{
-    type Error = TranscriptionError;
-
-    fn try_from(value: MistralTranscriptionResponse) -> Result<Self, Self::Error> {
-        Ok(transcription::TranscriptionResponse {
-            text: value.text.clone(),
-            response: value,
-        })
+impl NormalizeTranscriptionResponse for MistralTranscriptionResponse {
+    fn normalize(
+        self,
+        provider: &str,
+    ) -> Result<transcription::TranscriptionResponse, TranscriptionError> {
+        let usage = Usage {
+            input_tokens: self.usage.prompt_tokens.max(0) as u64,
+            output_tokens: self.usage.completion_tokens.max(0) as u64,
+            total_tokens: self.usage.total_tokens.max(0) as u64,
+            ..Usage::new()
+        };
+        Ok(
+            transcription::TranscriptionResponse::new(self.text, provider)
+                .with_model(self.model)
+                .with_usage(usage),
+        )
     }
 }
 
@@ -96,21 +104,29 @@ pub type TranscriptionModel<T = reqwest::Client> =
         T,
     >;
 
-impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
+impl<T> TranscriptionModel<T>
 where
     T: HttpClientExt + Clone + std::fmt::Debug + Default + WasmCompatSend + 'static,
 {
-    type Response = MistralTranscriptionResponse;
-    type Client = Client<T>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
+    /// Perform the transcription and return Mistral's native response instead
+    /// of the normalized [`transcription::TranscriptionResponse`]. Same
+    /// request, transport, parser, and error path as
+    /// [`transcription::TranscriptionModel::transcription`].
+    pub async fn raw_transcription(
+        &self,
+        request: transcription::TranscriptionRequest,
+    ) -> Result<MistralTranscriptionResponse, TranscriptionError> {
+        self.raw_transcription_with_request_id(request)
+            .await
+            .map(|(response, _)| response)
     }
 
-    async fn transcription(
+    /// [`Self::raw_transcription`] plus the `mistral-correlation-id` transport
+    /// request id, when the response carried one.
+    pub async fn raw_transcription_with_request_id(
         &self,
         mut request: transcription::TranscriptionRequest,
-    ) -> Result<transcription::TranscriptionResponse<Self::Response>, TranscriptionError> {
+    ) -> Result<(MistralTranscriptionResponse, Option<String>), TranscriptionError> {
         // Mistral's transcription endpoint has no `prompt` field; it has
         // always been dropped rather than sent.
         request.prompt = None;
@@ -134,8 +150,13 @@ where
             .await
             .map_err(TranscriptionError::HttpError)?;
 
-        let status = response.status();
-        let response_bytes = response.into_body().await?;
+        let (parts, body) = response.into_parts();
+        let status = parts.status;
+        let provider_request_id = request_id_from_headers(
+            &parts.headers,
+            <super::client::MistralExt as crate::providers::openai::completion::OpenAICompatibleProvider>::REQUEST_ID_HEADER,
+        );
+        let response_bytes = body.await?;
 
         if status.is_success() {
             let response_body: MistralTranscriptionResponse =
@@ -143,22 +164,47 @@ where
 
             tracing::info!(target: "rig", "Mistral transcription token usage: {}", &response_body.usage);
 
-            Ok(transcription::TranscriptionResponse::try_from(
-                response_body,
-            )?)
+            Ok((response_body, provider_request_id))
         } else {
             Err(TranscriptionError::from_http_response(
                 status,
                 String::from_utf8_lossy(&response_bytes),
-            ))
+            )
+            .with_response_headers(Some(Box::new(parts.headers))))
         }
+    }
+}
+
+impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
+where
+    T: HttpClientExt + Clone + std::fmt::Debug + Default + WasmCompatSend + 'static,
+{
+    async fn transcription(
+        &self,
+        request: transcription::TranscriptionRequest,
+    ) -> Result<transcription::TranscriptionResponse, TranscriptionError> {
+        let (response, provider_request_id) =
+            self.raw_transcription_with_request_id(request).await?;
+        let captured = serde_json::to_value(&response)?;
+        Ok(response
+            .normalize("mistral")?
+            .with_optional_provider_request_id(provider_request_id)
+            .with_raw(captured))
+    }
+}
+
+impl<T> crate::client::ConstructTranscriptionModel<Client<T>> for TranscriptionModel<T>
+where
+    T: HttpClientExt + Clone + std::fmt::Debug + Default + WasmCompatSend + 'static,
+{
+    fn construct(client: &Client<T>, model: String) -> Self {
+        Self::new(client.clone(), model)
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::transcription::TranscriptionResponse;
 
     #[test]
     fn test_mistral_transcription_response_deserialize() {
@@ -235,16 +281,19 @@ mod test {
             },
         };
 
-        let response: TranscriptionResponse<MistralTranscriptionResponse> = mistral_response
-            .try_into()
+        let response = mistral_response
+            .normalize("mistral")
             .expect("conversion should succeed");
 
         assert_eq!(
             response.text,
             "Lorem Ipsum is simply dummy text of the printing and typesetting industry."
         );
-        assert_eq!(response.response.model, VOXTRAL_MINI);
-        assert_eq!(response.response.language, Some("en".to_string()));
+        assert_eq!(response.provider, "mistral");
+        assert_eq!(response.model.as_deref(), Some(VOXTRAL_MINI));
+        assert_eq!(response.usage.input_tokens, 10);
+        assert_eq!(response.usage.output_tokens, 10);
+        assert_eq!(response.usage.total_tokens, 20);
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -217,16 +217,6 @@ impl<T> embeddings::EmbeddingModel for EmbeddingModel<T>
 where
     T: HttpClientExt + Clone + 'static,
 {
-    type Client = Client<T>;
-
-    fn make(client: &Self::Client, model: impl Into<String>, dims: Option<usize>) -> Self {
-        let model = model.into();
-        let dims = dims
-            .or(model_dimensions_from_identifier(&model))
-            .unwrap_or_default();
-        Self::new(client.clone(), model, dims)
-    }
-
     const MAX_DOCUMENTS: usize = 1024;
     fn ndims(&self) -> usize {
         self.ndims
@@ -272,6 +262,18 @@ where
             .zip(docs.into_iter())
             .map(|(vec, document)| embeddings::Embedding { document, vec })
             .collect())
+    }
+}
+
+impl<T> crate::client::ConstructEmbeddingModel<Client<T>> for EmbeddingModel<T>
+where
+    T: HttpClientExt + Clone + 'static,
+{
+    fn construct(client: &Client<T>, model: String, dims: Option<usize>) -> Self {
+        let dims = dims
+            .or(model_dimensions_from_identifier(&model))
+            .unwrap_or_default();
+        Self::new(client.clone(), model, dims)
     }
 }
 

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -217,7 +217,9 @@ impl<T> embeddings::EmbeddingModel for EmbeddingModel<T>
 where
     T: HttpClientExt + Clone + 'static,
 {
-    const MAX_DOCUMENTS: usize = 1024;
+    fn max_documents(&self) -> usize {
+        1024
+    }
     fn ndims(&self) -> usize {
         self.ndims
     }

--- a/crates/rig-core/src/providers/openai/audio_generation.rs
+++ b/crates/rig-core/src/providers/openai/audio_generation.rs
@@ -16,10 +16,14 @@ pub type CompletionsAudioGenerationModel<T = reqwest::Client> =
 
 impl RawAudioGenerationProvider for OpenAIResponsesExt {
     const AUDIO_GENERATION_PATH: &'static str = "/audio/speech";
+    const PROVIDER_NAME: &'static str = "openai";
+    const REQUEST_ID_HEADER: Option<&'static str> = Some("x-request-id");
 }
 
 impl RawAudioGenerationProvider for OpenAICompletionsExt {
     const AUDIO_GENERATION_PATH: &'static str = "/audio/speech";
+    const PROVIDER_NAME: &'static str = "openai";
+    const REQUEST_ID_HEADER: Option<&'static str> = Some("x-request-id");
 }
 
 #[cfg(test)]
@@ -51,8 +55,7 @@ mod tests {
         let error = model
             .audio_generation(request)
             .await
-            .err()
-            .expect("should fail with non-success status");
+            .expect_err("should fail with non-success status");
 
         assert!(matches!(error, AudioGenerationError::HttpError(_)));
         assert_eq!(

--- a/crates/rig-core/src/providers/openai/embedding.rs
+++ b/crates/rig-core/src/providers/openai/embedding.rs
@@ -179,18 +179,6 @@ where
 {
     const MAX_DOCUMENTS: usize = Ext::MAX_DOCUMENTS;
 
-    type Client = crate::client::Client<Ext, H>;
-
-    fn make(client: &Self::Client, model: impl Into<String>, ndims: Option<usize>) -> Self {
-        let model = model.into();
-        let dimensions_were_explicitly_set = ndims.is_some();
-        let dims = ndims
-            .or_else(|| Ext::default_ndims(&model))
-            .unwrap_or_default();
-
-        Self::from_parts(client.clone(), model, dims, dimensions_were_explicitly_set)
-    }
-
     fn ndims(&self) -> usize {
         self.ndims
     }
@@ -365,6 +353,27 @@ where
             let text = http_client::text(response).await?;
             Err(EmbeddingError::from_http_response(status, text))
         }
+    }
+}
+
+impl<Ext, H> crate::client::ConstructEmbeddingModel<crate::client::Client<Ext, H>>
+    for GenericEmbeddingModel<Ext, H>
+where
+    crate::client::Client<Ext, H>:
+        HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
+    Ext: OpenAIEmbeddingsCompatible + Clone + 'static,
+{
+    fn construct(
+        client: &crate::client::Client<Ext, H>,
+        model: String,
+        ndims: Option<usize>,
+    ) -> Self {
+        let dimensions_were_explicitly_set = ndims.is_some();
+        let dims = ndims
+            .or_else(|| Ext::default_ndims(&model))
+            .unwrap_or_default();
+
+        Self::from_parts(client.clone(), model, dims, dimensions_were_explicitly_set)
     }
 }
 

--- a/crates/rig-core/src/providers/openai/embedding.rs
+++ b/crates/rig-core/src/providers/openai/embedding.rs
@@ -177,7 +177,9 @@ where
         HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
     Ext: OpenAIEmbeddingsCompatible + Clone + 'static,
 {
-    const MAX_DOCUMENTS: usize = Ext::MAX_DOCUMENTS;
+    fn max_documents(&self) -> usize {
+        Ext::MAX_DOCUMENTS
+    }
 
     fn ndims(&self) -> usize {
         self.ndims

--- a/crates/rig-core/src/providers/openai/image_generation.rs
+++ b/crates/rig-core/src/providers/openai/image_generation.rs
@@ -1,11 +1,13 @@
 use super::{OpenAICompletionsExt, OpenAIResponsesExt};
 use crate::image_generation;
-use crate::image_generation::{ImageGenerationError, ImageGenerationRequest};
+use crate::image_generation::{
+    ImageGenerationError, ImageGenerationRequest, NormalizeImageGenerationResponse,
+};
 use crate::json_utils::merge_inplace;
 use crate::providers::internal::image_generation::{
     GenericImageGenerationModel, JsonImageGenerationProvider, decode_base64_image,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 // ================================================================
@@ -17,29 +19,31 @@ pub const GPT_IMAGE_1: &str = "gpt-image-1";
 pub const GPT_IMAGE_1_5: &str = "gpt-image-1.5";
 pub const GPT_IMAGE_2: &str = "gpt-image-2";
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImageGenerationData {
     pub b64_json: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImageGenerationResponse {
     pub created: i32,
     pub data: Vec<ImageGenerationData>,
 }
 
-impl TryFrom<ImageGenerationResponse>
-    for image_generation::ImageGenerationResponse<ImageGenerationResponse>
-{
-    type Error = ImageGenerationError;
-
-    fn try_from(value: ImageGenerationResponse) -> Result<Self, Self::Error> {
-        decode_base64_image(
-            value,
+impl NormalizeImageGenerationResponse for ImageGenerationResponse {
+    fn normalize(
+        self,
+        provider: &str,
+    ) -> Result<image_generation::ImageGenerationResponse, ImageGenerationError> {
+        let image = decode_base64_image(
+            &self,
             |response| response.data.first().map(|image| image.b64_json.as_str()),
             "missing image data",
             None,
-        )
+        )?;
+        Ok(image_generation::ImageGenerationResponse::new(
+            image, provider,
+        ))
     }
 }
 
@@ -99,6 +103,8 @@ fn build_request(
 
 impl JsonImageGenerationProvider for OpenAIResponsesExt {
     const IMAGE_GENERATION_PATH: &'static str = "/images/generations";
+    const PROVIDER_NAME: &'static str = "openai";
+    const REQUEST_ID_HEADER: Option<&'static str> = Some("x-request-id");
     type Response = ImageGenerationResponse;
 
     fn image_generation_request_body(
@@ -111,6 +117,8 @@ impl JsonImageGenerationProvider for OpenAIResponsesExt {
 
 impl JsonImageGenerationProvider for OpenAICompletionsExt {
     const IMAGE_GENERATION_PATH: &'static str = "/images/generations";
+    const PROVIDER_NAME: &'static str = "openai";
+    const REQUEST_ID_HEADER: Option<&'static str> = Some("x-request-id");
     type Response = ImageGenerationResponse;
 
     fn image_generation_request_body(

--- a/crates/rig-core/src/providers/openai/transcription.rs
+++ b/crates/rig-core/src/providers/openai/transcription.rs
@@ -1,9 +1,10 @@
+use crate::completion::Usage;
 use crate::http_client::HttpClientExt;
 use crate::providers::internal::transcription::OpenAiTranscriptionClient;
 use crate::providers::openai::{Client, CompletionsClient};
 use crate::transcription;
-use crate::transcription::TranscriptionError;
-use serde::Deserialize;
+use crate::transcription::{NormalizeTranscriptionResponse, TranscriptionError};
+use serde::{Deserialize, Serialize};
 
 // ================================================================
 // OpenAI Transcription API
@@ -11,16 +12,16 @@ use serde::Deserialize;
 
 pub const WHISPER_1: &str = "whisper-1";
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TranscriptionResponse {
     pub text: String,
     /// What the transcription cost, as the endpoint reported it.
     ///
-    /// Both live model families return this beside the transcript, and it is
-    /// the only accounting a caller gets for a transcription — the normalized
-    /// [`transcription::TranscriptionResponse`] carries no usage slot, so
-    /// dropping it here dropped it everywhere. Optional because a compatible
-    /// provider on this wire may not report one.
+    /// Token-billed shapes normalize onto
+    /// [`transcription::TranscriptionResponse::usage`]; the duration-billed
+    /// `seconds` figure has no normalized slot and is read from here (via the
+    /// raw route). Optional because a compatible provider on this wire may
+    /// not report one.
     #[serde(default)]
     pub usage: Option<TranscriptionUsage>,
 }
@@ -39,7 +40,7 @@ pub struct TranscriptionResponse {
 /// falls to the verbatim catch-all rather than failing the whole
 /// transcription — the same invariant the Responses `Output` enum keeps for
 /// unmodeled output items.
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum TranscriptionUsage {
     /// Duration-billed models.
@@ -70,7 +71,7 @@ pub enum TranscriptionUsage {
 }
 
 /// The wire tag of [`TranscriptionUsage::Duration`].
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum DurationTag {
     /// `"duration"`.
@@ -78,7 +79,7 @@ pub enum DurationTag {
 }
 
 /// The wire tag of [`TranscriptionUsage::Tokens`].
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TokensTag {
     /// `"tokens"`.
@@ -86,7 +87,7 @@ pub enum TokensTag {
 }
 
 /// How a token-billed transcription's input tokens split by modality.
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TranscriptionInputTokenDetails {
     /// Input tokens attributable to the audio.
     #[serde(default)]
@@ -96,16 +97,31 @@ pub struct TranscriptionInputTokenDetails {
     pub text_tokens: u64,
 }
 
-impl TryFrom<TranscriptionResponse>
-    for transcription::TranscriptionResponse<TranscriptionResponse>
-{
-    type Error = TranscriptionError;
-
-    fn try_from(value: TranscriptionResponse) -> Result<Self, Self::Error> {
-        Ok(transcription::TranscriptionResponse {
-            text: value.text.clone(),
-            response: value,
-        })
+impl NormalizeTranscriptionResponse for TranscriptionResponse {
+    fn normalize(
+        self,
+        provider: &str,
+    ) -> Result<transcription::TranscriptionResponse, TranscriptionError> {
+        let usage = match &self.usage {
+            Some(TranscriptionUsage::Tokens {
+                input_tokens,
+                output_tokens,
+                total_tokens,
+                ..
+            }) => Usage {
+                input_tokens: *input_tokens,
+                output_tokens: *output_tokens,
+                total_tokens: *total_tokens,
+                ..Usage::new()
+            },
+            // Duration billing reports no token counts; the zero sentinel is
+            // the documented "not reported" value, and the seconds stay
+            // reachable on the raw payload.
+            Some(TranscriptionUsage::Duration { .. })
+            | Some(TranscriptionUsage::Other(_))
+            | None => Usage::new(),
+        };
+        Ok(transcription::TranscriptionResponse::new(self.text, provider).with_usage(usage))
     }
 }
 
@@ -122,6 +138,8 @@ where
     T: HttpClientExt + Clone + 'static,
 {
     const MODEL_IN_FORM: bool = true;
+    const PROVIDER_NAME: &'static str = "openai";
+    const REQUEST_ID_HEADER: Option<&'static str> = Some("x-request-id");
 
     fn transcription_request(
         &self,
@@ -136,6 +154,8 @@ where
     T: HttpClientExt + Clone + 'static,
 {
     const MODEL_IN_FORM: bool = true;
+    const PROVIDER_NAME: &'static str = "openai";
+    const REQUEST_ID_HEADER: Option<&'static str> = Some("x-request-id");
 
     fn transcription_request(
         &self,

--- a/crates/rig-core/src/providers/openrouter/audio_generation.rs
+++ b/crates/rig-core/src/providers/openrouter/audio_generation.rs
@@ -25,6 +25,7 @@ pub type AudioGenerationModel<T = reqwest::Client> = GenericAudioGenerationModel
 
 impl RawAudioGenerationProvider for OpenRouterExt {
     const AUDIO_GENERATION_PATH: &'static str = "/audio/speech";
+    const PROVIDER_NAME: &'static str = "openrouter";
     const EXPLICIT_JSON_CONTENT_TYPE: bool = true;
 
     fn audio_generation_request_body(
@@ -125,8 +126,7 @@ mod tests {
         let error = model
             .audio_generation(request)
             .await
-            .err()
-            .expect("should fail with non-success status");
+            .expect_err("should fail with non-success status");
 
         assert!(matches!(error, AudioGenerationError::HttpError(_)));
         assert_eq!(

--- a/crates/rig-core/src/providers/openrouter/transcription.rs
+++ b/crates/rig-core/src/providers/openrouter/transcription.rs
@@ -1,12 +1,13 @@
+use crate::completion::Usage;
 use crate::http_client::HttpClientExt;
 use crate::providers::internal::transcription::send_json_transcription;
 use crate::providers::openrouter::Client;
 use crate::transcription;
-use crate::transcription::TranscriptionError;
+use crate::transcription::{NormalizeTranscriptionResponse, TranscriptionError};
 use crate::wasm_compat::WasmCompatSend;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 // ================================================================
 // Model constants
@@ -29,14 +30,14 @@ pub const CHIRP_3: &str = "google/chirp-3";
 // Request/Response types
 // ================================================================
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TranscriptionResponse {
     pub text: String,
     #[serde(default)]
     pub usage: Option<TranscriptionUsage>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TranscriptionUsage {
     #[serde(default)]
     pub seconds: Option<f64>,
@@ -50,22 +51,24 @@ pub struct TranscriptionUsage {
     pub cost: Option<f64>,
 }
 
-impl TryFrom<TranscriptionResponse>
-    for transcription::TranscriptionResponse<TranscriptionResponse>
-{
-    type Error = TranscriptionError;
-
-    fn try_from(value: TranscriptionResponse) -> Result<Self, Self::Error> {
-        Ok(transcription::TranscriptionResponse {
-            text: value.text.clone(),
-            response: value,
-        })
+impl NormalizeTranscriptionResponse for TranscriptionResponse {
+    fn normalize(
+        self,
+        provider: &str,
+    ) -> Result<transcription::TranscriptionResponse, TranscriptionError> {
+        let usage = self
+            .usage
+            .as_ref()
+            .map(|usage| Usage {
+                input_tokens: usage.input_tokens.unwrap_or(0) as u64,
+                output_tokens: usage.output_tokens.unwrap_or(0) as u64,
+                total_tokens: usage.total_tokens.unwrap_or(0) as u64,
+                ..Usage::new()
+            })
+            .unwrap_or_default();
+        Ok(transcription::TranscriptionResponse::new(self.text, provider).with_usage(usage))
     }
 }
-
-// ================================================================
-// Model
-// ================================================================
 
 pub type TranscriptionModel<T = reqwest::Client> =
     crate::providers::internal::transcription::GenericTranscriptionModel<
@@ -91,21 +94,29 @@ fn infer_format_from_filename(filename: &str) -> String {
         .to_string()
 }
 
-impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
+impl<T> TranscriptionModel<T>
 where
     T: HttpClientExt + Clone + std::fmt::Debug + Default + WasmCompatSend + 'static,
 {
-    type Response = TranscriptionResponse;
-    type Client = Client<T>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
-
-    async fn transcription(
+    /// Perform the transcription and return OpenRouter's native response
+    /// instead of the normalized [`transcription::TranscriptionResponse`].
+    /// Same request, transport, parser, and error path as
+    /// [`transcription::TranscriptionModel::transcription`].
+    pub async fn raw_transcription(
         &self,
         request: transcription::TranscriptionRequest,
-    ) -> Result<transcription::TranscriptionResponse<Self::Response>, TranscriptionError> {
+    ) -> Result<TranscriptionResponse, TranscriptionError> {
+        self.raw_transcription_with_request_id(request)
+            .await
+            .map(|(response, _)| response)
+    }
+
+    /// [`Self::raw_transcription`] plus the transport request id, when the
+    /// response carried one.
+    pub async fn raw_transcription_with_request_id(
+        &self,
+        request: transcription::TranscriptionRequest,
+    ) -> Result<(TranscriptionResponse, Option<String>), TranscriptionError> {
         if let Some(_prompt) = request.prompt {
             return Err(TranscriptionError::RequestError(Box::new(
                 std::io::Error::new(
@@ -160,12 +171,37 @@ where
                 .post("/audio/transcriptions")?
                 .header("Content-Type", "application/json"),
             body,
-            |_, body_bytes| {
-                let resp: TranscriptionResponse = serde_json::from_slice(body_bytes)?;
-                resp.try_into()
-            },
+            <super::client::OpenRouterExt as crate::providers::openai::completion::OpenAICompatibleProvider>::REQUEST_ID_HEADER,
+            |_, body_bytes| Ok(serde_json::from_slice::<TranscriptionResponse>(body_bytes)?),
         )
         .await
+    }
+}
+
+impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
+where
+    T: HttpClientExt + Clone + std::fmt::Debug + Default + WasmCompatSend + 'static,
+{
+    async fn transcription(
+        &self,
+        request: transcription::TranscriptionRequest,
+    ) -> Result<transcription::TranscriptionResponse, TranscriptionError> {
+        let (response, provider_request_id) =
+            self.raw_transcription_with_request_id(request).await?;
+        let captured = serde_json::to_value(&response)?;
+        Ok(response
+            .normalize(super::completion::PROVIDER_NAME)?
+            .with_optional_provider_request_id(provider_request_id)
+            .with_raw(captured))
+    }
+}
+
+impl<T> crate::client::ConstructTranscriptionModel<Client<T>> for TranscriptionModel<T>
+where
+    T: HttpClientExt + Clone + std::fmt::Debug + Default + WasmCompatSend + 'static,
+{
+    fn construct(client: &Client<T>, model: String) -> Self {
+        Self::new(client.clone(), model)
     }
 }
 
@@ -228,8 +264,7 @@ mod tests {
         let error = model
             .transcription(request)
             .await
-            .err()
-            .expect("should fail with non-success status");
+            .expect_err("should fail with non-success status");
 
         assert!(matches!(error, TranscriptionError::HttpError(_)));
         assert_eq!(

--- a/crates/rig-core/src/providers/venice/audio_generation.rs
+++ b/crates/rig-core/src/providers/venice/audio_generation.rs
@@ -29,6 +29,7 @@ pub type AudioGenerationModel<T = reqwest::Client> = GenericAudioGenerationModel
 
 impl RawAudioGenerationProvider for VeniceExt {
     const AUDIO_GENERATION_PATH: &'static str = "/audio/speech";
+    const PROVIDER_NAME: &'static str = "venice";
 
     fn audio_generation_request_body(
         model: &str,
@@ -86,8 +87,7 @@ mod tests {
         let error = model
             .audio_generation(request)
             .await
-            .err()
-            .expect("should fail with non-success status");
+            .expect_err("should fail with non-success status");
 
         assert!(matches!(error, AudioGenerationError::HttpError(_)));
         assert_eq!(

--- a/crates/rig-core/src/providers/venice/image_generation.rs
+++ b/crates/rig-core/src/providers/venice/image_generation.rs
@@ -9,7 +9,9 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::image_generation::{self, ImageGenerationError, ImageGenerationRequest};
+use crate::image_generation::{
+    self, ImageGenerationError, ImageGenerationRequest, NormalizeImageGenerationResponse,
+};
 use crate::json_utils::merge_inplace;
 use crate::providers::internal::image_generation::{
     GenericImageGenerationModel, JsonImageGenerationProvider, decode_base64_image,
@@ -61,18 +63,20 @@ pub struct ImageGenerationResponse {
     pub timing: Option<ImageGenerationTiming>,
 }
 
-impl TryFrom<ImageGenerationResponse>
-    for image_generation::ImageGenerationResponse<ImageGenerationResponse>
-{
-    type Error = ImageGenerationError;
-
-    fn try_from(value: ImageGenerationResponse) -> Result<Self, Self::Error> {
-        decode_base64_image(
-            value,
+impl NormalizeImageGenerationResponse for ImageGenerationResponse {
+    fn normalize(
+        self,
+        provider: &str,
+    ) -> Result<image_generation::ImageGenerationResponse, ImageGenerationError> {
+        let image = decode_base64_image(
+            &self,
             |response| response.images.first().map(String::as_str),
             "No image data returned",
             Some("Base64 decode error: "),
-        )
+        )?;
+        Ok(image_generation::ImageGenerationResponse::new(
+            image, provider,
+        ))
     }
 }
 
@@ -82,6 +86,7 @@ pub type ImageGenerationModel<T = reqwest::Client> =
 
 impl JsonImageGenerationProvider for super::client::VeniceExt {
     const IMAGE_GENERATION_PATH: &'static str = "/image/generate";
+    const PROVIDER_NAME: &'static str = "venice";
     type Response = ImageGenerationResponse;
 
     fn image_generation_request_body(
@@ -169,7 +174,8 @@ mod tests {
             .expect("image generation should succeed");
 
         assert_eq!(response.image, b"hello");
-        assert_eq!(response.response.id, "abc");
+        assert_eq!(response.provider, "venice");
+        assert_eq!(response.raw["id"], "abc");
 
         let requests = http_client.requests();
         let recorded = requests.first().expect("one request");

--- a/crates/rig-core/src/providers/venice/transcription.rs
+++ b/crates/rig-core/src/providers/venice/transcription.rs
@@ -30,6 +30,8 @@ where
     T: HttpClientExt + Clone + 'static,
 {
     const MODEL_IN_FORM: bool = true;
+    const PROVIDER_NAME: &'static str = "venice";
+    const REQUEST_ID_HEADER: Option<&'static str> = None;
 
     fn transcription_request(
         &self,

--- a/crates/rig-core/src/providers/voyageai.rs
+++ b/crates/rig-core/src/providers/voyageai.rs
@@ -189,17 +189,6 @@ where
 {
     const MAX_DOCUMENTS: usize = 1024;
 
-    type Client = Client<T>;
-
-    fn make(client: &Self::Client, model: impl Into<String>, dims: Option<usize>) -> Self {
-        let model = model.into();
-        let dims = dims
-            .or(model_dimensions_from_identifier(&model))
-            .unwrap_or_default();
-
-        Self::new(client.clone(), model, dims)
-    }
-
     fn ndims(&self) -> usize {
         self.ndims
     }
@@ -302,6 +291,19 @@ where
     }
 }
 
+impl<T> crate::client::ConstructEmbeddingModel<Client<T>> for EmbeddingModel<T>
+where
+    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
+{
+    fn construct(client: &Client<T>, model: String, dims: Option<usize>) -> Self {
+        let dims = dims
+            .or(model_dimensions_from_identifier(&model))
+            .unwrap_or_default();
+
+        Self::new(client.clone(), model, dims)
+    }
+}
+
 // ================================================================
 // Voyage AI Rerank API
 // ================================================================
@@ -380,12 +382,6 @@ where
     T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
 {
     const MAX_DOCUMENTS: usize = 1000;
-
-    type Client = Client<T>;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
-        Self::new(client.clone(), model)
-    }
 
     async fn rerank(
         &self,
@@ -472,6 +468,15 @@ where
                 String::from_utf8_lossy(&response_body),
             ))
         }
+    }
+}
+
+impl<T> crate::client::ConstructRerankModel<Client<T>> for RerankModel<T>
+where
+    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
+{
+    fn construct(client: &Client<T>, model: String) -> Self {
+        Self::new(client.clone(), model)
     }
 }
 

--- a/crates/rig-core/src/providers/voyageai.rs
+++ b/crates/rig-core/src/providers/voyageai.rs
@@ -187,7 +187,9 @@ impl<T> embeddings::EmbeddingModel for EmbeddingModel<T>
 where
     T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
 {
-    const MAX_DOCUMENTS: usize = 1024;
+    fn max_documents(&self) -> usize {
+        1024
+    }
 
     fn ndims(&self) -> usize {
         self.ndims

--- a/crates/rig-core/src/providers/xai/audio_generation.rs
+++ b/crates/rig-core/src/providers/xai/audio_generation.rs
@@ -16,6 +16,7 @@ pub type AudioGenerationModel<T = reqwest::Client> = GenericAudioGenerationModel
 
 impl RawAudioGenerationProvider for XAiExt {
     const AUDIO_GENERATION_PATH: &'static str = "/v1/tts";
+    const PROVIDER_NAME: &'static str = "xai";
 
     fn audio_generation_request_body(
         _model: &str,
@@ -101,8 +102,7 @@ mod tests {
         let error = model
             .audio_generation(request)
             .await
-            .err()
-            .expect("should fail with non-success status");
+            .expect_err("should fail with non-success status");
 
         assert!(matches!(error, AudioGenerationError::HttpError(_)));
         assert_eq!(

--- a/crates/rig-core/src/providers/xai/image_generation.rs
+++ b/crates/rig-core/src/providers/xai/image_generation.rs
@@ -1,10 +1,12 @@
 use crate::image_generation;
-use crate::image_generation::{ImageGenerationError, ImageGenerationRequest};
+use crate::image_generation::{
+    ImageGenerationError, ImageGenerationRequest, NormalizeImageGenerationResponse,
+};
 use crate::json_utils::merge_inplace;
 use crate::providers::internal::image_generation::{
     GenericImageGenerationModel, JsonImageGenerationProvider, decode_base64_image,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 // ================================================================
@@ -13,28 +15,30 @@ use serde_json::json;
 pub const GROK_IMAGINE_IMAGE: &str = "grok-imagine-image";
 pub const GROK_IMAGINE_IMAGE_PRO: &str = "grok-imagine-image-pro";
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImageGenerationData {
     pub b64_json: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImageGenerationResponse {
     pub data: Vec<ImageGenerationData>,
 }
 
-impl TryFrom<ImageGenerationResponse>
-    for image_generation::ImageGenerationResponse<ImageGenerationResponse>
-{
-    type Error = ImageGenerationError;
-
-    fn try_from(value: ImageGenerationResponse) -> Result<Self, Self::Error> {
-        decode_base64_image(
-            value,
+impl NormalizeImageGenerationResponse for ImageGenerationResponse {
+    fn normalize(
+        self,
+        provider: &str,
+    ) -> Result<image_generation::ImageGenerationResponse, ImageGenerationError> {
+        let image = decode_base64_image(
+            &self,
             |response| response.data.first().map(|image| image.b64_json.as_str()),
             "No image data returned",
             Some("Base64 decode error: "),
-        )
+        )?;
+        Ok(image_generation::ImageGenerationResponse::new(
+            image, provider,
+        ))
     }
 }
 
@@ -44,6 +48,7 @@ pub type ImageGenerationModel<T = reqwest::Client> =
 
 impl JsonImageGenerationProvider for super::client::XAiExt {
     const IMAGE_GENERATION_PATH: &'static str = "/v1/images/generations";
+    const PROVIDER_NAME: &'static str = "xai";
     type Response = ImageGenerationResponse;
 
     fn image_generation_request_body(

--- a/crates/rig-core/src/rerank.rs
+++ b/crates/rig-core/src/rerank.rs
@@ -23,12 +23,6 @@ pub trait RerankModel: WasmCompatSend + WasmCompatSync {
     /// The maximum number of documents that can be reranked in a single request.
     const MAX_DOCUMENTS: usize;
 
-    /// Provider client type used to construct this rerank model.
-    type Client;
-
-    /// Construct a model handle from a provider client and model identifier.
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self;
-
     /// Rerank a list of documents against a query.
     fn rerank(
         &self,

--- a/crates/rig-core/src/test_utils/embeddings.rs
+++ b/crates/rig-core/src/test_utils/embeddings.rs
@@ -15,7 +15,9 @@ use crate::{
 pub struct MockEmbeddingModel;
 
 impl EmbeddingModel for MockEmbeddingModel {
-    const MAX_DOCUMENTS: usize = 5;
+    fn max_documents(&self) -> usize {
+        5
+    }
 
     fn ndims(&self) -> usize {
         10

--- a/crates/rig-core/src/test_utils/embeddings.rs
+++ b/crates/rig-core/src/test_utils/embeddings.rs
@@ -17,12 +17,6 @@ pub struct MockEmbeddingModel;
 impl EmbeddingModel for MockEmbeddingModel {
     const MAX_DOCUMENTS: usize = 5;
 
-    type Client = Nothing;
-
-    fn make(_: &Self::Client, _: impl Into<String>, _: Option<usize>) -> Self {
-        Self
-    }
-
     fn ndims(&self) -> usize {
         10
     }
@@ -38,6 +32,12 @@ impl EmbeddingModel for MockEmbeddingModel {
                 vec: vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
             })
             .collect())
+    }
+}
+
+impl crate::client::ConstructEmbeddingModel<Nothing> for MockEmbeddingModel {
+    fn construct(_: &Nothing, _: String, _: Option<usize>) -> Self {
+        Self
     }
 }
 

--- a/crates/rig-core/src/transcription.rs
+++ b/crates/rig-core/src/transcription.rs
@@ -117,7 +117,7 @@ pub trait NormalizeTranscriptionResponse {
 /// either from a third-party provider (e.g: OpenAI) or a local model.
 ///
 /// The trait describes only what a model *does*: it has no associated types.
-/// Construction lives on [`crate::client::TranscriptionClient`], and
+/// Construction lives on [`crate::client::transcription::TranscriptionClient`], and
 /// `Clone` is required only by [`TranscriptionModel::transcription_request`],
 /// which needs to hand the builder its own copy. A model behind an `Arc` is a
 /// model: the trait is implemented for `Arc<M>` by forwarding.

--- a/crates/rig-core/src/transcription.rs
+++ b/crates/rig-core/src/transcription.rs
@@ -1,10 +1,13 @@
 //! This module provides functionality for working with audio transcription models.
 //! It provides traits, structs, and enums for generating audio transcription requests,
 //! handling transcription responses, and defining transcription models.
+use crate::completion::{ResponseIdentity, Usage};
 use crate::json_utils;
 use crate::markers::{Missing, Provided};
 use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use serde::{Deserialize, Serialize};
 use std::io;
+use std::sync::Arc;
 use std::{fs, path::Path};
 
 crate::provider_response::provider_error_enum!(
@@ -21,36 +24,133 @@ crate::provider_response::provider_error_enum!(
     }
 );
 
-/// General transcription response struct that contains the transcription text
-/// and the raw response.
-pub struct TranscriptionResponse<T> {
+/// The normalized transcription response: the transcript plus the metadata
+/// every provider can report, attributed to the provider that produced it.
+///
+/// This type is concrete — it carries no provider type parameter — so the
+/// provider does not leak into [`TranscriptionRequestBuilder`] or into any
+/// caller holding a [`TranscriptionModel`]. The provider's own payload stays
+/// reachable two ways: a model's inherent `raw_transcription` method performs
+/// the same request and returns the provider's native type, and
+/// [`TranscriptionResponse::raw`] carries that value serialized.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TranscriptionResponse {
+    /// The transcribed text.
     pub text: String,
-    pub response: T,
+    /// Token or duration usage as the provider reported it. Zero-valued when
+    /// the provider reported none — the same sentinel [`Usage`] documents for
+    /// completions. Duration-billed endpoints report no token counts.
+    #[serde(default)]
+    pub usage: Usage,
+    /// Stable descriptor name of the provider that produced this response,
+    /// for example `"openai"`. Always populated.
+    pub provider: String,
+    /// Provider-reported model identifier, when the wire response named one.
+    /// This is the model the provider says answered, not the model requested.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Provider-assigned response-scoped identifier, when reported.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_id: Option<String>,
+    /// The provider's transport-level request identifier, taken from the HTTP
+    /// response headers (OpenAI `x-request-id`, Mistral
+    /// `mistral-correlation-id`) — the id provider support asks for. `None`
+    /// means the provider reported none; that is a documented outcome, never
+    /// an error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_request_id: Option<String>,
+    /// The provider's own response for this call: the value the model's
+    /// inherent `raw_transcription` would have returned, serialized. Every
+    /// provider seam populates it. `Value::Null` means the value was built
+    /// without a provider behind it ([`TranscriptionResponse::new`] in a test
+    /// double), never that the provider sent nothing.
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub raw: serde_json::Value,
+}
+
+impl TranscriptionResponse {
+    /// Create a response from its required parts; optional metadata starts
+    /// unset and is filled in with the `with_*` helpers.
+    pub fn new(text: impl Into<String>, provider: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            usage: Usage::new(),
+            provider: provider.into(),
+            model: None,
+            response_id: None,
+            provider_request_id: None,
+            raw: serde_json::Value::Null,
+        }
+    }
+
+    /// This response's identity metadata as one [`ResponseIdentity`] carrier.
+    /// Transcriptions are never replayed as assistant messages, so
+    /// `message_id` is always `None`.
+    pub fn identity(&self) -> ResponseIdentity {
+        ResponseIdentity {
+            message_id: None,
+            response_id: self.response_id.clone(),
+            provider_request_id: self.provider_request_id.clone(),
+        }
+    }
+}
+
+crate::provider_response::modality_response_metadata_setters!(TranscriptionResponse);
+
+/// Convert a provider's own transcription payload into the normalized
+/// [`TranscriptionResponse`].
+///
+/// The provider descriptor name is an *input*, never something the conversion
+/// knows: the OpenAI transcription wire shape is shared by several providers,
+/// and a conversion that hardcoded a name would mislabel every provider but
+/// one. This is a trait rather than `TryFrom<(&str, T)>` so that a provider
+/// extension outside `rig-core` can implement it on its own response type —
+/// a tuple is not a local type, and the orphan rule would reject the `TryFrom`
+/// form anywhere but here.
+pub trait NormalizeTranscriptionResponse {
+    /// Normalize this payload, attributing it to `provider`.
+    fn normalize(self, provider: &str) -> Result<TranscriptionResponse, TranscriptionError>;
 }
 
 /// Trait defining a transcription model that can be used to generate transcription requests.
 /// This trait is meant to be implemented by the user to define a custom transcription model,
 /// either from a third-party provider (e.g: OpenAI) or a local model.
-pub trait TranscriptionModel: Clone + WasmCompatSend + WasmCompatSync {
-    /// The raw response type returned by the underlying model.
-    type Response: WasmCompatSend + WasmCompatSync;
-    type Client;
-
-    fn make(client: &Self::Client, model: impl Into<String>) -> Self;
-
+///
+/// The trait describes only what a model *does*: it has no associated types.
+/// Construction lives on [`crate::client::TranscriptionClient`], and
+/// `Clone` is required only by [`TranscriptionModel::transcription_request`],
+/// which needs to hand the builder its own copy. A model behind an `Arc` is a
+/// model: the trait is implemented for `Arc<M>` by forwarding.
+pub trait TranscriptionModel: WasmCompatSend + WasmCompatSync {
     /// Generates a completion response for the given transcription model
     fn transcription(
         &self,
         request: TranscriptionRequest,
-    ) -> impl std::future::Future<
-        Output = Result<TranscriptionResponse<Self::Response>, TranscriptionError>,
-    > + WasmCompatSend;
+    ) -> impl std::future::Future<Output = Result<TranscriptionResponse, TranscriptionError>>
+    + WasmCompatSend;
 
     /// Generates a transcription request builder for the given `file`
-    fn transcription_request(&self) -> TranscriptionRequestBuilder<Self, Missing> {
+    fn transcription_request(&self) -> TranscriptionRequestBuilder<Self, Missing>
+    where
+        Self: Sized + Clone,
+    {
         TranscriptionRequestBuilder::new(self.clone())
     }
 }
+
+impl<M> TranscriptionModel for Arc<M>
+where
+    M: TranscriptionModel,
+{
+    fn transcription(
+        &self,
+        request: TranscriptionRequest,
+    ) -> impl std::future::Future<Output = Result<TranscriptionResponse, TranscriptionError>>
+    + WasmCompatSend {
+        (**self).transcription(request)
+    }
+}
+
 /// Struct representing a general transcription request that can be sent to a transcription model provider.
 pub struct TranscriptionRequest {
     /// The file data to be sent to the transcription model provider
@@ -238,22 +338,37 @@ where
     M: TranscriptionModel,
 {
     /// Builds the transcription request
-    /// Panics if data is empty.
     pub fn build(self) -> TranscriptionRequest {
-        TranscriptionRequest {
-            data: self.data.0,
-            filename: self.filename.unwrap_or("file".to_string()),
-            language: self.language,
-            prompt: self.prompt,
-            temperature: self.temperature,
-            additional_params: self.additional_params,
-        }
+        self.into_parts().1
+    }
+
+    fn into_parts(self) -> (M, TranscriptionRequest) {
+        let Self {
+            model,
+            data,
+            filename,
+            language,
+            prompt,
+            temperature,
+            additional_params,
+        } = self;
+        (
+            model,
+            TranscriptionRequest {
+                data: data.0,
+                filename: filename.unwrap_or("file".to_string()),
+                language,
+                prompt,
+                temperature,
+                additional_params,
+            },
+        )
     }
 
     /// Sends the transcription request to the transcription model provider and returns the transcription response
-    pub async fn send(self) -> Result<TranscriptionResponse<M::Response>, TranscriptionError> {
-        let model = self.model.clone();
-        model.transcription(self.build()).await
+    pub async fn send(self) -> Result<TranscriptionResponse, TranscriptionError> {
+        let (model, request) = self.into_parts();
+        model.transcription(request).await
     }
 }
 

--- a/crates/rig-core/src/vector_store/in_memory_store.rs
+++ b/crates/rig-core/src/vector_store/in_memory_store.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{IndexStrategy, VectorStoreError, VectorStoreIndex, request::VectorSearchRequest};
 use crate::{
-    embeddings::{Embedding, EmbeddingModel, distance::VectorDistance},
+    embeddings::{Embedding, EmbeddingModel, EmbeddingModelHandle, distance::VectorDistance},
     vector_store::request::Filter,
 };
 
@@ -359,7 +359,7 @@ impl<D: Serialize + Eq> PartialOrd for RankingItem<'_, D> {
 type EmbeddingRanking<'a, D> = BinaryHeap<Reverse<RankingItem<'a, D>>>;
 
 impl<D: Serialize> InMemoryVectorStore<D> {
-    pub fn index<M: EmbeddingModel>(self, model: M) -> InMemoryVectorIndex<M, D> {
+    pub fn index(self, model: impl EmbeddingModel + 'static) -> InMemoryVectorIndex<D> {
         InMemoryVectorIndex::new(model, self)
     }
 
@@ -376,14 +376,30 @@ impl<D: Serialize> InMemoryVectorStore<D> {
     }
 }
 
-pub struct InMemoryVectorIndex<M: EmbeddingModel, D: Serialize> {
-    model: M,
+/// An in-memory vector index: a store plus the embedding model that turns
+/// queries into vectors.
+///
+/// The model's concrete type is erased at construction into an
+/// [`EmbeddingModelHandle`], so the index's type names no provider. The index
+/// is a long-lived consumer of a model, not a place to swap one: the handle
+/// it holds is fixed for the index's lifetime, because an index populated
+/// under one model is only meaningful under that model.
+pub struct InMemoryVectorIndex<D: Serialize> {
+    model: EmbeddingModelHandle,
     pub store: InMemoryVectorStore<D>,
 }
 
-impl<M: EmbeddingModel, D: Serialize> InMemoryVectorIndex<M, D> {
-    pub fn new(model: M, store: InMemoryVectorStore<D>) -> Self {
-        Self { model, store }
+impl<D: Serialize> InMemoryVectorIndex<D> {
+    pub fn new(model: impl EmbeddingModel + 'static, store: InMemoryVectorStore<D>) -> Self {
+        Self {
+            model: EmbeddingModelHandle::new(model),
+            store,
+        }
+    }
+
+    /// The erased embedding model this index queries with.
+    pub fn model(&self) -> &EmbeddingModelHandle {
+        &self.model
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&String, &(D, Vec<Embedding>))> {
@@ -399,9 +415,7 @@ impl<M: EmbeddingModel, D: Serialize> InMemoryVectorIndex<M, D> {
     }
 }
 
-impl<M: EmbeddingModel + Sync, D: Serialize + Sync + Send + Eq> VectorStoreIndex
-    for InMemoryVectorIndex<M, D>
-{
+impl<D: Serialize + Sync + Send + Eq> VectorStoreIndex for InMemoryVectorIndex<D> {
     type Filter = Filter<serde_json::Value>;
 
     async fn top_n<T: for<'a> Deserialize<'a>>(

--- a/crates/rig-fastembed/src/lib.rs
+++ b/crates/rig-fastembed/src/lib.rs
@@ -173,7 +173,9 @@ impl EmbeddingModel {
 }
 
 impl embeddings::EmbeddingModel for EmbeddingModel {
-    const MAX_DOCUMENTS: usize = 1024;
+    fn max_documents(&self) -> usize {
+        1024
+    }
 
     fn ndims(&self) -> usize {
         self.ndims

--- a/crates/rig-fastembed/src/lib.rs
+++ b/crates/rig-fastembed/src/lib.rs
@@ -175,17 +175,6 @@ impl EmbeddingModel {
 impl embeddings::EmbeddingModel for EmbeddingModel {
     const MAX_DOCUMENTS: usize = 1024;
 
-    type Client = Client;
-
-    fn make(_: &Self::Client, _: impl Into<String>, _: Option<usize>) -> Self {
-        Self {
-            embedder: None,
-            init_error: Some(FastembedError::UnsupportedMake),
-            model: FastembedModel::AllMiniLML6V2Q,
-            ndims: 0,
-        }
-    }
-
     fn ndims(&self) -> usize {
         self.ndims
     }
@@ -222,5 +211,16 @@ impl embeddings::EmbeddingModel for EmbeddingModel {
             .collect::<Vec<embeddings::Embedding>>();
 
         Ok(docs)
+    }
+}
+
+impl rig_core::client::ConstructEmbeddingModel<Client> for EmbeddingModel {
+    fn construct(_: &Client, _: String, _: Option<usize>) -> Self {
+        Self {
+            embedder: None,
+            init_error: Some(FastembedError::UnsupportedMake),
+            model: FastembedModel::AllMiniLML6V2Q,
+            ndims: 0,
+        }
     }
 }

--- a/crates/rig-gemini-grpc/src/embedding.rs
+++ b/crates/rig-gemini-grpc/src/embedding.rs
@@ -30,12 +30,6 @@ impl EmbeddingModel {
 impl embeddings::EmbeddingModel for EmbeddingModel {
     const MAX_DOCUMENTS: usize = 100;
 
-    type Client = super::Client;
-
-    fn make(client: &Self::Client, model: impl Into<String>, dims: Option<usize>) -> Self {
-        Self::new(client.clone(), model, dims)
-    }
-
     fn ndims(&self) -> usize {
         self.ndims
     }
@@ -88,6 +82,12 @@ impl embeddings::EmbeddingModel for EmbeddingModel {
         }
 
         Ok(embeddings)
+    }
+}
+
+impl rig_core::client::ConstructEmbeddingModel<super::Client> for EmbeddingModel {
+    fn construct(client: &super::Client, model: String, dims: Option<usize>) -> Self {
+        Self::new(client.clone(), model, dims)
     }
 }
 

--- a/crates/rig-gemini-grpc/src/embedding.rs
+++ b/crates/rig-gemini-grpc/src/embedding.rs
@@ -28,7 +28,9 @@ impl EmbeddingModel {
 }
 
 impl embeddings::EmbeddingModel for EmbeddingModel {
-    const MAX_DOCUMENTS: usize = 100;
+    fn max_documents(&self) -> usize {
+        100
+    }
 
     fn ndims(&self) -> usize {
         self.ndims

--- a/crates/rig-helixdb/src/lib.rs
+++ b/crates/rig-helixdb/src/lib.rs
@@ -10,7 +10,7 @@ use std::future::Future;
 
 use reqwest::{Client, StatusCode};
 use rig_core::{
-    embeddings::EmbeddingModel,
+    embeddings::{EmbeddingModel, EmbeddingModelHandle},
     vector_store::{InsertDocuments, VectorStoreError, VectorStoreIndex, request::Filter},
     wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
@@ -130,9 +130,13 @@ impl HelixDBClient for HelixDB {
 /// # Ok(())
 /// # }
 /// ```
-pub struct HelixDBVectorStore<C, E> {
+///
+/// The embedding model's concrete type is erased at construction into an
+/// [`EmbeddingModelHandle`], which is fixed for the store's lifetime: an index
+/// populated under one model is only meaningful when queried under that model.
+pub struct HelixDBVectorStore<C> {
     client: C,
-    model: E,
+    model: EmbeddingModelHandle,
 }
 
 pub type HelixDBFilter = Filter<serde_json::Value>;
@@ -171,14 +175,16 @@ struct VecResult {
     vec_docs: Vec<QueryResult>,
 }
 
-impl<C, E> HelixDBVectorStore<C, E>
+impl<C> HelixDBVectorStore<C>
 where
     C: HelixDBClient + WasmCompatSend,
-    E: EmbeddingModel,
 {
     /// Creates a new HelixDB vector store.
-    pub fn new(client: C, model: E) -> Self {
-        Self { client, model }
+    pub fn new(client: C, model: impl EmbeddingModel + 'static) -> Self {
+        Self {
+            client,
+            model: EmbeddingModelHandle::new(model),
+        }
     }
 
     /// Returns the underlying HelixDB client.
@@ -187,11 +193,10 @@ where
     }
 }
 
-impl<C, E> HelixDBVectorStore<C, E>
+impl<C> HelixDBVectorStore<C>
 where
     C: HelixDBClient + WasmCompatSend + WasmCompatSync,
     C::Err: std::error::Error + WasmCompatSend + WasmCompatSync + 'static,
-    E: EmbeddingModel + WasmCompatSend + WasmCompatSync,
 {
     /// Embeds the query and runs the `VectorSearch` HelixDB query.
     async fn vector_search(
@@ -213,11 +218,10 @@ where
     }
 }
 
-impl<C, E> InsertDocuments for HelixDBVectorStore<C, E>
+impl<C> InsertDocuments for HelixDBVectorStore<C>
 where
     C: HelixDBClient + WasmCompatSend + WasmCompatSync,
     C::Err: std::error::Error + WasmCompatSend + WasmCompatSync + 'static,
-    E: EmbeddingModel + WasmCompatSend + WasmCompatSync,
 {
     async fn insert_documents<Doc: Serialize + rig_core::Embed + WasmCompatSend>(
         &self,
@@ -254,11 +258,10 @@ where
     }
 }
 
-impl<C, E> VectorStoreIndex for HelixDBVectorStore<C, E>
+impl<C> VectorStoreIndex for HelixDBVectorStore<C>
 where
     C: HelixDBClient + WasmCompatSend + WasmCompatSync,
     C::Err: std::error::Error + WasmCompatSend + WasmCompatSync + 'static,
-    E: EmbeddingModel + WasmCompatSend + WasmCompatSync,
 {
     type Filter = HelixDBFilter;
 

--- a/crates/rig-lancedb/src/lib.rs
+++ b/crates/rig-lancedb/src/lib.rs
@@ -25,7 +25,7 @@ use lancedb::{
     query::{QueryBase, VectorQuery},
 };
 use rig_core::{
-    embeddings::embedding::EmbeddingModel,
+    embeddings::{EmbeddingModelHandle, embedding::EmbeddingModel},
     vector_store::{
         VectorStoreError, VectorStoreIndex,
         request::{FilterError, SearchFilter, VectorSearchRequest},
@@ -50,9 +50,13 @@ mod utils;
 /// let model: EmbeddingModel = openai_client.embedding_model(TEXT_EMBEDDING_ADA_002); // <-- Replace with your embedding model here.
 /// let vector_store_index = LanceDbVectorIndex::new(table, model, "id", SearchParams::default()).await?;
 /// ```
-pub struct LanceDbVectorIndex<M: EmbeddingModel> {
+///
+/// The embedding model's concrete type is erased at construction into an
+/// [`EmbeddingModelHandle`]; the handle is fixed for the index's lifetime, since an
+/// index populated under one model is only meaningful under that same model.
+pub struct LanceDbVectorIndex {
     /// Defines which model is used to generate embeddings for the vector store.
-    model: M,
+    model: EmbeddingModelHandle,
     /// LanceDB table containing embeddings.
     table: lancedb::Table,
     /// Column name in `table` that contains the id of a record.
@@ -61,22 +65,19 @@ pub struct LanceDbVectorIndex<M: EmbeddingModel> {
     search_params: SearchParams,
 }
 
-impl<M> LanceDbVectorIndex<M>
-where
-    M: EmbeddingModel,
-{
+impl LanceDbVectorIndex {
     /// Create an instance of `LanceDbVectorIndex` with an existing table and model.
     /// Define the id field name of the table.
     /// Define search parameters that will be used to perform vector searches on the table.
     pub async fn new(
         table: lancedb::Table,
-        model: M,
+        model: impl EmbeddingModel + 'static,
         id_field: &str,
         search_params: SearchParams,
     ) -> Result<Self, lancedb::Error> {
         Ok(Self {
             table,
-            model,
+            model: EmbeddingModelHandle::new(model),
             id_field: id_field.to_string(),
             search_params,
         })
@@ -368,10 +369,7 @@ impl SearchParams {
     }
 }
 
-impl<M> VectorStoreIndex for LanceDbVectorIndex<M>
-where
-    M: EmbeddingModel + Sync + Send,
-{
+impl VectorStoreIndex for LanceDbVectorIndex {
     type Filter = LanceDBFilter;
 
     /// Implement the `top_n` method of the `VectorStoreIndex` trait for `LanceDbVectorIndex`.

--- a/crates/rig-milvus/src/lib.rs
+++ b/crates/rig-milvus/src/lib.rs
@@ -11,7 +11,7 @@ mod filter;
 use reqwest::StatusCode;
 use rig_core::{
     Embed,
-    embeddings::{Embedding, EmbeddingModel},
+    embeddings::{Embedding, EmbeddingModel, EmbeddingModelHandle},
     vector_store::{
         InsertDocuments, VectorStoreError, VectorStoreIndex,
         request::{SearchFilter, VectorSearchRequest},
@@ -22,9 +22,13 @@ use serde::{Deserialize, Serialize};
 use crate::filter::Filter;
 
 /// Represents a vector store implementation using Milvus - <https://milvus.io/> as the backend.
-pub struct MilvusVectorStore<M> {
+///
+/// The embedding model's concrete type is erased at construction into an
+/// [`EmbeddingModelHandle`]; the handle is fixed for the store's lifetime (an index
+/// populated under one model is only meaningful under that same model).
+pub struct MilvusVectorStore {
     /// Model used to generate embeddings for the vector store
-    model: M,
+    model: EmbeddingModelHandle,
     base_url: String,
     client: reqwest::Client,
     database_name: String,
@@ -84,10 +88,7 @@ struct SearchResultDataOnlyId {
     distance: f64,
 }
 
-impl<M> MilvusVectorStore<M>
-where
-    M: EmbeddingModel,
-{
+impl MilvusVectorStore {
     /// Creates a new instance of `MilvusVectorStore`.
     ///
     /// # Arguments
@@ -95,9 +96,14 @@ where
     /// * `base_url` - The URL of where your Milvus instance is located. Alternatively if you're using the Milvus offering provided by Zilliz, your cluster endpoint.
     /// * `database_name` - The name of your database
     /// * `collection_name` - The name of your collection
-    pub fn new(model: M, base_url: String, database_name: String, collection_name: String) -> Self {
+    pub fn new(
+        model: impl EmbeddingModel + 'static,
+        base_url: String,
+        database_name: String,
+        collection_name: String,
+    ) -> Self {
         Self {
-            model,
+            model: EmbeddingModelHandle::new(model),
             base_url,
             client: reqwest::Client::new(),
             database_name,
@@ -195,10 +201,7 @@ where
     }
 }
 
-impl<Model> InsertDocuments for MilvusVectorStore<Model>
-where
-    Model: EmbeddingModel + Send + Sync,
-{
+impl InsertDocuments for MilvusVectorStore {
     async fn insert_documents<Doc: Serialize + Embed + Send>(
         &self,
         documents: Vec<(Doc, Vec<Embedding>)>,
@@ -239,10 +242,7 @@ where
     }
 }
 
-impl<M> VectorStoreIndex for MilvusVectorStore<M>
-where
-    M: EmbeddingModel,
-{
+impl VectorStoreIndex for MilvusVectorStore {
     type Filter = Filter;
 
     /// Search for the top `n` nearest neighbors to the given query within the Milvus vector store.

--- a/crates/rig-mongodb/src/lib.rs
+++ b/crates/rig-mongodb/src/lib.rs
@@ -11,7 +11,10 @@ use mongodb::bson::{self, Bson, Document, doc, to_bson};
 
 use rig_core::{
     Embed,
-    embeddings::embedding::{Embedding, EmbeddingModel},
+    embeddings::{
+        EmbeddingModelHandle,
+        embedding::{Embedding, EmbeddingModel},
+    },
     vector_store::{
         InsertDocuments, VectorStoreError, VectorStoreIndex,
         request::{DynamicSearchFilter, Filter, FilterError, SearchFilter, VectorSearchRequest},
@@ -107,22 +110,24 @@ struct Field {
 /// # }
 /// # let _ = example();
 /// ```
-pub struct MongoDbVectorIndex<C, M>
+///
+/// The embedding model's concrete type is erased at construction into an
+/// [`EmbeddingModelHandle`]; the handle is fixed for the store's lifetime (an index
+/// populated under one model is only meaningful under that same model).
+pub struct MongoDbVectorIndex<C>
 where
     C: Send + Sync,
-    M: EmbeddingModel,
 {
     collection: mongodb::Collection<C>,
-    model: M,
+    model: EmbeddingModelHandle,
     index_name: String,
     embedded_field: String,
     search_params: SearchParams,
 }
 
-impl<C, M> MongoDbVectorIndex<C, M>
+impl<C> MongoDbVectorIndex<C>
 where
     C: Send + Sync,
-    M: EmbeddingModel,
 {
     /// Vector search stage of aggregation pipeline of mongoDB collection.
     /// To be used by implementations of top_n and top_n_ids methods on VectorStoreIndex trait for MongoDbVectorIndex.
@@ -228,9 +233,8 @@ where
     }
 }
 
-impl<C, M> MongoDbVectorIndex<C, M>
+impl<C> MongoDbVectorIndex<C>
 where
-    M: EmbeddingModel,
     C: Send + Sync,
 {
     /// Create a new `MongoDbVectorIndex`.
@@ -239,7 +243,7 @@ where
     /// See the MongoDB [documentation](https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/) for more information on creating indexes.
     pub async fn new(
         collection: mongodb::Collection<C>,
-        model: M,
+        model: impl EmbeddingModel + 'static,
         index_name: &str,
         search_params: SearchParams,
     ) -> Result<Self, VectorStoreError> {
@@ -264,7 +268,7 @@ where
 
         Ok(Self {
             collection,
-            model,
+            model: EmbeddingModelHandle::new(model),
             index_name: index_name.to_string(),
             embedded_field,
             search_params,
@@ -387,10 +391,9 @@ impl DynamicSearchFilter for MongoDbSearchFilter {
     }
 }
 
-impl<C, M> VectorStoreIndex for MongoDbVectorIndex<C, M>
+impl<C> VectorStoreIndex for MongoDbVectorIndex<C>
 where
     C: Sync + Send,
-    M: EmbeddingModel + Sync + Send,
 {
     type Filter = MongoDbSearchFilter;
 
@@ -438,10 +441,9 @@ where
     }
 }
 
-impl<C, M> InsertDocuments for MongoDbVectorIndex<C, M>
+impl<C> InsertDocuments for MongoDbVectorIndex<C>
 where
     C: Send + Sync,
-    M: EmbeddingModel + Send + Sync,
 {
     async fn insert_documents<Doc: Serialize + Embed + Send>(
         &self,

--- a/crates/rig-neo4j/src/lib.rs
+++ b/crates/rig-neo4j/src/lib.rs
@@ -322,11 +322,11 @@ impl Neo4jClient {
     /// See the Neo4j [documentation (Create vector index)](https://neo4j.com/docs/genai/tutorials/embeddings-vector-indexes/setup/vector-index/) for more information on creating indexes.
     ///
     /// ❗IMPORTANT: The index must be created with the same embedding model that will be used to query the index.
-    pub async fn get_index<M: EmbeddingModel>(
+    pub async fn get_index(
         &self,
-        model: M,
+        model: impl EmbeddingModel + 'static,
         index_name: &str,
-    ) -> Result<Neo4jVectorIndex<M>, VectorStoreError> {
+    ) -> Result<Neo4jVectorIndex, VectorStoreError> {
         #[derive(Deserialize)]
         #[serde(rename_all = "camelCase")]
         struct IndexInfo {

--- a/crates/rig-neo4j/src/vector_index.rs
+++ b/crates/rig-neo4j/src/vector_index.rs
@@ -7,7 +7,7 @@
 use neo4rs::{Graph, Query};
 use rig_core::{
     Embed,
-    embeddings::{Embedding, EmbeddingModel},
+    embeddings::{Embedding, EmbeddingModel, EmbeddingModelHandle},
     vector_store::{
         InsertDocuments, VectorStoreError, VectorStoreIndex,
         request::{SearchFilter, VectorSearchRequest},
@@ -17,12 +17,12 @@ use serde::{Deserialize, Serialize, de::Error};
 
 use crate::{Neo4jClient, Neo4jSearchFilter, ToBoltType};
 
-pub struct Neo4jVectorIndex<M>
-where
-    M: EmbeddingModel,
-{
+/// The embedding model's concrete type is erased at construction into an
+/// [`EmbeddingModelHandle`]; the handle is fixed for the store's lifetime (an
+/// index populated under one model is only meaningful under that model).
+pub struct Neo4jVectorIndex {
     graph: Graph,
-    embedding_model: M,
+    embedding_model: EmbeddingModelHandle,
     index_config: IndexConfig,
 }
 
@@ -120,14 +120,15 @@ const BASE_VECTOR_SEARCH_QUERY: &str = "
     YIELD node, score
 ";
 
-impl<M> Neo4jVectorIndex<M>
-where
-    M: EmbeddingModel,
-{
-    pub fn new(graph: Graph, embedding_model: M, index_config: IndexConfig) -> Self {
+impl Neo4jVectorIndex {
+    pub fn new(
+        graph: Graph,
+        embedding_model: impl EmbeddingModel + 'static,
+        index_config: IndexConfig,
+    ) -> Self {
         Self {
             graph,
-            embedding_model,
+            embedding_model: EmbeddingModelHandle::new(embedding_model),
             index_config,
         }
     }
@@ -209,10 +210,7 @@ struct RowResult {
     element_id: i64,
 }
 
-impl<M> VectorStoreIndex for Neo4jVectorIndex<M>
-where
-    M: EmbeddingModel + std::marker::Sync + Send,
-{
+impl VectorStoreIndex for Neo4jVectorIndex {
     type Filter = Neo4jSearchFilter;
 
     /// Get the top n nodes and scores matching the query.
@@ -265,10 +263,7 @@ fn insert_documents_query(node_label: &str) -> String {
     format!("UNWIND $items AS item CREATE (n:{node_label}) SET n = item")
 }
 
-impl<M> InsertDocuments for Neo4jVectorIndex<M>
-where
-    M: EmbeddingModel + Send + Sync,
-{
+impl InsertDocuments for Neo4jVectorIndex {
     /// Inserts one node per embedding, flattening the document's JSON fields
     /// onto the node alongside the embedding (`embedding_property`) and its
     /// source text (`embedded_text`). Nodes are written under the index's

--- a/crates/rig-postgres/src/lib.rs
+++ b/crates/rig-postgres/src/lib.rs
@@ -12,7 +12,7 @@ use std::{fmt::Display, ops::RangeInclusive};
 
 use rig_core::{
     Embed,
-    embeddings::{Embedding, EmbeddingModel},
+    embeddings::{Embedding, EmbeddingModel, EmbeddingModelHandle},
     vector_store::{
         InsertDocuments, VectorStoreError, VectorStoreIndex,
         request::{SearchFilter, SqlCondition, VectorSearchRequest},
@@ -23,8 +23,11 @@ use serde_json::Value;
 use sqlx::{PgPool, Postgres, postgres::PgArguments, query::QueryAs};
 use uuid::Uuid;
 
-pub struct PostgresVectorStore<Model: EmbeddingModel> {
-    model: Model,
+/// The embedding model's concrete type is erased at construction into an
+/// [`EmbeddingModelHandle`]; the handle is fixed for the store's lifetime (an
+/// index populated under one model is only meaningful under that model).
+pub struct PostgresVectorStore {
+    model: EmbeddingModelHandle,
     pg_pool: PgPool,
     documents_table: String,
     distance_function: PgVectorDistanceFunction,
@@ -212,25 +215,22 @@ impl SearchResult {
     }
 }
 
-impl<Model> PostgresVectorStore<Model>
-where
-    Model: EmbeddingModel,
-{
+impl PostgresVectorStore {
     pub fn new(
-        model: Model,
+        model: impl EmbeddingModel + 'static,
         pg_pool: PgPool,
         documents_table: Option<String>,
         distance_function: PgVectorDistanceFunction,
     ) -> Self {
         Self {
-            model,
+            model: EmbeddingModelHandle::new(model),
             pg_pool,
             documents_table: documents_table.unwrap_or(String::from("documents")),
             distance_function,
         }
     }
 
-    pub fn with_defaults(model: Model, pg_pool: PgPool) -> Self {
+    pub fn with_defaults(model: impl EmbeddingModel + 'static, pg_pool: PgPool) -> Self {
         Self::new(model, pg_pool, None, PgVectorDistanceFunction::Cosine)
     }
 
@@ -332,10 +332,7 @@ where
     }
 }
 
-impl<Model> InsertDocuments for PostgresVectorStore<Model>
-where
-    Model: EmbeddingModel + Send + Sync,
-{
+impl InsertDocuments for PostgresVectorStore {
     async fn insert_documents<Doc: Serialize + Embed + Send>(
         &self,
         documents: Vec<(Doc, Vec<Embedding>)>,
@@ -366,10 +363,7 @@ where
     }
 }
 
-impl<Model> VectorStoreIndex for PostgresVectorStore<Model>
-where
-    Model: EmbeddingModel,
-{
+impl VectorStoreIndex for PostgresVectorStore {
     type Filter = PgSearchFilter;
 
     /// Get the top n documents based on the distance to the given query.

--- a/crates/rig-qdrant/src/lib.rs
+++ b/crates/rig-qdrant/src/lib.rs
@@ -19,7 +19,7 @@ use qdrant_client::{
 };
 use rig_core::{
     Embed,
-    embeddings::{Embedding, EmbeddingModel},
+    embeddings::{Embedding, EmbeddingModel, EmbeddingModelHandle},
     vector_store::{
         InsertDocuments, VectorStoreError, VectorStoreIndex, request::VectorSearchRequest,
     },
@@ -28,19 +28,20 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// Represents a vector store implementation using Qdrant - <https://qdrant.tech/> as the backend.
-pub struct QdrantVectorStore<M: EmbeddingModel> {
+///
+/// The embedding model's concrete type is erased at construction into an
+/// [`EmbeddingModelHandle`]; the handle is fixed for the store's lifetime, since an
+/// index populated under one model is only meaningful under that same model.
+pub struct QdrantVectorStore {
     /// Model used to generate embeddings for the vector store
-    model: M,
+    model: EmbeddingModelHandle,
     /// Client instance for Qdrant server communication
     client: Qdrant,
     /// Default search parameters
     query_params: QueryPoints,
 }
 
-impl<M> QdrantVectorStore<M>
-where
-    M: EmbeddingModel,
-{
+impl QdrantVectorStore {
     /// Creates a new instance of `QdrantVectorStore`.
     ///
     /// # Arguments
@@ -48,10 +49,14 @@ where
     /// * `model` - Embedding model instance
     /// * `query_params` - Search parameters for vector queries
     ///   Reference: <https://api.qdrant.tech/v-1-12-x/api-reference/search/query-points>
-    pub fn new(client: Qdrant, model: M, query_params: QueryPoints) -> Self {
+    pub fn new(
+        client: Qdrant,
+        model: impl EmbeddingModel + 'static,
+        query_params: QueryPoints,
+    ) -> Self {
         Self {
             client,
-            model,
+            model: EmbeddingModelHandle::new(model),
             query_params,
         }
     }
@@ -115,10 +120,7 @@ where
     }
 }
 
-impl<Model> InsertDocuments for QdrantVectorStore<Model>
-where
-    Model: EmbeddingModel + Send + Sync,
-{
+impl InsertDocuments for QdrantVectorStore {
     async fn insert_documents<Doc: Serialize + Embed + Send>(
         &self,
         documents: Vec<(Doc, Vec<Embedding>)>,
@@ -165,10 +167,7 @@ fn stringify_id(id: PointId) -> Result<String, VectorStoreError> {
     }
 }
 
-impl<M> VectorStoreIndex for QdrantVectorStore<M>
-where
-    M: EmbeddingModel + std::marker::Sync + Send,
-{
+impl VectorStoreIndex for QdrantVectorStore {
     type Filter = QdrantFilter;
 
     /// Search for the top `n` nearest neighbors to the given query within the Qdrant vector store.

--- a/crates/rig-s3vectors/src/lib.rs
+++ b/crates/rig-s3vectors/src/lib.rs
@@ -17,7 +17,7 @@ use aws_sdk_s3vectors::{
 };
 use aws_smithy_types::Document;
 use rig_core::{
-    embeddings::EmbeddingModel,
+    embeddings::{EmbeddingModel, EmbeddingModelHandle},
     vector_store::{
         InsertDocuments, VectorStoreError, VectorStoreIndex,
         request::{DynamicSearchFilter, Filter, FilterError, SearchFilter, VectorSearchRequest},
@@ -123,25 +123,25 @@ impl S3SearchFilter {
     }
 }
 
-pub struct S3VectorsVectorStore<M> {
-    embedding_model: M,
+/// The embedding model's concrete type is erased at construction into an
+/// [`EmbeddingModelHandle`]; the handle is fixed for the store's lifetime (an
+/// index populated under one model is only meaningful under that model).
+pub struct S3VectorsVectorStore {
+    embedding_model: EmbeddingModelHandle,
     client: Client,
     bucket_name: String,
     index_name: String,
 }
 
-impl<M> S3VectorsVectorStore<M>
-where
-    M: EmbeddingModel,
-{
+impl S3VectorsVectorStore {
     pub fn new(
-        embedding_model: M,
+        embedding_model: impl EmbeddingModel + 'static,
         client: aws_sdk_s3vectors::Client,
         bucket_name: &str,
         index_name: &str,
     ) -> Self {
         Self {
-            embedding_model,
+            embedding_model: EmbeddingModelHandle::new(embedding_model),
             client,
             bucket_name: bucket_name.to_string(),
             index_name: index_name.to_string(),
@@ -230,10 +230,7 @@ where
     }
 }
 
-impl<M> InsertDocuments for S3VectorsVectorStore<M>
-where
-    M: EmbeddingModel,
-{
+impl InsertDocuments for S3VectorsVectorStore {
     async fn insert_documents<Doc: serde::Serialize + rig_core::Embed + Send>(
         &self,
         documents: Vec<(Doc, Vec<rig_core::embeddings::Embedding>)>,
@@ -335,10 +332,7 @@ fn document_to_json_value(value: &Document) -> Value {
     }
 }
 
-impl<M> VectorStoreIndex for S3VectorsVectorStore<M>
-where
-    M: EmbeddingModel,
-{
+impl VectorStoreIndex for S3VectorsVectorStore {
     type Filter = S3SearchFilter;
 
     async fn top_n<T: for<'a> serde::Deserialize<'a> + Send>(

--- a/crates/rig-scylladb/src/lib.rs
+++ b/crates/rig-scylladb/src/lib.rs
@@ -9,7 +9,7 @@
 
 use rig_core::{
     Embed,
-    embeddings::{Embedding, EmbeddingModel},
+    embeddings::{Embedding, EmbeddingModel, EmbeddingModelHandle},
     vector_store::{
         InsertDocuments, VectorStoreError, VectorStoreIndex,
         request::{
@@ -35,9 +35,13 @@ use uuid::Uuid;
 ///
 /// ScyllaDB is a high-performance NoSQL database that's compatible with Apache Cassandra
 /// and provides excellent performance for vector storage and similarity search operations.
-pub struct ScyllaDbVectorStore<M: EmbeddingModel> {
+///
+/// The embedding model's concrete type is erased at construction into an
+/// [`EmbeddingModelHandle`]; the handle is fixed for the store's lifetime, since an
+/// index populated under one model is only meaningful under that same model.
+pub struct ScyllaDbVectorStore {
     /// Model used to generate embeddings for the vector store
-    model: M,
+    model: EmbeddingModelHandle,
     /// Session instance for ScyllaDB communication
     pub session: Arc<Session>,
     /// Keyspace and table name for vector storage
@@ -179,10 +183,7 @@ impl DynamicSearchFilter for ScyllaSearchFilter {
     }
 }
 
-impl<M> ScyllaDbVectorStore<M>
-where
-    M: EmbeddingModel,
-{
+impl ScyllaDbVectorStore {
     /// Creates a new instance of `ScyllaDbVectorStore`.
     ///
     /// # Arguments
@@ -192,7 +193,7 @@ where
     /// * `table` - Table name for storing vectors
     /// * `dimensions` - Number of dimensions for the vectors
     pub async fn new(
-        model: M,
+        model: impl EmbeddingModel + 'static,
         session: Session,
         keyspace: &str,
         table: &str,
@@ -251,7 +252,7 @@ where
             .map_err(VectorStoreError::datastore)?;
 
         Ok(Self {
-            model,
+            model: EmbeddingModelHandle::new(model),
             session,
             keyspace: keyspace.to_string(),
             table: table.to_string(),
@@ -424,10 +425,7 @@ where
     }
 }
 
-impl<Model> InsertDocuments for ScyllaDbVectorStore<Model>
-where
-    Model: EmbeddingModel + Send + Sync,
-{
+impl InsertDocuments for ScyllaDbVectorStore {
     async fn insert_documents<Doc: Serialize + Embed + Send>(
         &self,
         documents: Vec<(Doc, Vec<Embedding>)>,
@@ -463,10 +461,7 @@ where
     }
 }
 
-impl<M> VectorStoreIndex for ScyllaDbVectorStore<M>
-where
-    M: EmbeddingModel + std::marker::Sync + Send,
-{
+impl VectorStoreIndex for ScyllaDbVectorStore {
     type Filter = ScyllaSearchFilter;
 
     /// Search for the top `n` nearest neighbors to the given query.

--- a/crates/rig-sqlite/examples/vector_search_sqlite.rs
+++ b/crates/rig-sqlite/examples/vector_search_sqlite.rs
@@ -97,7 +97,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .await?;
 
     // Initialize SQLite vector store
-    let vector_store: SqliteVectorStore<_, Document> =
+    let vector_store: SqliteVectorStore<Document> =
         SqliteVectorStore::with_distance_metric(conn, &model, SqliteDistanceMetric::Cosine).await?;
 
     // Add embeddings to vector store

--- a/crates/rig-sqlite/src/lib.rs
+++ b/crates/rig-sqlite/src/lib.rs
@@ -8,7 +8,7 @@
 //! `sqlite` feature is enabled.
 
 use rig_core::Embed;
-use rig_core::embeddings::{Embedding, EmbeddingModel};
+use rig_core::embeddings::{Embedding, EmbeddingModel, EmbeddingModelHandle};
 use rig_core::vector_store::request::{FilterError, SearchFilter, VectorSearchRequest};
 use rig_core::vector_store::{InsertDocuments, VectorStoreError, VectorStoreIndex};
 use rig_core::wasm_compat::{WasmCompatSend, WasmCompatSync};
@@ -346,21 +346,25 @@ fn sqlite_metadata_value(
     }
 }
 
+/// A SQLite-backed vector store for documents of type `T`.
+///
+/// The store does not name an embedding model in its type; the model is only
+/// consulted (for `ndims`) at construction, and the index built from it via
+/// [`SqliteVectorStore::index`] holds the model behind an erased
+/// [`EmbeddingModelHandle`].
 #[derive(Clone)]
-pub struct SqliteVectorStore<E, T>
+pub struct SqliteVectorStore<T>
 where
-    E: EmbeddingModel + 'static,
     T: SqliteVectorStoreTable + 'static,
 {
     conn: Connection,
     distance_metric: SqliteDistanceMetric,
     metadata_columns: Vec<SqliteMetadataColumn>,
-    _phantom: PhantomData<(E, T)>,
+    _phantom: PhantomData<T>,
 }
 
-impl<E, T> SqliteVectorStore<E, T>
+impl<T> SqliteVectorStore<T>
 where
-    E: EmbeddingModel + 'static,
     T: SqliteVectorStoreTable + 'static,
 {
     async fn candidate_limit(&self, samples: u64, exhaustive: bool) -> Result<u64, VectorStoreError>
@@ -411,13 +415,15 @@ where
     }
 }
 
-impl<E, T> SqliteVectorStore<E, T>
+impl<T> SqliteVectorStore<T>
 where
-    E: EmbeddingModel + Clone + 'static,
     T: SqliteVectorStoreTable + 'static,
 {
     /// Creates a SQLite vector store using cosine similarity.
-    pub async fn new(conn: Connection, embedding_model: &E) -> Result<Self, VectorStoreError> {
+    pub async fn new(
+        conn: Connection,
+        embedding_model: &impl EmbeddingModel,
+    ) -> Result<Self, VectorStoreError> {
         Self::with_distance_metric(conn, embedding_model, SqliteDistanceMetric::default()).await
     }
 
@@ -428,7 +434,7 @@ where
     /// returned score values.
     pub async fn with_distance_metric(
         conn: Connection,
-        embedding_model: &E,
+        embedding_model: &impl EmbeddingModel,
         distance_metric: SqliteDistanceMetric,
     ) -> Result<Self, VectorStoreError> {
         let dims = embedding_model.ndims();
@@ -558,7 +564,7 @@ where
         })
     }
 
-    pub fn index(self, model: E) -> SqliteVectorIndex<E, T> {
+    pub fn index(self, model: impl EmbeddingModel + 'static) -> SqliteVectorIndex<T> {
         SqliteVectorIndex::new(model, self)
     }
 
@@ -689,9 +695,8 @@ where
     }
 }
 
-impl<E, T> InsertDocuments for SqliteVectorStore<E, T>
+impl<T> InsertDocuments for SqliteVectorStore<T>
 where
-    E: EmbeddingModel + Clone + WasmCompatSend + WasmCompatSync + 'static,
     T: SqliteVectorStoreTable
         + for<'de> Deserialize<'de>
         + WasmCompatSend
@@ -1506,7 +1511,7 @@ fn sqlite_json_operator_operand_len(operand: &str) -> Option<usize> {
 /// let model = openai_client.embedding_model(TEXT_EMBEDDING_ADA_002);
 ///
 /// // Initialize vector store
-/// let vector_store: SqliteVectorStore<_, Document> = SqliteVectorStore::with_distance_metric(
+/// let vector_store: SqliteVectorStore<Document> = SqliteVectorStore::with_distance_metric(
 ///     conn,
 ///     &model,
 ///     SqliteDistanceMetric::Cosine,
@@ -1546,31 +1551,35 @@ fn sqlite_json_operator_operand_len(operand: &str) -> Option<usize> {
 /// # }
 /// # let _ = example();
 /// ```
-pub struct SqliteVectorIndex<E, T>
+///
+/// The embedding model's concrete type is erased at construction into an
+/// [`EmbeddingModelHandle`], which is fixed for the index's lifetime: an index
+/// populated under one model is only meaningful when queried under that model.
+pub struct SqliteVectorIndex<T>
 where
-    E: EmbeddingModel + 'static,
     T: SqliteVectorStoreTable + 'static,
 {
-    store: SqliteVectorStore<E, T>,
-    embedding_model: E,
+    store: SqliteVectorStore<T>,
+    embedding_model: EmbeddingModelHandle,
 }
 
-impl<E, T> SqliteVectorIndex<E, T>
+impl<T> SqliteVectorIndex<T>
 where
-    E: EmbeddingModel + 'static,
     T: SqliteVectorStoreTable,
 {
-    pub fn new(embedding_model: E, store: SqliteVectorStore<E, T>) -> Self {
+    pub fn new(
+        embedding_model: impl EmbeddingModel + 'static,
+        store: SqliteVectorStore<T>,
+    ) -> Self {
         Self {
             store,
-            embedding_model,
+            embedding_model: EmbeddingModelHandle::new(embedding_model),
         }
     }
 }
 
-impl<E, T> SqliteVectorIndex<E, T>
+impl<T> SqliteVectorIndex<T>
 where
-    E: EmbeddingModel + 'static,
     T: SqliteVectorStoreTable + 'static,
 {
     /// Runs the shared candidate search for `top_n`/`top_n_ids`.
@@ -1933,9 +1942,7 @@ fn sqlite_id_value_to_string(index: usize, value: ValueRef<'_>) -> rusqlite::Res
     }
 }
 
-impl<E: EmbeddingModel + std::marker::Sync, T: SqliteVectorStoreTable> VectorStoreIndex
-    for SqliteVectorIndex<E, T>
-{
+impl<T: SqliteVectorStoreTable> VectorStoreIndex for SqliteVectorIndex<T> {
     type Filter = SqliteSearchFilter;
 
     async fn top_n<D>(
@@ -2981,7 +2988,7 @@ mod tests {
         )
         .await?;
         let model = TestEmbeddingModel;
-        let vector_store: SqliteVectorStore<_, TestDocument> =
+        let vector_store: SqliteVectorStore<TestDocument> =
             SqliteVectorStore::new(conn, &model).await?;
 
         vector_store
@@ -3037,7 +3044,7 @@ mod tests {
         )
         .await?;
         let model = TestEmbeddingModel;
-        let vector_store: SqliteVectorStore<_, TestDocument> =
+        let vector_store: SqliteVectorStore<TestDocument> =
             SqliteVectorStore::new(conn, &model).await?;
 
         let multi_document = TestDocument {
@@ -3825,7 +3832,7 @@ mod tests {
         )
         .await?;
         let model = TestEmbeddingModel;
-        let vector_store: SqliteVectorStore<_, ReorderedIdDocument> =
+        let vector_store: SqliteVectorStore<ReorderedIdDocument> =
             SqliteVectorStore::new(conn, &model).await?;
 
         vector_store
@@ -3873,7 +3880,7 @@ mod tests {
         )
         .await?;
         let model = TestEmbeddingModel;
-        let vector_store: SqliteVectorStore<_, InternalAliasDocument> =
+        let vector_store: SqliteVectorStore<InternalAliasDocument> =
             SqliteVectorStore::new(conn, &model).await?;
 
         vector_store
@@ -4252,7 +4259,7 @@ mod tests {
     async fn live_test_index(
         name: &str,
         rows: Vec<(TestDocument, Vec<Embedding>)>,
-    ) -> anyhow::Result<SqliteVectorIndex<TestEmbeddingModel, TestDocument>> {
+    ) -> anyhow::Result<SqliteVectorIndex<TestDocument>> {
         live_test_index_with_metric(name, rows, SqliteDistanceMetric::Cosine).await
     }
 
@@ -4260,7 +4267,7 @@ mod tests {
         name: &str,
         rows: Vec<(TestDocument, Vec<Embedding>)>,
         distance_metric: SqliteDistanceMetric,
-    ) -> anyhow::Result<SqliteVectorIndex<TestEmbeddingModel, TestDocument>> {
+    ) -> anyhow::Result<SqliteVectorIndex<TestDocument>> {
         register_sqlite_vec_extension();
 
         let conn = Connection::open(format!("file:{name}?mode=memory")).await?;
@@ -4276,7 +4283,7 @@ mod tests {
     async fn live_typed_test_index(
         name: &str,
         rows: Vec<(TypedTestDocument, Vec<Embedding>)>,
-    ) -> anyhow::Result<SqliteVectorIndex<TestEmbeddingModel, TypedTestDocument>> {
+    ) -> anyhow::Result<SqliteVectorIndex<TypedTestDocument>> {
         live_typed_test_index_with_metric(name, rows, SqliteDistanceMetric::Cosine).await
     }
 
@@ -4284,12 +4291,12 @@ mod tests {
         name: &str,
         rows: Vec<(TypedTestDocument, Vec<Embedding>)>,
         distance_metric: SqliteDistanceMetric,
-    ) -> anyhow::Result<SqliteVectorIndex<TestEmbeddingModel, TypedTestDocument>> {
+    ) -> anyhow::Result<SqliteVectorIndex<TypedTestDocument>> {
         register_sqlite_vec_extension();
 
         let conn = Connection::open(format!("file:{name}?mode=memory")).await?;
         let model = TestEmbeddingModel;
-        let vector_store: SqliteVectorStore<_, TypedTestDocument> =
+        let vector_store: SqliteVectorStore<TypedTestDocument> =
             SqliteVectorStore::with_distance_metric(conn, &model, distance_metric).await?;
 
         vector_store.add_rows(rows).await?;
@@ -4300,12 +4307,12 @@ mod tests {
     async fn live_common_type_test_index(
         name: &str,
         rows: Vec<(CommonTypeDocument, Vec<Embedding>)>,
-    ) -> anyhow::Result<SqliteVectorIndex<TestEmbeddingModel, CommonTypeDocument>> {
+    ) -> anyhow::Result<SqliteVectorIndex<CommonTypeDocument>> {
         register_sqlite_vec_extension();
 
         let conn = Connection::open(format!("file:{name}?mode=memory")).await?;
         let model = TestEmbeddingModel;
-        let vector_store: SqliteVectorStore<_, CommonTypeDocument> =
+        let vector_store: SqliteVectorStore<CommonTypeDocument> =
             SqliteVectorStore::new(conn, &model).await?;
 
         vector_store.add_rows(rows).await?;
@@ -4316,12 +4323,12 @@ mod tests {
     async fn live_json_metadata_test_index(
         name: &str,
         rows: Vec<(JsonMetadataDocument, Vec<Embedding>)>,
-    ) -> anyhow::Result<SqliteVectorIndex<TestEmbeddingModel, JsonMetadataDocument>> {
+    ) -> anyhow::Result<SqliteVectorIndex<JsonMetadataDocument>> {
         register_sqlite_vec_extension();
 
         let conn = Connection::open(format!("file:{name}?mode=memory")).await?;
         let model = TestEmbeddingModel;
-        let vector_store: SqliteVectorStore<_, JsonMetadataDocument> =
+        let vector_store: SqliteVectorStore<JsonMetadataDocument> =
             SqliteVectorStore::new(conn, &model).await?;
 
         vector_store.add_rows(rows).await?;
@@ -4332,12 +4339,12 @@ mod tests {
     async fn live_structured_json_metadata_test_index(
         name: &str,
         rows: Vec<(StructuredJsonMetadataDocument, Vec<Embedding>)>,
-    ) -> anyhow::Result<SqliteVectorIndex<TestEmbeddingModel, StructuredJsonMetadataDocument>> {
+    ) -> anyhow::Result<SqliteVectorIndex<StructuredJsonMetadataDocument>> {
         register_sqlite_vec_extension();
 
         let conn = Connection::open(format!("file:{name}?mode=memory")).await?;
         let model = TestEmbeddingModel;
-        let vector_store: SqliteVectorStore<_, StructuredJsonMetadataDocument> =
+        let vector_store: SqliteVectorStore<StructuredJsonMetadataDocument> =
             SqliteVectorStore::new(conn, &model).await?;
 
         vector_store.add_rows(rows).await?;
@@ -4994,7 +5001,9 @@ mod tests {
     struct TestEmbeddingModel;
 
     impl EmbeddingModel for TestEmbeddingModel {
-        const MAX_DOCUMENTS: usize = 16;
+        fn max_documents(&self) -> usize {
+            16
+        }
 
         fn ndims(&self) -> usize {
             2

--- a/crates/rig-sqlite/src/lib.rs
+++ b/crates/rig-sqlite/src/lib.rs
@@ -4996,12 +4996,6 @@ mod tests {
     impl EmbeddingModel for TestEmbeddingModel {
         const MAX_DOCUMENTS: usize = 16;
 
-        type Client = ();
-
-        fn make(_: &Self::Client, _: impl Into<String>, _: Option<usize>) -> Self {
-            Self
-        }
-
         fn ndims(&self) -> usize {
             2
         }
@@ -5017,6 +5011,12 @@ mod tests {
                     vec: vec![1.0, 0.0],
                 })
                 .collect())
+        }
+    }
+
+    impl rig_core::client::ConstructEmbeddingModel<()> for TestEmbeddingModel {
+        fn construct(_: &(), _: String, _: Option<usize>) -> Self {
+            Self
         }
     }
 }

--- a/crates/rig-surrealdb/src/lib.rs
+++ b/crates/rig-surrealdb/src/lib.rs
@@ -11,7 +11,7 @@ use std::fmt::Display;
 
 use rig_core::{
     Embed,
-    embeddings::{Embedding, EmbeddingModel},
+    embeddings::{Embedding, EmbeddingModel, EmbeddingModelHandle},
     vector_store::{
         InsertDocuments, VectorStoreError, VectorStoreIndex,
         request::{DynamicSearchFilter, Filter, FilterError, SearchFilter, VectorSearchRequest},
@@ -26,12 +26,16 @@ use surrealdb::{
 pub use surrealdb::engine::local::Mem;
 pub use surrealdb::engine::remote::ws::{Ws, Wss};
 
-pub struct SurrealVectorStore<C, Model>
+/// A SurrealDB-backed vector store.
+///
+/// The embedding model's concrete type is erased at construction into an
+/// [`EmbeddingModelHandle`], which is fixed for the store's lifetime: an index
+/// populated under one model is only meaningful when queried under that model.
+pub struct SurrealVectorStore<C>
 where
     C: Connection,
-    Model: EmbeddingModel,
 {
-    model: Model,
+    model: EmbeddingModelHandle,
     surreal: Surreal<C>,
     documents_table: String,
     distance_function: SurrealDistanceFunction,
@@ -96,10 +100,9 @@ fn record_key_to_string(key: &RecordIdKey) -> String {
     }
 }
 
-impl<C, Model> InsertDocuments for SurrealVectorStore<C, Model>
+impl<C> InsertDocuments for SurrealVectorStore<C>
 where
     C: Connection + Send + Sync,
-    Model: EmbeddingModel + Send + Sync,
 {
     async fn insert_documents<Doc: Serialize + Embed + Send>(
         &self,
@@ -248,19 +251,18 @@ impl SurrealSearchFilter {
     }
 }
 
-impl<C, Model> SurrealVectorStore<C, Model>
+impl<C> SurrealVectorStore<C>
 where
     C: Connection,
-    Model: EmbeddingModel,
 {
     pub fn new(
-        model: Model,
+        model: impl EmbeddingModel + 'static,
         surreal: Surreal<C>,
         documents_table: Option<String>,
         distance_function: SurrealDistanceFunction,
     ) -> Self {
         Self {
-            model,
+            model: EmbeddingModelHandle::new(model),
             surreal,
             documents_table: documents_table.unwrap_or(String::from("documents")),
             distance_function,
@@ -271,7 +273,7 @@ where
         &self.surreal
     }
 
-    pub fn with_defaults(model: Model, surreal: Surreal<C>) -> Self {
+    pub fn with_defaults(model: impl EmbeddingModel + 'static, surreal: Surreal<C>) -> Self {
         Self::new(model, surreal, None, SurrealDistanceFunction::Cosine)
     }
 
@@ -319,10 +321,9 @@ where
     }
 }
 
-impl<C, Model> VectorStoreIndex for SurrealVectorStore<C, Model>
+impl<C> VectorStoreIndex for SurrealVectorStore<C>
 where
     C: Connection,
-    Model: EmbeddingModel,
 {
     type Filter = SurrealSearchFilter;
 
@@ -382,7 +383,9 @@ mod tests {
     struct MockEmbeddingModel;
 
     impl EmbeddingModel for MockEmbeddingModel {
-        const MAX_DOCUMENTS: usize = 4;
+        fn max_documents(&self) -> usize {
+            4
+        }
 
         fn ndims(&self) -> usize {
             3

--- a/crates/rig-surrealdb/src/lib.rs
+++ b/crates/rig-surrealdb/src/lib.rs
@@ -384,12 +384,6 @@ mod tests {
     impl EmbeddingModel for MockEmbeddingModel {
         const MAX_DOCUMENTS: usize = 4;
 
-        type Client = Nothing;
-
-        fn make(_: &Self::Client, _: impl Into<String>, _: Option<usize>) -> Self {
-            Self
-        }
-
         fn ndims(&self) -> usize {
             3
         }
@@ -405,6 +399,12 @@ mod tests {
                     vec: vec![0.0, 0.0, 0.0],
                 })
                 .collect())
+        }
+    }
+
+    impl rig_core::client::ConstructEmbeddingModel<Nothing> for MockEmbeddingModel {
+        fn construct(_: &Nothing, _: String, _: Option<usize>) -> Self {
+            Self
         }
     }
 

--- a/crates/rig-vectorize/src/lib.rs
+++ b/crates/rig-vectorize/src/lib.rs
@@ -31,7 +31,7 @@ pub use client::{
 };
 
 use client::{QueryRequest as ApiQueryRequest, VectorInput as ApiVectorInput};
-use rig_core::embeddings::EmbeddingModel;
+use rig_core::embeddings::{EmbeddingModel, EmbeddingModelHandle};
 use rig_core::vector_store::request::VectorSearchRequest;
 use rig_core::vector_store::{InsertDocuments, VectorStoreError, VectorStoreIndex};
 use rig_core::{Embed, embeddings::Embedding};
@@ -48,15 +48,19 @@ impl From<VectorizeError> for VectorStoreError {
 ///
 /// This struct implements [`VectorStoreIndex`] to provide vector similarity search
 /// using Cloudflare's globally distributed Vectorize service.
+///
+/// The embedding model's concrete type is erased at construction into an
+/// [`EmbeddingModelHandle`]; the handle is fixed for the store's lifetime (an index
+/// populated under one model is only meaningful under that same model).
 #[derive(Debug, Clone)]
-pub struct VectorizeVectorStore<M> {
+pub struct VectorizeVectorStore {
     /// The embedding model used to generate query embeddings.
-    model: M,
+    model: EmbeddingModelHandle,
     /// The HTTP client for Vectorize API.
     client: VectorizeClient,
 }
 
-impl<M> VectorizeVectorStore<M> {
+impl VectorizeVectorStore {
     /// Creates a new Vectorize vector store.
     ///
     /// # Arguments
@@ -65,22 +69,19 @@ impl<M> VectorizeVectorStore<M> {
     /// * `index_name` - Name of the Vectorize index
     /// * `api_token` - Cloudflare API token with Vectorize read permissions
     pub fn new(
-        model: M,
+        model: impl EmbeddingModel + 'static,
         account_id: impl Into<String>,
         index_name: impl Into<String>,
         api_token: impl Into<String>,
     ) -> Self {
         Self {
-            model,
+            model: EmbeddingModelHandle::new(model),
             client: VectorizeClient::new(account_id, index_name, api_token),
         }
     }
 }
 
-impl<M> VectorizeVectorStore<M>
-where
-    M: EmbeddingModel + Sync + Send,
-{
+impl VectorizeVectorStore {
     /// Validates the filter, embeds the query, and returns the threshold-filtered matches.
     async fn query_matches(
         &self,
@@ -111,10 +112,7 @@ where
     }
 }
 
-impl<M> VectorStoreIndex for VectorizeVectorStore<M>
-where
-    M: EmbeddingModel + Sync + Send,
-{
+impl VectorStoreIndex for VectorizeVectorStore {
     type Filter = VectorizeFilter;
 
     async fn top_n<T: for<'a> Deserialize<'a> + Send>(
@@ -147,10 +145,7 @@ where
     }
 }
 
-impl<M> InsertDocuments for VectorizeVectorStore<M>
-where
-    M: EmbeddingModel + Sync + Send,
-{
+impl InsertDocuments for VectorizeVectorStore {
     async fn insert_documents<Doc: Serialize + Embed + Send>(
         &self,
         documents: Vec<(Doc, Vec<Embedding>)>,

--- a/tests/integrations/sqlite.rs
+++ b/tests/integrations/sqlite.rs
@@ -247,7 +247,7 @@ async fn insert_documents_test() {
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
     let embeddings = create_embeddings(model.clone()).await;
 
-    let vector_store: SqliteVectorStore<_, Word> = SqliteVectorStore::new(conn.clone(), &model)
+    let vector_store: SqliteVectorStore<Word> = SqliteVectorStore::new(conn.clone(), &model)
         .await
         .expect("Could not initialize SQLite vector store");
 

--- a/tests/integrations/vectorize.rs
+++ b/tests/integrations/vectorize.rs
@@ -493,18 +493,8 @@ impl MockEmbeddingModel {
     }
 }
 
-struct MockClient;
-
 impl EmbeddingModel for MockEmbeddingModel {
     const MAX_DOCUMENTS: usize = 100;
-
-    type Client = MockClient;
-
-    fn make(_client: &Self::Client, _model: impl Into<String>, dims: Option<usize>) -> Self {
-        Self {
-            dimensions: dims.unwrap_or(1536),
-        }
-    }
 
     fn ndims(&self) -> usize {
         self.dimensions

--- a/tests/integrations/vectorize.rs
+++ b/tests/integrations/vectorize.rs
@@ -494,7 +494,9 @@ impl MockEmbeddingModel {
 }
 
 impl EmbeddingModel for MockEmbeddingModel {
-    const MAX_DOCUMENTS: usize = 100;
+    fn max_documents(&self) -> usize {
+        100
+    }
 
     fn ndims(&self) -> usize {
         self.dimensions
@@ -537,7 +539,7 @@ fn get_env_or_skip(var: &str) -> Option<String> {
     std::env::var(var).ok()
 }
 
-fn create_vector_store() -> Option<VectorizeVectorStore<MockEmbeddingModel>> {
+fn create_vector_store() -> Option<VectorizeVectorStore> {
     let account_id = get_env_or_skip("CLOUDFLARE_ACCOUNT_ID")?;
     let api_token = get_env_or_skip("CLOUDFLARE_API_TOKEN")?;
     let index_name = get_env_or_skip("VECTORIZE_INDEX_NAME")?;

--- a/tests/providers/gemini/cassette/dynamic_tools.rs
+++ b/tests/providers/gemini/cassette/dynamic_tools.rs
@@ -25,10 +25,7 @@ use crate::support::assert_mentions_expected_number;
 async fn build_tool_index(
     client: &gemini::Client,
     toolset: &ToolSet,
-) -> rig::vector_store::in_memory_store::InMemoryVectorIndex<
-    gemini::embedding::EmbeddingModel,
-    rig::embeddings::ToolSchema,
-> {
+) -> rig::vector_store::in_memory_store::InMemoryVectorIndex<rig::embeddings::ToolSchema> {
     let embedding_model = client.embedding_model(gemini::embedding::EMBEDDING_001);
     // ToolSet::schemas() returns registration order, so the recorded
     // embedding batch replays deterministically.

--- a/tests/providers/gemini/cassette/image_generation.rs
+++ b/tests/providers/gemini/cassette/image_generation.rs
@@ -24,7 +24,7 @@ async fn nano_banana_image_generation_smoke() {
                 "expected non-empty generated image bytes"
             );
             assert_eq!(
-                response.response.model_version.as_deref(),
+                response.model.as_deref(),
                 Some(gemini::GEMINI_2_5_FLASH_IMAGE),
                 "expected Gemini response to identify the image model"
             );

--- a/tests/providers/gemini/cassette/thought_text_matrix.rs
+++ b/tests/providers/gemini/cassette/thought_text_matrix.rs
@@ -8,7 +8,7 @@
 //! become `AssistantContent::Reasoning`); two other readers of the same
 //! payload did not:
 //!
-//! * `TryFrom<GenerateContentResponse> for TranscriptionResponse` read
+//! * `NormalizeTranscriptionResponse for GenerateContentResponse` read
 //!   `parts.first()`. With thoughts on, parts[0] is the reasoning — so
 //!   `response.text` was **the model's private reasoning** and the actual
 //!   transcript, sitting in parts[1], was dropped. A transcript split across
@@ -220,7 +220,10 @@ async fn transcription_body(
     }
 
     let response = request.send().await.expect("transcription should succeed");
-    let (visible, thoughts) = split_parts(&response.response);
+    let raw: rig::providers::gemini::completion::gemini_api_types::GenerateContentResponse =
+        serde_json::from_value(response.raw.clone())
+            .expect("raw payload should round-trip to Gemini's own response type");
+    let (visible, thoughts) = split_parts(&raw);
 
     assert_eq!(
         !thoughts.is_empty(),
@@ -1131,7 +1134,7 @@ async fn streaming_twin_agrees_on_a_trailing_thought_signature() {
 mod unit {
     use rig::providers::gemini::completion::gemini_api_types::GenerateContentResponse;
     use rig::telemetry::ProviderResponseExt;
-    use rig::transcription::TranscriptionResponse;
+    use rig::transcription::{NormalizeTranscriptionResponse, TranscriptionResponse};
     use serde_json::{Value, json};
 
     /// A thought part with the shape recorded in
@@ -1218,8 +1221,9 @@ mod unit {
             "model",
         );
 
-        let transcription: TranscriptionResponse<GenerateContentResponse> =
-            response.try_into().expect("transcription should convert");
+        let transcription = response
+            .normalize("gcp.gemini")
+            .expect("transcription should convert");
         assert_eq!(
             transcription.text,
             "The sun was setting slowly, casting long shadows across the empty field.",
@@ -1235,18 +1239,13 @@ mod unit {
     fn transcription_rejects_a_thought_only_candidate() {
         let response = response_with(vec![thought_part("Let me listen again...")], "model");
         assert_transcription_response_error(
-            TranscriptionResponse::<GenerateContentResponse>::try_from(response),
+            response.normalize("gcp.gemini"),
             "a thought-only candidate has no transcript",
         );
     }
 
-    /// `TranscriptionResponse` carries the provider payload and is not
-    /// `Debug`, so `expect_err` is unavailable; assert on the `Err` directly.
     fn assert_transcription_response_error(
-        result: Result<
-            TranscriptionResponse<GenerateContentResponse>,
-            rig::transcription::TranscriptionError,
-        >,
+        result: Result<TranscriptionResponse, rig::transcription::TranscriptionError>,
         context: &str,
     ) {
         match result {
@@ -1269,8 +1268,8 @@ mod unit {
     #[test]
     fn transcription_keeps_an_empty_visible_text_part() {
         let response = response_with(vec![thought_part("hmm"), text_part("")], "model");
-        let transcription: TranscriptionResponse<GenerateContentResponse> = response
-            .try_into()
+        let transcription = response
+            .normalize("gcp.gemini")
             .expect("an empty visible text part is still a (blank) transcript");
         assert_eq!(transcription.text, "");
     }
@@ -1292,7 +1291,7 @@ mod unit {
         }))
         .expect("recorded-shape payload should deserialize");
         assert_transcription_response_error(
-            TranscriptionResponse::<GenerateContentResponse>::try_from(response),
+            response.normalize("gcp.gemini"),
             "a candidate with no parts at all has no transcript",
         );
     }
@@ -1307,7 +1306,7 @@ mod unit {
             "model",
         );
         assert_transcription_response_error(
-            TranscriptionResponse::<GenerateContentResponse>::try_from(response),
+            response.normalize("gcp.gemini"),
             "a candidate with no text part has no transcript",
         );
     }

--- a/tests/providers/openai/cassette/transcription_usage_matrix.rs
+++ b/tests/providers/openai/cassette/transcription_usage_matrix.rs
@@ -73,6 +73,13 @@ fn audio() -> Vec<u8> {
     std::fs::read(AUDIO_FIXTURE_PATH).expect("audio fixture should be readable")
 }
 
+/// The provider's own payload, recovered from the normalized response's
+/// `raw` field — the same value `raw_transcription` would have returned.
+fn raw(response: &rig::transcription::TranscriptionResponse) -> openai::TranscriptionResponse {
+    serde_json::from_value(response.raw.clone())
+        .expect("raw payload should round-trip to OpenAI's own transcription type")
+}
+
 /// The transcript itself, so no cell asserts usage while ignoring whether the
 /// endpoint still did its job.
 fn assert_transcribed(text: &str) {
@@ -101,7 +108,7 @@ async fn whisper_reports_duration_usage() {
                 .expect("transcription should succeed");
 
             assert_transcribed(&response.text);
-            match response.response.usage {
+            match raw(&response).usage {
                 Some(TranscriptionUsage::Duration { seconds, .. }) => assert!(seconds > 0.0),
                 other => panic!("whisper-1 bills by duration, got {other:?}"),
             }
@@ -125,7 +132,7 @@ async fn gpt_4o_transcribe_reports_token_usage() {
                 .expect("transcription should succeed");
 
             assert_transcribed(&response.text);
-            match response.response.usage {
+            match raw(&response).usage {
                 Some(TranscriptionUsage::Tokens {
                     input_tokens,
                     input_token_details,
@@ -163,7 +170,7 @@ async fn gpt_4o_mini_transcribe_reports_token_usage() {
 
             assert_transcribed(&response.text);
             assert!(matches!(
-                response.response.usage,
+                raw(&response).usage,
                 Some(TranscriptionUsage::Tokens { .. })
             ));
         },
@@ -190,7 +197,7 @@ async fn completions_client_reports_duration_usage() {
 
             assert_transcribed(&response.text);
             assert!(matches!(
-                response.response.usage,
+                raw(&response).usage,
                 Some(TranscriptionUsage::Duration { .. })
             ));
         },
@@ -215,7 +222,7 @@ async fn completions_client_reports_token_usage() {
 
             assert_transcribed(&response.text);
             assert!(matches!(
-                response.response.usage,
+                raw(&response).usage,
                 Some(TranscriptionUsage::Tokens { .. })
             ));
         },
@@ -248,11 +255,11 @@ async fn verbose_json_still_reports_duration_usage() {
             // variant-selection regression would surface first.
             assert!(
                 matches!(
-                    response.response.usage,
+                    raw(&response).usage,
                     Some(TranscriptionUsage::Duration { .. })
                 ),
                 "a richer response format must not cost or reshape the usage: {:?}",
-                response.response.usage
+                raw(&response).usage
             );
         },
     )
@@ -275,7 +282,8 @@ async fn transcript_still_reaches_the_normalized_response() {
                 .await
                 .expect("transcription should succeed");
 
-            assert_eq!(response.text, response.response.text);
+            assert_eq!(response.text, raw(&response).text);
+            assert_eq!(response.provider, "openai");
             assert_transcribed(&response.text);
         },
     )

--- a/tests/providers/venice/cassette/image_generation.rs
+++ b/tests/providers/venice/cassette/image_generation.rs
@@ -37,12 +37,16 @@ async fn image_generation_smoke() {
                 !response.image.is_empty(),
                 "expected decoded image bytes from the base64 payload"
             );
+            assert_eq!(response.provider, "venice");
+            let raw: rig::providers::venice::ImageGenerationResponse =
+                serde_json::from_value(response.raw.clone())
+                    .expect("raw payload should round-trip to Venice's own type");
             assert!(
-                !response.response.id.is_empty(),
+                !raw.id.is_empty(),
                 "expected Venice to report a generation id"
             );
             assert_eq!(
-                response.response.images.len(),
+                raw.images.len(),
                 1,
                 "expected exactly one image for a single-variant request"
             );


### PR DESCRIPTION
## Summary

#2257 ("The Generics Are Gone") made two changes to completions, in a forced order: normalize the response at the provider boundary so it stops depending on the provider type, then erase the model type at construction. This PR applies the same argument to the four places 0.42 left behind, in one branch so the sweep lands whole:

| # | Where the same argument applied | What this does |
|---|---|---|
| 1 | `TranscriptionModel` / `ImageGenerationModel` / `AudioGenerationModel` still carried `type Response`, and their response structs were literally the pre-#2257 `{ normalized value, raw_response: T }` shape | **Normalize at the provider boundary.** `type Response` is gone; `TranscriptionResponse` / `ImageGenerationResponse` / `AudioGenerationResponse` are concrete, carrying `usage`, `provider`, `model`, `response_id`, `provider_request_id` (the id provider support asks for — #2313's argument applies to a failed transcription exactly as to a failed completion), a serialized `raw`, and `identity() -> ResponseIdentity`. |
| 2 | The construction associated type (`type Client` + `fn make`) survived on all five non-completion traits; `ConstructCompletionModel` was the only `Construct*` hook in the tree | **Move construction off the traits.** Public `ConstructTranscriptionModel` / `ConstructImageGenerationModel` / `ConstructAudioGenerationModel` / `ConstructEmbeddingModel` / `ConstructRerankModel` hooks beside `ConstructCompletionModel`; the blanket capability-client impls over `Client<Ext, H>` bound on them. Same orphan-rule reason the completion hook had to be public: an out-of-tree extension cannot implement `TranscriptionClient` for the foreign `Client<Ext, H>`, so without a public hook it could not reach `transcription_model` at all. A compile probe (`client::external_modality_extension_probe`) shows an external extension reaching every blanket impl through public API only. |
| 3 | `EmbeddingModel` leaked into every vector store — the structural twin of `Agent<M>` | **Erase at construction.** `rig_core::embeddings::EmbeddingModelHandle` (the `ModelHandle` shape: private object-safe `ErasedEmbeddingModel`, blanket impl, one `Arc`, `ndims`/`max_documents` captured by value, clone-counting probe), and `M` deleted from all 13 store/index types across 12 crates. |
| 4 | The `Clone` supertrait relaxation was not propagated | Dropped `Clone` (and `Sized` on audio) from the three generation traits and from `ImageEmbeddingModel`; `*_request()` gates on `where Self: Sized + Clone`; each trait is implemented for `Arc<M>`. |

**The single most important lesson from #2257 was the #2366 regression** — erasure made `raw_completion` unreachable, and a follow-up had to restore it. This PR designs the route back in up front: every concrete provider model gains an inherent `raw_transcription` / `raw_image_generation` / `raw_audio_generation` returning the provider's native type from the same request, transport, parser and error path as the normalized call, and the normalized response carries that value serialized in `raw` (with the byte-bodied endpoints — HF images, every OpenAI-style TTS — documented as the `Null`/`raw_*` case). Normalization is expressible out of tree through `NormalizeTranscriptionResponse` / `NormalizeImageGenerationResponse` / `NormalizeAudioGenerationResponse` (a trait, not `TryFrom<(&str, T)>`, for the orphan-rule reason #2257 hit), and the provider name is an **input** to it — the shared OpenAI-style drivers now take `PROVIDER_NAME` from the provider ext rather than hardcoding one.

Request construction is untouched. **`git diff main..HEAD -- tests/cassettes` is empty** (verified; see below). Every recorded transcription/image/audio cassette replays unchanged against the new response types.

## Breaks (all documented in `MIGRATING.md`, three new subsections after "Agents erase the model type at construction")

Workstream A — modality responses
- `TranscriptionModel::Response`, `ImageGenerationModel::Response`, `AudioGenerationModel::Response` removed; the three response structs lose their type parameter and their `response` field. Table in MIGRATING maps every 0.42 `r.response.<x>` read to its new home (`r.text`, `r.usage`, `r.model`, `r.response_id`, `r.raw[..]`, or `raw_*`).
- `impl TryFrom<Payload> for XResponse<Payload>` → `impl NormalizeXResponse for Payload`.
- `Clone` dropped from the three traits' supertraits (`Sized` from audio); `*_request()` now `where Self: Sized + Clone`.
- Provider payload types gain `Serialize` (`openai::TranscriptionResponse` + usage enums, `openrouter::TranscriptionResponse`, `mistral::MistralTranscriptionResponse`, the image `ImageGenerationResponse` types, `hyperbolic::{Image, ImageGenerationResponse, AudioGenerationResponse}` — whose fields also become `pub` — and Bedrock's `TextToImageResponse`). `huggingface::ImageGenerationResponse::data` becomes `pub`.
- `internal::transcription::OpenAiTranscriptionClient` and `internal::audio_generation::RawAudioGenerationProvider` are now `#[doc(hidden)] pub` (they bound the new `pub` inherent `raw_*` methods) and gain `PROVIDER_NAME` / `REQUEST_ID_HEADER`; `JsonImageGenerationProvider` gains the same and its `Response` is now bounded by `Serialize + NormalizeImageGenerationResponse`.

Workstream C — construction
- `type Client` + `fn make` removed from `EmbeddingModel`, `RerankModel`, `TranscriptionModel`, `ImageGenerationModel`, `AudioGenerationModel`.
- `EmbeddingModel::MAX_DOCUMENTS` (const) → `fn max_documents(&self) -> usize` (a const cannot survive erasure; `RerankModel::MAX_DOCUMENTS` / `ImageEmbeddingModel::MAX_DOCUMENTS` unchanged).
- `AudioGenerationClient::audio_generation_model` loses its default body; `ImageGenerationClient::ImageGenerationModel` / `AudioGenerationClient::AudioGenerationModel` lose the `<Client = Self>` bound.
- `ImageEmbeddingModel` drops `Clone`.

Workstream B — vector stores
- `InMemoryVectorIndex<M, D>` → `<D>`, `QdrantVectorStore<M>`, `LanceDbVectorIndex<M>`, `ScyllaDbVectorStore<M>`, `MongoDbVectorIndex<C, M>` → `<C>`, `MilvusVectorStore<M>`, `VectorizeVectorStore<M>`, `Neo4jVectorIndex<M>`, `S3VectorsVectorStore<M>`, `PostgresVectorStore<M>`, `SqliteVectorStore<E, T>` / `SqliteVectorIndex<E, T>` → `<T>`, `SurrealVectorStore<C, M>` → `<C>`, `HelixDBVectorStore<C, E>` → `<C>`; constructors take `impl EmbeddingModel + 'static`. `Neo4jClient::get_index` loses its generic. Construction call sites are unchanged.

## Design note for workstream B (the vector-store erasure)

Conceding the caveat first: for `Agent`, runtime swapping was the *point* of erasure. For a vector store it is a footgun — swapping the embedding model under a populated index changes the vector space and usually breaks `ndims`. So this PR does **not** ship a `set_model` on any store, and `EmbeddingModelHandle` offers no way to replace what it holds. The case here is the smaller one and stands on its own:

- **Ergonomics.** Today every downstream signature that holds an index names the provider — `QdrantVectorStore<openai::EmbeddingModel>` in app code, `InMemoryVectorIndex<M, D>` in every helper. After #2257 an `Agent` no longer does; an index is the same kind of long-lived object that calls two methods on its model, and there is no reason for it to be the odd one out.
- **Dyn-storability.** Heterogeneous collections of indexes (`Vec<Box<dyn VectorStoreIndex<Filter = _>>>`) no longer need a provider name per element, and a store type can be named in a struct field without threading `M` through the owner.
- **Mechanism is settled, not invented.** `EmbeddingModelHandle` copies `ModelHandle` structurally (private dyn-safe mirror + blanket impl, single `Arc` with snapshot-first layout, by-value capture of `ndims`/`max_documents`, `WasmCompat` supertraits carrying the cfg fork, clone-counting probe). `max_documents` had to become a method for this — a constant has no vtable slot — which is the one trait change B forces.
- **What stays generic.** `EmbeddingsBuilder<M, T>` keeps its parameter: it is transient and dropped at `build()`, the same reason `CompletionRequestBuilder<M>` kept its own.

**On #58** ("refactor: Add generic type to `VectorStoreIndex` trait"): that issue pushes the trait the other direction — parameterizing `VectorStoreIndex` itself. This PR takes the opposite position and I think #58 should be closed against it: the thing a `VectorStoreIndex` consumer wants to be generic over is the *document* type (which the store structs already are) and the *filter* capability (which `VectorStoreIndex::Filter` already is), not the embedding provider. Once the provider is erased at construction there is nothing left for a trait-level generic to name. If the maintainer disagrees this is the piece to argue about before merge, not after.

## Verification

```
cargo test --workspace --all-features                                   # all green (see below)
cargo clippy --workspace --all-targets --all-features -- -D warnings    # clean
cargo fmt --check                                                       # clean
cargo check --target wasm32-unknown-unknown -p rig-core -p rig-agent -p rig   # clean
RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps (rig-core, rig-agent, rig, rig-qdrant, rig-sqlite, rig-bedrock)  # clean
git diff $(git merge-base main HEAD)..HEAD -- tests/cassettes           # EMPTY
```

No cassette was added, re-recorded, or touched. The cassette-backed transcription/image/audio tests (`openai::transcription_usage_matrix`, `gemini::thought_text_matrix`, `gemini::image_generation`, `venice::image_generation`) were rewritten to read the new normalized fields and to deserialize `raw` back into the provider type, and pass against the unchanged recordings. `rig` facade tarball size is unaffected.

Re-verification of the research doc's counts at `6ef740290` before starting: trait shapes, 5/4/2 impl files for transcription/image/audio, 13 `EmbeddingModel` impl files, 2 `RerankModel`, `ConstructCompletionModel` the only `Construct*` hook — all as written. One drift worth noting: the survey under-counted the vector-store crates (it listed ten; there are fourteen store/index types across twelve crates) — all are converted here.

## Commits

1. `feat(core)!` — workstreams A + C (they share `client/mod.rs`'s blanket-impl macro and could not be split into independently-compiling commits; the commit message itemizes each).
2. `feat(embeddings)!` — workstream B.
3. `docs(migrating)`.

## Open questions for the maintainer

1. Is the modality normalization wanted at all, or is transcription/image/audio considered a thin passthrough where `raw` *is* the product? #2257's argument was that callers reach into `raw_response` for a small, knowable set of metadata — that claim should be re-tested per modality rather than assumed. (The cassette tests in this repo reached into `response` for exactly `text`, `usage`, `model_version`, `response_id`, and Venice's `id` — all of which now have named homes or `raw[..]`.)
2. Does anyone actually maintain an out-of-tree provider extension for a non-completion modality? If not, finding 2 is latent rather than live — the construction hooks are shipped here anyway for consistency, but say so.
3. #58 versus the vector-store erasure — which direction does `VectorStoreIndex` go? This PR's position is above; it should be settled before merge.
