### PR TITLE
refactor!: ownership audit round 2 — borrow-shaped telemetry getters, slice-shaped embed seams, Copy usage types, minimal transport bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10208,7 +10208,6 @@ dependencies = [
  "tokio-rusqlite",
  "tracing",
  "tracing-subscriber",
- "zerocopy",
 ]
 
 [[package]]

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -796,6 +796,121 @@ handed back a silently short list.
 
 ## 0.41 → next
 
+### Telemetry getters borrow: `ProviderResponseExt::get_response_id` / `get_response_model_name` return `Option<&str>`
+
+Both getters exist to hand a value to `tracing::Span::record`, which takes
+`&str`; the owning return forced every one of the sixteen provider impls to
+clone a `String` per completion turn just to have it read once and dropped.
+They now return `Option<&str>`. `get_text_response` and `get_usage` are
+unchanged.
+
+```rust
+// before
+fn get_response_id(&self) -> Option<String> { Some(self.id.clone()) }
+
+// after
+fn get_response_id(&self) -> Option<&str> { Some(self.id.as_str()) }
+```
+
+Callers that need an owned value add `.map(str::to_owned)`.
+
+### `ReasoningSummary::text()` returns `&str`
+
+The one-variant enum's accessor cloned the summary text; it now borrows.
+Callers that need ownership add `.to_owned()`.
+
+### Request assembly accessors that need the history by value now consume the request
+
+`rig_vertexai::types::completion_request::VertexCompletionRequest::contents`
+and `rig_bedrock::types::completion_request::AwsCompletionRequest::messages`
+took `&self` and cloned the entire chat history per request. Each now takes
+`self`. Every other accessor on both types still borrows — call the borrowing
+accessors first and the consuming one last, which is the order the completion
+paths already used.
+
+```rust
+// before
+let contents = vertex_request.contents()?;          // cloned the history
+let system_instruction = vertex_request.system_instruction();
+
+// after
+let system_instruction = vertex_request.system_instruction();
+let contents = vertex_request.contents()?;          // moves the history
+```
+
+### `TextToImageGeneration::width`/`height` are chainable builders
+
+The two setters took `&mut self` and returned `&Self`, which chained with
+nothing else in the tree; every other rig builder is `mut self -> Self`. They
+now follow the house idiom.
+
+```rust
+// before
+let mut request = TextToImageGeneration::new(prompt);
+request.width(1024);
+request.height(1024);
+
+// after
+let request = TextToImageGeneration::new(prompt).width(1024).height(1024);
+```
+
+### `rig-s3vectors`: `set_bucket_name` / `set_index_name` removed
+
+Both setters had zero callers anywhere in the workspace and re-allocated from
+`&str`. Construct the store with the right names instead; the read accessors
+(`bucket_name()`, `index_name()`) are unchanged.
+
+### Vector-store filter constructors take `impl Into<String>` keys
+
+`MongoDbSearchFilter`, `SqliteSearchFilter`, `ScyllaSearchFilter`,
+`S3VectorsSearchFilter`, and `PgSearchFilter` constructors that took
+`key: String` now take `key: impl Into<String>`, matching the rest of the
+workspace (and the other parameter of the same functions, which already did).
+`filter::gte("price".to_string(), v)` still compiles; `filter::gte("price", v)`
+now also does. The only source break is a caller passing `"key".into()`, which
+becomes ambiguous — pass the literal.
+
+### Loosened bounds (no action needed)
+
+These accept strictly more code than before:
+
+- Transport/HTTP-client generic chains across the providers no longer demand
+  `Default` or `Debug` (`mistral`/`openrouter` transcription, `hyperbolic`,
+  `voyageai`, `ollama`, `gemini` image-generation and Interactions API,
+  `anthropic`, `copilot`, `chatgpt`, `openai` completions/responses/websocket).
+  Nothing constructed or formatted the client; the minimal chain is
+  `HttpClientExt + Clone (+ WasmCompatSend/WasmCompatSync) + 'static`.
+- `GenericCompletionModel::new` (and `with_strict_tools`,
+  `with_tool_result_array_content`) no longer bound `Client<Ext, H>` or `Ext`
+  at all.
+- `TypeMap`/`ToolContext` read-side methods (`get`, `get_mut`, `remove`,
+  `contains`, `require`, `result`, `require_result`) need only `T: 'static`
+  (pure `Any` lookups); the write side keeps
+  `Clone + WasmCompatSend + WasmCompatSync + 'static`.
+- `SqliteVectorStore<T>`/`SqliteVectorIndex<T>` struct declarations no longer
+  carry `T: SqliteVectorStoreTable + 'static`; the `'static` survives only on
+  the impl blocks whose `conn.call` closures actually need it.
+  `EmbeddingsBuilder`, `InMemoryVectorStoreBuilder`,
+  `TranscriptionRequestBuilder`, and `ImageGenerationRequestBuilder` likewise
+  drop their struct-level where clauses.
+- `HelixDBVectorStore::new`/`client()` require no bounds; the store impls no
+  longer restate `C::Err: std::error::Error` (declared on the trait).
+- The `VectorStoreIndexDyn` blanket impl no longer restates `WasmCompatSend +
+  WasmCompatSync + 'static` on the filter type (implied by
+  `VectorStoreIndex::Filter`).
+- `ToolSchema::try_from` and gemini's `ConstructEmbeddingModel` impl drop a
+  `'static` neither uses.
+- Extractor/vector-store generics spell `DeserializeOwned` instead of the
+  equivalent `for<'de> Deserialize<'de>`.
+
+### Provider usage types are `Copy`
+
+The scalar-only usage payloads (`openai` chat + responses, `anthropic`,
+`deepseek`, `openrouter`, `cohere`, gemini `InteractionUsage`, and their
+detail structs) now derive `Copy`. Mistral's `Usage` is not `Copy` — it
+carries `service_tier: Option<String>`.
+
+
 ### `providers::llamafile` is now `providers::llamacpp`
 
 The provider named after Mozilla's single-file distribution is gone; the one

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -339,7 +339,7 @@ pub(crate) async fn build_prepared_completion_request(
         tool_snapshot.retain_names(&allowed);
     }
 
-    let mut tooldefs = tool_snapshot.definitions().to_vec();
+    let mut tooldefs = tool_snapshot.take_definitions();
 
     // Executable tools are the real tool-server tools, computed BEFORE any
     // synthetic output tool is appended.

--- a/crates/rig-agent/src/agent/prompt_request/mod.rs
+++ b/crates/rig-agent/src/agent/prompt_request/mod.rs
@@ -1144,7 +1144,7 @@ mod tests {
             AssistantContent::text("answer")
         ]));
         assert!(
-            !turn_delivered_no_answer(&[reasoning.clone(), image.clone()]),
+            !turn_delivered_no_answer(&[reasoning.clone(), image]),
             "a thinking image model that produced an image has answered"
         );
         assert!(turn_delivered_no_answer(&[

--- a/crates/rig-agent/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-agent/src/agent/prompt_request/streaming.rs
@@ -5822,10 +5822,7 @@ mod migrated_tests {
                     internal.clone(),
                     ToolCallDeltaContent::Delta("{\"x\":".to_string())
                 ),
-                (
-                    internal.clone(),
-                    ToolCallDeltaContent::Delta("1}".to_string())
-                ),
+                (internal, ToolCallDeltaContent::Delta("1}".to_string())),
             ]
         );
     }
@@ -6211,10 +6208,7 @@ mod migrated_tests {
                     internal.clone(),
                     ToolCallDeltaContent::Delta("{\"x\":".to_string())
                 ),
-                (
-                    internal.clone(),
-                    ToolCallDeltaContent::Delta("1}".to_string())
-                ),
+                (internal, ToolCallDeltaContent::Delta("1}".to_string())),
             ]
         );
     }
@@ -6279,10 +6273,7 @@ mod migrated_tests {
                     internal.clone(),
                     ToolCallDeltaContent::Delta("{\"x\":".to_string())
                 ),
-                (
-                    internal.clone(),
-                    ToolCallDeltaContent::Delta("1}".to_string())
-                ),
+                (internal, ToolCallDeltaContent::Delta("1}".to_string())),
             ]
         );
     }

