### PR TITLE
refactor!: purge reqwest types from rig-core's public error surface

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -796,6 +796,47 @@ handed back a silently short list.
 
 ## 0.41 → next
 
+### `VectorStoreError::ReqwestError` is now `VectorStoreError::Http(http_client::Error)`
+
+The variant carried a raw `reqwest::Error`, which tied rig-core's public
+error surface to one HTTP backend. It now carries the transport-agnostic
+[`rig::http_client::Error`]: a non-success response arrives as one of its
+status-bearing variants (so the status code is still inspectable), and a
+response-less transport failure (connect, decode, timeout) arrives as
+`http_client::Error::Instance`.
+
+```rust
+// before
+Err(VectorStoreError::ReqwestError(e)) => {
+    if let Some(status) = e.status() { /* … */ }
+}
+
+// after
+Err(VectorStoreError::Http(e)) => match e {
+    http_client::Error::InvalidStatusCode(status)
+    | http_client::Error::InvalidStatusCodeWithMessage(status, _)
+    | http_client::Error::InvalidStatusCodeWithDetails { status, .. } => { /* … */ }
+    http_client::Error::Instance(source) => { /* transport failure */ }
+    _ => { /* … */ }
+},
+```
+
+Code that relied on `?` converting a `reqwest::Error` straight into
+`VectorStoreError` must map it first; `rig::http_client::from_reqwest`
+applies the routing above:
+
+```rust
+let res = client.send().await.map_err(http_client::from_reqwest)?;
+```
+
+### `ClientBuilderError` is removed
+
+The enum (`HttpError(reqwest::Error)` / `InvalidProperty`) had no remaining
+constructor or match site in the workspace — `Client::builder()`/`build()`
+return `http_client::Result` — so it is deleted rather than ported off
+reqwest. Nothing to migrate unless you named the type yourself; use
+`http_client::Error` in its place.
+
 ### `ToolServerHandle` registration methods are now synchronous
 
 `add_tool`, `add_dynamic_tool`, `add_portable_dynamic_tool`, `append_toolset`,

