### PR TITLE
refactor!: ownership audit — borrow-shaped signatures, dead clones, clone_from in hot accumulators, minimal bounds

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -2146,6 +2146,36 @@ merged `RequestPatch` and the previous model, and may pick a different handle
 per model call). `CompletionModel::capabilities()` is captured by value when
 the handle is created.
 
+### Borrow-shaped signatures: filter builders, rmcp registration, streaming prompt construction
+
+An ownership audit converted signatures that took owned values they never
+consumed into borrows, removing the caller-side clones they forced. Call
+sites passing string literals compile unchanged; sites that built an owned
+`String`/`Value`/`Vec` just to hand it over now pass a reference (and can
+usually stop building the owned value at all).
+
+- Vector-store filter builders take `&str` keys (and, where the value was
+  only serialized, borrowed values): `rig_qdrant::QdrantFilter`
+  (`exists`/`is_null`/`is_empty`/the four `range_*`, values now
+  `&serde_json::Value`), `rig_milvus::Filter` (`gte`/`lte`/`in_values`/
+  `not_in`/`like`/`array_*`), `rig_surrealdb::SurrealSearchFilter`
+  (`contains`/`all`/`any`/`member`/geometry ops, values now `&Value`),
+  `rig_lancedb::LanceDBFilter`, `rig_neo4j::Neo4jSearchFilter`,
+  `rig_postgres::PgSearchFilter`, and `rig_vectorize::VectorizeFilter`
+  (`ne`/`gte`/`lte` take `&Value`; `in_values`/`nin` take `&[Value]`).
+- `MilvusVectorStore::auth(&str, &str)` (was `String, String`).
+- `SqliteVectorStore::add_rows_with_txn` takes `&[(T, Vec<Embedding>)]`.
+- `StreamingPromptRequest::new(&Agent, …)` (was `Arc<Agent>`) — it only ever
+  read through the `Arc`; callers holding an `Arc` pass `&arc`.
+- `ToolServer::rmcp_tools` / `rmcp_tools_with_timeout` and the corresponding
+  `AgentBuilder` wrappers take `client: &ServerSink` (each registered tool
+  clones it anyway); the single-tool `rmcp_tool_with_timeout` still consumes
+  the sink it stores. Callers drop their `peer.clone()`.
+- `rig_vertexai::types::completion_response::map_finish_reason(&FinishReason)`.
+- `VectorStoreIndex::top_n`'s bound is spelled `DeserializeOwned` instead of
+  `for<'a> Deserialize<'a>` — the same bound, so implementations and callers
+  are unaffected; only the spelling changed.
+
 ### Transcription, image-generation and audio-generation responses are concrete and normalized
 
 The same argument #2257 applied to completions now applies to the three