--- a/crates/rig-agent/src/agent/run/mod.rs
+++ b/crates/rig-agent/src/agent/run/mod.rs
@@ -1008,12 +1008,13 @@ impl AgentRun {
         self.record_completion_call(
             turn.usage,
             ResponseIdentity {
+                // The message id is also written into run history below.
                 message_id: turn.message_id.clone(),
-                response_id: turn.response_id.clone(),
-                provider_request_id: turn.provider_request_id.clone(),
+                response_id: turn.response_id,
+                provider_request_id: turn.provider_request_id,
             },
-            turn.finish_reason.clone(),
-            turn.raw.clone(),
+            turn.finish_reason,
+            turn.raw,
         );
 
         let items: Vec<AssistantContent> = turn.choice.clone();
@@ -1597,7 +1598,7 @@ impl AgentRun {
                     message_id: turn.message_id.clone(),
                     ..ResponseIdentity::default()
                 },
-                turn.finish_reason.clone(),
+                turn.finish_reason,
                 // A streamed turn's raw lives on the terminal record, which
                 // this fallback never saw; the driver records it via
                 // `record_streamed_completion_call` when it has one.

--- a/crates/rig-agent/src/agent/run/streamed.rs
+++ b/crates/rig-agent/src/agent/run/streamed.rs
@@ -494,16 +494,15 @@ impl StreamedTurnAssembler {
     /// ([`Self::assembled_reasoning`]) — agreement between the two is pinned
     /// by `canonical_choice_and_partial_turn_agree_on_multi_part_reasoning`.
     fn canonical_choice_with(
-        &self,
+        pending_tool_calls: Vec<(ToolCall, String)>,
         reasoning: Vec<Reasoning>,
         provider_choice: &[AssistantContent],
     ) -> Vec<AssistantContent> {
-        if !self.pending_tool_calls.is_empty() || !reasoning.is_empty() {
+        if !pending_tool_calls.is_empty() || !reasoning.is_empty() {
             let text_items = assistant_text_items_from_choice(provider_choice);
-            let tool_items = self
-                .pending_tool_calls
-                .iter()
-                .map(|(tool_call, _)| AssistantContent::ToolCall(tool_call.clone()))
+            let tool_items = pending_tool_calls
+                .into_iter()
+                .map(|(tool_call, _)| AssistantContent::ToolCall(tool_call))
                 .collect::<Vec<_>>();
             // Infallible on purpose: the enclosing guard makes at least one
             // input non-empty and the assembly maps its inputs 1:1, so there
@@ -854,14 +853,14 @@ impl StreamedTurnAssembler {
         final_choice: &[AssistantContent],
     ) -> StreamedTurn {
         let reasoning = self.drain_reasoning();
-        let choice = self.canonical_choice_with(reasoning, final_choice);
-        let internal_call_ids: Vec<(String, String)> = self
-            .pending_tool_calls
+        let pending_tool_calls = std::mem::take(&mut self.pending_tool_calls);
+        let internal_call_ids: Vec<(String, String)> = pending_tool_calls
             .iter()
             .map(|(tool_call, internal_call_id)| {
                 (tool_call.id.as_str().to_owned(), internal_call_id.clone())
             })
             .collect();
+        let choice = Self::canonical_choice_with(pending_tool_calls, reasoning, final_choice);
 
         StreamedTurn {
             message_id,

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -832,7 +832,10 @@ impl UnaryTurnSource {
     fn chain_span(&self, span: tracing::Span) -> tracing::Span {
         let span = match self.current_span_id.load(Ordering::Relaxed) {
             0 => span,
-            id => span.follows_from(Id::from_u64(id)).to_owned(),
+            id => {
+                span.follows_from(Id::from_u64(id));
+                span
+            }
         };
         if let Some(id) = span.id() {
             self.current_span_id.store(id.into_u64(), Ordering::Relaxed);

--- a/crates/rig-agent/src/client.rs
+++ b/crates/rig-agent/src/client.rs
@@ -1,7 +1,7 @@
 //! Classic runtime construction extensions for portable completion clients and models.
 
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::{agent::AgentBuilder, extractor::ExtractorBuilder};
 use rig_core::wasm_compat::{WasmCompatSend, WasmCompatSync};
@@ -34,7 +34,7 @@ pub trait AgentClientExt: rig_core::client::completion::CompletionClient {
     fn extractor<T>(&self, model: impl Into<String>) -> ExtractorBuilder<T>
     where
         T: JsonSchema
-            + for<'de> Deserialize<'de>
+            + serde::de::DeserializeOwned
             + Serialize
             + WasmCompatSend
             + WasmCompatSync

--- a/crates/rig-agent/src/extractor.rs
+++ b/crates/rig-agent/src/extractor.rs
@@ -33,7 +33,7 @@
 use std::marker::PhantomData;
 
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde::{Serialize, de::DeserializeOwned};
 
 use rig_core::{
     message::{Message, ToolChoice},
@@ -90,7 +90,7 @@ where
 #[must_use = "an extraction override does nothing until an extract method is awaited"]
 pub struct ExtractorRun<'a, T>
 where
-    T: JsonSchema + for<'de> Deserialize<'de> + WasmCompatSend + WasmCompatSync,
+    T: JsonSchema + DeserializeOwned + WasmCompatSend + WasmCompatSync,
 {
     extractor: &'a Extractor<T>,
     model: Option<ModelHandle>,
@@ -281,7 +281,7 @@ where
 
 impl<T> ExtractorRun<'_, T>
 where
-    T: JsonSchema + for<'de> Deserialize<'de> + WasmCompatSend + WasmCompatSync,
+    T: JsonSchema + DeserializeOwned + WasmCompatSend + WasmCompatSync,
 {
     /// Extract structured data with the run-local model.
     pub async fn extract(
@@ -447,6 +447,7 @@ mod tests {
     use rig_core::vector_store::{
         VectorSearchRequest, VectorStoreError, VectorStoreIndex, request::Filter,
     };
+    use serde::Deserialize;
 
     #[derive(Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
     struct Person {

--- a/crates/rig-agent/src/integrations/discord_bot.rs
+++ b/crates/rig-agent/src/integrations/discord_bot.rs
@@ -24,14 +24,14 @@ pub enum DiscordBotError {
 // Bot state containing the agent and conversation histories
 struct BotState {
     agent: Agent,
-    conversations: Arc<RwLock<HashMap<u64, Vec<RigMessage>>>>,
+    conversations: RwLock<HashMap<u64, Vec<RigMessage>>>,
 }
 
 impl BotState {
     fn new(agent: Agent) -> Self {
         Self {
             agent,
-            conversations: Arc::new(RwLock::new(HashMap::new())),
+            conversations: RwLock::new(HashMap::new()),
         }
     }
 }

--- a/crates/rig-agent/src/tool/extensions.rs
+++ b/crates/rig-agent/src/tool/extensions.rs
@@ -89,7 +89,7 @@ impl TypeMap {
 
     pub(crate) fn get<T>(&self) -> Option<&T>
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: 'static,
     {
         self.map
             .as_ref()
@@ -99,7 +99,7 @@ impl TypeMap {
 
     pub(crate) fn get_mut<T>(&mut self) -> Option<&mut T>
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: 'static,
     {
         self.map
             .as_mut()
@@ -109,7 +109,7 @@ impl TypeMap {
 
     pub(crate) fn remove<T>(&mut self) -> Option<T>
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: 'static,
     {
         self.map
             .as_mut()
@@ -120,7 +120,7 @@ impl TypeMap {
 
     pub(crate) fn contains<T>(&self) -> bool
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: 'static,
     {
         self.map
             .as_ref()
@@ -179,7 +179,7 @@ impl ToolContext {
     /// Read an inbound typed value.
     pub fn get<T>(&self) -> Option<&T>
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: 'static,
     {
         self.inbound.get::<T>()
     }
@@ -187,7 +187,7 @@ impl ToolContext {
     /// Require an inbound typed value.
     pub fn require<T>(&self) -> Result<&T, MissingToolContext>
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: 'static,
     {
         self.get::<T>().ok_or(MissingToolContext(type_name::<T>()))
     }
@@ -195,7 +195,7 @@ impl ToolContext {
     /// Mutably access an inbound typed value.
     pub fn get_mut<T>(&mut self) -> Option<&mut T>
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: 'static,
     {
         self.inbound.get_mut::<T>()
     }
@@ -203,7 +203,7 @@ impl ToolContext {
     /// Remove an inbound typed value.
     pub fn remove<T>(&mut self) -> Option<T>
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: 'static,
     {
         self.inbound.remove::<T>()
     }
@@ -219,7 +219,7 @@ impl ToolContext {
     /// Read host-only result metadata.
     pub fn result<T>(&self) -> Option<&T>
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: 'static,
     {
         self.result.get::<T>()
     }
@@ -227,7 +227,7 @@ impl ToolContext {
     /// Require host-only result metadata.
     pub fn require_result<T>(&self) -> Result<&T, MissingToolContext>
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: 'static,
     {
         self.result::<T>()
             .ok_or(MissingToolContext(type_name::<T>()))
@@ -236,7 +236,7 @@ impl ToolContext {
     /// Whether this context contains the inbound type `T`.
     pub fn contains<T>(&self) -> bool
     where
-        T: WasmCompatSend + WasmCompatSync + 'static,
+        T: 'static,
     {
         self.inbound.contains::<T>()
     }

--- a/crates/rig-agent/src/tool/mod.rs
+++ b/crates/rig-agent/src/tool/mod.rs
@@ -273,7 +273,7 @@ where
 
 fn parse_tool_args<A>(args: &str) -> Result<A, ToolExecutionError>
 where
-    A: for<'de> Deserialize<'de>,
+    A: serde::de::DeserializeOwned,
 {
     match serde_json::from_str(args) {
         Ok(parsed) => Ok(parsed),
@@ -748,27 +748,29 @@ impl ToolSet {
 
     /// Documents describing all registered tools.
     pub fn documents(&self) -> Vec<completion::Document> {
-        let mut docs = Vec::new();
-        for (name, registration) in &self.tools {
-            let definition = registration.tool.definition_with_name(name.clone());
-            let serialized = serde_json::to_string_pretty(&definition).unwrap_or_else(|error| {
-                tracing::warn!(
-                    tool_name = %name,
-                    %error,
-                    "tool definition could not be pretty-printed; using a plain representation"
-                );
-                format!(
-                    "name: {}\ndescription: {}\nparameters: {}",
-                    definition.name, definition.description, definition.parameters
-                )
-            });
-            docs.push(completion::Document {
-                id: name.clone(),
-                text: format!("Tool: {name}\nDefinition: \n{serialized}"),
-                additional_props: HashMap::new(),
-            });
-        }
-        docs
+        self.tools
+            .iter()
+            .map(|(name, registration)| {
+                let definition = registration.tool.definition_with_name(name.clone());
+                let serialized =
+                    serde_json::to_string_pretty(&definition).unwrap_or_else(|error| {
+                        tracing::warn!(
+                            tool_name = %name,
+                            %error,
+                            "tool definition could not be pretty-printed; using a plain representation"
+                        );
+                        format!(
+                            "name: {}\ndescription: {}\nparameters: {}",
+                            definition.name, definition.description, definition.parameters
+                        )
+                    });
+                completion::Document {
+                    id: name.clone(),
+                    text: format!("Tool: {name}\nDefinition: \n{serialized}"),
+                    additional_props: HashMap::new(),
+                }
+            })
+            .collect()
     }
 
     /// Convert embedding tools to vector-store schemas.

--- a/crates/rig-agent/src/tool/rmcp.rs
+++ b/crates/rig-agent/src/tool/rmcp.rs
@@ -56,7 +56,6 @@
 //! `event.tool_context.result::<T>()`. These values are host-only; only the
 //! response's ordered presentation content is sent to the model.
 
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::{
     Arc,
@@ -448,14 +447,14 @@ fn mcp_result_output(result: &CallToolResult) -> Result<ToolOutput, ToolExecutio
     }
 }
 
-fn preserve_mcp_result(context: &mut ToolContext, result: &CallToolResult) {
+fn preserve_mcp_result(context: &mut ToolContext, result: CallToolResult) {
     if let Some(structured) = result.structured_content.clone() {
         context.insert_result(structured);
     }
     if let Some(meta) = result.meta.clone() {
         context.insert_result(meta);
     }
-    context.insert_result(result.clone());
+    context.insert_result(result);
 }
 
 impl ErasedTool for McpTool {
@@ -466,8 +465,8 @@ impl ErasedTool for McpTool {
     fn description(&self) -> String {
         self.definition
             .description
-            .clone()
-            .unwrap_or(Cow::from(""))
+            .as_deref()
+            .unwrap_or("")
             .to_string()
     }
 
@@ -489,8 +488,9 @@ impl ErasedTool for McpTool {
             match self.execute_mcp(args, meta).await {
                 Ok(result) => {
                     let is_error = result.is_error == Some(true);
-                    preserve_mcp_result(context, &result);
-                    let output = match mcp_result_output(&result) {
+                    let output = mcp_result_output(&result);
+                    preserve_mcp_result(context, result);
+                    let output = match output {
                         Ok(output) => output,
                         Err(error) => return ToolResult::failed(error),
                     };

--- a/crates/rig-agent/src/tool/server.rs
+++ b/crates/rig-agent/src/tool/server.rs
@@ -45,6 +45,13 @@ impl ToolRegistrySnapshot {
         &self.definitions
     }
 
+    /// Moves the definitions out of the snapshot. The per-turn request
+    /// assembly is the sole consumer and never reads them again, so it takes
+    /// them instead of deep-cloning every tool's JSON schema each turn.
+    pub(crate) fn take_definitions(&mut self) -> Vec<ToolDefinition> {
+        std::mem::take(&mut self.definitions)
+    }
+
     /// Narrow both provider exposure and dispatch to one per-turn allow-list.
     pub(crate) fn retain_names(&mut self, names: &BTreeSet<String>) {
         self.definitions

--- a/crates/rig-bedrock/src/completion.rs
+++ b/crates/rig-bedrock/src/completion.rs
@@ -234,13 +234,16 @@ impl CompletionModel {
             .model_id(request_model.clone());
 
         let tool_config = request.tools_config()?;
-        let messages = request.messages()?;
         let output_config = request.output_config()?;
+        let additional_params = request.additional_params();
+        let inference_config = request.inference_config();
+        let system_prompt = request.system_prompt()?;
+        let messages = request.messages()?;
         converse_builder = converse_builder
-            .set_additional_model_request_fields(request.additional_params())
-            .set_inference_config(request.inference_config())
+            .set_additional_model_request_fields(additional_params)
+            .set_inference_config(inference_config)
             .set_tool_config(tool_config)
-            .set_system(request.system_prompt()?)
+            .set_system(system_prompt)
             .set_messages(Some(messages))
             .set_output_config(output_config)
             .set_guardrail_config(self.guardrail.clone());

--- a/crates/rig-bedrock/src/image.rs
+++ b/crates/rig-bedrock/src/image.rs
@@ -53,9 +53,9 @@ impl ImageGenerationModel {
         &self,
         generation_request: ImageGenerationRequest,
     ) -> Result<(TextToImageResponse, Option<String>), ImageGenerationError> {
-        let mut request = TextToImageGeneration::new(generation_request.prompt);
-        request.width(generation_request.width);
-        request.height(generation_request.height);
+        let request = TextToImageGeneration::new(generation_request.prompt)
+            .width(generation_request.width)
+            .height(generation_request.height);
 
         let body = serde_json::to_string(&request)?;
         let model_response = self

--- a/crates/rig-bedrock/src/streaming.rs
+++ b/crates/rig-bedrock/src/streaming.rs
@@ -430,13 +430,16 @@ impl CompletionModel {
             .model_id(request_model);
 
         let tool_config = request.tools_config()?;
-        let prompt_with_history = request.messages()?;
         let output_config = request.output_config()?;
+        let additional_params = request.additional_params();
+        let inference_config = request.inference_config();
+        let system_prompt = request.system_prompt()?;
+        let prompt_with_history = request.messages()?;
         converse_builder = converse_builder
-            .set_additional_model_request_fields(request.additional_params())
-            .set_inference_config(request.inference_config())
+            .set_additional_model_request_fields(additional_params)
+            .set_inference_config(inference_config)
             .set_tool_config(tool_config)
-            .set_system(request.system_prompt()?)
+            .set_system(system_prompt)
             .set_messages(Some(prompt_with_history))
             .set_output_config(output_config);
 

--- a/crates/rig-bedrock/src/types/assistant_content.rs
+++ b/crates/rig-bedrock/src/types/assistant_content.rs
@@ -38,11 +38,11 @@ pub(crate) fn normalize_usage(usage: &TokenUsage) -> completion::Usage {
 impl ProviderResponseExt for AwsConverseOutput {
     type Usage = completion::Usage;
 
-    fn get_response_id(&self) -> Option<String> {
+    fn get_response_id(&self) -> Option<&str> {
         None // Bedrock Converse API doesn't return a response ID
     }
 
-    fn get_response_model_name(&self) -> Option<String> {
+    fn get_response_model_name(&self) -> Option<&str> {
         None // Bedrock doesn't echo model name in response
     }
 

--- a/crates/rig-bedrock/src/types/completion_request.rs
+++ b/crates/rig-bedrock/src/types/completion_request.rs
@@ -120,7 +120,7 @@ impl AwsCompletionRequest {
             .output_schema_name()
             .unwrap_or_else(|| "response_schema".to_string());
 
-        let schema_json = serde_json::to_string(&schema.clone().to_value())
+        let schema_json = serde_json::to_string(schema.as_value())
             .map_err(|e| CompletionError::RequestError(e.into()))?;
 
         let json_schema_def = aws_bedrock::JsonSchemaDefinition::builder()
@@ -171,7 +171,9 @@ impl AwsCompletionRequest {
         }
     }
 
-    pub fn messages(&self) -> Result<Vec<aws_bedrock::Message>, CompletionError> {
+    /// Consumes the request: this is the one accessor that needs the chat
+    /// history by value, so call it after the borrowing accessors.
+    pub fn messages(self) -> Result<Vec<aws_bedrock::Message>, CompletionError> {
         let mut full_history: Vec<Message> = Vec::new();
 
         if !self.inner.documents.is_empty() {
@@ -191,12 +193,19 @@ impl AwsCompletionRequest {
             full_history.push(Message::User { content });
         }
 
+        // Compute before the history is moved below.
+        let has_reasoning = self.inner.chat_history.iter().any(|message| match message {
+            Message::Assistant { content, .. } => content
+                .iter()
+                .any(|c| matches!(c, rig_core::completion::AssistantContent::Reasoning(_))),
+            _ => false,
+        });
+
         full_history.extend(
             self.inner
                 .chat_history
-                .iter()
-                .filter(|message| !matches!(message, Message::System { .. }))
-                .cloned(),
+                .into_iter()
+                .filter(|message| !matches!(message, Message::System { .. })),
         );
 
         let mut messages: Vec<aws_bedrock::Message> = full_history
@@ -212,18 +221,11 @@ impl AwsCompletionRequest {
         // result. Skip the message-level checkpoint in that case; the
         // system-prompt cache point still applies and captures the largest
         // stable prefix.
-        let has_reasoning = self.inner.chat_history.iter().any(|message| match message {
-            Message::Assistant { content, .. } => content
-                .iter()
-                .any(|c| matches!(c, rig_core::completion::AssistantContent::Reasoning(_))),
-            _ => false,
-        });
-
         if self.prompt_caching
             && !has_reasoning
             && let Some(last_msg) = messages.last_mut()
         {
-            let mut content = last_msg.content.clone();
+            let mut content = std::mem::take(&mut last_msg.content);
             content.push(aws_bedrock::ContentBlock::CachePoint(cache_point_block()?));
             *last_msg = aws_bedrock::Message::builder()
                 .role(last_msg.role.clone())
@@ -616,6 +618,12 @@ mod tests {
         };
 
         let aws_request = aws_request(request, true);
+
+        // The system-prompt cache point path is independent and unaffected;
+        // read it before `messages()` consumes the request.
+        let system_only = aws_request.system_prompt().expect("system prompt builds");
+        assert!(system_only.is_none() || !system_only.unwrap().is_empty());
+
         let messages = aws_request.messages().expect("messages should convert");
 
         let last_message = messages.last().expect("messages should not be empty");
@@ -626,10 +634,6 @@ mod tests {
                 .any(|c| matches!(c, aws_bedrock::ContentBlock::CachePoint(_))),
             "message-level cache point should be skipped when chat history contains reasoning"
         );
-
-        // The system-prompt cache point path is independent and unaffected.
-        let system_only = aws_request.system_prompt().expect("system prompt builds");
-        assert!(system_only.is_none() || !system_only.unwrap().is_empty());
     }
 
     #[test]

--- a/crates/rig-bedrock/src/types/document.rs
+++ b/crates/rig-bedrock/src/types/document.rs
@@ -167,7 +167,7 @@ mod tests {
             media_type: Some(DocumentMediaType::Javascript),
             additional_params: None,
         });
-        let aws_document: Result<aws_bedrock::DocumentBlock, _> = rig_document.clone().try_into();
+        let aws_document: Result<aws_bedrock::DocumentBlock, _> = rig_document.try_into();
         assert_eq!(
             aws_document.err().unwrap().to_string(),
             CompletionError::ProviderError(

--- a/crates/rig-bedrock/src/types/image.rs
+++ b/crates/rig-bedrock/src/types/image.rs
@@ -134,7 +134,7 @@ mod tests {
             detail: None,
             additional_params: None,
         });
-        let aws_image: Result<aws_bedrock::ImageBlock, _> = rig_image.clone().try_into();
+        let aws_image: Result<aws_bedrock::ImageBlock, _> = rig_image.try_into();
         assert_eq!(
             aws_image.err().unwrap().to_string(),
             CompletionError::ProviderError("Unsupported format image/heic".into()).to_string()

--- a/crates/rig-bedrock/src/types/text_to_image.rs
+++ b/crates/rig-bedrock/src/types/text_to_image.rs
@@ -83,12 +83,12 @@ impl TextToImageGeneration {
         }
     }
 
-    pub fn height(&mut self, height: u32) -> &Self {
+    pub fn height(mut self, height: u32) -> Self {
         self.image_generation_config.height = Some(height);
         self
     }
 
-    pub fn width(&mut self, width: u32) -> &Self {
+    pub fn width(mut self, width: u32) -> Self {
         self.image_generation_config.width = Some(width);
         self
     }

--- a/crates/rig-core/src/embeddings/builder.rs
+++ b/crates/rig-core/src/embeddings/builder.rs
@@ -48,11 +48,7 @@ use crate::{
 /// # Ok(())
 /// # }
 /// ```
-pub struct EmbeddingsBuilder<M, T>
-where
-    M: EmbeddingModel,
-    T: Embed,
-{
+pub struct EmbeddingsBuilder<M, T> {
     model: M,
     documents: Vec<(T, Vec<String>)>,
 }

--- a/crates/rig-core/src/embeddings/embedding.rs
+++ b/crates/rig-core/src/embeddings/embedding.rs
@@ -372,9 +372,9 @@ pub trait ImageEmbeddingModel: WasmCompatSend + WasmCompatSync {
     }
 
     /// Embed a single image from its encoded file bytes.
-    fn embed_image<'a>(
-        &'a self,
-        bytes: &'a [u8],
+    fn embed_image(
+        &self,
+        bytes: &[u8],
     ) -> impl std::future::Future<Output = Result<Embedding, EmbeddingError>> + WasmCompatSend {
         async move {
             let mut embeddings = self.embed_images(vec![bytes.to_owned()]).await?;

--- a/crates/rig-core/src/embeddings/tool.rs
+++ b/crates/rig-core/src/embeddings/tool.rs
@@ -85,7 +85,7 @@ impl ToolSchema {
     /// ```
     pub fn try_from<T>(tool: &T) -> Result<Self, EmbedError>
     where
-        T: PortableToolEmbedding + 'static,
+        T: PortableToolEmbedding,
     {
         Ok(ToolSchema {
             name: T::NAME.to_string(),

--- a/crates/rig-core/src/image_generation.rs
+++ b/crates/rig-core/src/image_generation.rs
@@ -141,10 +141,7 @@ pub struct ImageGenerationRequest {
 
 /// A builder for `ImageGenerationRequest`.
 /// Can be sent to a model provider.
-pub struct ImageGenerationRequestBuilder<M, P = Missing>
-where
-    M: ImageGenerationModel,
-{
+pub struct ImageGenerationRequestBuilder<M, P = Missing> {
     model: M,
     prompt: P,
     width: u32,

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -111,12 +111,12 @@ pub(crate) fn map_finish_reason(stop_reason: &str) -> completion::FinishReason {
 impl ProviderResponseExt for CompletionResponse {
     type Usage = Usage;
 
-    fn get_response_id(&self) -> Option<String> {
-        Some(self.id.clone())
+    fn get_response_id(&self) -> Option<&str> {
+        Some(self.id.as_str())
     }
 
-    fn get_response_model_name(&self) -> Option<String> {
-        Some(self.model.clone())
+    fn get_response_model_name(&self) -> Option<&str> {
+        Some(self.model.as_str())
     }
 
     fn get_text_response(&self) -> Option<String> {
@@ -136,11 +136,11 @@ impl ProviderResponseExt for CompletionResponse {
     }
 
     fn get_usage(&self) -> Option<Self::Usage> {
-        Some(self.usage.clone())
+        Some(self.usage)
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct Usage {
     pub input_tokens: u64,
     pub cache_read_input_tokens: Option<u64>,
@@ -176,7 +176,7 @@ pub struct OutputTokensDetails {
 /// 5-minute writes (~1.25x), which is what makes a mixed-TTL configuration
 /// (see [`CompletionModel::with_static_prefix_cache_ttl`]) observable.
 /// Unknown buckets a provider may add later are ignored on deserialization.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct CacheCreation {
     /// Tokens written to the 5-minute cache on this turn.
     #[serde(default)]
@@ -342,11 +342,10 @@ pub enum SystemContent {
 /// to forget.
 impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
     fn normalize(self, provider: &str) -> Result<completion::CompletionResponse, CompletionError> {
-        let response = self;
-        let content = response
-            .content
-            .iter()
-            .map(|content| content.clone().try_into())
+        let mut response = self;
+        let content = std::mem::take(&mut response.content)
+            .into_iter()
+            .map(TryInto::try_into)
             .collect::<Result<Vec<_>, _>>()?;
 
         // Anthropic has two ways to end a turn that genuinely carried no
@@ -396,7 +395,7 @@ impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
             provider,
         )
         .with_optional_message_id(Some(response.id.as_str()).filter(|id| !id.is_empty()))
-        .with_optional_provider_request_id(response.provider_request_id.clone())
+        .with_optional_provider_request_id(response.provider_request_id)
         .with_model(response.model.as_str())
         .with_optional_finish_reason(finish_reason))
     }
@@ -796,7 +795,7 @@ pub fn anthropic_citations(text: &message::Text) -> Result<Vec<Citation>, serde_
         .as_ref()
         .and_then(|v| v.get("citations"))
     {
-        Some(c) => serde_json::from_value::<Vec<Citation>>(c.clone()),
+        Some(c) => <Vec<Citation> as serde::Deserialize>::deserialize(c),
         None => Ok(Vec::new()),
     }
 }
@@ -837,7 +836,7 @@ fn extract_anthropic_raw_content(text: &message::Text) -> Result<Option<Content>
         return Ok(None);
     };
 
-    let content = serde_json::from_value::<Content>(raw_content.clone()).map_err(|err| {
+    let content = <Content as serde::Deserialize>::deserialize(raw_content).map_err(|err| {
         MessageError::ConversionError(format!(
             "Text `{ANTHROPIC_RAW_CONTENT_KEY}` metadata is not valid Anthropic content: {err}"
         ))
@@ -2981,7 +2980,7 @@ where
 
 impl<Ext, T> GenericCompletionModel<Ext, T>
 where
-    T: HttpClientExt + Clone + Default + WasmCompatSend + WasmCompatSync + 'static,
+    T: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
     Ext: AnthropicCompatibleProvider + Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     /// Execute a completion and return Anthropic's own wire response.
@@ -3034,7 +3033,7 @@ where
 
 impl<Ext, T> completion::CompletionModel for GenericCompletionModel<Ext, T>
 where
-    T: HttpClientExt + Clone + Default + WasmCompatSend + WasmCompatSync + 'static,
+    T: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
     Ext: AnthropicCompatibleProvider + Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     // Anthropic's native structured outputs (constrained decoding) are designed
@@ -5933,7 +5932,7 @@ mod tests {
         };
 
         let converted: Message = msg.try_into().expect("convert assistant message");
-        let converted_content = converted.content.clone();
+        let converted_content = converted.content;
 
         assert_eq!(converted_content.len(), 1);
         assert!(matches!(
@@ -6553,7 +6552,7 @@ mod tests {
                 "input_tokens": 10,
                 "output_tokens": 20
             },
-            "content": [raw_block.clone()]
+            "content": [raw_block]
         });
 
         let response: CompletionResponse = serde_json::from_value(value).unwrap();

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -424,10 +424,7 @@ impl WireAdapter for AnthropicAdapter {
                         .filter(|tokens| *tokens > 0)
                         .or_else(|| usize::try_from(self.input_tokens).ok()),
                     cache_creation_input_tokens: usage.cache_creation_input_tokens,
-                    cache_creation: usage
-                        .cache_creation
-                        .clone()
-                        .or_else(|| self.cache_creation.clone()),
+                    cache_creation: usage.cache_creation.or(self.cache_creation),
                     cache_read_input_tokens: usage.cache_read_input_tokens,
                     // Taken from this frame alone, with no `message_start`
                     // fallback: unlike `cache_creation`, Anthropic reports the
@@ -551,7 +548,7 @@ impl From<(&str, StreamingCompletionResponse)> for StreamFinal {
 
 impl<Ext, T> GenericCompletionModel<Ext, T>
 where
-    T: HttpClientExt + Clone + Default + 'static,
+    T: HttpClientExt + Clone + 'static,
     Ext: AnthropicCompatibleProvider + Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     /// Open a stream whose terminal record stays Anthropic-native.

--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -325,7 +325,7 @@ pub struct ResponsesCompletionModel<H = reqwest::Client> {
 impl<H> ResponsesCompletionModel<H>
 where
     Client<H>: HttpClientExt + Clone + Debug + 'static,
-    H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     pub fn new(client: Client<H>, model: impl Into<String>) -> Self {
         Self {
@@ -546,7 +546,7 @@ where
 
 impl<H> Client<H>
 where
-    H: HttpClientExt + Clone + Debug + Default + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     pub async fn authorize(&self) -> Result<(), auth::AuthError> {
         self.ext().auth.auth_context().await.map(|_| ())
@@ -556,7 +556,7 @@ where
 impl<H> crate::client::ConstructCompletionModel<Client<H>> for ResponsesCompletionModel<H>
 where
     Client<H>: HttpClientExt + Clone + Debug + 'static,
-    H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     fn construct(client: &Client<H>, model: String) -> Self {
         Self::new(client.clone(), model)
@@ -566,7 +566,7 @@ where
 impl<H> completion::CompletionModel for ResponsesCompletionModel<H>
 where
     Client<H>: HttpClientExt + Clone + Debug + 'static,
-    H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     async fn completion(
         &self,
@@ -599,7 +599,7 @@ where
 impl<H> ResponsesCompletionModel<H>
 where
     Client<H>: HttpClientExt + Clone + Debug + 'static,
-    H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     /// Open a stream normalized to rig's terminal record.
     ///

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -50,11 +50,11 @@ impl CompletionResponse {
 impl crate::telemetry::ProviderResponseExt for CompletionResponse {
     type Usage = Usage;
 
-    fn get_response_id(&self) -> Option<String> {
-        Some(self.id.clone())
+    fn get_response_id(&self) -> Option<&str> {
+        Some(self.id.as_str())
     }
 
-    fn get_response_model_name(&self) -> Option<String> {
+    fn get_response_model_name(&self) -> Option<&str> {
         None
     }
 
@@ -79,7 +79,7 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
     }
 
     fn get_usage(&self) -> Option<Self::Usage> {
-        self.usage.clone()
+        self.usage
     }
 }
 
@@ -112,7 +112,7 @@ pub(crate) fn map_finish_reason(reason: &FinishReason) -> completion::FinishReas
     }
 }
 
-#[derive(Debug, Deserialize, Clone, Serialize)]
+#[derive(Copy, Debug, Deserialize, Clone, Serialize)]
 pub struct Usage {
     #[serde(default)]
     pub billed_units: Option<BilledUnits>,
@@ -148,7 +148,7 @@ impl From<Usage> for crate::completion::Usage {
     }
 }
 
-#[derive(Debug, Deserialize, Clone, Serialize)]
+#[derive(Copy, Debug, Deserialize, Clone, Serialize)]
 pub struct BilledUnits {
     #[serde(default)]
     pub output_tokens: Option<f64>,
@@ -160,7 +160,7 @@ pub struct BilledUnits {
     pub input_tokens: Option<f64>,
 }
 
-#[derive(Debug, Deserialize, Clone, Serialize)]
+#[derive(Copy, Debug, Deserialize, Clone, Serialize)]
 pub struct Tokens {
     #[serde(default)]
     pub input_tokens: Option<f64>,
@@ -975,7 +975,7 @@ mod tests {
             )],
         };
 
-        let messages: Vec<Message> = completion_message.clone().try_into().unwrap();
+        let messages: Vec<Message> = completion_message.try_into().unwrap();
         let _converted_back: Vec<completion::Message> = messages
             .into_iter()
             .map(|msg| msg.try_into().unwrap())
@@ -990,7 +990,7 @@ mod tests {
             }],
         };
 
-        let completion_message: completion::Message = message.clone().try_into().unwrap();
+        let completion_message: completion::Message = message.try_into().unwrap();
         let _converted_back: Vec<Message> = completion_message.try_into().unwrap();
     }
 

--- a/crates/rig-core/src/providers/cohere/embeddings.rs
+++ b/crates/rig-core/src/providers/cohere/embeddings.rs
@@ -208,9 +208,18 @@ where
         documents: impl IntoIterator<Item = String>,
     ) -> Result<EmbeddingResponse, EmbeddingError> {
         let documents = documents.into_iter().collect::<Vec<_>>();
+        self.raw_embed_texts_slice(&documents).await
+    }
 
+    /// Borrow-shaped twin of [`Self::raw_embed_texts`]: the batch is only
+    /// serialized into the request body, so callers that keep their documents
+    /// (the normalize path) can lend them instead of cloning the batch.
+    async fn raw_embed_texts_slice(
+        &self,
+        documents: &[String],
+    ) -> Result<EmbeddingResponse, EmbeddingError> {
         let body = json!({
-            "model": self.model.clone(),
+            "model": self.model,
             "texts": documents,
             "input_type": self.input_type
         });
@@ -292,7 +301,7 @@ where
 
                 let documents = documents.into_iter().collect::<Vec<_>>();
                 // Cohere reports no transport request-id header on this endpoint.
-                let response = self.raw_embed_texts(documents.clone()).await?;
+                let response = self.raw_embed_texts_slice(&documents).await?;
                 let captured = serde_json::to_value(&response)?;
                 Ok(response
                     .normalize(super::completion::PROVIDER_NAME, documents)?

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -365,7 +365,7 @@ where
 
 impl<H> Client<H>
 where
-    H: HttpClientExt + Clone + Debug + Default + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     pub async fn authorize(&self) -> Result<(), auth::AuthError> {
         self.ext().auth.auth_context().await.map(|_| ())
@@ -677,7 +677,7 @@ pub struct CompletionModel<H = reqwest::Client> {
 impl<H> CompletionModel<H>
 where
     Client<H>: HttpClientExt + Clone + Debug + 'static,
-    H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     pub fn new(client: Client<H>, model: impl Into<String>) -> Self {
         Self {
@@ -1054,7 +1054,7 @@ where
 impl<H> crate::client::ConstructCompletionModel<Client<H>> for CompletionModel<H>
 where
     Client<H>: HttpClientExt + Clone + Debug + 'static,
-    H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     fn construct(client: &Client<H>, model: String) -> Self {
         Self::new(client.clone(), model)
@@ -1064,7 +1064,7 @@ where
 impl<H> completion::CompletionModel for CompletionModel<H>
 where
     Client<H>: HttpClientExt + Clone + Debug + 'static,
-    H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     async fn completion(
         &self,
@@ -1154,7 +1154,7 @@ impl embeddings::NormalizeEmbeddingResponse for CopilotEmbeddingResponse {
 impl<H> EmbeddingModel<H>
 where
     Client<H>: HttpClientExt + Clone + Debug + 'static,
-    H: Clone + Default + Debug + 'static,
+    H: Clone + 'static,
 {
     pub fn new(client: Client<H>, model: impl Into<String>, ndims: usize) -> Self {
         Self {
@@ -1170,7 +1170,7 @@ where
 impl<H> EmbeddingModel<H>
 where
     Client<H>: HttpClientExt + Clone + Debug + WasmCompatSend + WasmCompatSync + 'static,
-    H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     /// Perform the request and return Copilot's native response instead of
     /// the normalized [`embeddings::EmbeddingResponse`]. Same request,
@@ -1192,6 +1192,17 @@ where
         documents: impl IntoIterator<Item = String>,
     ) -> Result<(CopilotEmbeddingResponse, Option<String>), EmbeddingError> {
         let documents = documents.into_iter().collect::<Vec<_>>();
+        self.raw_embed_texts_slice(&documents).await
+    }
+
+    /// Borrow-shaped twin of [`Self::raw_embed_texts_with_request_id`]: the
+    /// batch is only serialized into the request body, so callers that keep
+    /// their documents (the normalize path) can lend them instead of cloning
+    /// the batch.
+    async fn raw_embed_texts_slice(
+        &self,
+        documents: &[String],
+    ) -> Result<(CopilotEmbeddingResponse, Option<String>), EmbeddingError> {
         let auth = self
             .client
             .ext()
@@ -1284,7 +1295,7 @@ where
 impl<H> embeddings::EmbeddingModel for EmbeddingModel<H>
 where
     Client<H>: HttpClientExt + Clone + Debug + WasmCompatSend + WasmCompatSync + 'static,
-    H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     fn max_documents(&self) -> usize {
         1024
@@ -1306,9 +1317,8 @@ where
                 use embeddings::NormalizeEmbeddingResponse as _;
 
                 let documents = documents.into_iter().collect::<Vec<_>>();
-                let (response, provider_request_id) = self
-                    .raw_embed_texts_with_request_id(documents.clone())
-                    .await?;
+                let (response, provider_request_id) =
+                    self.raw_embed_texts_slice(&documents).await?;
                 let captured = serde_json::to_value(&response)?;
                 Ok(response
                     .normalize(PROVIDER_NAME, documents)?
@@ -1323,7 +1333,7 @@ where
 impl<H> crate::client::ConstructEmbeddingModel<Client<H>> for EmbeddingModel<H>
 where
     Client<H>: HttpClientExt + Clone + Debug + WasmCompatSend + WasmCompatSync + 'static,
-    H: Clone + Default + Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     fn construct(client: &Client<H>, model: String, ndims: Option<usize>) -> Self {
         let dims = ndims.unwrap_or(match model.as_str() {
@@ -1380,7 +1390,7 @@ pub struct CopilotModelLister<H = reqwest::Client> {
 
 impl<H> ModelLister<H> for CopilotModelLister<H>
 where
-    H: HttpClientExt + Clone + Debug + Default + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     async fn list_all(&self) -> Result<ModelList, ModelListingError> {
         let auth = self.client.ext().auth.auth_context().await.map_err(|err| {
@@ -1419,7 +1429,7 @@ where
 
 impl<H> crate::client::ConstructModelLister<Client<H>> for CopilotModelLister<H>
 where
-    H: HttpClientExt + Clone + Debug + Default + WasmCompatSend + WasmCompatSync + 'static,
+    H: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     fn construct(client: &Client<H>) -> Self {
         let client = client.clone();

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -186,12 +186,12 @@ pub struct CompletionResponse {
 impl ProviderResponseExt for CompletionResponse {
     type Usage = Usage;
 
-    fn get_response_id(&self) -> Option<String> {
-        self.id.clone()
+    fn get_response_id(&self) -> Option<&str> {
+        self.id.as_deref()
     }
 
-    fn get_response_model_name(&self) -> Option<String> {
-        self.model.clone()
+    fn get_response_model_name(&self) -> Option<&str> {
+        self.model.as_deref()
     }
 
     fn get_text_response(&self) -> Option<String> {
@@ -204,11 +204,11 @@ impl ProviderResponseExt for CompletionResponse {
     }
 
     fn get_usage(&self) -> Option<Self::Usage> {
-        Some(self.usage.clone())
+        Some(self.usage)
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct Usage {
     pub completion_tokens: u32,
@@ -253,13 +253,13 @@ impl From<Usage> for crate::completion::Usage {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Default)]
 pub struct CompletionTokensDetails {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_tokens: Option<u32>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Default)]
 pub struct PromptTokensDetails {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cached_tokens: Option<u32>,

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -888,12 +888,12 @@ pub mod gemini_api_types {
     impl ProviderResponseExt for GenerateContentResponse {
         type Usage = UsageMetadata;
 
-        fn get_response_id(&self) -> Option<String> {
-            Some(self.response_id.clone())
+        fn get_response_id(&self) -> Option<&str> {
+            Some(self.response_id.as_str())
         }
 
-        fn get_response_model_name(&self) -> Option<String> {
-            self.model_version.clone()
+        fn get_response_model_name(&self) -> Option<&str> {
+            self.model_version.as_deref()
         }
 
         fn get_text_response(&self) -> Option<String> {

--- a/crates/rig-core/src/providers/gemini/embedding.rs
+++ b/crates/rig-core/src/providers/gemini/embedding.rs
@@ -68,7 +68,16 @@ where
         documents: impl IntoIterator<Item = String> + WasmCompatSend,
     ) -> Result<gemini_api_types::EmbeddingResponse, EmbeddingError> {
         let documents: Vec<String> = documents.into_iter().collect();
+        self.raw_embed_texts_slice(&documents).await
+    }
 
+    /// Borrow-shaped twin of [`Self::raw_embed_texts`]: the batch is only
+    /// serialized into the request body, so callers that keep their documents
+    /// (the normalize path) can lend them instead of cloning the batch.
+    async fn raw_embed_texts_slice(
+        &self,
+        documents: &[String],
+    ) -> Result<gemini_api_types::EmbeddingResponse, EmbeddingError> {
         // Google batch embed requests. See docstrings for API ref link.
         let requests: Vec<_> = documents
             .iter()
@@ -77,7 +86,7 @@ where
                     "model": format!("models/{}", self.model),
                     "content": json!({
                         "parts": [json!({
-                            "text": doc.clone()
+                            "text": doc
                         })]
                     }),
                     "output_dimensionality": self.ndims,
@@ -153,7 +162,7 @@ where
 
                 let documents: Vec<String> = documents.into_iter().collect();
                 // Gemini sends no transport request-id header.
-                let response = self.raw_embed_texts(documents.clone()).await?;
+                let response = self.raw_embed_texts_slice(&documents).await?;
                 let captured = serde_json::to_value(&response)?;
                 Ok(response
                     .normalize(super::completion::PROVIDER_NAME, documents)?
@@ -166,7 +175,7 @@ where
 
 impl<T> crate::client::ConstructEmbeddingModel<Client<T>> for EmbeddingModel<T>
 where
-    T: Clone + HttpClientExt + 'static,
+    T: Clone + HttpClientExt,
 {
     fn construct(client: &Client<T>, model: String, dims: Option<usize>) -> Self {
         let ndims = dims.or_else(|| model_default_ndims(&model)).unwrap_or(768);

--- a/crates/rig-core/src/providers/gemini/image_generation.rs
+++ b/crates/rig-core/src/providers/gemini/image_generation.rs
@@ -58,7 +58,7 @@ impl NormalizeImageGenerationResponse for GenerateContentResponse {
 
 impl<T> ImageGenerationModel<T>
 where
-    T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+    T: HttpClientExt + Clone + Send + 'static,
 {
     /// Perform the generation and return Gemini's native
     /// [`GenerateContentResponse`] instead of the normalized
@@ -98,7 +98,7 @@ where
 
 impl<T> image_generation::ImageGenerationModel for ImageGenerationModel<T>
 where
-    T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+    T: HttpClientExt + Clone + Send + 'static,
 {
     async fn image_generation(
         &self,
@@ -122,7 +122,7 @@ where
 
 impl<T> crate::client::ConstructImageGenerationModel<Client<T>> for ImageGenerationModel<T>
 where
-    T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+    T: HttpClientExt + Clone + Send + 'static,
 {
     fn construct(client: &Client<T>, model: String) -> Self {
         Self::new(client.clone(), model)

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -72,7 +72,7 @@ impl<T> InteractionsCompletionModel<T> {
 
 impl<T> InteractionsCompletionModel<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
+    T: HttpClientExt + Clone + 'static,
 {
     /// Create an interaction and return the raw response payload.
     pub async fn create_interaction(
@@ -114,7 +114,7 @@ where
 
 impl<T> InteractionsCompletionModel<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
+    T: HttpClientExt + Clone + 'static,
 {
     /// Execute a completion and return the Interactions API's own payload.
     ///
@@ -176,7 +176,7 @@ where
 
 impl<T> completion::CompletionModel for InteractionsCompletionModel<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
+    T: HttpClientExt + Clone + 'static,
 {
     async fn completion(
         &self,
@@ -209,7 +209,7 @@ where
 
 impl<T> InteractionsClient<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
+    T: HttpClientExt + Clone + 'static,
 {
     /// Create a new interaction and return the raw response payload.
     pub async fn create_interaction(
@@ -396,7 +396,7 @@ async fn send_interaction_request<T>(
     request: crate::http_client::Request<Vec<u8>>,
 ) -> Result<Interaction, CompletionError>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
+    T: HttpClientExt + Clone + 'static,
 {
     let response = client.send::<_, Vec<u8>>(request).await?;
 
@@ -755,16 +755,16 @@ pub mod interactions_api_types {
     impl ProviderResponseExt for Interaction {
         type Usage = InteractionUsage;
 
-        fn get_response_id(&self) -> Option<String> {
+        fn get_response_id(&self) -> Option<&str> {
             if self.id.is_empty() {
                 None
             } else {
-                Some(self.id.clone())
+                Some(self.id.as_str())
             }
         }
 
-        fn get_response_model_name(&self) -> Option<String> {
-            self.model.clone()
+        fn get_response_model_name(&self) -> Option<&str> {
+            self.model.as_deref()
         }
 
         fn get_text_response(&self) -> Option<String> {
@@ -782,7 +782,7 @@ pub mod interactions_api_types {
         }
 
         fn get_usage(&self) -> Option<Self::Usage> {
-            self.usage.clone()
+            self.usage
         }
     }
 
@@ -1186,7 +1186,7 @@ pub mod interactions_api_types {
     }
 
     /// Token usage metadata for an interaction.
-    #[derive(Clone, Debug, Deserialize, Serialize, Default)]
+    #[derive(Clone, Copy, Debug, Deserialize, Serialize, Default)]
     #[serde(rename_all = "snake_case")]
     pub struct InteractionUsage {
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
@@ -114,7 +114,7 @@ fn map_stream_final(
 
 impl<T> InteractionsCompletionModel<T>
 where
-    T: HttpClientExt + Clone + Default + std::fmt::Debug + 'static,
+    T: HttpClientExt + Clone + 'static,
 {
     /// Open an Interactions stream whose terminal record stays provider-native.
     ///
@@ -412,7 +412,7 @@ impl WireAdapter for InteractionsAdapter {
                 let model_version = interaction.model.clone();
                 out.push(Ok(streaming::RawStreamingChoice::FinalResponse(
                     StreamingCompletionResponse {
-                        usage: interaction.usage.clone(),
+                        usage: interaction.usage,
                         interaction: Some(interaction),
                         model_version,
                     },
@@ -456,7 +456,7 @@ pub(crate) fn stream_interaction_events<T>(
     request: Request<Vec<u8>>,
 ) -> InteractionEventStream
 where
-    T: HttpClientExt + Clone + Default + std::fmt::Debug + 'static,
+    T: HttpClientExt + Clone + 'static,
 {
     let mut event_source = GenericEventSource::new(client, request);
 

--- a/crates/rig-core/src/providers/hyperbolic.rs
+++ b/crates/rig-core/src/providers/hyperbolic.rs
@@ -271,7 +271,7 @@ mod audio_generation {
 
     impl<T> AudioGenerationModel<T>
     where
-        T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+        T: HttpClientExt + Clone + Send + 'static,
     {
         /// Perform the generation and return Hyperbolic's native response
         /// (base64 audio) instead of the normalized
@@ -323,7 +323,7 @@ mod audio_generation {
 
     impl<T> audio_generation::AudioGenerationModel for AudioGenerationModel<T>
     where
-        T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+        T: HttpClientExt + Clone + Send + 'static,
     {
         async fn audio_generation(
             &self,
@@ -345,7 +345,7 @@ mod audio_generation {
 
     impl<T> crate::client::ConstructAudioGenerationModel<Client<T>> for AudioGenerationModel<T>
     where
-        T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+        T: HttpClientExt + Clone + Send + 'static,
     {
         fn construct(client: &Client<T>, language: String) -> Self {
             Self {

--- a/crates/rig-core/src/providers/llamacpp/completion.rs
+++ b/crates/rig-core/src/providers/llamacpp/completion.rs
@@ -125,11 +125,11 @@ impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
 impl crate::telemetry::ProviderResponseExt for CompletionResponse {
     type Usage = openai::Usage;
 
-    fn get_response_id(&self) -> Option<String> {
+    fn get_response_id(&self) -> Option<&str> {
         self.openai.get_response_id()
     }
 
-    fn get_response_model_name(&self) -> Option<String> {
+    fn get_response_model_name(&self) -> Option<&str> {
         self.openai.get_response_model_name()
     }
 
@@ -181,7 +181,7 @@ mod tests {
         assert_eq!(response.predicted_tokens_per_second(), Some(118.3));
 
         // The OpenAI half is intact and normalizes exactly as before.
-        assert_eq!(response.get_response_id().as_deref(), Some("chatcmpl-abc"));
+        assert_eq!(response.get_response_id(), Some("chatcmpl-abc"));
         assert_eq!(
             response.openai.system_fingerprint.as_deref(),
             Some("b10499-6d05498")

--- a/crates/rig-core/src/providers/mira.rs
+++ b/crates/rig-core/src/providers/mira.rs
@@ -152,16 +152,16 @@ pub type CompletionModel<H = reqwest::Client> =
 impl crate::telemetry::ProviderResponseExt for CompletionResponse {
     type Usage = Usage;
 
-    fn get_response_id(&self) -> Option<String> {
+    fn get_response_id(&self) -> Option<&str> {
         match self {
-            Self::Structured { id, .. } => Some(id.clone()),
+            Self::Structured { id, .. } => Some(id.as_str()),
             Self::Simple(_) => None,
         }
     }
 
-    fn get_response_model_name(&self) -> Option<String> {
+    fn get_response_model_name(&self) -> Option<&str> {
         match self {
-            Self::Structured { model, .. } => Some(model.clone()),
+            Self::Structured { model, .. } => Some(model.as_str()),
             Self::Simple(_) => None,
         }
     }

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -395,12 +395,12 @@ pub struct CompletionResponse {
 impl crate::telemetry::ProviderResponseExt for CompletionResponse {
     type Usage = Usage;
 
-    fn get_response_id(&self) -> Option<String> {
-        Some(self.id.clone())
+    fn get_response_id(&self) -> Option<&str> {
+        Some(self.id.as_str())
     }
 
-    fn get_response_model_name(&self) -> Option<String> {
-        Some(self.model.clone())
+    fn get_response_model_name(&self) -> Option<&str> {
+        Some(self.model.as_str())
     }
 
     fn get_text_response(&self) -> Option<String> {

--- a/crates/rig-core/src/providers/mistral/transcription.rs
+++ b/crates/rig-core/src/providers/mistral/transcription.rs
@@ -106,7 +106,7 @@ pub type TranscriptionModel<T = reqwest::Client> =
 
 impl<T> TranscriptionModel<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + WasmCompatSend + 'static,
+    T: HttpClientExt + Clone + WasmCompatSend + 'static,
 {
     /// Perform the transcription and return Mistral's native response instead
     /// of the normalized [`transcription::TranscriptionResponse`]. Same
@@ -177,7 +177,7 @@ where
 
 impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + WasmCompatSend + 'static,
+    T: HttpClientExt + Clone + WasmCompatSend + 'static,
 {
     async fn transcription(
         &self,
@@ -203,7 +203,7 @@ where
 
 impl<T> crate::client::ConstructTranscriptionModel<Client<T>> for TranscriptionModel<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + WasmCompatSend + 'static,
+    T: HttpClientExt + Clone + WasmCompatSend + 'static,
 {
     fn construct(client: &Client<T>, model: String) -> Self {
         Self::new(client.clone(), model)

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -254,7 +254,16 @@ where
         documents: impl IntoIterator<Item = String>,
     ) -> Result<EmbeddingResponse, EmbeddingError> {
         let docs: Vec<String> = documents.into_iter().collect();
+        self.raw_embed_texts_slice(&docs).await
+    }
 
+    /// Borrow-shaped twin of [`Self::raw_embed_texts`]: the batch is only
+    /// serialized into the request body, so callers that keep their documents
+    /// (the normalize path) can lend them instead of cloning the batch.
+    async fn raw_embed_texts_slice(
+        &self,
+        docs: &[String],
+    ) -> Result<EmbeddingResponse, EmbeddingError> {
         let body = serde_json::to_vec(&json!({
             "model": self.model,
             "input": docs
@@ -304,7 +313,7 @@ where
 
                 let docs: Vec<String> = documents.into_iter().collect();
                 // Ollama reports no transport request-id header.
-                let response = self.raw_embed_texts(docs.clone()).await?;
+                let response = self.raw_embed_texts_slice(&docs).await?;
                 let captured = serde_json::to_value(&response)?;
                 Ok(response.normalize(PROVIDER_NAME, docs)?.with_raw(captured))
             },
@@ -382,12 +391,12 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
     type Usage = Usage;
 
     /// Ollama's chat API carries no response ID.
-    fn get_response_id(&self) -> Option<String> {
+    fn get_response_id(&self) -> Option<&str> {
         None
     }
 
-    fn get_response_model_name(&self) -> Option<String> {
-        Some(self.model.clone())
+    fn get_response_model_name(&self) -> Option<&str> {
+        Some(self.model.as_str())
     }
 
     fn get_text_response(&self) -> Option<String> {
@@ -739,7 +748,7 @@ impl NdjsonBuffer {
 
 impl<T> CompletionModel<T>
 where
-    T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+    T: HttpClientExt + Clone + Send + 'static,
 {
     /// Execute a completion and return Ollama's own wire response.
     ///
@@ -1018,7 +1027,7 @@ impl internal::adapter::WireAdapter for OllamaAdapter {
 
 impl<T> completion::CompletionModel for CompletionModel<T>
 where
-    T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+    T: HttpClientExt + Clone + Send + 'static,
 {
     async fn completion(
         &self,

--- a/crates/rig-core/src/providers/openai/client.rs
+++ b/crates/rig-core/src/providers/openai/client.rs
@@ -109,13 +109,7 @@ client::impl_default_provider_builder!(
 
 impl<H> Client<H>
 where
-    H: HttpClientExt
-        + Clone
-        + std::fmt::Debug
-        + Default
-        + WasmCompatSend
-        + WasmCompatSync
-        + 'static,
+    H: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     /// Sets where Rig system instructions are placed in Responses requests for
     /// every completion model created from this client. Models capture the
@@ -179,13 +173,7 @@ impl Client<reqwest::Client> {
 
 impl<H> CompletionsClient<H>
 where
-    H: HttpClientExt
-        + Clone
-        + std::fmt::Debug
-        + Default
-        + WasmCompatSend
-        + WasmCompatSync
-        + 'static,
+    H: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     /// Create a Responses API client from this Completions API client.
     /// Useful for switching to the newer Responses API. A system-instructions

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -1393,12 +1393,12 @@ impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
 impl ProviderResponseExt for CompletionResponse {
     type Usage = Usage;
 
-    fn get_response_id(&self) -> Option<String> {
-        Some(self.id.clone())
+    fn get_response_id(&self) -> Option<&str> {
+        Some(self.id.as_str())
     }
 
-    fn get_response_model_name(&self) -> Option<String> {
-        Some(self.model.clone())
+    fn get_response_model_name(&self) -> Option<&str> {
+        Some(self.model.as_str())
     }
 
     fn get_text_response(&self) -> Option<String> {
@@ -1417,7 +1417,7 @@ impl ProviderResponseExt for CompletionResponse {
     }
 
     fn get_usage(&self) -> Option<Self::Usage> {
-        self.usage.clone()
+        self.usage
     }
 }
 
@@ -1504,21 +1504,21 @@ pub struct Choice {
     pub finish_reason: String,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Default)]
 pub struct PromptTokensDetails {
     /// Cached tokens from prompt caching
     #[serde(default)]
     pub cached_tokens: usize,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Default)]
 pub struct CompletionTokensDetails {
     /// Reasoning tokens reported by reasoning-capable providers.
     #[serde(default)]
     pub reasoning_tokens: usize,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct Usage {
     pub prompt_tokens: usize,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1960,11 +1960,7 @@ pub struct GenericCompletionModel<Ext = super::OpenAICompletionsExt, H = reqwest
 pub type CompletionModel<H = reqwest::Client> =
     GenericCompletionModel<super::OpenAICompletionsExt, H>;
 
-impl<Ext, H> GenericCompletionModel<Ext, H>
-where
-    crate::client::Client<Ext, H>: std::fmt::Debug + Clone + 'static,
-    Ext: crate::client::Provider + Clone + 'static,
-{
+impl<Ext, H> GenericCompletionModel<Ext, H> {
     pub fn new(client: crate::client::Client<Ext, H>, model: impl Into<String>) -> Self {
         Self {
             client,
@@ -2410,7 +2406,7 @@ where
         + WasmCompatSend
         + WasmCompatSync
         + 'static,
-    H: Clone + Default + std::fmt::Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     /// Execute a chat completion and return the provider's own wire response.
     ///
@@ -2521,7 +2517,7 @@ where
         + WasmCompatSend
         + WasmCompatSync
         + 'static,
-    H: Clone + Default + std::fmt::Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     // OpenAI Chat Completions *defers* `response_format` while tools are present
     // and no tool result exists yet (see `should_apply_response_format`), then

--- a/crates/rig-core/src/providers/openai/embedding.rs
+++ b/crates/rig-core/src/providers/openai/embedding.rs
@@ -257,7 +257,17 @@ where
         documents: impl IntoIterator<Item = String>,
     ) -> Result<(CompatibleEmbeddingResponse, Option<String>), EmbeddingError> {
         let documents: Vec<String> = documents.into_iter().collect();
+        self.raw_embed_texts_slice(&documents).await
+    }
 
+    /// Borrow-shaped twin of [`Self::raw_embed_texts_with_request_id`]: the
+    /// batch is only serialized into the request body, so callers that keep
+    /// their documents (the normalize path) can lend them instead of cloning
+    /// the batch.
+    async fn raw_embed_texts_slice(
+        &self,
+        documents: &[String],
+    ) -> Result<(CompatibleEmbeddingResponse, Option<String>), EmbeddingError> {
         if self.encoding_format == Some(EncodingFormat::Base64) {
             return Err(EmbeddingError::UnsupportedResponseEncoding {
                 provider: Ext::PROVIDER_NAME,
@@ -293,7 +303,7 @@ where
 
         let body = serde_json::to_vec(&CompatibleEmbeddingRequest {
             model: Ext::SENDS_MODEL_FIELD.then_some(self.model.as_str()),
-            input: &documents,
+            input: documents,
             dimensions,
             output_dimension,
             encoding_format: self.encoding_format,
@@ -371,9 +381,8 @@ where
                 use embeddings::NormalizeEmbeddingResponse as _;
 
                 let documents: Vec<String> = documents.into_iter().collect();
-                let (response, provider_request_id) = self
-                    .raw_embed_texts_with_request_id(documents.clone())
-                    .await?;
+                let (response, provider_request_id) =
+                    self.raw_embed_texts_slice(&documents).await?;
 
                 if response.usage.is_none() && Ext::REQUIRES_USAGE {
                     return Err(EmbeddingError::MissingUsage {

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -237,9 +237,9 @@ impl ReasoningSummary {
         }
     }
 
-    pub fn text(&self) -> String {
+    pub fn text(&self) -> &str {
         let ReasoningSummary::SummaryText { text } = self;
-        text.clone()
+        text
     }
 }
 
@@ -953,7 +953,7 @@ impl TryFrom<message::ToolChoice> for ToolChoice {
 
 /// Token usage.
 /// Token usage from the OpenAI Responses API generally shows the input tokens and output tokens (both with more in-depth details) as well as a total tokens field.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct ResponsesUsage {
     /// Input tokens
     pub input_tokens: u64,
@@ -1041,7 +1041,7 @@ impl Add for ResponsesUsage {
 }
 
 /// In-depth details on input tokens.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct InputTokensDetails {
     /// Cached tokens from OpenAI
     pub cached_tokens: u64,
@@ -1063,7 +1063,7 @@ impl Add for InputTokensDetails {
 }
 
 /// In-depth details on output tokens.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct OutputTokensDetails {
     /// Reasoning tokens
     pub reasoning_tokens: u64,
@@ -1307,7 +1307,8 @@ pub trait ResponsesProviderExt {
         if stream {
             request.stream = Some(true);
         }
-        Ok((request.model.clone(), serde_json::to_value(request)?))
+        let body = serde_json::to_value(&request)?;
+        Ok((request.model, body))
     }
 }
 
@@ -1642,7 +1643,7 @@ where
 
 impl<T> GenericResponsesCompletionModel<super::OpenAIResponsesExt, T>
 where
-    T: HttpClientExt + Clone + Default + std::fmt::Debug + 'static,
+    T: HttpClientExt + Clone + 'static,
 {
     /// Use the Completions API instead of Responses.
     pub fn completions_api(self) -> crate::providers::openai::completion::CompletionModel<T> {
@@ -2468,12 +2469,12 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
 
     /// The response ID (`resp_...`), which is deliberately *not* the assistant
     /// message ID (`msg_...`) that the normalized response carries.
-    fn get_response_id(&self) -> Option<String> {
-        Some(self.id.clone())
+    fn get_response_id(&self) -> Option<&str> {
+        Some(self.id.as_str())
     }
 
-    fn get_response_model_name(&self) -> Option<String> {
-        Some(self.model.clone())
+    fn get_response_model_name(&self) -> Option<&str> {
+        Some(self.model.as_str())
     }
 
     fn get_text_response(&self) -> Option<String> {
@@ -2481,7 +2482,7 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
     }
 
     fn get_usage(&self) -> Option<Self::Usage> {
-        self.usage.clone()
+        self.usage
     }
 }
 
@@ -2521,7 +2522,7 @@ where
         + WasmCompatSend
         + WasmCompatSync
         + 'static,
-    H: Clone + Default + std::fmt::Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     /// Execute a completion and return the provider's own wire response.
     ///
@@ -2615,7 +2616,7 @@ where
         + WasmCompatSend
         + WasmCompatSync
         + 'static,
-    H: Clone + Default + std::fmt::Debug + WasmCompatSend + WasmCompatSync + 'static,
+    H: Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     fn capabilities(&self) -> completion::ProviderCapabilities {
         // The OpenAI Responses API constrains only the final assistant message via
@@ -3081,7 +3082,7 @@ mod tests {
             }
         }))
         .expect("object params");
-        let replayed = OutputText::from_message_text("real", hostile.clone());
+        let replayed = OutputText::from_message_text("real", hostile);
         assert_eq!(replayed.text, "real");
         assert!(replayed.extras.get("text").is_none());
         assert!(replayed.extras.get("type").is_none());
@@ -3352,7 +3353,7 @@ mod tests {
 
         let items = Vec::<InputItem>::try_from(crate::completion::Message::Assistant {
             id: None,
-            content: drained.choice.clone(),
+            content: drained.choice,
         })
         .expect("history should convert");
         assert!(
@@ -4729,7 +4730,7 @@ mod tests {
             "created_at": 0,
             "status": "completed",
             "model": "gpt-future",
-            "reasoning": metadata.clone(),
+            "reasoning": metadata,
             "output": [],
             "tools": []
         }))

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -918,13 +918,8 @@ pub(crate) async fn completion_response_from_sse_body(
     body: &str,
     raw_response: CompletionResponse,
 ) -> Result<completion::CompletionResponse, CompletionError> {
-    let raw_choices = raw_choices_from_sse_body(
-        body,
-        raw_response
-            .usage
-            .clone()
-            .unwrap_or_else(ResponsesUsage::new),
-    )?;
+    let raw_choices =
+        raw_choices_from_sse_body(body, raw_response.usage.unwrap_or_else(ResponsesUsage::new))?;
     completion_response_from_raw_choices(provider, raw_choices, &raw_response)
         .await?
         .ok_or_else(|| CompletionError::ResponseError("Response contained no parts".to_owned()))
@@ -1221,7 +1216,7 @@ impl WireAdapter for ResponsesAdapter {
             &mut self.accumulator,
             RawChoiceAccumulator::new(ResponsesUsage::new()),
         );
-        let final_usage = accumulator.final_usage.clone();
+        let final_usage = accumulator.final_usage;
 
         // Flush buffered tool calls, then the terminal record when a genuine
         // terminal event arrived; EOF without one is truncation and the
@@ -2080,7 +2075,7 @@ mod tests {
         });
         assert_eq!(
             unknown,
-            Some(&item.clone().into()),
+            Some(&item.into()),
             "the raw web_search_call item should reach the consumer verbatim",
         );
     }

--- a/crates/rig-core/src/providers/openai/responses_api/websocket.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/websocket.rs
@@ -251,13 +251,7 @@ impl<H> ResponsesWebSocketSessionBuilder<H> {
 
 impl<H> ResponsesWebSocketSessionBuilder<H>
 where
-    H: HttpClientExt
-        + Clone
-        + std::fmt::Debug
-        + Default
-        + WasmCompatSend
-        + WasmCompatSync
-        + 'static,
+    H: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     /// Opens the websocket session using the configured builder options.
     pub async fn connect(self) -> Result<ResponsesWebSocketSession<H>, CompletionError> {
@@ -291,13 +285,7 @@ pub struct ResponsesWebSocketSession<H = reqwest::Client> {
 
 impl<H> ResponsesWebSocketSession<H>
 where
-    H: HttpClientExt
-        + Clone
-        + std::fmt::Debug
-        + Default
-        + WasmCompatSend
-        + WasmCompatSync
-        + 'static,
+    H: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
     async fn connect_with_timeouts(
         model: ResponsesCompletionModel<H>,

--- a/crates/rig-core/src/providers/openrouter/client.rs
+++ b/crates/rig-core/src/providers/openrouter/client.rs
@@ -48,7 +48,7 @@ client::impl_provider_client!(
     api_key_env = "OPENROUTER_API_KEY",
 );
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
 pub struct Usage {
     pub prompt_tokens: usize,
     #[serde(default)]
@@ -71,7 +71,7 @@ pub struct Usage {
 /// Prompt-token breakdown reported by OpenRouter for cached requests.
 // `usize` matches the parent `Usage` struct in this module; the streaming counterpart
 // in `streaming.rs` uses `u32` to match its own parent.
-#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Default)]
 pub struct PromptTokensDetails {
     /// Tokens served from cache (cache hit).
     #[serde(default)]
@@ -86,7 +86,7 @@ pub struct PromptTokensDetails {
 /// Only the reasoning share is modeled: it is the one entry rig's normalized
 /// [`crate::completion::Usage`] has a slot for, and OpenRouter documents usage
 /// accounting as always present (on the final SSE message when streaming).
-#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Default)]
 pub struct CompletionTokensDetails {
     /// Tokens the upstream spent on hidden reasoning, counted inside
     /// `completion_tokens`.

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -845,12 +845,12 @@ impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
 impl ProviderResponseExt for CompletionResponse {
     type Usage = Usage;
 
-    fn get_response_id(&self) -> Option<String> {
-        Some(self.id.clone())
+    fn get_response_id(&self) -> Option<&str> {
+        Some(self.id.as_str())
     }
 
-    fn get_response_model_name(&self) -> Option<String> {
-        Some(self.model.clone())
+    fn get_response_model_name(&self) -> Option<&str> {
+        Some(self.model.as_str())
     }
 
     fn get_text_response(&self) -> Option<String> {
@@ -867,7 +867,7 @@ impl ProviderResponseExt for CompletionResponse {
     }
 
     fn get_usage(&self) -> Option<Self::Usage> {
-        self.usage.clone()
+        self.usage
     }
 }
 

--- a/crates/rig-core/src/providers/openrouter/transcription.rs
+++ b/crates/rig-core/src/providers/openrouter/transcription.rs
@@ -96,7 +96,7 @@ fn infer_format_from_filename(filename: &str) -> String {
 
 impl<T> TranscriptionModel<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + WasmCompatSend + 'static,
+    T: HttpClientExt + Clone + WasmCompatSend + 'static,
 {
     /// Perform the transcription and return OpenRouter's native response
     /// instead of the normalized [`transcription::TranscriptionResponse`].
@@ -180,7 +180,7 @@ where
 
 impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + WasmCompatSend + 'static,
+    T: HttpClientExt + Clone + WasmCompatSend + 'static,
 {
     async fn transcription(
         &self,
@@ -206,7 +206,7 @@ where
 
 impl<T> crate::client::ConstructTranscriptionModel<Client<T>> for TranscriptionModel<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + WasmCompatSend + 'static,
+    T: HttpClientExt + Clone + WasmCompatSend + 'static,
 {
     fn construct(client: &Client<T>, model: String) -> Self {
         Self::new(client.clone(), model)

--- a/crates/rig-core/src/providers/venice/completion.rs
+++ b/crates/rig-core/src/providers/venice/completion.rs
@@ -305,11 +305,11 @@ impl NormalizeCompletionResponse for CompletionResponse {
 impl ProviderResponseExt for CompletionResponse {
     type Usage = <openai::CompletionResponse as ProviderResponseExt>::Usage;
 
-    fn get_response_id(&self) -> Option<String> {
+    fn get_response_id(&self) -> Option<&str> {
         self.openai.get_response_id()
     }
 
-    fn get_response_model_name(&self) -> Option<String> {
+    fn get_response_model_name(&self) -> Option<&str> {
         self.openai.get_response_model_name()
     }
 

--- a/crates/rig-core/src/providers/voyageai.rs
+++ b/crates/rig-core/src/providers/voyageai.rs
@@ -220,7 +220,7 @@ pub struct EmbeddingModel<T> {
 
 impl<T> EmbeddingModel<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
+    T: HttpClientExt + Clone + 'static,
 {
     /// Perform the request and return Voyage AI's native response instead of
     /// the normalized [`embeddings::EmbeddingResponse`]. Same request,
@@ -231,6 +231,16 @@ where
         documents: impl IntoIterator<Item = String>,
     ) -> Result<EmbeddingResponse, EmbeddingError> {
         let documents: Vec<String> = documents.into_iter().collect();
+        self.raw_embed_texts_slice(&documents).await
+    }
+
+    /// Borrow-shaped twin of [`Self::raw_embed_texts`]: the batch is only
+    /// serialized into the request body, so callers that keep their documents
+    /// (the normalize path) can lend them instead of cloning the batch.
+    async fn raw_embed_texts_slice(
+        &self,
+        documents: &[String],
+    ) -> Result<EmbeddingResponse, EmbeddingError> {
         let mut request = json!({
             "model": self.model,
             "input": documents,
@@ -290,7 +300,7 @@ where
 
 impl<T> embeddings::EmbeddingModel for EmbeddingModel<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
+    T: HttpClientExt + Clone + 'static,
 {
     fn max_documents(&self) -> usize {
         1024
@@ -313,7 +323,7 @@ where
 
                 let documents: Vec<String> = documents.into_iter().collect();
                 // Voyage AI reports no transport request-id header.
-                let response = self.raw_embed_texts(documents.clone()).await?;
+                let response = self.raw_embed_texts_slice(&documents).await?;
                 let captured = serde_json::to_value(&response)?;
                 Ok(response
                     .normalize("voyageai", documents)?
@@ -326,7 +336,7 @@ where
 
 impl<T> crate::client::ConstructEmbeddingModel<Client<T>> for EmbeddingModel<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
+    T: HttpClientExt + Clone + 'static,
 {
     fn construct(client: &Client<T>, model: String, dims: Option<usize>) -> Self {
         let dims = dims
@@ -434,7 +444,7 @@ impl<T> RerankModel<T> {
 
 impl<T> RerankModel<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
+    T: HttpClientExt + Clone + 'static,
 {
     /// Perform the request and return Voyage AI's native response instead of
     /// the normalized [`rerank::RerankResponse`]. Same request, transport,
@@ -504,7 +514,7 @@ where
 
 impl<T> rerank::RerankModel for RerankModel<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
+    T: HttpClientExt + Clone + 'static,
 {
     fn max_documents(&self) -> usize {
         1000
@@ -534,7 +544,7 @@ where
 
 impl<T> crate::client::ConstructRerankModel<Client<T>> for RerankModel<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
+    T: HttpClientExt + Clone + 'static,
 {
     fn construct(client: &Client<T>, model: String) -> Self {
         Self::new(client.clone(), model)

--- a/crates/rig-core/src/streaming/mod.rs
+++ b/crates/rig-core/src/streaming/mod.rs
@@ -1952,7 +1952,7 @@ mod tests {
             encoded
         );
 
-        let wrapped = StreamedAssistantContent::Final(final_record.clone());
+        let wrapped = StreamedAssistantContent::Final(final_record);
         let encoded = serde_json::to_value(&wrapped).expect("serialize wrapped");
         let decoded = serde_json::from_value::<StreamedAssistantContent>(encoded)
             .expect("deserialize wrapped");

--- a/crates/rig-core/src/telemetry/mod.rs
+++ b/crates/rig-core/src/telemetry/mod.rs
@@ -925,10 +925,10 @@ pub trait ProviderResponseExt {
     type Usage: Serialize;
 
     /// Returns the provider response ID, if supplied.
-    fn get_response_id(&self) -> Option<String>;
+    fn get_response_id(&self) -> Option<&str>;
 
     /// Returns the provider response model name, if supplied.
-    fn get_response_model_name(&self) -> Option<String>;
+    fn get_response_model_name(&self) -> Option<&str>;
 
     /// Returns the primary text response, when available.
     fn get_text_response(&self) -> Option<String>;

--- a/crates/rig-core/src/transcription.rs
+++ b/crates/rig-core/src/transcription.rs
@@ -218,10 +218,7 @@ pub struct TranscriptionRequest {
 ///
 /// Note: It is usually unnecessary to create a completion request builder directly.
 /// Instead, use the [TranscriptionModel::transcription_request] method.
-pub struct TranscriptionRequestBuilder<M, D>
-where
-    M: TranscriptionModel,
-{
+pub struct TranscriptionRequestBuilder<M, D> {
     model: M,
     data: D, // starts Missing, becomes Provided<Vec<u8>> after data is set or load_file is called
     filename: Option<String>,

--- a/crates/rig-core/src/vector_store/builder.rs
+++ b/crates/rig-core/src/vector_store/builder.rs
@@ -6,10 +6,7 @@ use crate::embeddings::Embedding;
 use super::{IndexStrategy, in_memory_store::InMemoryVectorStore};
 
 /// Builder for creating an [`InMemoryVectorStore`] with custom configuration.
-pub struct InMemoryVectorStoreBuilder<D>
-where
-    D: Serialize,
-{
+pub struct InMemoryVectorStoreBuilder<D> {
     /// Embeddings of the documents.
     embeddings: HashMap<String, (D, Vec<Embedding>)>,
 

--- a/crates/rig-core/src/vector_store/mod.rs
+++ b/crates/rig-core/src/vector_store/mod.rs
@@ -150,27 +150,27 @@ pub type TopNResults = Result<Vec<(f64, String, Value)>, VectorStoreError>;
 /// Type-erased [`VectorStoreIndex`] for dynamic dispatch.
 pub trait VectorStoreIndexDyn: WasmCompatSend + WasmCompatSync {
     /// Returns the top N documents for a JSON-serializable request.
-    fn top_n<'a>(
-        &'a self,
+    fn top_n(
+        &self,
         req: VectorSearchRequest<Filter<serde_json::Value>>,
-    ) -> WasmBoxedFuture<'a, TopNResults>;
+    ) -> WasmBoxedFuture<'_, TopNResults>;
 
     /// Returns only the top N document IDs for a JSON-serializable request.
-    fn top_n_ids<'a>(
-        &'a self,
+    fn top_n_ids(
+        &self,
         req: VectorSearchRequest<Filter<serde_json::Value>>,
-    ) -> WasmBoxedFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>>;
+    ) -> WasmBoxedFuture<'_, Result<Vec<(f64, String)>, VectorStoreError>>;
 }
 
 impl<I, F> VectorStoreIndexDyn for I
 where
     I: VectorStoreIndex<Filter = F>,
-    F: DynamicSearchFilter + WasmCompatSend + WasmCompatSync + 'static,
+    F: DynamicSearchFilter,
 {
-    fn top_n<'a>(
-        &'a self,
+    fn top_n(
+        &self,
         req: VectorSearchRequest<Filter<serde_json::Value>>,
-    ) -> WasmBoxedFuture<'a, TopNResults> {
+    ) -> WasmBoxedFuture<'_, TopNResults> {
         Box::pin(async move {
             let req = req.try_map_filter(F::from_dynamic_filter)?;
             Ok(self
@@ -182,10 +182,10 @@ where
         })
     }
 
-    fn top_n_ids<'a>(
-        &'a self,
+    fn top_n_ids(
+        &self,
         req: VectorSearchRequest<Filter<serde_json::Value>>,
-    ) -> WasmBoxedFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>> {
+    ) -> WasmBoxedFuture<'_, Result<Vec<(f64, String)>, VectorStoreError>> {
         Box::pin(async move {
             let req = req.try_map_filter(F::from_dynamic_filter)?;
             self.top_n_ids(req).await
@@ -209,7 +209,7 @@ where
     F: SearchFilter<Value = serde_json::Value>
         + WasmCompatSend
         + WasmCompatSync
-        + for<'de> Deserialize<'de>,
+        + serde::de::DeserializeOwned,
     T: VectorStoreIndex<Filter = F>,
 {
     const NAME: &'static str = "search_vector_store";

--- a/crates/rig-core/src/vector_store/request.rs
+++ b/crates/rig-core/src/vector_store/request.rs
@@ -294,7 +294,7 @@ where
 
 impl<V> SearchFilter for Filter<V>
 where
-    V: std::fmt::Debug + Clone + Serialize + for<'de> Deserialize<'de>,
+    V: std::fmt::Debug + Clone + Serialize + serde::de::DeserializeOwned,
 {
     type Value = V;
 

--- a/crates/rig-derive/examples/rig_tool/simple.rs
+++ b/crates/rig-derive/examples/rig_tool/simple.rs
@@ -67,10 +67,7 @@ fn how_many_rs(
     /// The string to search
     s: String,
 ) -> Result<usize, rig_core::tool::ToolExecutionError> {
-    Ok(s.chars()
-        .filter(|c| *c == 'r' || *c == 'R')
-        .collect::<Vec<_>>()
-        .len())
+    Ok(s.chars().filter(|c| *c == 'r' || *c == 'R').count())
 }
 
 /// Sum a list of numbers

--- a/crates/rig-gemini-grpc/src/completion.rs
+++ b/crates/rig-gemini-grpc/src/completion.rs
@@ -563,19 +563,19 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse {
 impl ProviderResponseExt for GenerateContentResponse {
     type Usage = proto::UsageMetadata;
 
-    fn get_response_id(&self) -> Option<String> {
+    fn get_response_id(&self) -> Option<&str> {
         if self.response_id.is_empty() {
             None
         } else {
-            Some(self.response_id.clone())
+            Some(self.response_id.as_str())
         }
     }
 
-    fn get_response_model_name(&self) -> Option<String> {
+    fn get_response_model_name(&self) -> Option<&str> {
         if self.model_version.is_empty() {
             None
         } else {
-            Some(self.model_version.clone())
+            Some(self.model_version.as_str())
         }
     }
 

--- a/crates/rig-helixdb/src/lib.rs
+++ b/crates/rig-helixdb/src/lib.rs
@@ -175,10 +175,7 @@ struct VecResult {
     vec_docs: Vec<QueryResult>,
 }
 
-impl<C> HelixDBVectorStore<C>
-where
-    C: HelixDBClient + WasmCompatSend,
-{
+impl<C> HelixDBVectorStore<C> {
     /// Creates a new HelixDB vector store.
     pub fn new(client: C, model: impl EmbeddingModel + 'static) -> Self {
         Self {
@@ -196,7 +193,7 @@ where
 impl<C> HelixDBVectorStore<C>
 where
     C: HelixDBClient + WasmCompatSend + WasmCompatSync,
-    C::Err: std::error::Error + WasmCompatSend + WasmCompatSync + 'static,
+    C::Err: WasmCompatSend + WasmCompatSync + 'static,
 {
     /// Embeds the query and runs the `VectorSearch` HelixDB query.
     async fn vector_search(
@@ -221,7 +218,7 @@ where
 impl<C> InsertDocuments for HelixDBVectorStore<C>
 where
     C: HelixDBClient + WasmCompatSend + WasmCompatSync,
-    C::Err: std::error::Error + WasmCompatSend + WasmCompatSync + 'static,
+    C::Err: WasmCompatSend + WasmCompatSync + 'static,
 {
     async fn insert_documents<Doc: Serialize + rig_core::Embed + WasmCompatSend>(
         &self,
@@ -261,7 +258,7 @@ where
 impl<C> VectorStoreIndex for HelixDBVectorStore<C>
 where
     C: HelixDBClient + WasmCompatSend + WasmCompatSync,
-    C::Err: std::error::Error + WasmCompatSend + WasmCompatSync + 'static,
+    C::Err: WasmCompatSend + WasmCompatSync + 'static,
 {
     type Filter = HelixDBFilter;
 

--- a/crates/rig-lancedb/examples/fixtures/lib.rs
+++ b/crates/rig-lancedb/examples/fixtures/lib.rs
@@ -34,30 +34,21 @@ pub fn as_record_batch(
     records: Vec<(Word, Vec<Embedding>)>,
     dims: usize,
 ) -> Result<RecordBatch, lancedb::arrow::arrow_schema::ArrowError> {
-    let id = StringArray::from_iter_values(
-        records
-            .iter()
-            .map(|(Word { id, .. }, _)| id)
-            .collect::<Vec<_>>(),
-    );
+    let id = StringArray::from_iter_values(records.iter().map(|(Word { id, .. }, _)| id));
 
     let definition = StringArray::from_iter_values(
         records
             .iter()
-            .map(|(Word { definition, .. }, _)| definition)
-            .collect::<Vec<_>>(),
+            .map(|(Word { definition, .. }, _)| definition),
     );
 
     let embedding = FixedSizeListArray::from_iter_primitive::<Float64Type, _, _>(
-        records
-            .into_iter()
-            .map(|(_, embeddings)| {
-                embeddings
-                    .into_iter()
-                    .next()
-                    .map(|embedding| embedding.vec.into_iter().map(Some).collect::<Vec<_>>())
-            })
-            .collect::<Vec<_>>(),
+        records.into_iter().map(|(_, embeddings)| {
+            embeddings
+                .into_iter()
+                .next()
+                .map(|embedding| embedding.vec.into_iter().map(Some).collect::<Vec<_>>())
+        }),
         dims as i32,
     );
 

--- a/crates/rig-lancedb/src/lib.rs
+++ b/crates/rig-lancedb/src/lib.rs
@@ -363,8 +363,8 @@ impl SearchParams {
     /// Sets the column of the search params.
     /// Only set this value if there is more than one column that contains lists of floats.
     /// If there is only one column of list of floats, this column will be chosen for the vector search automatically.
-    pub fn column(mut self, column: &str) -> Self {
-        self.column = Some(column.to_string());
+    pub fn column(mut self, column: impl Into<String>) -> Self {
+        self.column = Some(column.into());
         self
     }
 }

--- a/crates/rig-memory/src/lib.rs
+++ b/crates/rig-memory/src/lib.rs
@@ -135,6 +135,9 @@ pub trait IntoFilter: MemoryPolicy + Sized + 'static {
     fn into_filter(self) -> BoxedFilter {
         let policy = Arc::new(self);
         Box::new(move |msgs| {
+            // Deliberate clone: `apply` consumes the history, and the
+            // graceful-degradation contract above requires handing the
+            // original back when the policy errors.
             let fallback = msgs.clone();
             match policy.apply(msgs) {
                 Ok(out) => out,

--- a/crates/rig-mongodb/src/lib.rs
+++ b/crates/rig-mongodb/src/lib.rs
@@ -145,7 +145,7 @@ where
 
         let thresh = req
             .threshold()
-            .map(|thresh| MongoDbSearchFilter::gte("score".into(), thresh.into()));
+            .map(|thresh| MongoDbSearchFilter::gte("score", thresh.into()));
 
         let filter = match (thresh, req.filter()) {
             (Some(thresh), Some(filt)) => thresh.and(filt.clone()).into_inner(),
@@ -347,11 +347,13 @@ impl MongoDbSearchFilter {
         self.0
     }
 
-    pub fn gte(key: String, value: <Self as SearchFilter>::Value) -> Self {
+    pub fn gte(key: impl Into<String>, value: <Self as SearchFilter>::Value) -> Self {
+        let key = key.into();
         Self(doc! { key: { "$gte": value } })
     }
 
-    pub fn lte(key: String, value: <Self as SearchFilter>::Value) -> Self {
+    pub fn lte(key: impl Into<String>, value: <Self as SearchFilter>::Value) -> Self {
+        let key = key.into();
         Self(doc! { key: { "$lte": value } })
     }
 
@@ -361,20 +363,24 @@ impl MongoDbSearchFilter {
     }
 
     /// Tests whether the value at `key` is the BSON type `typ`
-    pub fn is_type(key: String, typ: &'static str) -> Self {
+    pub fn is_type(key: impl Into<String>, typ: &'static str) -> Self {
+        let key = key.into();
         Self(doc! { key: { "$type": typ } })
     }
 
-    pub fn size(key: String, size: i32) -> Self {
+    pub fn size(key: impl Into<String>, size: i32) -> Self {
+        let key = key.into();
         Self(doc! { key: { "$size": size } })
     }
 
     // Array ops
-    pub fn all(key: String, values: Vec<Bson>) -> Self {
+    pub fn all(key: impl Into<String>, values: Vec<Bson>) -> Self {
+        let key = key.into();
         Self(doc! { key: { "$all": values } })
     }
 
-    pub fn any(key: String, condition: Document) -> Self {
+    pub fn any(key: impl Into<String>, condition: Document) -> Self {
+        let key = key.into();
         Self(doc! { key: { "$elemMatch": condition } })
     }
 }

--- a/crates/rig-postgres/src/lib.rs
+++ b/crates/rig-postgres/src/lib.rs
@@ -107,11 +107,13 @@ impl PgSearchFilter {
         Self(self.0.not())
     }
 
-    pub fn gte(key: String, value: <Self as SearchFilter>::Value) -> Self {
+    pub fn gte(key: impl Into<String>, value: <Self as SearchFilter>::Value) -> Self {
+        let key = key.into();
         Self(SqlCondition::binary(key, ">=", PLACEHOLDER, value))
     }
 
-    pub fn lte(key: String, value: <Self as SearchFilter>::Value) -> Self {
+    pub fn lte(key: impl Into<String>, value: <Self as SearchFilter>::Value) -> Self {
+        let key = key.into();
         Self(SqlCondition::binary(key, "<=", PLACEHOLDER, value))
     }
 
@@ -408,8 +410,8 @@ mod tests {
     /// any `?` would reach Postgres verbatim and break the query.
     #[test]
     fn every_parameterised_operator_uses_dollar_placeholders() {
-        let gte = PgSearchFilter::gte("price".into(), json!(5));
-        let lte = PgSearchFilter::lte("price".into(), json!(10));
+        let gte = PgSearchFilter::gte("price", json!(5));
+        let lte = PgSearchFilter::lte("price", json!(10));
 
         let (cond, values) = gte.and(lte).into_clause();
         assert_eq!(cond, "(price >= $) AND (price <= $)");

--- a/crates/rig-s3vectors/src/lib.rs
+++ b/crates/rig-s3vectors/src/lib.rs
@@ -102,15 +102,18 @@ impl S3SearchFilter {
         self.0
     }
 
-    pub fn gte(key: String, value: <Self as SearchFilter>::Value) -> Self {
+    pub fn gte(key: impl Into<String>, value: <Self as SearchFilter>::Value) -> Self {
+        let key = key.into();
         Self(document_comparison(key, "$gte", value))
     }
 
-    pub fn lte(key: String, value: <Self as SearchFilter>::Value) -> Self {
+    pub fn lte(key: impl Into<String>, value: <Self as SearchFilter>::Value) -> Self {
+        let key = key.into();
         Self(document_comparison(key, "$lte", value))
     }
 
-    pub fn exists(key: String) -> Self {
+    pub fn exists(key: impl Into<String>) -> Self {
+        let key = key.into();
         Self(document_object([(
             "$exists",
             document_object([(key, Document::Bool(true))]),
@@ -152,16 +155,8 @@ impl S3VectorsVectorStore {
         &self.bucket_name
     }
 
-    pub fn set_bucket_name(&mut self, bucket_name: &str) {
-        self.bucket_name = bucket_name.to_string();
-    }
-
     pub fn index_name(&self) -> &str {
         &self.index_name
-    }
-
-    pub fn set_index_name(&mut self, index_name: &str) {
-        self.index_name = index_name.to_string();
     }
 
     pub fn client(&self) -> &Client {
@@ -398,9 +393,9 @@ mod tests {
     #[test]
     fn extension_operators_build_the_documented_filter_shapes() {
         let number = |n| Document::Number(aws_smithy_types::Number::PosInt(n));
-        let filter = S3SearchFilter::gte("score".into(), number(5))
-            .or(S3SearchFilter::lte("score".into(), number(1)))
-            .or(S3SearchFilter::exists("status".into()))
+        let filter = S3SearchFilter::gte("score", number(5))
+            .or(S3SearchFilter::lte("score", number(1)))
+            .or(S3SearchFilter::exists("status"))
             .not();
 
         assert_eq!(

--- a/crates/rig-scylladb/src/lib.rs
+++ b/crates/rig-scylladb/src/lib.rs
@@ -152,19 +152,23 @@ impl ScyllaSearchFilter {
         Self(self.0.not())
     }
 
-    pub fn gte(key: String, value: <Self as SearchFilter>::Value) -> Self {
+    pub fn gte(key: impl Into<String>, value: <Self as SearchFilter>::Value) -> Self {
+        let key = key.into();
         Self(SqlCondition::binary(key, ">=", PLACEHOLDER, value))
     }
 
-    pub fn lte(key: String, value: <Self as SearchFilter>::Value) -> Self {
+    pub fn lte(key: impl Into<String>, value: <Self as SearchFilter>::Value) -> Self {
+        let key = key.into();
         Self(SqlCondition::binary(key, "<=", PLACEHOLDER, value))
     }
 
-    pub fn ne(key: String, value: <Self as SearchFilter>::Value) -> Self {
+    pub fn ne(key: impl Into<String>, value: <Self as SearchFilter>::Value) -> Self {
+        let key = key.into();
         Self(SqlCondition::binary(key, "!=", PLACEHOLDER, value))
     }
 
-    pub fn member(key: String, values: Vec<<Self as SearchFilter>::Value>) -> Self {
+    pub fn member(key: impl Into<String>, values: Vec<<Self as SearchFilter>::Value>) -> Self {
+        let key = key.into();
         Self(SqlCondition::list(key, "IN", PLACEHOLDER, values))
     }
 }
@@ -514,12 +518,12 @@ mod tests {
     /// `?` per parameter — including `IN`, which renders one per value.
     #[test]
     fn every_parameterised_operator_uses_question_mark_placeholders() {
-        let filter = ScyllaSearchFilter::gte("price".into(), CqlValue::BigInt(5))
+        let filter = ScyllaSearchFilter::gte("price", CqlValue::BigInt(5))
             .and(ScyllaSearchFilter::member(
-                "id".into(),
+                "id",
                 vec![CqlValue::BigInt(1), CqlValue::BigInt(2)],
             ))
-            .or(ScyllaSearchFilter::ne("kind".into(), CqlValue::Text("veg".into())).not());
+            .or(ScyllaSearchFilter::ne("kind", CqlValue::Text("veg".to_string())).not());
 
         assert_eq!(
             filter.condition(),

--- a/crates/rig-sqlite/Cargo.toml
+++ b/crates/rig-sqlite/Cargo.toml
@@ -22,7 +22,6 @@ sqlite-vec = { workspace = true }
 thiserror = { workspace = true }
 tokio-rusqlite = { workspace = true, features = ["bundled"] }
 tracing = { workspace = true }
-zerocopy = { workspace = true }
 chrono = { workspace = true }
 
 [dev-dependencies]

--- a/crates/rig-sqlite/src/lib.rs
+++ b/crates/rig-sqlite/src/lib.rs
@@ -19,7 +19,6 @@ use std::marker::PhantomData;
 use std::ops::RangeInclusive;
 use tokio_rusqlite::Connection;
 use tracing::{debug, info};
-use zerocopy::IntoBytes;
 
 /// Maximum `k` accepted by a `sqlite-vec` `vec0` KNN query (`embedding MATCH ?
 /// AND k = ?`). `sqlite-vec` enforces this as a hard `#define
@@ -353,10 +352,7 @@ fn sqlite_metadata_value(
 /// [`SqliteVectorStore::index`] holds the model behind an erased
 /// [`EmbeddingModelHandle`].
 #[derive(Clone)]
-pub struct SqliteVectorStore<T>
-where
-    T: SqliteVectorStoreTable + 'static,
-{
+pub struct SqliteVectorStore<T> {
     conn: Connection,
     distance_metric: SqliteDistanceMetric,
     metadata_columns: Vec<SqliteMetadataColumn>,
@@ -365,7 +361,7 @@ where
 
 impl<T> SqliteVectorStore<T>
 where
-    T: SqliteVectorStoreTable + 'static,
+    T: SqliteVectorStoreTable,
 {
     async fn candidate_limit(
         &self,
@@ -658,13 +654,13 @@ where
                     "Storing embedding {} of {} (size: {} bytes)",
                     i + 1,
                     embeddings.len(),
-                    vec.len() * 4
+                    vec.len()
                 );
                 txn.execute(&insert_embedding_map_sql, [last_id])?;
                 let embedding_rowid = txn.last_insert_rowid();
                 let mut params = Vec::with_capacity(2 + metadata_values.len());
                 params.push(Value::Integer(embedding_rowid));
-                params.push(Value::Blob(vec.as_bytes().to_vec()));
+                params.push(Value::Blob(vec));
                 params.extend(metadata_values.iter().cloned());
                 stmt.execute(rusqlite::params_from_iter(params))?;
             }
@@ -695,7 +691,7 @@ where
 impl<T> InsertDocuments for SqliteVectorStore<T>
 where
     T: SqliteVectorStoreTable
-        + for<'de> Deserialize<'de>
+        + serde::de::DeserializeOwned
         + WasmCompatSend
         + WasmCompatSync
         + 'static,
@@ -952,10 +948,11 @@ impl SqliteSearchFilter {
     /// Non-boolean indexed metadata ranges are applied during sqlite-vec
     /// candidate search. Document-table ranges are applied after candidate
     /// search and may require exhaustive candidate retrieval.
-    pub fn between<N>(key: String, range: RangeInclusive<N>) -> Self
+    pub fn between<N>(key: impl Into<String>, range: RangeInclusive<N>) -> Self
     where
         N: Into<serde_json::Value>,
     {
+        let key = key.into();
         let (lo, hi) = range.into_inner();
 
         Self {
@@ -968,11 +965,13 @@ impl SqliteSearchFilter {
     }
 
     // Null checks
-    pub fn is_null(key: String) -> Self {
+    pub fn is_null(key: impl Into<String>) -> Self {
+        let key = key.into();
         Self::null_check(key, false)
     }
 
-    pub fn is_not_null(key: String) -> Self {
+    pub fn is_not_null(key: impl Into<String>) -> Self {
+        let key = key.into();
         Self::null_check(key, true)
     }
 
@@ -980,7 +979,8 @@ impl SqliteSearchFilter {
     ///
     /// sqlite-vec cannot enforce `GLOB` during candidate search, so this is
     /// applied as a document-table post-filter.
-    pub fn glob(key: String, pattern: impl Into<String>) -> Self {
+    pub fn glob(key: impl Into<String>, pattern: impl Into<String>) -> Self {
+        let key = key.into();
         Self::pattern(key, SqlitePatternOp::Glob, pattern)
     }
 
@@ -988,7 +988,8 @@ impl SqliteSearchFilter {
     ///
     /// sqlite-vec cannot enforce `LIKE` during candidate search, so this is
     /// applied as a document-table post-filter.
-    pub fn like(key: String, pattern: impl Into<String>) -> Self {
+    pub fn like(key: impl Into<String>, pattern: impl Into<String>) -> Self {
+        let key = key.into();
         Self::pattern(key, SqlitePatternOp::Like, pattern)
     }
 }
@@ -1552,10 +1553,7 @@ fn sqlite_json_operator_operand_len(operand: &str) -> Option<usize> {
 /// The embedding model's concrete type is erased at construction into an
 /// [`EmbeddingModelHandle`], which is fixed for the index's lifetime: an index
 /// populated under one model is only meaningful when queried under that model.
-pub struct SqliteVectorIndex<T>
-where
-    T: SqliteVectorStoreTable + 'static,
-{
+pub struct SqliteVectorIndex<T> {
     store: SqliteVectorStore<T>,
     embedding_model: EmbeddingModelHandle,
 }
@@ -1577,7 +1575,7 @@ where
 
 impl<T> SqliteVectorIndex<T>
 where
-    T: SqliteVectorStoreTable + 'static,
+    T: SqliteVectorStoreTable,
 {
     /// Runs the shared candidate search for `top_n`/`top_n_ids`.
     ///
@@ -1595,7 +1593,7 @@ where
         F: Fn(&rusqlite::Row<'_>) -> rusqlite::Result<R> + Send + 'static,
     {
         let embedding = self.embedding_model.embed_text(req.query()).await?;
-        let query_vec: Vec<f32> = serialize_embedding(&embedding);
+        let query_vec: Vec<u8> = serialize_embedding(&embedding);
         let table_name = T::name();
         let embedding_map_table_name = format!("{table_name}_embedding_map");
 
@@ -1705,7 +1703,7 @@ fn render_search_filters(
 }
 
 fn build_search_query(
-    query_vec: Vec<f32>,
+    query_vec: Vec<u8>,
     filters: SqliteRenderedFilters,
     candidate_limit: u64,
 ) -> Result<SqliteSearchQuery, FilterError> {
@@ -1750,7 +1748,6 @@ fn build_search_query(
         )
     };
 
-    let query_vec = query_vec.into_iter().flat_map(f32::to_le_bytes).collect();
     let query_vec = Value::Blob(query_vec);
 
     // Parameter binding is positional. The score expression uses the explicit
@@ -1779,7 +1776,7 @@ fn build_search_query(
 #[cfg(test)]
 fn build_where_clause(
     req: &VectorSearchRequest<SqliteSearchFilter>,
-    query_vec: Vec<f32>,
+    query_vec: Vec<u8>,
     distance_metric: SqliteDistanceMetric,
     metadata_columns: &[SqliteMetadataColumn],
     candidate_limit: u64,
@@ -1947,7 +1944,7 @@ impl<T: SqliteVectorStoreTable> VectorStoreIndex for SqliteVectorIndex<T> {
         req: VectorSearchRequest<SqliteSearchFilter>,
     ) -> Result<Vec<(f64, String, D)>, VectorStoreError>
     where
-        D: for<'de> Deserialize<'de>,
+        D: serde::de::DeserializeOwned,
     {
         tracing::debug!("Finding top {} matches for query", req.samples() as usize);
         if req.samples() == 0 {
@@ -2029,8 +2026,15 @@ impl<T: SqliteVectorStoreTable> VectorStoreIndex for SqliteVectorIndex<T> {
     }
 }
 
-fn serialize_embedding(embedding: &Embedding) -> Vec<f32> {
-    embedding.vec.iter().map(|x| *x as f32).collect()
+/// Serializes an embedding straight to the little-endian f32 blob SQLite
+/// stores, so neither the insert nor the query path needs an intermediate
+/// `Vec<f32>`.
+fn serialize_embedding(embedding: &Embedding) -> Vec<u8> {
+    embedding
+        .vec
+        .iter()
+        .flat_map(|x| (*x as f32).to_le_bytes())
+        .collect()
 }
 
 macro_rules! impl_column_value {
@@ -2060,6 +2064,11 @@ impl_column_value! {
 
 #[cfg(test)]
 mod tests {
+
+    /// f32 slice -> the little-endian blob `build_search_query` now takes.
+    fn query_blob(values: &[f32]) -> Vec<u8> {
+        values.iter().flat_map(|x| x.to_le_bytes()).collect()
+    }
     use super::*;
     use rig_core::embeddings::{EmbeddingError, EmbeddingResponse};
     use rusqlite::ffi::{sqlite3, sqlite3_api_routines, sqlite3_auto_extension};
@@ -2213,8 +2222,13 @@ mod tests {
             .threshold(0.95)
             .build();
 
-        let (where_clause, params) =
-            build_where_clause(&req, vec![1.0, 0.0], SqliteDistanceMetric::Cosine, &[], 5)?;
+        let (where_clause, params) = build_where_clause(
+            &req,
+            query_blob(&[1.0, 0.0]),
+            SqliteDistanceMetric::Cosine,
+            &[],
+            5,
+        )?;
 
         anyhow::ensure!(
             where_clause.contains("e.embedding MATCH ?"),
@@ -2245,8 +2259,13 @@ mod tests {
             .threshold(-1.5)
             .build();
 
-        let (where_clause, params) =
-            build_where_clause(&req, vec![1.0, 0.0], SqliteDistanceMetric::L2, &[], 5)?;
+        let (where_clause, params) = build_where_clause(
+            &req,
+            query_blob(&[1.0, 0.0]),
+            SqliteDistanceMetric::L2,
+            &[],
+            5,
+        )?;
 
         anyhow::ensure!(
             where_clause.contains("(-vec_distance_l2(?1, e.embedding)) >= ?"),
@@ -2268,8 +2287,13 @@ mod tests {
             .samples(5)
             .build();
 
-        let (where_clause, params) =
-            build_where_clause(&req, vec![1.0, 0.0], SqliteDistanceMetric::Cosine, &[], 5)?;
+        let (where_clause, params) = build_where_clause(
+            &req,
+            query_blob(&[1.0, 0.0]),
+            SqliteDistanceMetric::Cosine,
+            &[],
+            5,
+        )?;
 
         anyhow::ensure!(
             where_clause == "WHERE e.embedding MATCH ? AND k = ?",
@@ -2289,7 +2313,7 @@ mod tests {
 
         let (where_clause, params) = build_where_clause(
             &req,
-            vec![1.0, 0.0],
+            query_blob(&[1.0, 0.0]),
             SqliteDistanceMetric::Cosine,
             &[],
             SQLITE_VEC_MAX_K,
@@ -2318,7 +2342,7 @@ mod tests {
 
         let (where_clause, params) = build_where_clause(
             &req,
-            vec![1.0, 0.0],
+            query_blob(&[1.0, 0.0]),
             SqliteDistanceMetric::Cosine,
             &[],
             SQLITE_VEC_MAX_K + 1,
@@ -2356,7 +2380,7 @@ mod tests {
 
         let (where_clause, params) = build_where_clause(
             &req,
-            vec![1.0, 0.0],
+            query_blob(&[1.0, 0.0]),
             SqliteDistanceMetric::Cosine,
             &[],
             SQLITE_VEC_MAX_K + 1,
@@ -2396,7 +2420,7 @@ mod tests {
 
         let filters =
             render_search_filters(&req, SqliteDistanceMetric::Cosine, &test_metadata_columns())?;
-        let query = build_search_query(vec![1.0, 0.0], filters, 5)?;
+        let query = build_search_query(query_blob(&[1.0, 0.0]), filters, 5)?;
         anyhow::ensure!(
             query.document_filter_clause == "AND ((1 = 1) OR (d.category = ?))",
             "default() under OR should render as a tautology: {}",
@@ -2424,7 +2448,7 @@ mod tests {
             filters.has_post_filters(),
             "OR filters should be applied after vector candidate search"
         );
-        let query = build_search_query(vec![1.0, 0.0], filters, 5)?;
+        let query = build_search_query(query_blob(&[1.0, 0.0]), filters, 5)?;
 
         anyhow::ensure!(
             query.vector_where_clause == "WHERE e.embedding MATCH ? AND k = ?",
@@ -2459,7 +2483,7 @@ mod tests {
 
         let (where_clause, params) = build_where_clause(
             &req,
-            vec![1.0, 0.0],
+            query_blob(&[1.0, 0.0]),
             SqliteDistanceMetric::Cosine,
             &test_metadata_columns(),
             5,
@@ -2488,7 +2512,7 @@ mod tests {
 
         let (where_clause, params) = build_where_clause(
             &req,
-            vec![1.0, 0.0],
+            query_blob(&[1.0, 0.0]),
             SqliteDistanceMetric::Cosine,
             &test_metadata_columns(),
             5,
@@ -2517,7 +2541,7 @@ mod tests {
 
         let (where_clause, params) = build_where_clause(
             &req,
-            vec![1.0, 0.0],
+            query_blob(&[1.0, 0.0]),
             SqliteDistanceMetric::Cosine,
             &typed_metadata_columns(),
             5,
@@ -2546,7 +2570,7 @@ mod tests {
 
         let (where_clause, params) = build_where_clause(
             &req,
-            vec![1.0, 0.0],
+            query_blob(&[1.0, 0.0]),
             SqliteDistanceMetric::Cosine,
             &typed_metadata_columns(),
             5,
@@ -2582,7 +2606,7 @@ mod tests {
             filters.has_post_filters(),
             "negated range filters should be applied after vector candidate search"
         );
-        let query = build_search_query(vec![1.0, 0.0], filters, 5)?;
+        let query = build_search_query(query_blob(&[1.0, 0.0]), filters, 5)?;
 
         anyhow::ensure!(
             query.vector_where_clause == "WHERE e.embedding MATCH ? AND k = ?",
@@ -2618,7 +2642,7 @@ mod tests {
         let err = filter_error(
             build_where_clause(
                 &req,
-                vec![1.0, 0.0],
+                query_blob(&[1.0, 0.0]),
                 SqliteDistanceMetric::Cosine,
                 &typed_metadata_columns(),
                 5,
@@ -2645,7 +2669,7 @@ mod tests {
 
         let (where_clause, params) = build_where_clause(
             &req,
-            vec![1.0, 0.0],
+            query_blob(&[1.0, 0.0]),
             SqliteDistanceMetric::Cosine,
             &typed_metadata_columns(),
             5,
@@ -2699,7 +2723,7 @@ mod tests {
             let err = filter_error(
                 build_where_clause(
                     &req,
-                    vec![1.0, 0.0],
+                    query_blob(&[1.0, 0.0]),
                     SqliteDistanceMetric::Cosine,
                     &typed_metadata_columns()
                         .into_iter()
@@ -2738,7 +2762,7 @@ mod tests {
             filters.has_post_filters(),
             "pattern and null filters should be applied after vector candidate search"
         );
-        let query = build_search_query(vec![1.0, 0.0], filters, 5)?;
+        let query = build_search_query(query_blob(&[1.0, 0.0]), filters, 5)?;
 
         anyhow::ensure!(
             query.vector_where_clause == "WHERE e.embedding MATCH ? AND k = ?",
@@ -2775,7 +2799,7 @@ mod tests {
             filters.has_post_filters(),
             "non-indexed filters should be applied after vector candidate search"
         );
-        let query = build_search_query(vec![1.0, 0.0], filters, 5)?;
+        let query = build_search_query(query_blob(&[1.0, 0.0]), filters, 5)?;
 
         anyhow::ensure!(
             query.vector_where_clause == "WHERE e.embedding MATCH ? AND k = ?",
@@ -2813,7 +2837,7 @@ mod tests {
             filters.has_post_filters(),
             "JSON metadata expressions should be applied after vector candidate search"
         );
-        let query = build_search_query(vec![1.0, 0.0], filters, 5)?;
+        let query = build_search_query(query_blob(&[1.0, 0.0]), filters, 5)?;
 
         anyhow::ensure!(
             query.vector_where_clause == "WHERE e.embedding MATCH ? AND k = ?",
@@ -2847,7 +2871,7 @@ mod tests {
 
         let filters =
             render_search_filters(&req, SqliteDistanceMetric::Cosine, &test_metadata_columns())?;
-        let query = build_search_query(vec![1.0, 0.0], filters, 5)?;
+        let query = build_search_query(query_blob(&[1.0, 0.0]), filters, 5)?;
 
         anyhow::ensure!(
             query.document_filter_clause == "AND (d.metadata->'$.xxx' = ?)",
@@ -2876,7 +2900,7 @@ mod tests {
 
         let filters =
             render_search_filters(&req, SqliteDistanceMetric::Cosine, &test_metadata_columns())?;
-        let query = build_search_query(vec![1.0, 0.0], filters, 5)?;
+        let query = build_search_query(query_blob(&[1.0, 0.0]), filters, 5)?;
 
         anyhow::ensure!(
             query.document_filter_clause == "AND (d.metadata->'$.nested'->>'$.xxx' = ?)",
@@ -4387,7 +4411,7 @@ mod tests {
         (
             document.clone(),
             vec![Embedding {
-                document: document.name.clone(),
+                document: document.name,
                 vec,
             }],
         )
@@ -4410,7 +4434,7 @@ mod tests {
         (
             document.clone(),
             vec![Embedding {
-                document: document.title.clone(),
+                document: document.title,
                 vec,
             }],
         )
@@ -4431,7 +4455,7 @@ mod tests {
         (
             document.clone(),
             vec![Embedding {
-                document: document.title.clone(),
+                document: document.title,
                 vec,
             }],
         )
@@ -4452,7 +4476,7 @@ mod tests {
         (
             document.clone(),
             vec![Embedding {
-                document: document.title.clone(),
+                document: document.title,
                 vec,
             }],
         )
@@ -4475,7 +4499,7 @@ mod tests {
         (
             document.clone(),
             vec![Embedding {
-                document: document.title.clone(),
+                document: document.title,
                 vec,
             }],
         )

--- a/crates/rig-vertexai/src/completion.rs
+++ b/crates/rig-vertexai/src/completion.rs
@@ -74,11 +74,11 @@ impl CompletionModel {
 
         let vertex_request = VertexCompletionRequest(request);
 
-        let contents = vertex_request.contents()?;
         let generation_config = vertex_request.generation_config()?;
         let system_instruction = vertex_request.system_instruction();
         let tools = vertex_request.tools();
         let tool_config = vertex_request.tool_config();
+        let contents = vertex_request.contents()?;
         let model_path = self.model_path();
 
         let mut request_builder = self

--- a/crates/rig-vertexai/src/types/completion_request.rs
+++ b/crates/rig-vertexai/src/types/completion_request.rs
@@ -6,15 +6,16 @@ use rig_core::providers::gemini::completion::gemini_api_types::{
     ImageConfig as GeminiImageConfig, ResponseModality, ThinkingConfig as GeminiThinkingConfig,
     ThinkingLevel,
 };
-use serde_json::{Map, Value};
 
 pub struct VertexCompletionRequest(pub rig_core::completion::CompletionRequest);
 
 impl VertexCompletionRequest {
-    pub fn contents(&self) -> Result<Vec<vertexai::model::Content>, CompletionError> {
+    pub fn contents(self) -> Result<Vec<vertexai::model::Content>, CompletionError> {
         // Vertex's `functionResponse.name` is the *function name*, not a
         // call identifier — `ToolResult::name` carries it as required data.
-        let mut history: Vec<rig_core::completion::Message> = self.0.chat_history.clone();
+        // Consumes the request: this is the one accessor that needs the
+        // history by value, so call it after the borrowing accessors.
+        let mut history: Vec<rig_core::completion::Message> = self.0.chat_history;
         // Cross-provider ingested results arrive with an empty name and
         // their paired call carries it.
         rig_core::providers::internal::resolve_empty_tool_result_names(&mut history);
@@ -106,14 +107,12 @@ impl VertexCompletionRequest {
     pub fn generation_config(
         &self,
     ) -> Result<Option<vertexai::model::GenerationConfig>, CompletionError> {
-        let additional_params = self
-            .0
-            .additional_params
-            .clone()
-            .unwrap_or_else(|| Value::Object(Map::new()));
         let AdditionalParameters {
             generation_config, ..
-        } = serde_json::from_value(additional_params)?;
+        } = match self.0.additional_params.as_ref() {
+            Some(params) => serde::Deserialize::deserialize(params)?,
+            None => AdditionalParameters::default(),
+        };
 
         let mut config = generation_config
             .map(|mut config| {

--- a/tests/core/prompt_response_messages.rs
+++ b/tests/core/prompt_response_messages.rs
@@ -264,7 +264,7 @@ async fn prompt_response_with_messages_builder() {
 
     let messages = vec![Message::user("hello"), Message::assistant("world")];
 
-    let resp = PromptResponse::new("output", Usage::new()).with_messages(messages.clone());
+    let resp = PromptResponse::new("output", Usage::new()).with_messages(messages);
 
     assert!(resp.messages.is_some());
     assert_eq!(resp.messages.as_ref().unwrap().len(), 2);

--- a/tests/integrations/lancedb/fixtures/lib.rs
+++ b/tests/integrations/lancedb/fixtures/lib.rs
@@ -34,36 +34,27 @@ pub fn as_record_batch(
     records: Vec<(Word, Vec<Embedding>)>,
     dims: usize,
 ) -> Result<RecordBatch, lancedb::arrow::arrow_schema::ArrowError> {
-    let id = StringArray::from_iter_values(
-        records
-            .iter()
-            .map(|(Word { id, .. }, _)| id)
-            .collect::<Vec<_>>(),
-    );
+    let id = StringArray::from_iter_values(records.iter().map(|(Word { id, .. }, _)| id));
 
     let definition = StringArray::from_iter_values(
         records
             .iter()
-            .map(|(Word { definition, .. }, _)| definition)
-            .collect::<Vec<_>>(),
+            .map(|(Word { definition, .. }, _)| definition),
     );
 
     let embedding = FixedSizeListArray::from_iter_primitive::<Float64Type, _, _>(
-        records
-            .into_iter()
-            .map(|(_, embeddings)| {
-                Some(
-                    embeddings
-                        .into_iter()
-                        .next()
-                        .expect("expected at least one embedding")
-                        .vec
-                        .into_iter()
-                        .map(Some)
-                        .collect::<Vec<_>>(),
-                )
-            })
-            .collect::<Vec<_>>(),
+        records.into_iter().map(|(_, embeddings)| {
+            Some(
+                embeddings
+                    .into_iter()
+                    .next()
+                    .expect("expected at least one embedding")
+                    .vec
+                    .into_iter()
+                    .map(Some)
+                    .collect::<Vec<_>>(),
+            )
+        }),
         dims as i32,
     );
 

--- a/tests/providers/anthropic/cassette/empty_stop_sequence_matrix.rs
+++ b/tests/providers/anthropic/cassette/empty_stop_sequence_matrix.rs
@@ -587,7 +587,7 @@ async fn identity_survives_empty_stop() {
                 "transport request id must survive — it is what Anthropic support asks for"
             );
             assert!(response.usage.input_tokens > 0, "usage must survive");
-            *sink.lock().expect("model sink should not be poisoned") = response.model.clone();
+            *sink.lock().expect("model sink should not be poisoned") = response.model;
         },
     )
     .await;

--- a/tests/providers/anthropic/cassette/raw_completion_parity_matrix.rs
+++ b/tests/providers/anthropic/cassette/raw_completion_parity_matrix.rs
@@ -114,7 +114,7 @@ impl Reported {
 /// (`second`), for the fields that do not depend on which HTTP exchange
 /// produced them.
 fn assert_route_parity(first: &Reported, second: &Reported, expected: FinishReason) {
-    assert_eq!(first.finish_reason, Some(expected.clone()));
+    assert_eq!(first.finish_reason, Some(expected));
     assert_eq!(
         second.finish_reason, first.finish_reason,
         "the typed route must map the stop reason exactly as `completion` does"

--- a/tests/providers/bedrock/cassette/raw_capture_matrix.rs
+++ b/tests/providers/bedrock/cassette/raw_capture_matrix.rs
@@ -169,7 +169,7 @@ async fn raw_exposes_latency_metrics() {
                 "normalized CompletionResponse must not grow a `metrics` field"
             );
 
-            let raw = response.raw.clone();
+            let raw = response.raw;
             *sink.lock().expect("capture mutex") = Some(raw);
         },
     )

--- a/tests/providers/bedrock/cassette/raw_stream_capture_matrix.rs
+++ b/tests/providers/bedrock/cassette/raw_stream_capture_matrix.rs
@@ -215,7 +215,7 @@ async fn stream_raw_exposes_bedrock_stop_reason() {
                 Some(rig::completion::FinishReason::Stop)
             );
 
-            let raw = terminal.raw.clone();
+            let raw = terminal.raw;
             *sink.lock().expect("capture mutex") = Some(raw);
         },
     )

--- a/tests/providers/chatgpt/cassette/raw_capture_matrix.rs
+++ b/tests/providers/chatgpt/cassette/raw_capture_matrix.rs
@@ -187,7 +187,7 @@ async fn raw_exposes_response_envelope() {
                     "normalized CompletionResponse must not grow a `{field}` field"
                 );
             }
-            let raw = response.raw.clone();
+            let raw = response.raw;
             *sink.lock().expect("capture mutex") = Some(raw);
         },
     )

--- a/tests/providers/chatgpt/cassette/raw_stream_capture_matrix.rs
+++ b/tests/providers/chatgpt/cassette/raw_stream_capture_matrix.rs
@@ -178,7 +178,7 @@ async fn stream_raw_exposes_terminal_status() {
                 "normalized StreamFinal must not grow a `status` field"
             );
 
-            let raw = terminal.raw.clone();
+            let raw = terminal.raw;
             *sink.lock().expect("capture mutex") = Some(raw);
         },
     )

--- a/tests/providers/copilot/raw_capture_matrix.rs
+++ b/tests/providers/copilot/raw_capture_matrix.rs
@@ -229,7 +229,7 @@ async fn chat_raw_exposes_system_fingerprint() {
                 normalized.get("system_fingerprint").is_none(),
                 "normalized CompletionResponse must not grow a `system_fingerprint` field"
             );
-            let raw = response.raw.clone();
+            let raw = response.raw;
             *sink.lock().expect("capture mutex") = Some(raw);
         },
     )
@@ -378,7 +378,7 @@ async fn responses_raw_exposes_envelope() {
                     "normalized CompletionResponse must not grow a `{field}` field"
                 );
             }
-            let raw = response.raw.clone();
+            let raw = response.raw;
             *sink.lock().expect("capture mutex") = Some(raw);
         },
     )

--- a/tests/providers/copilot/raw_stream_capture_matrix.rs
+++ b/tests/providers/copilot/raw_stream_capture_matrix.rs
@@ -209,7 +209,7 @@ async fn chat_stream_raw_exposes_copilot_usage() {
                     "normalized StreamFinal must not grow a `{field}` field"
                 );
             }
-            let raw = terminal.raw.clone();
+            let raw = terminal.raw;
             *sink.lock().expect("capture mutex") = Some(raw);
         },
     )
@@ -344,7 +344,7 @@ async fn responses_stream_raw_exposes_terminal_status() {
             let normalized =
                 serde_json::to_value(&without_raw).expect("StreamFinal should serialize");
             assert!(normalized.get("status").is_none());
-            let raw = terminal.raw.clone();
+            let raw = terminal.raw;
             *sink.lock().expect("capture mutex") = Some(raw);
         },
     )

--- a/tests/providers/gemini/cassette/agent_run_recovery.rs
+++ b/tests/providers/gemini/cassette/agent_run_recovery.rs
@@ -161,7 +161,7 @@ async fn repair_renames_tool_call_and_executes_it() {
 
             // The repaired name is what history records; the original name
             // never reaches the conversation.
-            let messages = response.messages.clone().expect("run reports its messages");
+            let messages = response.messages.expect("run reports its messages");
             let recorded: Vec<String> = messages
                 .iter()
                 .flat_map(assistant_tool_call_names)

--- a/tests/providers/gemini/cassette/agent_run_stepping.rs
+++ b/tests/providers/gemini/cassette/agent_run_stepping.rs
@@ -87,7 +87,7 @@ async fn hand_driven_single_turn_completes() {
                 "cassette-recorded usage should be non-zero"
             );
 
-            let messages = response.messages.clone().expect("run reports its messages");
+            let messages = response.messages.expect("run reports its messages");
             assert_eq!(messages.as_slice(), run.messages());
             assert_eq!(
                 messages.len(),
@@ -181,7 +181,7 @@ async fn hand_driven_multi_turn_tool_run_completes() {
                 response.usage
             );
 
-            let messages = response.messages.clone().expect("run reports its messages");
+            let messages = response.messages.expect("run reports its messages");
             assert!(history_has_assistant_tool_call(&messages, "add"));
             assert!(history_has_assistant_tool_call(&messages, "subtract"));
             assert!(

--- a/tests/providers/gemini/cassette/agent_run_streamed.rs
+++ b/tests/providers/gemini/cassette/agent_run_streamed.rs
@@ -240,7 +240,7 @@ async fn streamed_hand_driven_multi_turn_run_completes() {
                 "cassette-recorded usage should be non-zero"
             );
 
-            let messages = response.messages.clone().expect("run reports its messages");
+            let messages = response.messages.expect("run reports its messages");
             assert!(history_has_assistant_tool_call(&messages, "add"));
             assert!(history_has_assistant_tool_call(&messages, "subtract"));
             // The assembler records streamed turns in canonical replay order.
@@ -367,7 +367,7 @@ async fn streamed_repair_continues_the_same_stream() {
 
             assert!(repaired, "the model should call a tool that gets repaired");
             assert_mentions_expected_number(&response.output, 5);
-            let messages = response.messages.clone().expect("run reports its messages");
+            let messages = response.messages.expect("run reports its messages");
             let recorded: Vec<String> = messages
                 .iter()
                 .flat_map(assistant_tool_call_names)

--- a/tests/providers/gemini/cassette/code_execution_matrix.rs
+++ b/tests/providers/gemini/cassette/code_execution_matrix.rs
@@ -1025,7 +1025,7 @@ mod unit {
             vec![
                 executable_code_part(),
                 code_result_part(),
-                text.clone(),
+                text,
                 executable_code_part(),
                 code_result_part(),
             ],

--- a/tests/providers/gemini/cassette/embeddings.rs
+++ b/tests/providers/gemini/cassette/embeddings.rs
@@ -33,7 +33,7 @@ async fn embeddings_smoke() {
             // `raw_embed_texts` returns.
             assert_eq!(response.provider, "gcp.gemini");
             let raw: gemini::embedding::gemini_api_types::EmbeddingResponse =
-                serde_json::from_value(response.raw.clone())
+                serde_json::from_value(response.raw)
                     .expect("raw payload should round-trip to Gemini's own type");
             assert_eq!(raw.embeddings.len(), EMBEDDING_INPUTS.len());
         },

--- a/tests/providers/groq/agent_tool_sessions.rs
+++ b/tests/providers/groq/agent_tool_sessions.rs
@@ -472,7 +472,7 @@ impl RawResponseMetadata {
                 .iter()
                 .map(|choice| choice.finish_reason.clone())
                 .collect(),
-            usage: raw.usage.clone(),
+            usage: raw.usage,
         }
     }
 }

--- a/tests/providers/llamacpp/cassette/raw_capture_matrix.rs
+++ b/tests/providers/llamacpp/cassette/raw_capture_matrix.rs
@@ -207,7 +207,7 @@ async fn raw_exposes_envelope_fields() {
                 );
             }
 
-            let raw = response.raw.clone();
+            let raw = response.raw;
             *sink.lock().expect("capture mutex") = Some(raw);
         },
     )

--- a/tests/providers/llamacpp/cassette/raw_stream_capture_matrix.rs
+++ b/tests/providers/llamacpp/cassette/raw_stream_capture_matrix.rs
@@ -213,7 +213,7 @@ async fn stream_raw_exposes_envelope_fields() {
                 );
             }
 
-            let raw = terminal.raw.clone();
+            let raw = terminal.raw;
             *sink.lock().expect("capture mutex") = Some(raw);
         },
     )
@@ -286,7 +286,7 @@ async fn stream_raw_preserves_llamacpp_timings() {
                     .expect("stream should start"),
             )
             .await;
-            *sink.lock().expect("capture mutex") = Some(terminal.raw.clone());
+            *sink.lock().expect("capture mutex") = Some(terminal.raw);
         },
     )
     .await;

--- a/tests/providers/llamacpp/cassette/response_identity_matrix.rs
+++ b/tests/providers/llamacpp/cassette/response_identity_matrix.rs
@@ -157,7 +157,6 @@ async fn the_response_id_reaches_the_caller_on_both_transports() {
 
             let id = response
                 .response_id
-                .clone()
                 .expect("llama.cpp mints a response id and rig surfaces it");
             assert!(
                 id.starts_with("chatcmpl-"),

--- a/tests/providers/mistralrs/cassette/raw_capture_matrix.rs
+++ b/tests/providers/mistralrs/cassette/raw_capture_matrix.rs
@@ -189,7 +189,7 @@ async fn raw_exposes_envelope_fields() {
                     "normalized CompletionResponse must not grow a `{field}` field"
                 );
             }
-            let raw = response.raw.clone();
+            let raw = response.raw;
             *sink.lock().expect("capture mutex") = Some(raw);
         },
     )

--- a/tests/providers/mistralrs/cassette/raw_stream_capture_matrix.rs
+++ b/tests/providers/mistralrs/cassette/raw_stream_capture_matrix.rs
@@ -197,7 +197,7 @@ async fn stream_raw_exposes_envelope_fields() {
                     "normalized StreamFinal must not grow a `{field}` field"
                 );
             }
-            let raw = terminal.raw.clone();
+            let raw = terminal.raw;
             *sink.lock().expect("capture mutex") = Some(raw);
         },
     )

--- a/tests/providers/ollama/cassette/raw_capture_matrix.rs
+++ b/tests/providers/ollama/cassette/raw_capture_matrix.rs
@@ -183,7 +183,7 @@ async fn raw_exposes_ollama_durations() {
                 );
             }
 
-            let raw = response.raw.clone();
+            let raw = response.raw;
             *sink.lock().expect("capture mutex") = Some(raw);
         },
     )

--- a/tests/providers/ollama/cassette/raw_stream_capture_matrix.rs
+++ b/tests/providers/ollama/cassette/raw_stream_capture_matrix.rs
@@ -201,7 +201,7 @@ async fn stream_raw_exposes_terminal_durations() {
                 );
             }
 
-            let raw = terminal.raw.clone();
+            let raw = terminal.raw;
             *sink.lock().expect("capture mutex") = Some(raw);
         },
     )

--- a/tests/providers/venice/cassette/image_generation.rs
+++ b/tests/providers/venice/cassette/image_generation.rs
@@ -39,7 +39,7 @@ async fn image_generation_smoke() {
             );
             assert_eq!(response.provider, "venice");
             let raw: rig::providers::venice::ImageGenerationResponse =
-                serde_json::from_value(response.raw.clone())
+                serde_json::from_value(response.raw)
                     .expect("raw payload should round-trip to Venice's own type");
             assert!(
                 !raw.id.is_empty(),


### PR DESCRIPTION
Second pass of the ownership/lifetimes/bounds audit, on top of #2391. The metric is the same: fewer unnecessary ownership transfers, weaker (more honest) bounds, clearer aliasing structure. The mechanical lint sweep (16 audit lints) found **zero production-code hits** — everything here came from the manual sweep.

## Bounds
- Strip dead `Default`/`Debug` from the transport (`H`/`T`) generic chains across 13 provider files (~40 impl blocks). Root cause: the two `openai/client.rs` chains that every downstream impl restated. Nothing constructs or formats the client; the minimal chain is `HttpClientExt + Clone (+ WasmCompat*) + 'static`.
- `GenericCompletionModel::new`/`with_strict_tools`/`with_tool_result_array_content`: all impl bounds dropped (none used).
- `TypeMap`/`ToolContext` read side (`get`/`get_mut`/`remove`/`contains`/`require`/`result`/`require_result`): `T: 'static` only — pure `Any` lookups. Write side unchanged.
- Struct-level where clauses removed: `SqliteVectorStore`/`SqliteVectorIndex` (with `'static` kept only on the impl blocks whose `conn.call` closures need it), `EmbeddingsBuilder`, `InMemoryVectorStoreBuilder`, `TranscriptionRequestBuilder`, `ImageGenerationRequestBuilder`.
- helixdb: constructor impl unbounded; `C::Err: std::error::Error` no longer restated over the trait declaration (×3).
- `VectorStoreIndexDyn` blanket: filter type down to bare `DynamicSearchFilter` (Send/Sync implied by the `Filter` projection; `'static` proved unnecessary).
- `for<'de> Deserialize<'de>` → `DeserializeOwned` where the crate already used it (8 sites); unused `'static` dropped from `ToolSchema::try_from` and gemini's `ConstructEmbeddingModel`.

## Clones and allocations
- **Embedding batch**: six providers (voyageai, ollama, cohere, gemini, openai-compatible, copilot) cloned the entire `Vec<String>` batch per call to keep a copy for `normalize`. Each gains a private borrow-shaped `raw_embed_texts_slice(&[String])` twin; the public by-value entry points forward to it.
- anthropic `normalize()`: `mem::take`s its content instead of cloning every block; provider request id moves.
- Per-turn tool-schema deep clone → `ToolRegistrySnapshot::take_definitions()` (dispatch only reads `tools`; pinned by the existing probes).
- Vertex/Bedrock request assembly: `contents()`/`messages()` consume the request instead of cloning the whole chat history; call sites reordered so the borrowing accessors run first.
- Seven provider usage families derive `Copy` → 14 `usage.clone()` sites become copies. Mistral's is excluded (`service_tier: Option<String>`).
- `serde_json::from_value(x.clone())` → `T::deserialize(&value)` (anthropic citations/raw content, vertexai additional params).
- sqlite `serialize_embedding` emits the little-endian byte blob directly (was `Vec<f32>` → bytes → `Blob` twice); drops the `zerocopy` dependency.
- Run-state: streamed/blocking turn identity fields (`response_id`, `provider_request_id`, `finish_reason`, `raw` — a full `Value` deep clone per turn) move instead of cloning; `finish()` moves `pending_tool_calls` once; rmcp `preserve_mcp_result` takes the result by value; assorted point fixes (`Cow` double-alloc, `follows_from().to_owned()`, `schema.clone().to_value()` → `as_value()`).

## API shape
- `ProviderResponseExt::get_response_id`/`get_response_model_name` → `Option<&str>` (16 impls; the only consumer is `Span::record`, which takes `&str` — span metadata recording is now allocation-free per completion).
- `ReasoningSummary::text()` → `&str` (no production caller needed ownership).
- bedrock `TextToImageGeneration::width`/`height`: `&mut self -> &Self` (unchainable) → the repo-wide `mut self -> Self` idiom.
- 20 vector-store filter constructors across mongodb/sqlite/scylladb/s3vectors/postgres: `key: String` → `key: impl Into<String>` (the sibling parameter of the same functions already did).
- Dead `set_bucket_name`/`set_index_name` deleted (rig-s3vectors, zero callers); discord example drops a nested `Arc`; `documents()` becomes a collect; lancedb `column()` takes `impl Into<String>`; `top_n` lifetimes elided; `embed_image` no longer ties `bytes` to the `&self` borrow.

## Deliberately kept (semantic, not oversights)
- rig-mongodb/surrealdb struct bounds — `mongodb::Collection<C>` / `Surreal<C>` demand them at the type level.
- rig-memory `IntoFilter` fallback clone — the documented graceful-degradation contract returns the original history on policy error (now commented in-source).
- The by-value `Into<Usage>` telemetry clone in the chat-completions-compatible seam — pinned by the trait bound; the value is retained afterward.
- `StreamFinal.provider: String` (public serde field; `Cow` churn > win) and `embeddings_path() -> String` (azure formats an owned path).

## Verification
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo nextest run --workspace --all-features`: **6151/6151 passed** (+ doctests)
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features`: clean
- wasm: `rig-core` (default + all-features), `rig-agent`, `rig`, `rig-candle`, `candle_wasm_chat` on `wasm32-unknown-unknown`: green
- Erasure/clone-counting probes: **33/33 passed**
- `git diff <merge-base> -- tests/cassettes`: **empty**
- No lint suppressions added anywhere.

`MIGRATING.md` has before/after entries for every breaking change under `0.41 → next`.