--- a/crates/rig-core/src/client/mod.rs
+++ b/crates/rig-core/src/client/mod.rs
@@ -44,20 +44,6 @@ use crate::{
     wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
 
-#[derive(Debug, Error)]
-pub enum ClientBuilderError {
-    /// The underlying HTTP backend failed during builder construction.
-    #[error("reqwest error: {0}")]
-    HttpError(
-        #[from]
-        #[source]
-        reqwest::Error,
-    ),
-    /// A provider-specific builder property was invalid.
-    #[error("invalid property: {0}")]
-    InvalidProperty(&'static str),
-}
-
 /// Errors returned while constructing provider clients from environment variables or explicit input.
 ///
 /// Provider-specific client constructors use this error for configuration problems that can be
@@ -167,7 +153,8 @@ impl ApiKey for Nothing {}
 /// Generic provider client shared by Rig provider integrations.
 ///
 /// `Ext` stores provider-specific behavior such as URL construction, request
-/// customization, and capabilities. `H` is the HTTP backend and defaults to
+/// customization, and capabilities. `H` is the HTTP backend — any
+/// [`crate::http_client::HttpClientExt`] implementation — and defaults to
 /// `reqwest::Client`.
 pub struct Client<Ext = Nothing, H = reqwest::Client> {
     base_url: Arc<str>,
@@ -505,6 +492,9 @@ pub(crate) use impl_provider_client;
 /// `new` is pinned to `H = reqwest::Client` so the call site infers without an explicit `H`
 /// annotation. Callers who want a different backend should go through [`Client::builder`] and
 /// chain [`ClientBuilder::http_client`] before [`ClientBuilder::build`].
+// bevy-prep: this reqwest-pinned construction surface (together with `builder()`'s inference
+// anchor and `ClientBuilder::build`'s default backend) relocates to the `rig` facade in the
+// transport-crate split.
 impl<Ext> Client<Ext, reqwest::Client>
 where
     Ext: Provider,
@@ -720,7 +710,7 @@ where
 
         match response.status() {
             StatusCode::OK => Ok(()),
-            StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN => {
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
                 Err(VerifyError::InvalidAuthentication)
             }
             // The failed response's headers are preserved on every branch, so

--- a/crates/rig-core/src/client/model_listing.rs
+++ b/crates/rig-core/src/client/model_listing.rs
@@ -80,7 +80,8 @@ pub trait ModelListingClient {
 ///
 /// # Type Parameters
 ///
-/// - `H`: The HTTP client type (typically `reqwest::Client`)
+/// - `H`: The HTTP backend, any [`crate::http_client::HttpClientExt`] implementation
+///   (defaults to `reqwest::Client`)
 ///
 /// # Example Implementation
 ///

--- a/crates/rig-core/src/http_client/mod.rs
+++ b/crates/rig-core/src/http_client/mod.rs
@@ -151,6 +151,21 @@ impl From<NoBody> for Body {
     }
 }
 
+/// Map a transport-level `reqwest::Error` onto the transport-agnostic
+/// [`Error`].
+///
+/// A failure that carries a status (an `error_for_status` rejection) keeps
+/// it as [`Error::InvalidStatusCode`] so provider retry and error-inspection
+/// paths can still read the code; a response-less failure (connect, decode,
+/// timeout) becomes [`Error::Instance`].
+// bevy-prep: moves to `rig-reqwest` in the transport-crate split.
+pub fn from_reqwest(err: reqwest::Error) -> Error {
+    match err.status() {
+        Some(status) => Error::InvalidStatusCode(status),
+        None => Error::Instance(Box::new(err)),
+    }
+}
+
 pub async fn text(response: Response<LazyBody<Vec<u8>>>) -> Result<String> {
     let text = response.into_body().await?;
     Ok(String::from(String::from_utf8_lossy(&text)))

--- a/crates/rig-core/src/vector_store/mod.rs
+++ b/crates/rig-core/src/vector_store/mod.rs
@@ -10,8 +10,8 @@
 //!
 //! Types implementing [`VectorStoreIndex`] automatically implement [`PortableTool`].
 
+use http::StatusCode;
 pub use request::VectorSearchRequest;
-use reqwest::StatusCode;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::{Value, json};
 
@@ -58,8 +58,13 @@ pub enum VectorStoreError {
     MissingIdError(String),
 
     /// HTTP request failed for an external vector store service.
+    ///
+    /// Non-success responses arrive as the status-bearing
+    /// [`crate::http_client::Error`] variants, so callers can still inspect
+    /// the status code; response-less transport failures arrive as
+    /// [`crate::http_client::Error::Instance`].
     #[error("HTTP request error: {0}")]
-    ReqwestError(#[from] reqwest::Error),
+    Http(#[from] crate::http_client::Error),
 
     /// External vector store service returned an error response.
     #[error("External call to API returned an error. Error code: {0} Message: {1}")]

--- a/crates/rig-milvus/src/lib.rs
+++ b/crates/rig-milvus/src/lib.rs
@@ -188,16 +188,26 @@ impl MilvusVectorStore {
 
         let body = serde_json::to_string(&body)?;
 
-        let res = client.body(body).send().await?;
+        let res = client
+            .body(body)
+            .send()
+            .await
+            .map_err(rig_core::http_client::from_reqwest)?;
 
         if res.status() != StatusCode::OK {
             let status = res.status();
-            let text = res.text().await?;
+            let text = res
+                .text()
+                .await
+                .map_err(rig_core::http_client::from_reqwest)?;
 
             return Err(VectorStoreError::ExternalAPIError(status, text));
         }
 
-        Ok(res.json().await?)
+        Ok(res
+            .json()
+            .await
+            .map_err(rig_core::http_client::from_reqwest)?)
     }
 }
 
@@ -229,11 +239,18 @@ impl InsertDocuments for MilvusVectorStore {
 
         let body = serde_json::to_string(&insert_request)?;
 
-        let res = client.body(body).send().await?;
+        let res = client
+            .body(body)
+            .send()
+            .await
+            .map_err(rig_core::http_client::from_reqwest)?;
 
         if res.status() != StatusCode::OK {
             let status = res.status();
-            let text = res.text().await?;
+            let text = res
+                .text()
+                .await
+                .map_err(rig_core::http_client::from_reqwest)?;
 
             return Err(VectorStoreError::ExternalAPIError(status, text));
         }


### PR DESCRIPTION
Bevy-prep PR 2 (follows #2394). rig-core's public API no longer names reqwest in its error enums or re-exported types — the prerequisite for re-founding the HTTP layer on `http`-crate types and splitting the reqwest transport into its own crate so Bevy/non-tokio users can plug a different backend.

## Changes

**`VectorStoreError::ReqwestError(reqwest::Error)` → `VectorStoreError::Http(http_client::Error)`.** `http_client::Error` was already fully transport-agnostic — status-bearing variants (including the rig#2314 `InvalidStatusCodeWithDetails { status, body, headers }`) plus a boxed `Instance` catch-all, dual-defined for wasm — so it is reused unchanged rather than redesigned. A new `http_client::from_reqwest` helper applies the routing rule: a status-carrying failure keeps its status (`InvalidStatusCode`) so provider retry/error-inspection paths can still read it; a response-less transport failure (connect, decode, timeout) becomes `Instance`. It's marked to move to the transport crate in the split. `rig-milvus` was the only `?` site in the workspace relying on the old `From<reqwest::Error>` impl; it now maps through the helper.

**`ClientBuilderError` deleted.** The enum (`HttpError(reqwest::Error)` / `InvalidProperty`) had no constructor or match site anywhere in the workspace — `Client::builder()`/`build()` already return `http_client::Result` — so it's removed rather than ported off reqwest.

**Re-export cleanups.** `vector_store` imported `reqwest::StatusCode` and `client::verify` used `reqwest::StatusCode::FORBIDDEN` (with `http::StatusCode` already in scope); both now use `http` directly. Doc comments describing `H` as "typically `reqwest::Client`" now point at the `HttpClientExt` transport trait.

## Deliberately left for the crate split

The reqwest-pinned construction surface in `client/mod.rs` stays for now and is cataloged here for that PR (a `// bevy-prep:` marker comment sits on the impl block):
- `impl<Ext> Client<Ext, reqwest::Client>` for `Client::new` (pinned so call sites infer `H`), the `builder()` inference anchor, and `ClientBuilder::build()` substituting `reqwest::Client::default()` / returning `Client<…, reqwest::Client>`; the `Missing`-placeholder docs.
- Type-parameter defaults: `Client<Ext = Nothing, H = reqwest::Client>`, `Capabilities<H = reqwest::Client>`, `ModelLister<H = reqwest::Client>`; and the tests that spell them out.

Removing these before the facade-level type aliases exist would churn every call site twice; they move together when the `rig` facade takes over the reqwest default.

## Verification

- `cargo check --workspace --all-features --all-targets` and `cargo clippy` (same flags): clean.
- `cargo test -p rig-core --all-features`: 1799 passed; `-p rig-agent`: 598 passed; 0 failures. The #1931 error-inspection and rig#2210/#2314 header-preservation tests pass unchanged — they're the proof the routing rule preserves status introspection.
- CI's `cargo check -p rig-core --all-features --target wasm32-unknown-unknown`: clean.
- `grep -rn reqwest crates/rig-core/src | grep -v 'http_client/\|providers/'` now returns only the cataloged construction anchors/defaults/tests and prose doc mentions — no error enums, no `StatusCode`/header re-exports.
- MIGRATING.md (`0.41 → next`): entries for the `VectorStoreError` variant change (with a before/after for reading the status code) and the `ClientBuilderError` removal.