--- a/crates/rig-agent/src/agent/builder.rs
+++ b/crates/rig-agent/src/agent/builder.rs
@@ -376,7 +376,7 @@ impl AgentBuilder<NoToolConfig> {
     pub fn rmcp_tool(
         self,
         tool: rmcp::model::Tool,
-        client: rmcp::service::ServerSink,
+        client: &rmcp::service::ServerSink,
     ) -> AgentBuilder<WithBuilderTools> {
         self.rmcp_tool_with_timeout(tool, client, crate::tool::rmcp::DEFAULT_MCP_TOOL_TIMEOUT)
     }
@@ -392,7 +392,7 @@ impl AgentBuilder<NoToolConfig> {
     pub fn rmcp_tool_with_timeout(
         self,
         tool: rmcp::model::Tool,
-        client: rmcp::service::ServerSink,
+        client: &rmcp::service::ServerSink,
         timeout: impl Into<Option<std::time::Duration>>,
     ) -> AgentBuilder<WithBuilderTools> {
         self.rmcp_tools_with_timeout(vec![tool], client, timeout)
@@ -445,7 +445,7 @@ forward_into_tool_builder! {
     /// Transitions the builder to the `WithBuilderTools` state.
     #[cfg(all(feature = "rmcp", not(target_family = "wasm")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "rmcp")))]
-    rmcp_tools(tools: Vec<rmcp::model::Tool>, client: rmcp::service::ServerSink);
+    rmcp_tools(tools: Vec<rmcp::model::Tool>, client: &rmcp::service::ServerSink);
 
     /// Add an array of MCP tools (from `rmcp`) with a per-call timeout (see
     /// issue #1914).
@@ -458,7 +458,7 @@ forward_into_tool_builder! {
     #[cfg_attr(docsrs, doc(cfg(feature = "rmcp")))]
     rmcp_tools_with_timeout(
         tools: Vec<rmcp::model::Tool>,
-        client: rmcp::service::ServerSink,
+        client: &rmcp::service::ServerSink,
         timeout: impl Into<Option<std::time::Duration>>
     );
 
@@ -523,7 +523,7 @@ impl AgentBuilder<WithBuilderTools> {
     pub fn rmcp_tools(
         self,
         tools: Vec<rmcp::model::Tool>,
-        client: rmcp::service::ServerSink,
+        client: &rmcp::service::ServerSink,
     ) -> Self {
         self.map_server(|server| server.rmcp_tools(tools, client))
     }
@@ -539,7 +539,7 @@ impl AgentBuilder<WithBuilderTools> {
     pub fn rmcp_tools_with_timeout(
         self,
         tools: Vec<rmcp::model::Tool>,
-        client: rmcp::service::ServerSink,
+        client: &rmcp::service::ServerSink,
         timeout: impl Into<Option<std::time::Duration>>,
     ) -> Self {
         self.map_server(|server| server.rmcp_tools_with_timeout(tools, client, timeout))
@@ -756,7 +756,7 @@ mod tests {
 
         // Every requested tool is registered against the shared client...
         let agent = AgentBuilder::new(MockCompletionModel::text("ok"))
-            .rmcp_tools(vec![tool("a"), tool("b")], peer.clone())
+            .rmcp_tools(vec![tool("a"), tool("b")], &peer)
             .build();
         let definitions = agent.tool_server_handle.get_tool_defs(None).await.unwrap();
         assert_eq!(
@@ -769,7 +769,11 @@ mod tests {
 
         // ...and the configured timeout actually bounds a hanging call.
         let agent = AgentBuilder::new(MockCompletionModel::text("ok"))
-            .rmcp_tools_with_timeout(vec![tool("hang_forever")], peer, Duration::from_millis(200))
+            .rmcp_tools_with_timeout(
+                vec![tool("hang_forever")],
+                &peer,
+                Duration::from_millis(200),
+            )
             .build();
         let timed = tokio::time::timeout(Duration::from_secs(5), async {
             let mut context = ToolContext::new();

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -493,7 +493,7 @@ pub(crate) async fn build_prepared_completion_request(
         .max_tokens_opt(max_tokens)
         .additional_params_opt(additional_params)
         .record_content_telemetry(record_telemetry_content)
-        .documents(static_context.to_vec())
+        .documents(static_context.clone())
         .tools(tooldefs);
 
     // Hook-supplied extra context documents (passive RAG) follow static context,

--- a/crates/rig-agent/src/agent/prompt_request/mod.rs
+++ b/crates/rig-agent/src/agent/prompt_request/mod.rs
@@ -669,7 +669,7 @@ pub(crate) fn tool_result_message(
 pub(crate) fn invalid_tool_retry_user_message(
     assistant_content: &[AssistantContent],
     invalid_tool_call_id: &ToolCallId,
-    feedback: String,
+    feedback: &str,
 ) -> Option<Message> {
     // Selecting the invalid call by id is correct by construction:
     // `ToolCallId` is unique and non-empty (minted at the provider boundary
@@ -683,7 +683,7 @@ pub(crate) fn invalid_tool_retry_user_message(
                     tool_call.id.clone(),
                     tool_call.provider.clone(),
                     tool_call.function.name.clone(),
-                    feedback.clone(),
+                    feedback.to_string(),
                 ))
             }
             AssistantContent::ToolCall(tool_call) => Some(tool_result_message(

--- a/crates/rig-agent/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-agent/src/agent/prompt_request/streaming.rs
@@ -262,8 +262,8 @@ pub struct StreamingPromptRequest {
 impl StreamingPromptRequest {
     /// Create a new `StreamingPromptRequest` from an agent, including its
     /// default hooks.
-    pub fn new(agent: Arc<Agent>, prompt: impl Into<Message>) -> StreamingPromptRequest {
-        Self::from_agent(agent.as_ref(), prompt)
+    pub fn new(agent: &Agent, prompt: impl Into<Message>) -> StreamingPromptRequest {
+        Self::from_agent(agent, prompt)
     }
 
     /// Create a new StreamingPromptRequest from an agent, cloning the agent's
@@ -1394,7 +1394,7 @@ impl TurnSource for StreamingTurnSource {
                 yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
                 return;
             }
-            self.last_message_id = streamed_turn.message_id.clone();
+            self.last_message_id.clone_from(&streamed_turn.message_id);
             // The canonical assistant content: `finish` normalizes
             // reasoning/text/tool ordering, so this can differ from the raw
             // `stream.choice` aggregate. `ModelTurnFinished` — the normalized
@@ -1717,7 +1717,7 @@ mod migrated_tests {
                 .build(),
         );
 
-        let mut stream = StreamingPromptRequest::new(agent, "go").await;
+        let mut stream = StreamingPromptRequest::new(&agent, "go").await;
         let error = stream
             .try_next()
             .await
@@ -1738,7 +1738,7 @@ mod migrated_tests {
             MockCompletionModel::from_stream_turns([[MockStreamEvent::text("partial answer")]]);
         let agent = Arc::new(AgentBuilder::new(model.clone()).build());
 
-        let mut stream = StreamingPromptRequest::new(agent, "go").await;
+        let mut stream = StreamingPromptRequest::new(&agent, "go").await;
         let mut saw_error = false;
         let mut saw_completion_call = false;
         while let Some(item) = stream.next().await {

--- a/crates/rig-agent/src/agent/run/mod.rs
+++ b/crates/rig-agent/src/agent/run/mod.rs
@@ -114,6 +114,7 @@ fn unknown_tool_call_error(
     }
 }
 
+#[derive(Clone, Copy)]
 struct InvalidToolCallDiagnostic<'a> {
     tool_call: &'a ToolCall,
     executable_tool_names: &'a BTreeSet<String>,
@@ -803,7 +804,7 @@ impl AgentRun {
                             missing.join(", ")
                         );
                         if let Some(user_message) =
-                            invalid_tool_retry_user_message(&items, &tool_call_id, feedback)
+                            invalid_tool_retry_user_message(&items, &tool_call_id, &feedback)
                         {
                             self.new_messages.push(user_message);
                         }
@@ -1209,7 +1210,7 @@ impl AgentRun {
                 let Some(user_message) = invalid_tool_retry_user_message(
                     &resolving.original_choice,
                     &tool_call.id,
-                    feedback,
+                    &feedback,
                 ) else {
                     return Err(PromptError::prompt_cancelled(
                         diagnostic_history,

--- a/crates/rig-agent/src/agent/run/streamed.rs
+++ b/crates/rig-agent/src/agent/run/streamed.rs
@@ -549,7 +549,7 @@ impl StreamedTurnAssembler {
             });
         if let Some(part) = replace_at.and_then(|index| self.reasoning_parts.get_mut(index)) {
             if reasoning.id.is_some() {
-                part.provider_id = reasoning.id.clone();
+                part.provider_id.clone_from(&reasoning.id);
             }
             part.state = ReasoningPartState::Completed(reasoning.clone());
             return;
@@ -660,7 +660,7 @@ impl StreamedTurnAssembler {
                         text.push_str(reasoning);
                     }
                     if part.provider_id.is_none() {
-                        part.provider_id = provider_id.clone();
+                        part.provider_id.clone_from(provider_id);
                     }
                 }
                 Ok(vec![StreamedTurnEvent::EmitIngested])
@@ -740,7 +740,7 @@ impl StreamedTurnAssembler {
                 // tool calls actually seen (see `StreamFinal::finish_reason`),
                 // so it is consumed as-is and never re-reconciled here.
                 let finish_reason = final_response.finish_reason.clone();
-                self.finish_reason = finish_reason.clone();
+                self.finish_reason.clone_from(&finish_reason);
                 Ok(vec![StreamedTurnEvent::Completed {
                     usage,
                     emit_final,
@@ -792,7 +792,7 @@ impl StreamedTurnAssembler {
                     internal_call_id,
                 },
             ) => {
-                tool_call.function.name = tool_name.clone();
+                tool_call.function.name.clone_from(tool_name);
                 self.pending_tool_calls.push((*tool_call, internal_call_id));
                 Vec::new()
             }

--- a/crates/rig-agent/src/extractor.rs
+++ b/crates/rig-agent/src/extractor.rs
@@ -33,7 +33,7 @@
 use std::marker::PhantomData;
 
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use rig_core::{
     message::{Message, ToolChoice},
@@ -75,7 +75,7 @@ pub enum ExtractionError {
 /// Extractor for structured data from text
 pub struct Extractor<T>
 where
-    T: JsonSchema + for<'a> Deserialize<'a> + WasmCompatSend + WasmCompatSync,
+    T: JsonSchema + DeserializeOwned + WasmCompatSend + WasmCompatSync,
 {
     agent: Agent,
     _t: PhantomData<T>,
@@ -129,7 +129,7 @@ macro_rules! forward_default_run {
 
 impl<T> Extractor<T>
 where
-    T: JsonSchema + for<'a> Deserialize<'a> + WasmCompatSend + WasmCompatSync,
+    T: JsonSchema + DeserializeOwned + WasmCompatSend + WasmCompatSync,
 {
     /// Set a different default model for this extractor's subsequent attempts.
     pub fn with_model_handle(mut self, model: ModelHandle) -> Self {
@@ -329,7 +329,7 @@ where
 /// Builder for the Extractor
 pub struct ExtractorBuilder<T>
 where
-    T: JsonSchema + for<'a> Deserialize<'a> + Serialize + WasmCompatSend + WasmCompatSync + 'static,
+    T: JsonSchema + DeserializeOwned + Serialize + WasmCompatSend + WasmCompatSync + 'static,
 {
     agent_builder: AgentBuilder,
     _t: PhantomData<T>,
@@ -355,7 +355,7 @@ macro_rules! forward_agent_builder {
 
 impl<T> ExtractorBuilder<T>
 where
-    T: JsonSchema + for<'a> Deserialize<'a> + Serialize + WasmCompatSend + WasmCompatSync + 'static,
+    T: JsonSchema + DeserializeOwned + Serialize + WasmCompatSend + WasmCompatSync + 'static,
 {
     pub fn new<M>(model: M) -> Self
     where
@@ -563,7 +563,7 @@ mod tests {
     impl VectorStoreIndex for ExtractorContextIndex {
         type Filter = Filter<serde_json::Value>;
 
-        async fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
+        async fn top_n<T: DeserializeOwned + WasmCompatSend>(
             &self,
             req: VectorSearchRequest,
         ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {

--- a/crates/rig-agent/src/tool/server.rs
+++ b/crates/rig-agent/src/tool/server.rs
@@ -207,7 +207,7 @@ impl ToolServer {
     pub fn rmcp_tools(
         self,
         tools: Vec<rmcp::model::Tool>,
-        client: rmcp::service::ServerSink,
+        client: &rmcp::service::ServerSink,
     ) -> Self {
         self.rmcp_tools_with_timeout(tools, client, crate::tool::rmcp::DEFAULT_MCP_TOOL_TIMEOUT)
     }
@@ -222,7 +222,7 @@ impl ToolServer {
     pub fn rmcp_tools_with_timeout(
         self,
         tools: Vec<rmcp::model::Tool>,
-        client: rmcp::service::ServerSink,
+        client: &rmcp::service::ServerSink,
         timeout: impl Into<Option<std::time::Duration>>,
     ) -> Self {
         let timeout = timeout.into();
@@ -486,7 +486,7 @@ impl ToolServerHandle {
         &self,
         prompt: Option<String>,
     ) -> Result<Vec<ToolDefinition>, ToolServerError> {
-        Ok(self.snapshot_tool_defs(prompt).await?.definitions.clone())
+        Ok(self.snapshot_tool_defs(prompt).await?.definitions)
     }
 
     /// Resolve one ordered provider/dispatch snapshot for an agent turn.
@@ -543,7 +543,7 @@ impl ToolServerHandle {
         };
 
         let tools = self
-            .with_registry(|state| snapshot_registered_tools(state, dynamic_tool_ids))
+            .with_registry(|state| snapshot_registered_tools(state, &dynamic_tool_ids))
             .await;
 
         Ok(ToolRegistrySnapshot::new(tools))
@@ -552,7 +552,7 @@ impl ToolServerHandle {
 
 fn snapshot_registered_tools(
     state: &ToolServerState,
-    dynamic_tool_ids: Vec<String>,
+    dynamic_tool_ids: &[String],
 ) -> IndexMap<String, RegisteredTool> {
     let mut tools = IndexMap::new();
     let insert = |tools: &mut IndexMap<String, RegisteredTool>, name: &str, warn_missing| {
@@ -578,7 +578,7 @@ fn snapshot_registered_tools(
 
     // Retrieved tools remain first, in index/result order. Duplicate IDs and
     // dynamic/static overlap retain the first provider declaration.
-    for name in &dynamic_tool_ids {
+    for name in dynamic_tool_ids {
         insert(&mut tools, name, true);
     }
     for name in state.toolset.always_exposed_names() {

--- a/crates/rig-bedrock/src/streaming.rs
+++ b/crates/rig-bedrock/src/streaming.rs
@@ -166,7 +166,7 @@ fn process_event(
 
                         if !text.is_empty() {
                             items.push(Ok(RawStreamingChoice::ReasoningDelta {
-                                reasoning: text.clone(),
+                                reasoning: text,
                                 // Derive identity from `contentBlockIndex`
                                 // (no wire id on Converse reasoning blocks).
                                 id: block_id(event.content_block_index),
@@ -178,7 +178,7 @@ fn process_event(
                         state
                             .current_reasoning
                             .get_or_insert_with(ReasoningState::default)
-                            .signature = Some(signature.clone());
+                            .signature = Some(signature);
                     }
                     aws_bedrock::ReasoningContentBlockDelta::RedactedContent(blob) => {
                         // Opaque provider state the safety classifier
@@ -395,7 +395,7 @@ fn normalize_bedrock_stream(
         let usage = (&response).into();
         let finish_reason = response.stop_reason.as_ref().map(map_stop_reason);
         Ok(rig_core::streaming::StreamFinal::new(PROVIDER_NAME, usage)
-            .with_optional_provider_request_id(response.provider_request_id.clone())
+            .with_optional_provider_request_id(response.provider_request_id)
             .with_optional_finish_reason(finish_reason))
     })
 }
@@ -478,7 +478,9 @@ impl CompletionModel {
         Ok(Box::pin(stream.map(move |item| {
             item.map(|choice| match choice {
                 RawStreamingChoice::FinalResponse(mut response) => {
-                    response.provider_request_id = provider_request_id.clone();
+                    response
+                        .provider_request_id
+                        .clone_from(&provider_request_id);
                     RawStreamingChoice::FinalResponse(response)
                 }
                 other => other,

--- a/crates/rig-bedrock/src/types/assistant_content.rs
+++ b/crates/rig-bedrock/src/types/assistant_content.rs
@@ -97,7 +97,7 @@ impl TryFrom<AwsConverseOutput> for completion::CompletionResponse {
 
     fn try_from(value: AwsConverseOutput) -> Result<Self, Self::Error> {
         let message: RigMessage = value
-            .to_owned()
+            .clone()
             .0
             .output
             .ok_or(CompletionError::ProviderError(

--- a/crates/rig-bedrock/src/types/completion_request.rs
+++ b/crates/rig-bedrock/src/types/completion_request.rs
@@ -24,7 +24,7 @@ impl AwsCompletionRequest {
     pub fn additional_params(&self) -> Option<aws_smithy_types::Document> {
         self.inner
             .additional_params
-            .to_owned()
+            .clone()
             .map(|params| params.into())
             .map(|doc: AwsDocument| doc.0)
     }
@@ -147,7 +147,7 @@ impl AwsCompletionRequest {
     pub fn system_prompt(&self) -> Result<Option<Vec<SystemContentBlock>>, CompletionError> {
         let mut system_blocks = Vec::new();
 
-        if let Some(system_prompt) = self.inner.preamble.to_owned()
+        if let Some(system_prompt) = self.inner.preamble.clone()
             && !system_prompt.is_empty()
         {
             system_blocks.push(SystemContentBlock::Text(system_prompt));

--- a/crates/rig-candle/src/generation.rs
+++ b/crates/rig-candle/src/generation.rs
@@ -367,12 +367,12 @@ impl SessionWeights<'_> {
 impl<'a> GenerationSession<'a> {
     pub(crate) fn new(
         loaded: &'a LoadedModel,
-        request: CompletionRequest,
+        request: &CompletionRequest,
         cancellation: &'a CancellationSignal,
     ) -> Result<Self, CandleError> {
-        let prompt = crate::protocol::render_prompt(&request, loaded.profile.definition.protocol)?;
+        let prompt = crate::protocol::render_prompt(request, loaded.profile.definition.protocol)?;
         let generation =
-            effective_generation(&request, &loaded.generation, loaded.profile.vocab_size)?;
+            effective_generation(request, &loaded.generation, loaded.profile.vocab_size)?;
         let encoding = loaded
             .tokenizer
             .encode(prompt, false)
@@ -530,7 +530,7 @@ fn duration_millis(duration: Duration) -> u64 {
 
 pub(crate) fn generate(
     loaded: &LoadedModel,
-    request: CompletionRequest,
+    request: &CompletionRequest,
     cancellation: &CancellationSignal,
     mut emit: impl FnMut(String) -> Result<(), CandleError>,
 ) -> Result<CandleCompletionResponse, CandleError> {
@@ -555,14 +555,13 @@ pub(crate) fn generate(
 
 pub(crate) fn infer(
     loaded: &LoadedModel,
-    request: CompletionRequest,
+    request: &CompletionRequest,
     cancellation: &CancellationSignal,
 ) -> Result<InferredCompletion, CandleError> {
-    let parse_request = request.clone();
     let mut raw_response = generate(loaded, request, cancellation, |_| Ok(()))?;
     let parsed = crate::protocol::parse_assistant(
         &raw_response.text,
-        &parse_request,
+        request,
         loaded.profile.definition.protocol,
     )?;
     raw_response.text = parsed.visible_text;
@@ -605,7 +604,7 @@ impl InferredCompletion {
 
 pub(crate) fn stream_generate(
     loaded: &LoadedModel,
-    request: CompletionRequest,
+    request: &CompletionRequest,
     cancellation: &CancellationSignal,
     mut emit: impl FnMut(RawStreamingChoice<CandleCompletionResponse>) -> Result<(), CandleError>,
 ) -> Result<CandleCompletionResponse, CandleError> {
@@ -615,14 +614,13 @@ pub(crate) fn stream_generate(
         });
     }
 
-    let parse_request = request.clone();
     // Qwen tool syntax can straddle arbitrary token boundaries. Buffer one
     // model turn so control markup is never leaked as assistant text; complete
     // tool calls are still delivered through Rig's streaming agent driver.
     let mut response = generate(loaded, request, cancellation, |_| Ok(()))?;
     let parsed = crate::protocol::parse_assistant(
         &response.text,
-        &parse_request,
+        request,
         loaded.profile.definition.protocol,
     )?;
     response.text = parsed.visible_text;

--- a/crates/rig-candle/src/model.rs
+++ b/crates/rig-candle/src/model.rs
@@ -349,7 +349,7 @@ impl Drop for CandleReceiverStream {
 #[cfg(not(target_family = "wasm"))]
 fn stream_infer(
     loaded: &LoadedModel,
-    request: CompletionRequest,
+    request: &CompletionRequest,
     cancellation: &CancellationSignal,
     sender: &tokio::sync::mpsc::Sender<CandleStreamItem>,
 ) -> Result<(), CandleError> {
@@ -455,7 +455,7 @@ impl CandleModel {
                 let result = loaded
                     .runtime
                     .device()
-                    .with_context(|| infer(&loaded, request, &cancellation));
+                    .with_context(|| infer(&loaded, &request, &cancellation));
                 drop(permit);
                 result
             })
@@ -467,7 +467,7 @@ impl CandleModel {
 
         #[cfg(target_family = "wasm")]
         {
-            infer(loaded, request, &CancellationSignal).map_err(CompletionError::from)
+            infer(loaded, &request, &CancellationSignal).map_err(CompletionError::from)
         }
     }
 
@@ -490,7 +490,7 @@ impl CandleModel {
             let producer_cancellation = cancellation.clone();
             let task = tokio::task::spawn_blocking(move || {
                 let result = loaded.runtime.device().with_context(|| {
-                    stream_infer(&loaded, request, &producer_cancellation, &producer_sender)
+                    stream_infer(&loaded, &request, &producer_cancellation, &producer_sender)
                 });
                 if let Err(error) = result {
                     let _ = producer_sender.blocking_send(Err(error.into()));
@@ -521,7 +521,7 @@ impl CandleModel {
         #[cfg(target_family = "wasm")]
         {
             let mut events = Vec::new();
-            let response = stream_generate(loaded, request, &CancellationSignal, |choice| {
+            let response = stream_generate(loaded, &request, &CancellationSignal, |choice| {
                 events.push(Ok(choice));
                 Ok(())
             })?;

--- a/crates/rig-candle/src/model/tests.rs
+++ b/crates/rig-candle/src/model/tests.rs
@@ -988,12 +988,8 @@ fn inference_clamps_context_and_uses_fresh_generation_state()
     let prompt_tokens = loaded.tokenizer.encode(prompt, false)?.len();
     loaded.profile.context_limit = prompt_tokens + 2;
 
-    let first = infer(
-        &loaded,
-        completion_request.clone(),
-        &CancellationSignal::default(),
-    )?;
-    let second = infer(&loaded, completion_request, &CancellationSignal::default())?;
+    let first = infer(&loaded, &completion_request, &CancellationSignal::default())?;
+    let second = infer(&loaded, &completion_request, &CancellationSignal::default())?;
     let (first, second) = (first.response, second.response);
     assert_eq!(first.text, second.text);
     assert_eq!(first.generated_tokens, 2);
@@ -1012,7 +1008,7 @@ fn eos_is_counted_but_excluded_from_decoded_text()
     loaded.profile.stop_tokens.insert(0);
     let mut completion_request = request(vec![Message::user("hello")]);
     completion_request.temperature = Some(0.0);
-    let response = infer(&loaded, completion_request, &CancellationSignal::default())?.response;
+    let response = infer(&loaded, &completion_request, &CancellationSignal::default())?.response;
     assert_eq!(response.finish_reason, FinishReason::Eos);
     assert_eq!(response.generated_tokens, 1);
     assert_eq!(
@@ -1120,7 +1116,7 @@ fn concurrency_limit_and_cancellation_are_deterministic()
     let signal = CancellationSignal::default();
     signal.cancel();
     assert!(matches!(
-        infer(&loaded, request(vec![Message::user("hello")]), &signal),
+        infer(&loaded, &request(vec![Message::user("hello")]), &signal),
         Err(CandleError::Cancelled)
     ));
     Ok(())

--- a/crates/rig-core/src/client/mod.rs
+++ b/crates/rig-core/src/client/mod.rs
@@ -839,7 +839,7 @@ where
             ext,
         } = self;
 
-        let new_ext = f(ext.clone());
+        let new_ext = f(ext);
 
         ClientBuilder {
             base_url,

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -112,11 +112,11 @@ impl ProviderResponseExt for CompletionResponse {
     type Usage = Usage;
 
     fn get_response_id(&self) -> Option<String> {
-        Some(self.id.to_owned())
+        Some(self.id.clone())
     }
 
     fn get_response_model_name(&self) -> Option<String> {
-        Some(self.model.to_owned())
+        Some(self.model.clone())
     }
 
     fn get_text_response(&self) -> Option<String> {
@@ -271,6 +271,9 @@ pub struct ToolDefinition {
     pub cache_control: Option<CacheControl>,
 }
 
+// `skip_serializing_if` requires a `fn(&bool) -> bool`, so the trivially-copy
+// lint does not apply here.
+#[allow(clippy::trivially_copy_pass_by_ref)]
 fn is_false(value: &bool) -> bool {
     !value
 }
@@ -1046,9 +1049,9 @@ impl TryFrom<message::ImageMediaType> for ImageFormat {
             message::ImageMediaType::GIF => ImageFormat::GIF,
             message::ImageMediaType::WEBP => ImageFormat::WEBP,
             _ => {
-                return Err(MessageError::ConversionError(
-                    format!("Unsupported image media type: {media_type:?}").to_owned(),
-                ));
+                return Err(MessageError::ConversionError(format!(
+                    "Unsupported image media type: {media_type:?}"
+                )));
             }
         })
     }
@@ -2705,7 +2708,7 @@ pub(super) fn extract_top_level_cache_control(
 
 pub(super) fn resolve_top_level_cache_control(
     automatic_caching: bool,
-    automatic_caching_ttl: Option<CacheTtl>,
+    automatic_caching_ttl: &Option<CacheTtl>,
     additional_params: &mut serde_json::Value,
 ) -> Result<Option<CacheControl>, CompletionError> {
     let raw_cache_control = extract_top_level_cache_control(additional_params)?;
@@ -2733,7 +2736,7 @@ pub(super) fn resolve_top_level_cache_control(
 }
 
 pub(super) fn split_system_messages_from_history(
-    history: Vec<message::Message>,
+    history: &[message::Message],
     preserve_mid_conversation_system_messages: bool,
 ) -> (Vec<SystemContent>, Vec<message::Message>) {
     let mut system = Vec::new();
@@ -2744,7 +2747,7 @@ pub(super) fn split_system_messages_from_history(
             message::Message::System { content } => {
                 if !content.is_empty() {
                     if preserve_mid_conversation_system_messages
-                        && is_valid_mid_conversation_system_message(&history, index)
+                        && is_valid_mid_conversation_system_message(history, index)
                     {
                         remaining.push(message.clone());
                     } else {
@@ -2839,7 +2842,7 @@ impl AnthropicCompletionRequest {
         };
 
         let (history_system, chat_history) = split_system_messages_from_history(
-            chat_history,
+            &chat_history,
             supports_mid_conversation_system_messages(model),
         );
         let mut full_history = vec![];
@@ -2856,7 +2859,7 @@ impl AnthropicCompletionRequest {
             .unwrap_or(serde_json::Value::Null);
         let top_level_cache_control = resolve_top_level_cache_control(
             automatic_caching,
-            automatic_caching_ttl,
+            &automatic_caching_ttl,
             &mut additional_params_payload,
         )?;
         let mut tools =

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -360,7 +360,8 @@ impl WireAdapter for AnthropicAdapter {
                 // body is a no-op, not an error.
                 let Some(message) = message else { return };
                 self.input_tokens = message.usage.input_tokens;
-                self.cache_creation = message.usage.cache_creation.clone();
+                self.cache_creation
+                    .clone_from(&message.usage.cache_creation);
                 self.message_id = Some(message.id.clone());
                 self.response_model = Some(message.model.clone());
 
@@ -1174,7 +1175,7 @@ mod tests {
             "cache_control": {"type": "ephemeral", "ttl": "1h"}
         });
         let top_level_cache_control =
-            resolve_top_level_cache_control(false, None, &mut additional_params).unwrap();
+            resolve_top_level_cache_control(false, &None, &mut additional_params).unwrap();
         let mut tools =
             build_tool_definitions::<crate::providers::anthropic::client::AnthropicExt>(
                 vec![crate::completion::ToolDefinition {

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -308,7 +308,7 @@ impl ProviderClient for Client {
             header,
         }: Self::Input,
     ) -> Result<Self, Self::Error> {
-        let auth = AzureOpenAIAuth::ApiKey(api_key.to_string());
+        let auth = AzureOpenAIAuth::ApiKey(api_key);
 
         Self::builder()
             .api_key(auth)

--- a/crates/rig-core/src/providers/chatgpt/auth/native.rs
+++ b/crates/rig-core/src/providers/chatgpt/auth/native.rs
@@ -93,7 +93,7 @@ impl PlatformAuthenticator {
                 .or_else(|| extract_account_id(record.id_token.as_deref()))
                 .or_else(|| extract_account_id(Some(&access_token)));
             if account_id != record.account_id {
-                record.account_id = account_id.clone();
+                record.account_id.clone_from(&account_id);
                 write_json_record(self.auth_file.as_deref(), &record)?;
             }
             return Ok(AuthContext {

--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -361,7 +361,7 @@ where
             self.client.clone(),
             self.model.clone(),
         );
-        model.tools = self.tools.clone();
+        model.tools.clone_from(&self.tools);
         model.strict_tools = self.strict_tools;
         model
     }

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -67,7 +67,7 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
             .iter()
             .filter_map(|x| {
                 if let AssistantContent::Text { text } = x {
-                    Some(text.to_string())
+                    Some(text.clone())
                 } else {
                     None
                 }
@@ -669,8 +669,7 @@ impl TryFrom<(&str, CompletionRequest)> for CohereCompletionRequest {
                 .map(message::Message::try_into)
                 .collect::<Result<Vec<Vec<Message>>, _>>()?
                 .into_iter()
-                .flatten()
-                .collect::<Vec<_>>(),
+                .flatten(),
         );
 
         let tool_choice = req
@@ -694,7 +693,7 @@ impl TryFrom<(&str, CompletionRequest)> for CohereCompletionRequest {
         }
 
         Ok(Self {
-            model: model.to_string(),
+            model,
             messages: full_history,
             documents,
             temperature: req.temperature,

--- a/crates/rig-core/src/providers/cohere/embeddings.rs
+++ b/crates/rig-core/src/providers/cohere/embeddings.rs
@@ -210,7 +210,7 @@ where
         let documents = documents.into_iter().collect::<Vec<_>>();
 
         let body = json!({
-            "model": self.model.to_string(),
+            "model": self.model.clone(),
             "texts": documents,
             "input_type": self.input_type
         });

--- a/crates/rig-core/src/providers/cohere/streaming.rs
+++ b/crates/rig-core/src/providers/cohere/streaming.rs
@@ -377,7 +377,7 @@ where
                 stream_ended_is_error: false,
                 log_transport_errors: true,
             },
-            skip_blank_and_done,
+            |data: String| skip_blank_and_done(&data),
             CohereAdapter::default(),
             span,
         ))

--- a/crates/rig-core/src/providers/gemini/embedding.rs
+++ b/crates/rig-core/src/providers/gemini/embedding.rs
@@ -77,7 +77,7 @@ where
                     "model": format!("models/{}", self.model),
                     "content": json!({
                         "parts": [json!({
-                            "text": doc.to_string()
+                            "text": doc.clone()
                         })]
                     }),
                     "output_dimensionality": self.ndims,

--- a/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
@@ -95,9 +95,9 @@ impl From<StreamingCompletionResponse> for crate::completion::Usage {
 /// the API has no `finishReason` field — and is absent when the stream ended
 /// without one.
 fn map_stream_final(
-    response: StreamingCompletionResponse,
+    response: &StreamingCompletionResponse,
 ) -> Result<streaming::StreamFinal, CompletionError> {
-    let usage = (&response).into();
+    let usage = response.into();
     let interaction = response.interaction.as_ref();
     let finish_reason = interaction
         .and_then(|interaction| interaction.status.as_ref())
@@ -173,7 +173,7 @@ where
 
         Ok(streaming::StreamingCompletionResponse::stream(
             PROVIDER_NAME,
-            streaming::normalize_stream(inner, map_stream_final),
+            streaming::normalize_stream(inner, |response| map_stream_final(&response)),
         ))
     }
 }
@@ -372,7 +372,7 @@ impl WireAdapter for InteractionsAdapter {
                 // (`Error` policy), matching the other complete-block wires.
                 if let Some(slot) = self.open_function_steps.remove(index) {
                     out.push(Ok(streaming::RawStreamingChoice::ToolInputEnd(
-                        function_step_end(slot),
+                        function_step_end(&slot),
                     )));
                 }
             }
@@ -401,7 +401,7 @@ impl WireAdapter for InteractionsAdapter {
                         "closing a function-call step left open at interaction.completed"
                     );
                     out.push(Ok(streaming::RawStreamingChoice::ToolInputEnd(
-                        function_step_end(slot),
+                        function_step_end(&slot),
                     )));
                 }
 
@@ -458,7 +458,7 @@ pub(crate) fn stream_interaction_events<T>(
 where
     T: HttpClientExt + Clone + Default + std::fmt::Debug + 'static,
 {
-    let mut event_source = GenericEventSource::new(client.clone(), request);
+    let mut event_source = GenericEventSource::new(client, request);
 
     let stream = stream! {
         while let Some(event_result) = event_source.next().await {
@@ -514,7 +514,7 @@ where
 /// Malformed accumulated input surfaces in-band (`Error` policy), matching
 /// the other complete-block wires.
 fn function_step_end(
-    slot: crate::providers::internal::tool_call_bridge::ToolCallSlot,
+    slot: &crate::providers::internal::tool_call_bridge::ToolCallSlot,
 ) -> streaming::ToolInputEnd {
     slot.end_event(streaming::UnparseableToolInput::Error)
 }

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -49,7 +49,7 @@ pub(crate) mod shared_parts {
         // *name* is never an identity — two calls to the same tool in one
         // turn must stay distinct, correlated by order and by the
         // rig-internal call id.
-        let tool_id = wire_id.clone().and_then(crate::streaming::WireId::new);
+        let tool_id = wire_id.and_then(crate::streaming::WireId::new);
         let id = tool_id
             .as_ref()
             .map(|id| StreamPartId::wire(id.as_str()))

--- a/crates/rig-core/src/providers/internal/sse_transport.rs
+++ b/crates/rig-core/src/providers/internal/sse_transport.rs
@@ -59,7 +59,7 @@ pub(crate) fn skip_blank_frames(data: String) -> FrameDisposition {
 /// Triage shared by wires whose heartbeats and `[DONE]` sentinel are both
 /// dropped at the transport: trim the payload, skip blanks and `[DONE]`,
 /// yield everything else trimmed.
-pub(crate) fn skip_blank_and_done(data: String) -> FrameDisposition {
+pub(crate) fn skip_blank_and_done(data: &str) -> FrameDisposition {
     let data = data.trim();
     if data.is_empty() || data == "[DONE]" {
         FrameDisposition::Skip
@@ -69,6 +69,7 @@ pub(crate) fn skip_blank_and_done(data: String) -> FrameDisposition {
 }
 
 /// The per-wire transport deltas.
+#[derive(Clone, Copy)]
 pub(crate) struct SseTransportOptions {
     pub open_log: OpenLog,
     /// `false`: `StreamEnded` is the normal end of the stream (break).

--- a/crates/rig-core/src/providers/internal/tool_call_bridge.rs
+++ b/crates/rig-core/src/providers/internal/tool_call_bridge.rs
@@ -89,10 +89,10 @@ impl ToolCallSlot {
         // call whose wire never supplied one carries no durable handle at
         // all (`WireId::new` rejects the empty string by construction).
         end.tool_id = crate::streaming::WireId::new(self.id.clone());
-        end.signature = self.signature.clone();
-        end.additional_params = self.additional_params.clone();
+        end.signature.clone_from(&self.signature);
+        end.additional_params.clone_from(&self.additional_params);
         if !self.saw_arguments_delta {
-            end.arguments = self.announce_arguments.clone();
+            end.arguments.clone_from(&self.announce_arguments);
         }
         end
     }
@@ -176,13 +176,13 @@ where
         if let Some(id) = wire_id
             && !id.is_empty()
         {
-            slot.id = id.to_owned();
+            id.clone_into(&mut slot.id);
         }
 
         if let Some(name) = name
             && !name.is_empty()
         {
-            slot.name = name.to_owned();
+            name.clone_into(&mut slot.name);
         }
 
         slot

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -218,7 +218,7 @@ fn audio_part_to_mistral_chunk(
 /// Dispatched on the `type` tag, which the shared OpenAI-compatible conversion
 /// always emits, so a part naming a chunk kind is converted as that kind
 /// regardless of what other keys it carries.
-fn into_mistral_chunk(part: serde_json::Value) -> Result<serde_json::Value, CompletionError> {
+fn into_mistral_chunk(part: &serde_json::Value) -> Result<serde_json::Value, CompletionError> {
     /// Text and refusal parts are both re-tagged as `text`: Mistral's chunk
     /// schema has no `refusal` field, and every chunk forbids unknown keys.
     fn text_chunk(part: &serde_json::Value) -> Result<serde_json::Value, CompletionError> {
@@ -228,7 +228,7 @@ fn into_mistral_chunk(part: serde_json::Value) -> Result<serde_json::Value, Comp
     }
 
     match part.get("type").and_then(serde_json::Value::as_str) {
-        Some(TEXT_CHUNK | REFUSAL_TYPE) => text_chunk(&part),
+        Some(TEXT_CHUNK | REFUSAL_TYPE) => text_chunk(part),
         // The payload needs no reshaping — Mistral's image chunk takes the
         // `{url, detail}` object rig sends as readily as a bare URL string, and
         // reads a base64 `data:` URI in either, with `detail` accepting exactly
@@ -242,8 +242,8 @@ fn into_mistral_chunk(part: serde_json::Value) -> Result<serde_json::Value, Comp
             })?;
             Ok(serde_json::json!({"type": IMAGE_CHUNK, IMAGE_CHUNK: image}))
         }
-        Some(AUDIO_CHUNK) => audio_part_to_mistral_chunk(&part),
-        Some(FILE_CHUNK) => file_part_to_mistral_chunk(&part),
+        Some(AUDIO_CHUNK) => audio_part_to_mistral_chunk(part),
+        Some(FILE_CHUNK) => file_part_to_mistral_chunk(part),
         // Already a Mistral document chunk — see `file_part_to_mistral_chunk`
         // on why an already-converted part passes through.
         Some(DOCUMENT_CHUNK) => {
@@ -262,7 +262,7 @@ fn into_mistral_chunk(part: serde_json::Value) -> Result<serde_json::Value, Comp
         ))),
         // Untagged, but textual: the shared flattening would have taken it, so
         // it converts rather than failing.
-        None if part_text(&part).is_some() => text_chunk(&part),
+        None if part_text(part).is_some() => text_chunk(part),
         None => Err(unsupported_content_error("untyped message content")),
     }
 }
@@ -308,7 +308,7 @@ pub(super) fn normalize_request_content(
     // unreachable — expressed as a no-op instead of an unwrap.
     if let Some(parts) = content.as_array_mut() {
         for part in parts {
-            *part = into_mistral_chunk(part.take())?;
+            *part = into_mistral_chunk(part)?;
         }
     }
 
@@ -412,7 +412,7 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
                     if content.is_empty() {
                         None
                     } else {
-                        Some(content.to_string())
+                        Some(content.clone())
                     }
                 }
                 _ => None,

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -542,8 +542,7 @@ impl TryFrom<(&str, CompletionRequest)> for OllamaCompletionRequest {
                 .map(message::Message::try_into)
                 .collect::<Result<Vec<Vec<Message>>, _>>()?
                 .into_iter()
-                .flatten()
-                .collect::<Vec<_>>(),
+                .flatten(),
         );
 
         let mut think: Option<Think> = None;
@@ -609,7 +608,7 @@ impl TryFrom<(&str, CompletionRequest)> for OllamaCompletionRequest {
         };
 
         Ok(Self {
-            model: model.to_string(),
+            model,
             messages: full_history,
             stream: false,
             think,

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -1394,11 +1394,11 @@ impl ProviderResponseExt for CompletionResponse {
     type Usage = Usage;
 
     fn get_response_id(&self) -> Option<String> {
-        Some(self.id.to_owned())
+        Some(self.id.clone())
     }
 
     fn get_response_model_name(&self) -> Option<String> {
-        Some(self.model.to_owned())
+        Some(self.model.clone())
     }
 
     fn get_text_response(&self) -> Option<String> {
@@ -2192,8 +2192,7 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
                 .map(message::Message::try_into)
                 .collect::<Result<Vec<Vec<Message>>, _>>()?
                 .into_iter()
-                .flatten()
-                .collect::<Vec<_>>(),
+                .flatten(),
         );
 
         if full_history.is_empty() {
@@ -2459,7 +2458,7 @@ where
             prompt_caching: self.prompt_caching,
         };
         let mut request = self.client.ext().build_completion_request(
-            self.model.to_owned(),
+            self.model.clone(),
             completion_request,
             options,
         )?;

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -756,6 +756,9 @@ fn is_json_null(value: &Value) -> bool {
     value.is_null()
 }
 
+// `skip_serializing_if` requires a `fn(&bool) -> bool`, so the trivially-copy
+// lint does not apply here.
+#[allow(clippy::trivially_copy_pass_by_ref)]
 fn is_false(value: &bool) -> bool {
     !value
 }

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -200,7 +200,7 @@ pub struct ResponseChunk {
 
 /// Response chunk type.
 /// Renames are used to ensure that this type gets (de)serialized properly.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 pub enum ResponseChunkKind {
     #[serde(rename = "response.created")]
     ResponseCreated,
@@ -942,12 +942,7 @@ pub(crate) async fn completion_response_from_raw_choices(
     raw_choices: Vec<StreamingRawChoice>,
     raw_response: &CompletionResponse,
 ) -> Result<Option<completion::CompletionResponse>, CompletionError> {
-    let stream = futures::stream::iter(
-        raw_choices
-            .into_iter()
-            .map(Ok::<_, CompletionError>)
-            .collect::<Vec<_>>(),
-    );
+    let stream = futures::stream::iter(raw_choices.into_iter().map(Ok::<_, CompletionError>));
     let mut stream = normalize_responses_stream(provider, Box::pin(stream));
 
     while let Some(item) = stream.next().await {

--- a/crates/rig-core/src/providers/openai/responses_api/websocket.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/websocket.rs
@@ -516,7 +516,10 @@ where
         request.additional_parameters.background = None;
 
         if request.additional_parameters.previous_response_id.is_none() {
-            request.additional_parameters.previous_response_id = self.previous_response_id.clone();
+            request
+                .additional_parameters
+                .previous_response_id
+                .clone_from(&self.previous_response_id);
         }
 
         Ok(request)
@@ -589,7 +592,7 @@ where
                     // (code + message + any extra fields) so provider_response_json()
                     // parses it, matching the response.failed path. No HTTP status on
                     // the websocket stream, so status: None.
-                    return Err(provider_error_from_event(error));
+                    return Err(provider_error_from_event(&error));
                 }
                 ResponsesWebSocketEvent::Item(chunk) => {
                     raw_choices.extend(
@@ -775,7 +778,7 @@ fn response_error_message(fallback: &str) -> String {
 /// HTTP status, so `status` is `None`. The body is the event re-serialized from
 /// the parsed representation (not byte-identical to the original wire bytes,
 /// which are not retained past parsing) — semantically the provider's payload.
-fn provider_error_from_event(error: ResponsesWebSocketErrorEvent) -> CompletionError {
+fn provider_error_from_event(error: &ResponsesWebSocketErrorEvent) -> CompletionError {
     CompletionError::from_provider_body(
         serde_json::to_string(&error).unwrap_or_else(|_| error.to_string()),
     )
@@ -1224,7 +1227,7 @@ mod tests {
             },
         };
 
-        let err = super::provider_error_from_event(event);
+        let err = super::provider_error_from_event(&event);
 
         // No HTTP status on the websocket stream, and the raw payload round-trips
         // through provider_response_json() (code + message + extra all preserved).

--- a/crates/rig-core/src/streaming/mod.rs
+++ b/crates/rig-core/src/streaming/mod.rs
@@ -1358,7 +1358,7 @@ impl Stream for StreamingCompletionResponse {
                             // An explicit `MessageId` event keeps precedence; the
                             // terminal record only fills a gap.
                             if stream.message_id.is_none() {
-                                stream.message_id = response.message_id.clone();
+                                stream.message_id.clone_from(&response.message_id);
                             }
                             stream.response = Some(response.clone());
                             stream

--- a/crates/rig-core/src/streaming/parts.rs
+++ b/crates/rig-core/src/streaming/parts.rs
@@ -315,12 +315,14 @@ impl PartsAccumulator {
                 if restatement.id.is_none()
                     && let AssistantContent::Reasoning(open) = &*part
                 {
-                    restatement.id = open.id.clone();
+                    restatement.id.clone_from(&open.id);
                 }
                 *part = AssistantContent::Reasoning(restatement);
             }
-            if let Some(signature) = signature {
-                attach_signature(self.parts.get_mut(index), signature);
+            if let Some(signature) = signature
+                && let Some(part) = self.parts.get_mut(index)
+            {
+                attach_signature(part, signature);
             }
             self.finished_reasoning.insert(id.clone(), index);
             return self.reasoning_at(index);
@@ -350,7 +352,9 @@ impl PartsAccumulator {
                     if part_already_signed {
                         return self.finish_signature_only(id, signature);
                     }
-                    attach_signature(self.parts.get_mut(index), signature);
+                    if let Some(part) = self.parts.get_mut(index) {
+                        attach_signature(part, signature);
+                    }
                     return self.reasoning_at(index);
                 }
                 // A repeated end with no new payload is a no-op — the
@@ -830,8 +834,8 @@ fn json_subsumes(outer: &serde_json::Value, inner: &serde_json::Value) -> bool {
     }
 }
 
-fn attach_signature(part: Option<&mut AssistantContent>, signature: String) {
-    if let Some(AssistantContent::Reasoning(reasoning)) = part {
+fn attach_signature(part: &mut AssistantContent, signature: String) {
+    if let AssistantContent::Reasoning(reasoning) = part {
         attach_reasoning_signature(reasoning, signature);
     }
 }

--- a/crates/rig-core/src/test_utils/streaming_conformance.rs
+++ b/crates/rig-core/src/test_utils/streaming_conformance.rs
@@ -2018,8 +2018,8 @@ pub mod fixtures {
         }
 
         fn completed_response(
-            usage: Option<serde_json::Value>,
-            output: serde_json::Value,
+            usage: Option<&serde_json::Value>,
+            output: &serde_json::Value,
         ) -> serde_json::Value {
             json!({
                 "id": "resp_1",
@@ -2033,7 +2033,7 @@ pub mod fixtures {
             })
         }
 
-        fn terminal(usage: Option<serde_json::Value>, output: serde_json::Value) -> WireInput {
+        fn terminal(usage: Option<&serde_json::Value>, output: &serde_json::Value) -> WireInput {
             sse(&json!({
                 "type": "response.completed",
                 "sequence_number": 99,
@@ -2159,8 +2159,8 @@ pub mod fixtures {
 
         fn reasoning_done_item(
             id: &str,
-            summary: serde_json::Value,
-            content: serde_json::Value,
+            summary: &serde_json::Value,
+            content: &serde_json::Value,
             encrypted: Option<&str>,
         ) -> WireInput {
             let mut item = json!({
@@ -2211,10 +2211,10 @@ pub mod fixtures {
                         "delta": "{\"cit",
                     })),
                 ]),
-                terminal_frames: vec![terminal(Some(usage_json()), json!([]))],
+                terminal_frames: vec![terminal(Some(&usage_json()), &json!([]))],
                 expected_usage_total: 15,
                 expected_finish_reason: Some(FinishReason::Stop),
-                zero_usage_terminal_frames: Some(vec![terminal(None, json!([]))]),
+                zero_usage_terminal_frames: Some(vec![terminal(None, &json!([]))]),
                 bare_terminal_frames: None,
                 malformed_frame: Some(sse_raw("{not json")),
                 unknown_event_frame: Some(sse(&json!({
@@ -2288,14 +2288,14 @@ pub mod fixtures {
 
         /// A terminal whose body carries text never seen as a delta.
         pub fn terminal_body_only_sse_body(text: &str) -> String {
-            frame_text(&terminal(Some(usage_json()), message_output(text)))
+            frame_text(&terminal(Some(&usage_json()), &message_output(text)))
         }
 
         /// A streamed delta plus a terminal body restating the same text.
         pub fn terminal_body_and_delta_sse_body(text: &str) -> String {
             let frames = [
                 text_delta(text),
-                terminal(Some(usage_json()), message_output(text)),
+                terminal(Some(&usage_json()), &message_output(text)),
             ];
             frames.iter().map(frame_text).collect()
         }
@@ -2303,7 +2303,7 @@ pub mod fixtures {
         /// A streamed delta whose terminal body carries no output items — the
         /// gpt-5.x shape the buffered fallback exists for.
         pub fn delta_only_sse_body(text: &str) -> String {
-            let frames = [text_delta(text), terminal(Some(usage_json()), json!([]))];
+            let frames = [text_delta(text), terminal(Some(&usage_json()), &json!([]))];
             frames.iter().map(frame_text).collect()
         }
 
@@ -2322,11 +2322,11 @@ pub mod fixtures {
                 sse(&delta),
                 reasoning_done_item(
                     "rs_1",
-                    json!([{"type": "summary_text", "text": "step 1"}]),
-                    json!([]),
+                    &json!([{"type": "summary_text", "text": "step 1"}]),
+                    &json!([]),
                     None,
                 ),
-                terminal(Some(usage_json()), json!([])),
+                terminal(Some(&usage_json()), &json!([])),
             ];
             (frames.iter().map(frame_text).collect(), "step 1")
         }
@@ -2346,11 +2346,11 @@ pub mod fixtures {
                 })),
                 reasoning_done_item(
                     "rs_1",
-                    json!([{"type": "summary_text", "text": "step 1"}]),
-                    json!([]),
+                    &json!([{"type": "summary_text", "text": "step 1"}]),
+                    &json!([]),
                     None,
                 ),
-                terminal(Some(usage_json()), json!([])),
+                terminal(Some(&usage_json()), &json!([])),
             ];
             (frames, "step 1")
         }
@@ -2361,14 +2361,14 @@ pub mod fixtures {
             let frames = vec![
                 reasoning_done_item(
                     "rs_1",
-                    json!([
+                    &json!([
                         {"type": "summary_text", "text": "s1"},
                         {"type": "summary_text", "text": "s2"},
                     ]),
-                    json!([{"type": "reasoning_text", "text": "visible"}]),
+                    &json!([{"type": "reasoning_text", "text": "visible"}]),
                     Some("enc_blob"),
                 ),
-                terminal(Some(usage_json()), json!([])),
+                terminal(Some(&usage_json()), &json!([])),
             ];
             (frames, vec!["s1", "s2", "visible", "enc_blob"])
         }
@@ -2388,11 +2388,11 @@ pub mod fixtures {
                 tool_call_done(),
                 reasoning_done_item(
                     "rs_2",
-                    json!([]),
-                    json!([{"type": "reasoning_text", "text": "full reasoning"}]),
+                    &json!([]),
+                    &json!([{"type": "reasoning_text", "text": "full reasoning"}]),
                     None,
                 ),
-                terminal(Some(usage_json()), json!([])),
+                terminal(Some(&usage_json()), &json!([])),
             ];
             (frames, "full reasoning")
         }
@@ -2475,7 +2475,7 @@ pub mod fixtures {
             }
         }
 
-        fn chunk(parts: serde_json::Value) -> WireInput {
+        fn chunk(parts: &serde_json::Value) -> WireInput {
             sse(&json!({
                 "candidates": [{"content": {"parts": parts, "role": "model"}}],
                 "responseId": "resp-1",
@@ -2504,11 +2504,11 @@ pub mod fixtures {
         fn interleaved_thought_fixture() -> InterleavedReasoningFixture {
             InterleavedReasoningFixture {
                 frames: vec![
-                    chunk(json!([{"text": "before tool", "thought": true}])),
-                    chunk(json!([{
+                    chunk(&json!([{"text": "before tool", "thought": true}])),
+                    chunk(&json!([{
                         "functionCall": {"name": "get_weather", "args": {"city": "Tokyo"}},
                     }])),
-                    chunk(json!([{"text": "after tool", "thought": true}])),
+                    chunk(&json!([{"text": "after tool", "thought": true}])),
                     terminal_frame(),
                 ],
                 first_reasoning: "before tool",
@@ -2522,11 +2522,11 @@ pub mod fixtures {
         pub fn interleaved_signed_thought_frames()
         -> (Vec<WireInput>, &'static str, &'static str, &'static str) {
             let frames = vec![
-                chunk(json!([{"text": "before tool", "thought": true}])),
-                chunk(json!([{
+                chunk(&json!([{"text": "before tool", "thought": true}])),
+                chunk(&json!([{
                     "functionCall": {"name": "get_weather", "args": {"city": "Tokyo"}},
                 }])),
-                chunk(json!([{
+                chunk(&json!([{
                     "text": "signed conclusion",
                     "thought": true,
                     "thoughtSignature": "sig-1",

--- a/crates/rig-core/src/vector_store/in_memory_store.rs
+++ b/crates/rig-core/src/vector_store/in_memory_store.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use ordered_float::OrderedFloat;
-use serde::{Deserialize, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 use super::{IndexStrategy, VectorStoreError, VectorStoreIndex, request::VectorSearchRequest};
 use crate::{
@@ -53,18 +53,22 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
         embeddings: HashMap<String, (D, Vec<Embedding>)>,
         index_strategy: IndexStrategy,
     ) -> Self {
+        // Initialize LSH index if needed
+        let lsh_params = match &index_strategy {
+            IndexStrategy::LSH {
+                num_tables,
+                num_hyperplanes,
+            } => Some((*num_tables, *num_hyperplanes)),
+            IndexStrategy::BruteForce => None,
+        };
+
         let mut vector_store = Self {
             embeddings,
-            index_strategy: index_strategy.clone(),
+            index_strategy,
             lsh_index: None,
         };
 
-        // Initialize LSH index if needed
-        if let IndexStrategy::LSH {
-            num_tables,
-            num_hyperplanes,
-        } = index_strategy
-        {
+        if let Some((num_tables, num_hyperplanes)) = lsh_params {
             vector_store.initialize_lsh_index(num_tables, num_hyperplanes);
         }
 
@@ -110,7 +114,7 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
     fn insert_document(&mut self, id: String, doc: D, embeddings: Vec<Embedding>) {
         if let Some(ref mut lsh_index) = self.lsh_index {
             for embedding in embeddings.iter() {
-                lsh_index.insert(id.clone(), &embedding.vec);
+                lsh_index.insert(&id, &embedding.vec);
             }
         }
         self.embeddings.insert(id, (doc, embeddings));
@@ -300,7 +304,7 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
         // Insert all existing embeddings into the LSH index
         for (id, (_, embeddings)) in self.embeddings.iter() {
             for embedding in embeddings.iter() {
-                lsh_index.insert(id.clone(), &embedding.vec);
+                lsh_index.insert(id, &embedding.vec);
             }
         }
 
@@ -418,7 +422,7 @@ impl<D: Serialize> InMemoryVectorIndex<D> {
 impl<D: Serialize + Sync + Send + Eq> VectorStoreIndex for InMemoryVectorIndex<D> {
     type Filter = Filter<serde_json::Value>;
 
-    async fn top_n<T: for<'a> Deserialize<'a>>(
+    async fn top_n<T: DeserializeOwned>(
         &self,
         req: VectorSearchRequest,
     ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {

--- a/crates/rig-core/src/vector_store/lsh.rs
+++ b/crates/rig-core/src/vector_store/lsh.rs
@@ -106,11 +106,11 @@ impl LSHIndex {
     }
 
     /// Insert a document ID with its embedding
-    pub fn insert(&mut self, id: String, embedding: &[f64]) {
+    pub fn insert(&mut self, id: &str, embedding: &[f64]) {
         for table_idx in 0..self.lsh.num_tables {
             let hash = self.lsh.hash(embedding, table_idx);
             if let Some(table) = self.tables.get_mut(table_idx) {
-                table.entry(hash).or_default().push(id.clone());
+                table.entry(hash).or_default().push(id.to_owned());
             }
         }
     }

--- a/crates/rig-core/src/vector_store/mod.rs
+++ b/crates/rig-core/src/vector_store/mod.rs
@@ -12,7 +12,7 @@
 
 pub use request::VectorSearchRequest;
 use reqwest::StatusCode;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::{Value, json};
 
 use crate::{
@@ -131,7 +131,7 @@ pub trait VectorStoreIndex: WasmCompatSend + WasmCompatSync {
     type Filter: SearchFilter + WasmCompatSend + WasmCompatSync;
 
     /// Returns the top N most similar documents as `(score, id, document)` tuples.
-    fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
+    fn top_n<T: DeserializeOwned + WasmCompatSend>(
         &self,
         req: VectorSearchRequest<Self::Filter>,
     ) -> impl std::future::Future<Output = Result<Vec<(f64, String, T)>, VectorStoreError>>
@@ -328,7 +328,7 @@ mod tests {
     impl VectorStoreIndex for NativeIndex {
         type Filter = NativeFilter;
 
-        async fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
+        async fn top_n<T: DeserializeOwned + WasmCompatSend>(
             &self,
             _req: VectorSearchRequest<Self::Filter>,
         ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
@@ -347,7 +347,7 @@ mod tests {
     impl VectorStoreIndex for TestIndex {
         type Filter = Filter<serde_json::Value>;
 
-        async fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
+        async fn top_n<T: DeserializeOwned + WasmCompatSend>(
             &self,
             req: VectorSearchRequest,
         ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {

--- a/crates/rig-derive/src/lib.rs
+++ b/crates/rig-derive/src/lib.rs
@@ -147,7 +147,7 @@ pub fn rig_tool(args: TokenStream, input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(args as tool::args::MacroArgs);
     let input_fn = parse_macro_input!(input as syn::ItemFn);
 
-    tool::expand::expand_rig_tool(args, input_fn)
+    tool::expand::expand_rig_tool(&args, &input_fn)
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
 }

--- a/crates/rig-derive/src/tool/expand.rs
+++ b/crates/rig-derive/src/tool/expand.rs
@@ -106,7 +106,10 @@ struct ModelParam<'a> {
     optional: bool,
 }
 
-pub(crate) fn expand_rig_tool(args: MacroArgs, input_fn: syn::ItemFn) -> syn::Result<TokenStream> {
+pub(crate) fn expand_rig_tool(
+    args: &MacroArgs,
+    input_fn: &syn::ItemFn,
+) -> syn::Result<TokenStream> {
     let refs = CrateRefs::resolve();
     let core = &refs.core;
 

--- a/crates/rig-fastembed/src/lib.rs
+++ b/crates/rig-fastembed/src/lib.rs
@@ -166,7 +166,7 @@ impl EmbeddingModel {
         Ok(Self {
             embedder: Some(embedder),
             init_error: None,
-            model: model_info.model.to_owned(),
+            model: model_info.model.clone(),
             ndims,
         })
     }

--- a/crates/rig-gemini-grpc/src/completion.rs
+++ b/crates/rig-gemini-grpc/src/completion.rs
@@ -105,7 +105,7 @@ impl CompletionModel {
         &self,
         completion_request: CompletionRequest,
     ) -> Result<GenerateContentResponse, CompletionError> {
-        let request = create_grpc_request(self.model.clone(), completion_request)?;
+        let request = create_grpc_request(&self.model, completion_request)?;
 
         let mut grpc_client = self
             .client
@@ -115,7 +115,7 @@ impl CompletionModel {
         let response = grpc_client
             .generate_content(request)
             .await
-            .map_err(rpc_error)?
+            .map_err(|status| rpc_error(&status))?
             .into_inner();
 
         Ok(response)
@@ -176,13 +176,13 @@ pub(crate) fn text_part(text: String) -> proto::Part {
 // not distinguish a server-returned gRPC error from a transport/connection
 // failure, so a pure connection error is also preserved here rather than gated
 // out as a Rig diagnostic the way Bedrock's typed service errors are.
-pub(crate) fn rpc_error(status: tonic::Status) -> CompletionError {
+pub(crate) fn rpc_error(status: &tonic::Status) -> CompletionError {
     CompletionError::from_provider_body(status.to_string())
 }
 
 // Helper function to create gRPC request from Rig's CompletionRequest
 pub(crate) fn create_grpc_request(
-    model: String,
+    model: &str,
     completion_request: CompletionRequest,
 ) -> Result<GenerateContentRequest, CompletionError> {
     let CompletionRequest {
@@ -811,7 +811,7 @@ mod tests {
         let status = tonic::Status::unavailable("boom");
         let expected = status.to_string();
 
-        let err = rpc_error(status);
+        let err = rpc_error(&status);
 
         // The raw provider error text is preserved verbatim, and there is no
         // HTTP status because gRPC is a non-HTTP transport.
@@ -1059,7 +1059,7 @@ mod tests {
         };
 
         let req = create_grpc_request(
-            "gemini-2.5-flash".to_string(),
+            "gemini-2.5-flash",
             CompletionRequest {
                 model: None,
                 preamble: None,
@@ -1121,7 +1121,7 @@ mod tests {
         };
 
         let req = create_grpc_request(
-            "gemini-2.5-flash".to_string(),
+            "gemini-2.5-flash",
             CompletionRequest {
                 model: None,
                 preamble: None,

--- a/crates/rig-gemini-grpc/src/embedding.rs
+++ b/crates/rig-gemini-grpc/src/embedding.rs
@@ -65,7 +65,7 @@ impl EmbeddingModel {
             let response = grpc_client
                 .embed_content(request)
                 .await
-                .map_err(rpc_error)?
+                .map_err(|status| rpc_error(&status))?
                 .into_inner();
 
             responses.push(response);
@@ -135,7 +135,7 @@ impl rig_core::client::ConstructEmbeddingModel<super::Client> for EmbeddingModel
 // not distinguish a server-returned gRPC error from a transport/connection
 // failure, so a pure connection error is also preserved here rather than gated
 // out as a Rig diagnostic the way Bedrock's typed service errors are.
-fn rpc_error(status: tonic::Status) -> EmbeddingError {
+fn rpc_error(status: &tonic::Status) -> EmbeddingError {
     EmbeddingError::from_provider_body(status.to_string())
 }
 
@@ -149,7 +149,7 @@ mod tests {
         let status = tonic::Status::unavailable("boom");
         let expected = status.to_string();
 
-        let err = rpc_error(status);
+        let err = rpc_error(&status);
 
         // The raw provider error text is preserved verbatim, and there is no
         // HTTP status because gRPC is a non-HTTP transport.

--- a/crates/rig-gemini-grpc/src/streaming.rs
+++ b/crates/rig-gemini-grpc/src/streaming.rs
@@ -224,7 +224,7 @@ pub(crate) async fn raw_stream(
     model: String,
     completion_request: CompletionRequest,
 ) -> Result<streaming::RawStreamingResult<StreamingCompletionResponse>, CompletionError> {
-    let request = super::completion::create_grpc_request(model, completion_request)?;
+    let request = super::completion::create_grpc_request(&model, completion_request)?;
 
     let mut grpc_client = client
         .grpc_client()
@@ -233,7 +233,7 @@ pub(crate) async fn raw_stream(
     let mut response_stream = grpc_client
         .stream_generate_content(request)
         .await
-        .map_err(super::completion::rpc_error)?
+        .map_err(|status| super::completion::rpc_error(&status))?
         .into_inner();
 
     // Transport layer: gRPC messages only — a `Status` error is a transport
@@ -243,7 +243,7 @@ pub(crate) async fn raw_stream(
             match item {
                 Ok(resp) => yield Ok(resp),
                 Err(status) => {
-                    yield Err(super::completion::rpc_error(status));
+                    yield Err(super::completion::rpc_error(&status));
                     break;
                 }
             }
@@ -287,7 +287,7 @@ fn normalize_grpc_stream(
                     Some(response.response_id.clone()).filter(|id| !id.is_empty()),
                 )
                 .with_optional_model(
-                    Some(response.model_version.clone()).filter(|model| !model.is_empty()),
+                    Some(response.model_version).filter(|model| !model.is_empty()),
                 ),
         )
     })
@@ -627,7 +627,7 @@ mod tests {
         let status = tonic::Status::unavailable("boom");
         let expected = status.to_string();
 
-        let err = super::super::completion::rpc_error(status);
+        let err = super::super::completion::rpc_error(&status);
 
         assert_eq!(err.provider_response_body(), Some(expected.as_str()));
         assert_eq!(err.provider_response_status(), None);

--- a/crates/rig-lancedb/src/lib.rs
+++ b/crates/rig-lancedb/src/lib.rs
@@ -223,7 +223,7 @@ impl LanceDBFilter {
     }
 
     /// IN operator
-    pub fn in_values(key: String, values: Vec<<Self as SearchFilter>::Value>) -> Self {
+    pub fn in_values(key: &str, values: Vec<<Self as SearchFilter>::Value>) -> Self {
         Self(
             values
                 .into_iter()
@@ -235,7 +235,7 @@ impl LanceDBFilter {
     }
 
     /// LIKE operator (string pattern matching)
-    pub fn like<S>(key: String, pattern: S) -> Self
+    pub fn like<S>(key: &str, pattern: S) -> Self
     where
         S: AsRef<str>,
     {
@@ -246,7 +246,7 @@ impl LanceDBFilter {
     }
 
     /// ILIKE operator (case-insensitive pattern matching)
-    pub fn ilike<S>(key: String, pattern: S) -> Self
+    pub fn ilike<S>(key: &str, pattern: S) -> Self
     where
         S: AsRef<str>,
     {
@@ -257,17 +257,17 @@ impl LanceDBFilter {
     }
 
     /// IS NULL check
-    pub fn is_null(key: String) -> Self {
+    pub fn is_null(key: &str) -> Self {
         Self(Ok(format!("{key} IS NULL")))
     }
 
     /// IS NOT NULL check
-    pub fn is_not_null(key: String) -> Self {
+    pub fn is_not_null(key: &str) -> Self {
         Self(Ok(format!("{key} IS NOT NULL")))
     }
 
     /// Array has any (for LIST columns with scalar index)
-    pub fn array_has_any(key: String, values: Vec<<Self as SearchFilter>::Value>) -> Self {
+    pub fn array_has_any(key: &str, values: Vec<<Self as SearchFilter>::Value>) -> Self {
         Self(
             values
                 .into_iter()
@@ -279,7 +279,7 @@ impl LanceDBFilter {
     }
 
     /// Array has all (for LIST columns with scalar index)
-    pub fn array_has_all(key: String, values: Vec<<Self as SearchFilter>::Value>) -> Self {
+    pub fn array_has_all(key: &str, values: Vec<<Self as SearchFilter>::Value>) -> Self {
         Self(
             values
                 .into_iter()
@@ -291,12 +291,12 @@ impl LanceDBFilter {
     }
 
     /// Array length comparison
-    pub fn array_length(key: String, length: i32) -> Self {
+    pub fn array_length(key: &str, length: i32) -> Self {
         Self(Ok(format!("array_length({key}) = {length}")))
     }
 
     /// BETWEEN operator
-    pub fn between<T>(key: String, Range { start, end }: Range<T>) -> Self
+    pub fn between<T>(key: &str, Range { start, end }: Range<T>) -> Self
     where
         T: PartialOrd + std::fmt::Display + Into<serde_json::Number>,
     {
@@ -426,7 +426,7 @@ impl VectorStoreIndex for LanceDbVectorIndex {
                         _ => 0.0,
                     },
                     match value.get(self.id_field.clone()) {
-                        Some(Value::String(id)) => id.to_string(),
+                        Some(Value::String(id)) => id.clone(),
                         _ => format!("unknown{i}"),
                     },
                     serde_json::from_value(value).map_err(VectorStoreError::JsonError)?,
@@ -483,7 +483,7 @@ impl VectorStoreIndex for LanceDbVectorIndex {
                         _ => 0.0,
                     },
                     match value.get(self.id_field.clone()) {
-                        Some(Value::String(id)) => id.to_string(),
+                        Some(Value::String(id)) => id.clone(),
                         _ => "".to_string(),
                     },
                 ))

--- a/crates/rig-lancedb/src/utils/deserializer.rs
+++ b/crates/rig-lancedb/src/utils/deserializer.rs
@@ -210,7 +210,7 @@ fn type_matcher(column: &Arc<dyn Array>) -> Result<Vec<Value>, VectorStoreError>
                 .zip(values)
                 .map(|(k, v)| {
                     let mut map = serde_json::Map::new();
-                    map.insert(k.to_string(), v);
+                    map.insert(k.clone(), v);
                     map
                 })
                 .map(Value::Object)
@@ -218,7 +218,7 @@ fn type_matcher(column: &Arc<dyn Array>) -> Result<Vec<Value>, VectorStoreError>
         }
         DataType::Union(..) => match column.as_any().downcast_ref::<UnionArray>() {
             Some(union_array) => (0..union_array.len())
-                .map(|i| union_array.value(i).clone())
+                .map(|i| union_array.value(i))
                 .collect::<Vec<_>>()
                 .iter()
                 .map(type_matcher)

--- a/crates/rig-lancedb/src/utils/mod.rs
+++ b/crates/rig-lancedb/src/utils/mod.rs
@@ -42,9 +42,9 @@ impl FilterTableColumns for Arc<Schema> {
             .filter_map(|field| match field.data_type() {
                 DataType::FixedSizeList(inner, ..) => match inner.data_type() {
                     DataType::Float64 => None,
-                    _ => Some(field.name().to_string()),
+                    _ => Some(field.name().clone()),
                 },
-                _ => Some(field.name().to_string()),
+                _ => Some(field.name().clone()),
             })
             .collect()
     }

--- a/crates/rig-milvus/examples/vector_search_milvus.rs
+++ b/crates/rig-milvus/examples/vector_search_milvus.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let vector_store =
         rig_milvus::MilvusVectorStore::new(model.clone(), base_url, database_name, collection_name)
-            .auth(milvus_user, milvus_password);
+            .auth(&milvus_user, &milvus_password);
 
     // create test documents with mocked embeddings
     let words = vec![

--- a/crates/rig-milvus/src/filter.rs
+++ b/crates/rig-milvus/src/filter.rs
@@ -146,16 +146,16 @@ impl Filter {
         Self(format!("NOT ({})", self.0))
     }
 
-    pub fn gte(key: String, value: <Self as SearchFilter>::Value) -> Self {
+    pub fn gte(key: &str, value: <Self as SearchFilter>::Value) -> Self {
         Self(format!("{key} >= {}", value.escaped()))
     }
 
-    pub fn lte(key: String, value: <Self as SearchFilter>::Value) -> Self {
+    pub fn lte(key: &str, value: <Self as SearchFilter>::Value) -> Self {
         Self(format!("{key} <= {}", value.escaped()))
     }
 
     /// IN operator
-    pub fn in_values(key: String, values: Vec<<Self as SearchFilter>::Value>) -> Self {
+    pub fn in_values(key: &str, values: Vec<<Self as SearchFilter>::Value>) -> Self {
         let values_str = values
             .into_iter()
             .map(|v| v.escaped())
@@ -165,7 +165,7 @@ impl Filter {
     }
 
     /// NOT IN operator
-    pub fn not_in(key: String, values: Vec<<Self as SearchFilter>::Value>) -> Self {
+    pub fn not_in(key: &str, values: Vec<<Self as SearchFilter>::Value>) -> Self {
         let values_str = values
             .into_iter()
             .map(|v| v.escaped())
@@ -175,17 +175,17 @@ impl Filter {
     }
 
     /// LIKE operator (string pattern matching)
-    pub fn like(key: String, pattern: String) -> Self {
+    pub fn like(key: &str, pattern: &str) -> Self {
         Self(format!("{} like '{}'", key, pattern))
     }
 
     /// Array contains
-    pub fn array_contains(key: String, value: <Self as SearchFilter>::Value) -> Self {
+    pub fn array_contains(key: &str, value: <Self as SearchFilter>::Value) -> Self {
         Self(format!("array_contains({}, {})", key, value.escaped()))
     }
 
     /// Array contains all
-    pub fn array_contains_all(key: String, values: Vec<<Self as SearchFilter>::Value>) -> Self {
+    pub fn array_contains_all(key: &str, values: Vec<<Self as SearchFilter>::Value>) -> Self {
         let values_str = values
             .into_iter()
             .map(|v| v.escaped())
@@ -195,7 +195,7 @@ impl Filter {
     }
 
     /// Array contains any
-    pub fn array_contains_any(key: String, values: Vec<<Self as SearchFilter>::Value>) -> Self {
+    pub fn array_contains_any(key: &str, values: Vec<<Self as SearchFilter>::Value>) -> Self {
         let values_str = values
             .into_iter()
             .map(|v| v.escaped())
@@ -205,7 +205,7 @@ impl Filter {
     }
 
     /// Array length comparison
-    pub fn array_length_eq(key: String, length: i32) -> Self {
+    pub fn array_length_eq(key: &str, length: i32) -> Self {
         Self(format!("array_length({}) == {}", key, length))
     }
 

--- a/crates/rig-milvus/src/lib.rs
+++ b/crates/rig-milvus/src/lib.rs
@@ -113,7 +113,7 @@ impl MilvusVectorStore {
     }
 
     /// Forms the auth token for Milvus from your username and password. Required if using a Milvus instance that requires authentication.
-    pub fn auth(mut self, username: String, password: String) -> Self {
+    pub fn auth(mut self, username: &str, password: &str) -> Self {
         let str = format!("{username}:{password}");
         self.token = Some(str);
 
@@ -147,7 +147,7 @@ impl MilvusVectorStore {
 
         let threshold = req
             .threshold()
-            .map(|thresh| Filter::gte("distance".into(), thresh.into()));
+            .map(|thresh| Filter::gte("distance", thresh.into()));
 
         let filter = match (threshold, req.filter()) {
             (Some(thresh), Some(filter)) => thresh.and(filter.clone()).into_inner(),

--- a/crates/rig-neo4j/src/lib.rs
+++ b/crates/rig-neo4j/src/lib.rs
@@ -137,15 +137,15 @@ impl Neo4jSearchFilter {
         Self(format!("NOT ({})", self.0))
     }
 
-    pub fn gte(key: String, value: <Self as SearchFilter>::Value) -> Self {
+    pub fn gte(key: &str, value: <Self as SearchFilter>::Value) -> Self {
         Self(format!("n.{key} >= {}", serialize_cypher(value)))
     }
 
-    pub fn lte(key: String, value: <Self as SearchFilter>::Value) -> Self {
+    pub fn lte(key: &str, value: <Self as SearchFilter>::Value) -> Self {
         Self(format!("n.{key} <= {}", serialize_cypher(value)))
     }
 
-    pub fn member(key: String, values: Vec<<Self as SearchFilter>::Value>) -> Self {
+    pub fn member(key: &str, values: Vec<<Self as SearchFilter>::Value>) -> Self {
         Self(format!(
             "n.{key} IN {}",
             serialize_cypher(serde_json::Value::Array(values))
@@ -155,7 +155,7 @@ impl Neo4jSearchFilter {
     // String matching
 
     /// Tests whether the value at `key` contains the pattern
-    pub fn contains<S>(key: String, pattern: S) -> Self
+    pub fn contains<S>(key: &str, pattern: S) -> Self
     where
         S: AsRef<str>,
     {
@@ -166,7 +166,7 @@ impl Neo4jSearchFilter {
     }
 
     /// Tests whether the value at `key` starts with the pattern
-    pub fn starts_with<S>(key: String, pattern: S) -> Self
+    pub fn starts_with<S>(key: &str, pattern: S) -> Self
     where
         S: AsRef<str>,
     {
@@ -177,7 +177,7 @@ impl Neo4jSearchFilter {
     }
 
     /// Tests whether the value at `key` ends with the pattern
-    pub fn ends_with<S>(key: String, pattern: S) -> Self
+    pub fn ends_with<S>(key: &str, pattern: S) -> Self
     where
         S: AsRef<str>,
     {
@@ -187,7 +187,7 @@ impl Neo4jSearchFilter {
         ))
     }
 
-    pub fn matches<S>(key: String, pattern: S) -> Self
+    pub fn matches<S>(key: &str, pattern: S) -> Self
     where
         S: AsRef<str>,
     {

--- a/crates/rig-postgres/src/lib.rs
+++ b/crates/rig-postgres/src/lib.rs
@@ -115,15 +115,15 @@ impl PgSearchFilter {
         Self(SqlCondition::binary(key, "<=", PLACEHOLDER, value))
     }
 
-    pub fn is_null(key: String) -> Self {
+    pub fn is_null(key: &str) -> Self {
         Self(SqlCondition::raw(format!("{key} is null")))
     }
 
-    pub fn is_not_null(key: String) -> Self {
+    pub fn is_not_null(key: &str) -> Self {
         Self(SqlCondition::raw(format!("{key} is not null")))
     }
 
-    pub fn between<T>(key: String, range: RangeInclusive<T>) -> Self
+    pub fn between<T>(key: &str, range: RangeInclusive<T>) -> Self
     where
         T: std::fmt::Display + Into<serde_json::Number> + Copy,
     {
@@ -133,7 +133,7 @@ impl PgSearchFilter {
         Self(SqlCondition::raw(format!("{key} between {lo} and {hi}")))
     }
 
-    pub fn member(key: String, values: Vec<<Self as SearchFilter>::Value>) -> Self {
+    pub fn member(key: &str, values: Vec<<Self as SearchFilter>::Value>) -> Self {
         Self(SqlCondition::list(key, "is in", PLACEHOLDER, values))
     }
 
@@ -141,13 +141,13 @@ impl PgSearchFilter {
 
     /// Tests whether the value at `key` matches the (case-sensitive) pattern
     /// `pattern` should be a valid SQL string pattern, with '%' and '_' as wildcards
-    pub fn like(key: String, pattern: &'static str) -> Self {
+    pub fn like(key: &str, pattern: &'static str) -> Self {
         Self(SqlCondition::raw(format!("{key} like {pattern}")))
     }
 
     /// Tests whether the value at `key` matches the SQL regex pattern
     /// `pattern` should be a valid regex
-    pub fn similar_to(key: String, pattern: &'static str) -> Self {
+    pub fn similar_to(key: &str, pattern: &'static str) -> Self {
         Self(SqlCondition::raw(format!("{key} similar to {pattern}")))
     }
 }
@@ -416,7 +416,7 @@ mod tests {
         assert!(!cond.contains('?'));
         assert_eq!(cond.matches('$').count(), values.len());
 
-        let member = PgSearchFilter::member("id".into(), vec![json!(1), json!(2)]);
+        let member = PgSearchFilter::member("id", vec![json!(1), json!(2)]);
         let (cond, values) = PgSearchFilter::eq("kind", json!("fruit"))
             .and(member)
             .into_clause();

--- a/crates/rig-qdrant/src/filter.rs
+++ b/crates/rig-qdrant/src/filter.rs
@@ -67,20 +67,20 @@ impl QdrantFilter {
         self.0
     }
 
-    pub fn exists(key: String) -> Self {
+    pub fn exists(key: &str) -> Self {
         Self(json!({ "key": key, "is_null": { "value": false } }))
     }
 
-    pub fn is_null(key: String) -> Self {
+    pub fn is_null(key: &str) -> Self {
         Self(json!({ "key": key, "is_null": { "value": true } }))
     }
 
-    pub fn is_empty(key: String) -> Self {
+    pub fn is_empty(key: &str) -> Self {
         Self(json!({ "is_empty": { "key": key } }))
     }
 
     /// Construct a range filter `(lo .. hi)`
-    pub fn range_exclusive(key: String, lo: serde_json::Value, hi: serde_json::Value) -> Self {
+    pub fn range_exclusive(key: &str, lo: &serde_json::Value, hi: &serde_json::Value) -> Self {
         Self(json!({
             "key": key,
             "range": {
@@ -92,9 +92,9 @@ impl QdrantFilter {
 
     /// Construct a range filter `[lo .. hi)`
     pub fn range_lower_inclusive(
-        key: String,
-        lo: serde_json::Value,
-        hi: serde_json::Value,
+        key: &str,
+        lo: &serde_json::Value,
+        hi: &serde_json::Value,
     ) -> Self {
         Self(json!({
             "key": key,
@@ -107,9 +107,9 @@ impl QdrantFilter {
 
     /// Construct a range filter `(lo .. hi]`
     pub fn range_higher_inclusive(
-        key: String,
-        lo: serde_json::Value,
-        hi: serde_json::Value,
+        key: &str,
+        lo: &serde_json::Value,
+        hi: &serde_json::Value,
     ) -> Self {
         Self(json!({
             "key": key,
@@ -121,7 +121,7 @@ impl QdrantFilter {
     }
 
     /// Construct a range filter `[lo .. hi]`
-    pub fn range_inclusive(key: String, lo: serde_json::Value, hi: serde_json::Value) -> Self {
+    pub fn range_inclusive(key: &str, lo: &serde_json::Value, hi: &serde_json::Value) -> Self {
         Self(json!({
             "key": key,
             "range": {

--- a/crates/rig-qdrant/src/lib.rs
+++ b/crates/rig-qdrant/src/lib.rs
@@ -160,7 +160,7 @@ impl InsertDocuments for QdrantVectorStore {
 fn stringify_id(id: PointId) -> Result<String, VectorStoreError> {
     match id.point_id_options {
         Some(PointIdOptions::Num(num)) => Ok(num.to_string()),
-        Some(PointIdOptions::Uuid(uuid)) => Ok(uuid.to_string()),
+        Some(PointIdOptions::Uuid(uuid)) => Ok(uuid),
         None => Err(VectorStoreError::DatastoreError(
             "Invalid point ID format".into(),
         )),

--- a/crates/rig-s3vectors/src/lib.rs
+++ b/crates/rig-s3vectors/src/lib.rs
@@ -246,7 +246,7 @@ impl InsertDocuments for S3VectorsVectorStore {
                 let document = json_value_to_document(&document);
                 let vec = y.vec.into_iter().map(|item| item as f32).collect();
                 PutInputVector::builder()
-                    .metadata(document.clone())
+                    .metadata(document)
                     .data(VectorData::Float32(vec))
                     .key(Uuid::new_v4())
                     .build()

--- a/crates/rig-sqlite/src/lib.rs
+++ b/crates/rig-sqlite/src/lib.rs
@@ -367,10 +367,11 @@ impl<T> SqliteVectorStore<T>
 where
     T: SqliteVectorStoreTable + 'static,
 {
-    async fn candidate_limit(&self, samples: u64, exhaustive: bool) -> Result<u64, VectorStoreError>
-    where
-        Self: 'static,
-    {
+    async fn candidate_limit(
+        &self,
+        samples: u64,
+        exhaustive: bool,
+    ) -> Result<u64, VectorStoreError> {
         if samples == 0 {
             return Ok(0);
         }
@@ -571,7 +572,7 @@ where
     pub fn add_rows_with_txn(
         &self,
         txn: &rusqlite::Transaction<'_>,
-        documents: Vec<(T, Vec<Embedding>)>,
+        documents: &[(T, Vec<Embedding>)],
     ) -> Result<i64, tokio_rusqlite::Error> {
         info!("Adding {} documents to store", documents.len());
         let table_name = T::name();
@@ -600,7 +601,7 @@ where
             format!("DELETE FROM {embedding_map_table_name} WHERE document_rowid = ?1");
         let delete_embeddings_sql = format!("DELETE FROM {embeddings_table_name} WHERE rowid = ?1");
 
-        for (doc, embeddings) in &documents {
+        for (doc, embeddings) in documents {
             debug!("Storing document with id {}", doc.id());
 
             let values = doc.column_values();
@@ -675,17 +676,13 @@ where
     pub async fn add_rows(
         &self,
         documents: Vec<(T, Vec<Embedding>)>,
-    ) -> Result<i64, VectorStoreError>
-    where
-        T: 'static,
-        Self: 'static,
-    {
+    ) -> Result<i64, VectorStoreError> {
         let cloned = self.clone();
 
         self.conn
             .call(move |conn| {
                 let tx = conn.transaction()?;
-                let result = cloned.add_rows_with_txn(&tx, documents)?;
+                let result = cloned.add_rows_with_txn(&tx, &documents)?;
                 tx.commit()?;
 
                 Ok(result)

--- a/crates/rig-surrealdb/src/lib.rs
+++ b/crates/rig-surrealdb/src/lib.rs
@@ -102,7 +102,7 @@ fn record_key_to_string(key: &RecordIdKey) -> String {
 
 impl<C> InsertDocuments for SurrealVectorStore<C>
 where
-    C: Connection + Send + Sync,
+    C: Connection,
 {
     async fn insert_documents<Doc: Serialize + Embed + Send>(
         &self,
@@ -189,64 +189,64 @@ impl SurrealSearchFilter {
     }
 
     /// Test if the value at `key` contains `val`
-    pub fn contains(key: String, val: <Self as SearchFilter>::Value) -> Self {
+    pub fn contains(key: &str, val: &<Self as SearchFilter>::Value) -> Self {
         Self(format!("{key} CONTAINS {}", val.to_sql()))
     }
 
     /// Test if the value at `key` does *not* contain `val`
-    pub fn does_not_contain(key: String, val: <Self as SearchFilter>::Value) -> Self {
+    pub fn does_not_contain(key: &str, val: &<Self as SearchFilter>::Value) -> Self {
         Self(format!("{key} CONTAINSNOT {}", val.to_sql()))
     }
 
     /// Test if the value at `key` contains every element of `vals`
     /// `vals` should be a SurrealDB collection
-    pub fn all(key: String, vals: <Self as SearchFilter>::Value) -> Self {
+    pub fn all(key: &str, vals: &<Self as SearchFilter>::Value) -> Self {
         Self(format!("{key} CONTAINSALL {}", vals.to_sql()))
     }
 
     /// Test if the value at `key` contains any elements of `vals`
     /// `vals` should be a SurrealDB collection
-    pub fn any(key: String, vals: <Self as SearchFilter>::Value) -> Self {
+    pub fn any(key: &str, vals: &<Self as SearchFilter>::Value) -> Self {
         Self(format!("{key} CONTAINSANY {}", vals.to_sql()))
     }
 
     /// Test if the value at `key` is a member of `vals`
     /// `vals` should be a SurrealDB collection
-    pub fn member(key: String, vals: <Self as SearchFilter>::Value) -> Self {
+    pub fn member(key: &str, vals: &<Self as SearchFilter>::Value) -> Self {
         Self(format!("{key} IN {}", vals.to_sql()))
     }
 
     /// Test if the value at `key` is *not* a member of `vals`
     /// `vals` should be a SurrealDB collection
-    pub fn not_member(key: String, vals: <Self as SearchFilter>::Value) -> Self {
+    pub fn not_member(key: &str, vals: &<Self as SearchFilter>::Value) -> Self {
         Self(format!("{key} NOTIN {}", vals.to_sql()))
     }
 
     // Geospatial filters
     /// Test if the value at `key` is inside `geometry`
-    pub fn inside(key: String, geometry: <Self as SearchFilter>::Value) -> Self {
+    pub fn inside(key: &str, geometry: &<Self as SearchFilter>::Value) -> Self {
         Self(format!("{key} INSIDE {}", geometry.to_sql()))
     }
 
     /// Test if the value at `key` is outside `geometry`
-    pub fn outside(key: String, geometry: <Self as SearchFilter>::Value) -> Self {
+    pub fn outside(key: &str, geometry: &<Self as SearchFilter>::Value) -> Self {
         Self(format!("{key} OUTSIDE {}", geometry.to_sql()))
     }
 
     /// Test if the value at `key` intersects `geometry`
-    pub fn intersects(key: String, geometry: <Self as SearchFilter>::Value) -> Self {
+    pub fn intersects(key: &str, geometry: &<Self as SearchFilter>::Value) -> Self {
         Self(format!("{key} INTERSECTS {}", geometry.to_sql()))
     }
 
     // String ops
     /// SurrealDB text search
-    pub fn matches<'a, S: AsRef<&'a str>>(key: String, query: S) -> Self {
+    pub fn matches<'a, S: AsRef<&'a str>>(key: &str, query: S) -> Self {
         Self(format!("{key} @@ {}", query.as_ref()))
     }
 
     /// Check if the value at `key` matches regex `pattern`
     /// `pattern` should be a valid surrealDB regex
-    pub fn regex<'a, S: AsRef<&'a str>>(key: String, pattern: S) -> Self {
+    pub fn regex<'a, S: AsRef<&'a str>>(key: &str, pattern: S) -> Self {
         Self(format!("{key} = /{}/", pattern.as_ref()))
     }
 }

--- a/crates/rig-vectorize/src/client/filter.rs
+++ b/crates/rig-vectorize/src/client/filter.rs
@@ -79,27 +79,27 @@ impl SearchFilter for VectorizeFilter {
 
 impl VectorizeFilter {
     /// Creates a "not equal" filter.
-    pub fn ne(key: impl AsRef<str>, value: Value) -> Self {
+    pub fn ne(key: impl AsRef<str>, value: &Value) -> Self {
         Self(json!({ key.as_ref(): { "$ne": value } }))
     }
 
     /// Creates a "greater than or equal" filter.
-    pub fn gte(key: impl AsRef<str>, value: Value) -> Self {
+    pub fn gte(key: impl AsRef<str>, value: &Value) -> Self {
         Self(json!({ key.as_ref(): { "$gte": value } }))
     }
 
     /// Creates a "less than or equal" filter.
-    pub fn lte(key: impl AsRef<str>, value: Value) -> Self {
+    pub fn lte(key: impl AsRef<str>, value: &Value) -> Self {
         Self(json!({ key.as_ref(): { "$lte": value } }))
     }
 
     /// Creates an "in" filter (value must be one of the provided values).
-    pub fn in_values(key: impl AsRef<str>, values: Vec<Value>) -> Self {
+    pub fn in_values(key: impl AsRef<str>, values: &[Value]) -> Self {
         Self(json!({ key.as_ref(): { "$in": values } }))
     }
 
     /// Creates a "not in" filter (value must not be any of the provided values).
-    pub fn nin(key: impl AsRef<str>, values: Vec<Value>) -> Self {
+    pub fn nin(key: impl AsRef<str>, values: &[Value]) -> Self {
         Self(json!({ key.as_ref(): { "$nin": values } }))
     }
 
@@ -146,7 +146,7 @@ mod tests {
 
     #[test]
     fn test_ne_filter() {
-        let filter = VectorizeFilter::ne("status", json!("deleted"));
+        let filter = VectorizeFilter::ne("status", &json!("deleted"));
         assert_eq!(
             filter.into_inner(),
             json!({ "status": { "$ne": "deleted" } })
@@ -155,20 +155,19 @@ mod tests {
 
     #[test]
     fn test_gte_filter() {
-        let filter = VectorizeFilter::gte("count", json!(10));
+        let filter = VectorizeFilter::gte("count", &json!(10));
         assert_eq!(filter.into_inner(), json!({ "count": { "$gte": 10 } }));
     }
 
     #[test]
     fn test_lte_filter() {
-        let filter = VectorizeFilter::lte("age", json!(65));
+        let filter = VectorizeFilter::lte("age", &json!(65));
         assert_eq!(filter.into_inner(), json!({ "age": { "$lte": 65 } }));
     }
 
     #[test]
     fn test_in_filter() {
-        let filter =
-            VectorizeFilter::in_values("category", vec![json!("a"), json!("b"), json!("c")]);
+        let filter = VectorizeFilter::in_values("category", &[json!("a"), json!("b"), json!("c")]);
         assert_eq!(
             filter.into_inner(),
             json!({ "category": { "$in": ["a", "b", "c"] } })
@@ -177,7 +176,7 @@ mod tests {
 
     #[test]
     fn test_nin_filter() {
-        let filter = VectorizeFilter::nin("status", vec![json!("deleted"), json!("archived")]);
+        let filter = VectorizeFilter::nin("status", &[json!("deleted"), json!("archived")]);
         assert_eq!(
             filter.into_inner(),
             json!({ "status": { "$nin": ["deleted", "archived"] } })

--- a/crates/rig-vertexai/src/types/completion_request.rs
+++ b/crates/rig-vertexai/src/types/completion_request.rs
@@ -232,7 +232,7 @@ fn vertex_generation_config(
     if let Some(response_modalities) = config.response_modalities {
         let response_modalities = response_modalities
             .into_iter()
-            .map(vertex_response_modality)
+            .map(|modality| vertex_response_modality(&modality))
             .collect::<Result<Vec<_>, _>>()?;
         vertex_config = vertex_config.set_response_modalities(response_modalities);
     }
@@ -283,7 +283,7 @@ fn vertex_thinking_config(
 }
 
 fn vertex_response_modality(
-    modality: ResponseModality,
+    modality: &ResponseModality,
 ) -> Result<vertexai::model::generation_config::Modality, CompletionError> {
     match modality {
         ResponseModality::Text => Ok(vertexai::model::generation_config::Modality::Text),

--- a/crates/rig-vertexai/src/types/completion_response.rs
+++ b/crates/rig-vertexai/src/types/completion_response.rs
@@ -20,7 +20,7 @@ pub const PROVIDER_NAME: &str = "vertexai";
 /// Unmapped values are carried verbatim in their wire SCREAMING_SNAKE spelling
 /// so a reason Vertex adds later surfaces instead of reading as a natural stop.
 pub fn map_finish_reason(
-    reason: vertexai::model::candidate::FinishReason,
+    reason: &vertexai::model::candidate::FinishReason,
 ) -> Option<rig_core::completion::FinishReason> {
     // `name()` yields the wire form (`MALFORMED_FUNCTION_CALL`) the shared
     // Google table keys on; a value the SDK does not model falls back to
@@ -163,7 +163,7 @@ impl TryFrom<VertexGenerateContentOutput> for CompletionResponse {
             })
             .unwrap_or_default();
 
-        let finish_reason = map_finish_reason(candidate.finish_reason.clone());
+        let finish_reason = map_finish_reason(&candidate.finish_reason);
         let model = Some(response.model_version.clone()).filter(|model| !model.is_empty());
 
         Ok(CompletionResponse::new(choice, usage, PROVIDER_NAME)

--- a/examples/pdf_agent/src/main.rs
+++ b/examples/pdf_agent/src/main.rs
@@ -8,7 +8,7 @@ use rig::{
     vector_store::in_memory_store::InMemoryVectorStore,
 };
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::Path;
 
 #[derive(Embed, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 struct Document {
@@ -17,7 +17,7 @@ struct Document {
     content: String,
 }
 
-fn load_pdf(path: PathBuf) -> Result<Vec<String>> {
+fn load_pdf(path: &Path) -> Result<Vec<String>> {
     const CHUNK_SIZE: usize = 2000;
     let content_chunks = PdfFileLoader::with_glob(path.to_str().context("Invalid path")?)?
         .read()
@@ -64,7 +64,7 @@ async fn main() -> Result<()> {
     // Load PDFs using Rig's built-in PDF loader
     let documents_dir = std::env::current_dir()?.join("examples/documents");
     let pdf_chunks =
-        load_pdf(documents_dir.join("deepseek_r1.pdf")).context("Failed to load pdf documents")?;
+        load_pdf(&documents_dir.join("deepseek_r1.pdf")).context("Failed to load pdf documents")?;
     println!("Successfully loaded and chunked PDF documents");
 
     // Create embedding model

--- a/tests/integrations/vectorize.rs
+++ b/tests/integrations/vectorize.rs
@@ -354,7 +354,7 @@ async fn test_query_with_combined_filters() {
 
     // category = "programming" AND id != "doc-rust"
     let filter = VectorizeFilter::eq("category", serde_json::json!("programming"))
-        .and(VectorizeFilter::ne("id", serde_json::json!("doc-rust")));
+        .and(VectorizeFilter::ne("id", &serde_json::json!("doc-rust")));
 
     let request = VectorSearchRequest::builder()
         .query("programming")
@@ -433,7 +433,7 @@ async fn test_query_with_in_filter() {
 
     let filter = VectorizeFilter::in_values(
         "category",
-        vec![
+        &[
             serde_json::json!("programming"),
             serde_json::json!("database"),
         ],


### PR DESCRIPTION
## Summary

A workspace-wide ownership audit: every `'static`, `clone()`, `mut`, and trait bound in production code should be load-bearing — required by what the code does, not inherited, cargo-culted, or added once to silence the compiler. This PR fixes what wasn't and documents what looked removable but isn't. **Line-neutral by design** (64 files, +307/−296): the metric is ownership shape, not LOC.

## What changed

**Clones eliminated (~45)**
- 15 clone-then-drop sites: bedrock streaming terminals, gemini/ollama/qdrant/s3vectors/lancedb provider seams, `ClientBuilder`'s ext-mapping closure.
- 23 `to_owned`/`to_vec`/`to_string` calls on already-owned data.
- Caller-side clones deleted by reshaping the signature that forced them: rig-candle's two whole-`CompletionRequest` clones (the generation chain now borrows end-to-end), rmcp registration callers' `peer.clone()`, two `id.clone()`s feeding `LSHIndex::insert`, and `InMemoryVectorStore::from_builder`'s `IndexStrategy` clone (reads params before moving).

**Signatures — 91 `needless_pass_by_value` findings fixed, 2 correctly kept**
- The filter-builder families in **qdrant, milvus, surrealdb, lancedb, neo4j, postgres, vectorize** take `&str` keys and borrowed values (`&Value`, `&[Value]`) — they only ever formatted or serialized them.
- `MilvusVectorStore::auth(&str, &str)`; `SqliteVectorStore::add_rows_with_txn(&[(T, Vec<Embedding>)])`.
- `StreamingPromptRequest::new(&Agent)` (was `Arc<Agent>` — it only read through the Arc); `ToolServer::rmcp_tools`/`rmcp_tools_with_timeout` + the `AgentBuilder` wrappers take `&ServerSink` (each registered tool clones it anyway; the single-tool variant still consumes the sink it stores).
- Internal helpers across anthropic, gemini (REST + interactions), mistral, openai-responses (HTTP + websocket), sse-transport, streaming parts, and the streaming-conformance test harness take borrows; `SseTransportOptions`, `ResponseChunkKind`, and `InvalidToolCallDiagnostic` are now `Copy`.
- `rig-derive`'s expander and `vertexai::map_finish_reason` take references.

**Allocation reuse**: 17 streaming-accumulator assignments (`x = y.clone()` on every event) now use `clone_from`/`clone_into` — the one hot in-process path where this matters.

**Bounds**: `Send + Sync` removed from `SurrealVectorStore`'s `InsertDocuments` impl; two redundant `where Self: 'static` clauses in rig-sqlite; bound-necessity passes over all 8 audited store crates found the rest already minimal. `for<'a> Deserialize<'a>` is spelled `DeserializeOwned` on `VectorStoreIndex::top_n` and friends — the identical bound, honest name, zero impact on impls or callers.

## Kept deliberately (verified, not skipped)

- **`T: 'static` on every provider model impl** — tested by deletion: `HttpClientExt::send` returns `'static` futures, so removal is E0310. Honest.
- **The embed-seam `documents.clone()`** — killing one small-`Vec` clone on a network-bound path isn't worth degrading the public raw route's `impl IntoIterator<Item = String>` ergonomics.
- **`identity()` / metadata-getter clones** — `ResponseIdentity` is an owned carrier by contract.
- **Two `is_false(&bool)`** — serde `skip_serializing_if` requires `fn(&T)`; allowed with a comment.
- **All `Arc<Mutex<_>>` topology** — audited: test capture layers, copilot auth's refresh serialization, and the genuinely shared in-memory message store. No `Mutex` held across `.await`, no `Arc<String>`/`Arc<Vec<_>>`, zero `large_enum_variant`/`rc_buffer`/`mutex_atomic` findings.
- Two clippy false-positives (parameters actually consumed) left as-is.

## Breaks

All public signature changes are listed in the new `MIGRATING.md` § "Borrow-shaped signatures: filter builders, rmcp registration, streaming prompt construction". Call sites passing literals compile unchanged; sites that built an owned value just to hand it over pass a reference and usually stop building the owned value at all. No shims, per house policy.

## Verification

```
cargo test --workspace --all-features            # 164 binaries, 0 failures
cargo clippy --workspace --all-targets --all-features -- -D warnings   # clean
# plus the audit lint set (redundant_clone, needless_pass_by_value, implicit_clone,
# assigning_clones, unnecessary_to_owned, needless_collect, ptr_arg, needless_lifetimes,
# trivially_copy_pass_by_ref, redundant_allocation, ...) — converged to zero findings
cargo fmt --check                                                       # clean
cargo check --target wasm32-unknown-unknown -p rig-core -p rig-agent -p rig   # clean
RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --all-features (rig-core, rig-agent, rig)  # clean
git diff main -- tests/cassettes                                        # EMPTY
```

The erasure handles' clone-counting probes (`erasure_never_clones_the_model` × 4) and the `external_modality_extension_probe` all pass — the documented shared-instance invariants are untouched.
