### PR TITLE
feat(agent): run_channel/RunEvents, static Send+Sync pins, bevy_tasks example, dependency-graph guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "agent_no_tokio"
+version = "0.42.0"
+dependencies = [
+ "anyhow",
+ "bevy_tasks",
+ "futures",
+ "rig",
+]
+
+[[package]]
 name = "agent_orchestrator"
 version = "0.42.0"
 dependencies = [
@@ -787,6 +797,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +869,9 @@ name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "async-trait"
@@ -889,6 +916,9 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "autocfg"
@@ -1475,6 +1505,46 @@ dependencies = [
  "getrandom 0.3.4",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "bevy_platform"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd610a417e7b4a3b9602cf11264d16cbbff8eabe689c5fed8be4e84c6a2680a3"
+dependencies = [
+ "critical-section",
+ "foldhash 0.2.0",
+ "futures-channel",
+ "futures-lite",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "spin 0.10.1",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "bevy_tasks"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f787d4ba7237b64b30bd2d690a8cbae1ba775e0eec326711c446654cb720e7c"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-task",
+ "atomic-waker",
+ "bevy_platform",
+ "concurrent-queue",
+ "crossbeam-queue",
+ "derive_more",
+ "futures-lite",
+ "heapless 0.9.3",
+ "web-task",
 ]
 
 [[package]]
@@ -3583,7 +3653,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3912,7 +3982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4204,7 +4274,7 @@ checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -4350,6 +4420,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -4610,7 +4693,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -5192,7 +5275,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32 0.2.1",
  "rustc_version",
- "spin",
+ "spin 0.9.9",
  "stable_deref_trait",
 ]
 
@@ -5203,6 +5286,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "hash32 0.3.1",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32 0.3.1",
+ "portable-atomic",
  "stable_deref_trait",
 ]
 
@@ -5596,7 +5690,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6051,7 +6145,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6780,7 +6874,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -7691,7 +7785,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8729,7 +8823,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -9033,7 +9127,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.39",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9072,9 +9166,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10636,7 +10730,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10731,7 +10825,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11035,7 +11129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11509,7 +11603,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11521,7 +11615,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11550,7 +11644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11583,6 +11677,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -12386,10 +12489,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13862,6 +13965,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-task"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdc136a53ccd64a1211f107ccc34404769fbcc0f165f1afa065f5d88ab93538"
+dependencies = [
+ "async-task",
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13956,7 +14071,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,8 @@ eventsource-stream = "0.2.3"
 fastembed = { version = "4.5", default-features = false }
 fastrand = "2"
 futures = "0.3"
+# Runtime-agnostic executor used by the `agent_no_tokio` example.
+bevy_tasks = { version = "0.19", features = ["multi_threaded"] }
 futures-timer = "3"
 glob = "0.3"
 google-cloud-auth = "1"

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -796,6 +796,21 @@ handed back a silently short list.
 
 ## 0.41 → next
 
+### `AgentRunner::run_channel` / `Agent::run_channel`: a future plus an event feed
+
+Additive. Beside `run()` (fold to a `PromptResponse`) and `stream()` (a
+`Stream` of `MultiTurnStreamItem`), the agent loop now has a third, runtime-
+agnostic shape: `AgentRunner::run_channel(self)` (also on `Agent` and a
+configured `StreamingPromptRequest`) returns `(impl Future<Output =
+Result<PromptResponse, PromptError>>, RunEvents)`. Spawn the future on any
+executor — tokio, `bevy_tasks`, a thread — and consume `RunEvents` wherever the
+events are needed: it implements `Stream` and offers a non-blocking
+`try_next()` / `is_done()` for tick-driven hosts. The feed is bounded
+(`RUN_EVENTS_CAPACITY`, back-pressure rather than drops), and dropping it
+does not cancel the run. `rig_agent::agent::{RunEvents, RUN_EVENTS_CAPACITY}`;
+`RunEvents` is also in the rig-agent and `rig` preludes. See
+`examples/agent_no_tokio` for a `bevy_tasks` host.
+
 ### MCP tool support moves from rig-agent's `rmcp` feature to the `rig-rmcp` crate
 
 rig-agent no longer has an `rmcp` feature or an rmcp dependency; MCP lives in

--- a/crates/rig-agent/src/agent/mod.rs
+++ b/crates/rig-agent/src/agent/mod.rs
@@ -126,7 +126,8 @@ pub use hook::{
 };
 pub use model::ModelHandle;
 pub use prompt_request::streaming::{
-    MultiTurnStreamItem, StreamingError, StreamingPromptRequest, StreamingResult, stream_to_stdout,
+    MultiTurnStreamItem, RUN_EVENTS_CAPACITY, RunEvents, StreamingError, StreamingPromptRequest,
+    StreamingResult, stream_to_stdout,
 };
 pub use prompt_request::{
     CompletionCall, Extended, PromptRequest, PromptResponse, PromptType, ResponseIdentity,

--- a/crates/rig-agent/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-agent/src/agent/prompt_request/streaming.rs
@@ -24,7 +24,7 @@ use crate::{
     streaming::{StreamedAssistantContent, StreamedUserContent, ToolCallDeltaContent},
     tool::{ToolContext, server::ToolRegistrySnapshot},
 };
-use futures::{Stream, StreamExt, stream};
+use futures::{SinkExt, Stream, StreamExt, channel::mpsc, stream::FusedStream, stream};
 use serde::{Deserialize, Serialize};
 use std::{collections::VecDeque, pin::Pin, sync::Arc};
 use tracing_futures::Instrument;
@@ -317,6 +317,17 @@ impl StreamingPromptRequest {
 
     async fn send(self) -> StreamingResult {
         self.runner.stream().await
+    }
+
+    /// Split the configured run into a driving future and a [`RunEvents`]
+    /// feed instead of a stream. See [`AgentRunner::run_channel`].
+    pub fn run_channel(
+        self,
+    ) -> (
+        impl Future<Output = Result<PromptResponse, PromptError>> + WasmCompatSend,
+        RunEvents,
+    ) {
+        self.runner.run_channel()
     }
 }
 
@@ -1594,6 +1605,137 @@ impl AgentRunner {
         });
 
         Box::pin(driver.instrument(agent_span))
+    }
+}
+
+/// Capacity of the event queue behind [`AgentRunner::run_channel`]: the number
+/// of [`MultiTurnStreamItem`]s the run may buffer ahead of the consumer before
+/// it parks on back-pressure.
+pub const RUN_EVENTS_CAPACITY: usize = 32;
+
+/// Event feed of an agent run started with [`AgentRunner::run_channel`] or
+/// [`Agent::run_channel`].
+///
+/// Every [`MultiTurnStreamItem`] the run would have streamed is delivered here
+/// in order, ending with [`MultiTurnStreamItem::FinalResponse`]. The feed is a
+/// bounded queue ([`RUN_EVENTS_CAPACITY`]): a slow consumer applies
+/// back-pressure to the run instead of losing events. Poll it as a
+/// [`Stream`] from async code, or drain it with the non-blocking
+/// [`try_next`](RunEvents::try_next) from a synchronous tick — a game loop, a
+/// UI frame, an ECS system.
+///
+/// Dropping the feed does not cancel the run; it simply stops receiving events
+/// and the run future still resolves with the final
+/// [`PromptResponse`](super::PromptResponse).
+#[derive(Debug)]
+pub struct RunEvents {
+    receiver: mpsc::Receiver<MultiTurnStreamItem>,
+}
+
+impl RunEvents {
+    /// Take the next buffered event without waiting.
+    ///
+    /// Returns `None` both when no event is queued yet and once the run has
+    /// finished and the feed is drained; use [`is_done`](RunEvents::is_done)
+    /// to tell the two apart.
+    pub fn try_next(&mut self) -> Option<MultiTurnStreamItem> {
+        self.receiver.try_recv().ok()
+    }
+
+    /// Whether the run has finished and every event has been taken.
+    pub fn is_done(&self) -> bool {
+        self.receiver.is_terminated()
+    }
+}
+
+impl Stream for RunEvents {
+    type Item = MultiTurnStreamItem;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        Pin::new(&mut self.receiver).poll_next(cx)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.receiver.size_hint()
+    }
+}
+
+impl FusedStream for RunEvents {
+    fn is_terminated(&self) -> bool {
+        self.receiver.is_terminated()
+    }
+}
+
+impl AgentRunner {
+    /// Split the run into a driving future and a [`RunEvents`] feed.
+    ///
+    /// The future performs the whole agent loop — the same engine as
+    /// [`run`](AgentRunner::run) and [`stream`](AgentRunner::stream) — and
+    /// resolves with the final [`PromptResponse`](super::PromptResponse); the
+    /// feed receives each intermediate [`MultiTurnStreamItem`] as it happens.
+    /// Spawn the future on any executor and poll the feed from wherever the
+    /// events are consumed; neither side assumes a runtime.
+    ///
+    /// The feed is bounded ([`RUN_EVENTS_CAPACITY`]); when it is full the run
+    /// waits for the consumer rather than dropping events. Dropping the feed
+    /// lets the run continue to completion unobserved.
+    pub fn run_channel(
+        self,
+    ) -> (
+        impl Future<Output = Result<PromptResponse, PromptError>> + WasmCompatSend,
+        RunEvents,
+    ) {
+        let (mut sender, receiver) = mpsc::channel(RUN_EVENTS_CAPACITY);
+        let future = async move {
+            let mut stream = self.stream().await;
+            let mut response = None;
+            let mut forward = true;
+            while let Some(item) = stream.next().await {
+                let item = item.map_err(streaming_error_into_prompt)?;
+                match item {
+                    MultiTurnStreamItem::FinalResponse(done) => {
+                        if forward {
+                            // The consumer is gone; nothing left to forward.
+                            let _ = sender
+                                .send(MultiTurnStreamItem::FinalResponse(done.clone()))
+                                .await;
+                        }
+                        response = Some(done);
+                    }
+                    item => {
+                        if forward && sender.send(item).await.is_err() {
+                            forward = false;
+                        }
+                    }
+                }
+            }
+            response.ok_or_else(|| {
+                PromptError::CompletionError(CompletionError::ResponseError(
+                    "agent run ended without producing a final response".to_string(),
+                ))
+            })
+        };
+        (future, RunEvents { receiver })
+    }
+}
+
+impl Agent {
+    /// Run `prompt` with the agent's defaults, returning the driving future and
+    /// a [`RunEvents`] feed. See [`AgentRunner::run_channel`]; to configure the
+    /// run first (history, turn budget, tool context, …), configure a
+    /// [`StreamingPromptRequest`] and call its
+    /// [`run_channel`](StreamingPromptRequest::run_channel).
+    pub fn run_channel<P: Into<Message> + WasmCompatSend>(
+        &self,
+        prompt: P,
+    ) -> (
+        impl Future<Output = Result<PromptResponse, PromptError>> + WasmCompatSend + use<P>,
+        RunEvents,
+    ) {
+        AgentRunner::from_agent(self, prompt).run_channel()
     }
 }
 
@@ -7514,5 +7656,91 @@ mod migrated_tests {
             saw_final,
             "FinalResponse must be yielded even when memory.append fails"
         );
+    }
+
+    /// `run_channel` delivers every event the stream would have produced, in
+    /// order and ending with the final response, while the future resolves
+    /// with that same response.
+    #[tokio::test]
+    async fn run_channel_forwards_events_and_resolves() {
+        let model = streaming_tool_then_text_model();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let (run, events) = agent.stream_prompt("do tool work").max_turns(3).run_channel();
+        let (response, items) = futures::join!(run, events.collect::<Vec<_>>());
+
+        let response = response.expect("run succeeds");
+        assert_eq!(response.output(), "done");
+        assert!(items.iter().any(|item| matches!(
+            item,
+            MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::ToolCall { .. })
+        )));
+        assert!(items.iter().any(|item| matches!(
+            item,
+            MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult { .. })
+        )));
+        match items.last() {
+            Some(MultiTurnStreamItem::FinalResponse(last)) => {
+                assert_eq!(last.output(), response.output());
+            }
+            other => panic!("expected FinalResponse last, got {other:?}"),
+        }
+    }
+
+    /// Dropping the event feed does not abort the run: the future still
+    /// drives the loop to completion and resolves.
+    #[tokio::test]
+    async fn run_channel_survives_dropped_events() {
+        let model = streaming_tool_then_text_model();
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let (run, events) = agent.stream_prompt("do tool work").max_turns(3).run_channel();
+        drop(events);
+
+        let response = run.await.expect("run succeeds without a consumer");
+        assert_eq!(response.output(), "done");
+        assert_eq!(recorded.requests().len(), 2);
+    }
+
+    /// The feed can be drained without awaiting — the shape a frame/tick loop
+    /// uses — and reports completion once the run is over and drained.
+    #[tokio::test]
+    async fn run_channel_try_next_drains_from_a_tick_loop() {
+        let model = streaming_tool_then_text_model();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let (run, mut events) = agent.stream_prompt("do tool work").max_turns(3).run_channel();
+        let run = tokio::spawn(run);
+
+        let mut seen = Vec::new();
+        while !events.is_done() {
+            match events.try_next() {
+                Some(item) => seen.push(item),
+                None => tokio::task::yield_now().await,
+            }
+        }
+
+        let response = run.await.expect("join").expect("run succeeds");
+        assert_eq!(response.output(), "done");
+        assert!(matches!(
+            seen.last(),
+            Some(MultiTurnStreamItem::FinalResponse(_))
+        ));
+    }
+
+    /// Load failures surface on the future as a `PromptError`, and the feed
+    /// closes without a final response.
+    #[tokio::test]
+    async fn run_channel_reports_stream_errors_on_the_future() {
+        let model = MockCompletionModel::text("unused");
+        let agent = AgentBuilder::new(model).build();
+
+        let (run, events) = agent.stream_prompt("budget of zero").max_turns(0).run_channel();
+        let _: (_, RunEvents) = agent.run_channel("plain entry point type-checks");
+        let (response, items) = futures::join!(run, events.collect::<Vec<_>>());
+
+        assert!(response.is_err(), "zero-turn budget must fail the run");
+        assert!(!items.iter().any(|item| matches!(item, MultiTurnStreamItem::FinalResponse(_))));
     }
 }

--- a/crates/rig-agent/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-agent/src/agent/prompt_request/streaming.rs
@@ -24,7 +24,7 @@ use crate::{
     streaming::{StreamedAssistantContent, StreamedUserContent, ToolCallDeltaContent},
     tool::{ToolContext, server::ToolRegistrySnapshot},
 };
-use futures::{SinkExt, Stream, StreamExt, channel::mpsc, stream::FusedStream, stream};
+use futures::{SinkExt, Stream, StreamExt, channel::mpsc, stream, stream::FusedStream};
 use serde::{Deserialize, Serialize};
 use std::{collections::VecDeque, pin::Pin, sync::Arc};
 use tracing_futures::Instrument;
@@ -1626,7 +1626,7 @@ pub const RUN_EVENTS_CAPACITY: usize = 32;
 ///
 /// Dropping the feed does not cancel the run; it simply stops receiving events
 /// and the run future still resolves with the final
-/// [`PromptResponse`](super::PromptResponse).
+/// [`PromptResponse`].
 #[derive(Debug)]
 pub struct RunEvents {
     receiver: mpsc::Receiver<MultiTurnStreamItem>,
@@ -1674,7 +1674,7 @@ impl AgentRunner {
     ///
     /// The future performs the whole agent loop — the same engine as
     /// [`run`](AgentRunner::run) and [`stream`](AgentRunner::stream) — and
-    /// resolves with the final [`PromptResponse`](super::PromptResponse); the
+    /// resolves with the final [`PromptResponse`]; the
     /// feed receives each intermediate [`MultiTurnStreamItem`] as it happens.
     /// Spawn the future on any executor and poll the feed from wherever the
     /// events are consumed; neither side assumes a runtime.
@@ -7666,7 +7666,10 @@ mod migrated_tests {
         let model = streaming_tool_then_text_model();
         let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
-        let (run, events) = agent.stream_prompt("do tool work").max_turns(3).run_channel();
+        let (run, events) = agent
+            .stream_prompt("do tool work")
+            .max_turns(3)
+            .run_channel();
         let (response, items) = futures::join!(run, events.collect::<Vec<_>>());
 
         let response = response.expect("run succeeds");
@@ -7695,7 +7698,10 @@ mod migrated_tests {
         let recorded = model.clone();
         let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
-        let (run, events) = agent.stream_prompt("do tool work").max_turns(3).run_channel();
+        let (run, events) = agent
+            .stream_prompt("do tool work")
+            .max_turns(3)
+            .run_channel();
         drop(events);
 
         let response = run.await.expect("run succeeds without a consumer");
@@ -7710,7 +7716,10 @@ mod migrated_tests {
         let model = streaming_tool_then_text_model();
         let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
-        let (run, mut events) = agent.stream_prompt("do tool work").max_turns(3).run_channel();
+        let (run, mut events) = agent
+            .stream_prompt("do tool work")
+            .max_turns(3)
+            .run_channel();
         let run = tokio::spawn(run);
 
         let mut seen = Vec::new();
@@ -7736,11 +7745,18 @@ mod migrated_tests {
         let model = MockCompletionModel::text("unused");
         let agent = AgentBuilder::new(model).build();
 
-        let (run, events) = agent.stream_prompt("budget of zero").max_turns(0).run_channel();
+        let (run, events) = agent
+            .stream_prompt("budget of zero")
+            .max_turns(0)
+            .run_channel();
         let _: (_, RunEvents) = agent.run_channel("plain entry point type-checks");
         let (response, items) = futures::join!(run, events.collect::<Vec<_>>());
 
         assert!(response.is_err(), "zero-turn budget must fail the run");
-        assert!(!items.iter().any(|item| matches!(item, MultiTurnStreamItem::FinalResponse(_))));
+        assert!(
+            !items
+                .iter()
+                .any(|item| matches!(item, MultiTurnStreamItem::FinalResponse(_)))
+        );
     }
 }

--- a/crates/rig-agent/src/lib.rs
+++ b/crates/rig-agent/src/lib.rs
@@ -87,3 +87,17 @@ pub use rig_derive::rig_tool;
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 pub use rig_derive::rig_tool as tool_macro;
+
+// Compile-time thread-safety contract: the agent surface must be safe to hold
+// in shared host state (worker pools, ECS resources) on native targets.
+#[cfg(not(target_family = "wasm"))]
+const _: fn() = || {
+    fn assert_send_sync_static<T: Send + Sync + 'static>() {}
+    assert_send_sync_static::<Agent>();
+    assert_send_sync_static::<AgentRunner>();
+    assert_send_sync_static::<ModelHandle>();
+    assert_send_sync_static::<agent::MultiTurnStreamItem>();
+    assert_send_sync_static::<agent::RunEvents>();
+    assert_send_sync_static::<agent::PromptResponse>();
+    assert_send_sync_static::<tool::server::ToolServerHandle>();
+};

--- a/crates/rig-agent/src/prelude.rs
+++ b/crates/rig-agent/src/prelude.rs
@@ -13,7 +13,7 @@ pub use rig_core::client::image_generation::ImageGenerationClient;
 
 pub use crate::agent::{
     Agent, AgentHook, HookContext, ModelHandle, ModelSelection, ModelSelectionAction,
-    MultiTurnStreamItem, StreamingResult,
+    MultiTurnStreamItem, RunEvents, StreamingResult,
 };
 pub use crate::client::{AgentClientExt, AgentModelExt};
 pub use crate::completion::{

--- a/crates/rig-core/src/lib.rs
+++ b/crates/rig-core/src/lib.rs
@@ -200,3 +200,19 @@ pub use rig_derive::Embed;
 pub use rig_derive::{rig_tool, rig_tool as tool_macro};
 
 pub mod telemetry;
+
+// Compile-time thread-safety contract. These types cross threads in host
+// runtimes (worker pools, ECS resources); on native they must stay
+// `Send + Sync + 'static`, and losing it is an API break that should fail the
+// build here rather than in a downstream crate.
+#[cfg(not(target_family = "wasm"))]
+const _: fn() = || {
+    fn assert_send_sync_static<T: Send + Sync + 'static>() {}
+    fn assert_send_static<T: Send + 'static>() {}
+    assert_send_sync_static::<tool::PortableDynamicTool>();
+    assert_send_sync_static::<tool::ManagedToolToken>();
+    assert_send_sync_static::<streaming::StreamedAssistantContent>();
+    // A live stream is owned by one poller: `Send` so it can move to a worker,
+    // not `Sync`.
+    assert_send_static::<streaming::StreamingCompletionResponse>();
+};

--- a/crates/rig-reqwest/src/lib.rs
+++ b/crates/rig-reqwest/src/lib.rs
@@ -474,6 +474,14 @@ impl_http_client_ext_via!(
     ReqwestMiddlewareClient
 );
 
+// Compile-time thread-safety contract: the transport handle is shared across
+// threads by every host runtime.
+#[cfg(not(target_family = "wasm"))]
+const _: fn() = || {
+    fn assert_send_sync_static<T: Send + Sync + 'static>() {}
+    assert_send_sync_static::<ReqwestClient>();
+};
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rig-rmcp/src/native.rs
+++ b/crates/rig-rmcp/src/native.rs
@@ -497,3 +497,10 @@ impl From<McpTool> for PortableDynamicTool {
         .with_liveness(move || !liveness_client.is_transport_closed())
     }
 }
+
+// Compile-time thread-safety contract: an `McpTool` is handed to the agent's
+// tool registry and executed from whichever thread the host runs tools on.
+const _: fn() = || {
+    fn assert_send_sync_static<T: Send + Sync + 'static>() {}
+    assert_send_sync_static::<McpTool>();
+};

--- a/crates/rig-rmcp/src/tests.rs
+++ b/crates/rig-rmcp/src/tests.rs
@@ -1347,3 +1347,10 @@ mod migrated_tests {
         server_task.abort();
     }
 }
+
+// Compile-time thread-safety contract: rmcp's `ClientHandler` requires it, and
+// rig-agent's `ToolServerHandle` is the sink the docs recommend.
+const _: fn() = || {
+    fn assert_send_sync_static<T: Send + Sync + 'static>() {}
+    assert_send_sync_static::<crate::McpClientHandler<rig_agent::tool::server::ToolServerHandle>>();
+};

--- a/examples/agent_no_tokio/Cargo.toml
+++ b/examples/agent_no_tokio/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "agent_no_tokio"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+rig.workspace = true
+anyhow = { workspace = true }
+bevy_tasks = { workspace = true }
+futures = { workspace = true }

--- a/examples/agent_no_tokio/README.md
+++ b/examples/agent_no_tokio/README.md
@@ -1,0 +1,21 @@
+# agent_no_tokio
+
+Runs a rig agent on Bevy's `AsyncComputeTaskPool` with no tokio dependency in
+this crate's manifest.
+
+`Agent::run_channel` splits a run into a runtime-agnostic future and a bounded
+`RunEvents` feed. The future is spawned on the pool; the main thread acts as a
+frame loop, draining events with the non-blocking `RunEvents::try_next` and
+checking the task with `bevy_tasks::futures::check_ready` — the shape a Bevy
+system or any other tick-driven host would use.
+
+```sh
+OPENAI_API_KEY=… cargo run -p agent_no_tokio
+```
+
+Tokio appears only transitively, inside `rig-reqwest`, which drives the HTTP
+wire on a private runtime:
+
+```sh
+cargo tree -p agent_no_tokio -e normal -i tokio
+```

--- a/examples/agent_no_tokio/src/main.rs
+++ b/examples/agent_no_tokio/src/main.rs
@@ -1,0 +1,64 @@
+//! An agent run driven by `bevy_tasks` instead of tokio.
+//!
+//! rig-agent has no runtime of its own: [`Agent::run_channel`] hands back a
+//! plain future plus a bounded [`RunEvents`] feed, so the future can be spawned
+//! on any executor — here Bevy's `AsyncComputeTaskPool` — while a synchronous
+//! loop (think: a game frame, an ECS system) drains the events with
+//! `try_next` and never blocks on the run. The HTTP transport (`rig-reqwest`)
+//! brings its own private tokio runtime for the wire; this crate's manifest
+//! depends on neither tokio nor reqwest.
+//!
+//! Requires `OPENAI_API_KEY`.
+
+use std::{thread, time::Duration};
+
+use anyhow::Result;
+use bevy_tasks::{AsyncComputeTaskPool, TaskPool, futures::check_ready};
+use rig::agent::MultiTurnStreamItem;
+use rig::prelude::*;
+use rig::providers::openai;
+use rig::streaming::StreamedAssistantContent;
+
+const PREAMBLE: &str = "You are a comedian here to entertain the user using humour and jokes.";
+const PROMPT: &str = "Entertain me!";
+/// How long the "frame" loop sleeps between ticks when nothing is ready.
+const FRAME: Duration = Duration::from_millis(16);
+
+fn main() -> Result<()> {
+    let agent = openai::Client::from_env()?
+        .agent(openai::GPT_4O)
+        .preamble(PREAMBLE)
+        .build();
+
+    // Split the run: a future for the pool, an event feed for the frame loop.
+    let (run, mut events) = agent.run_channel(PROMPT);
+    let pool = AsyncComputeTaskPool::get_or_init(TaskPool::new);
+    let mut task = pool.spawn(run);
+
+    // The "game loop": poll the feed without blocking, tick, repeat.
+    let response = loop {
+        while let Some(event) = events.try_next() {
+            match event {
+                MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::Text(text)) => {
+                    print!("{}", text.text)
+                }
+                MultiTurnStreamItem::ToolExecutionCommitted { tool_call, .. } => {
+                    println!("\n[tool {}]", tool_call.function.name);
+                }
+                MultiTurnStreamItem::FinalResponse(_) => println!(),
+                _ => {}
+            }
+        }
+        if let Some(outcome) = check_ready(&mut task) {
+            break outcome?;
+        }
+        thread::sleep(FRAME);
+    };
+
+    println!(
+        "done: {} completion call(s), {} total tokens",
+        response.completion_calls().len(),
+        response.usage().total_tokens
+    );
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,8 +145,8 @@ pub mod prelude {
     #[cfg(feature = "agent")]
     pub use rig_agent::prelude::{
         Agent, AgentClientExt, AgentModelExt, Chat, MultiTurnStreamItem, Prompt, PromptError,
-        RunEvents, StreamingChat, StreamingPrompt, StreamingResult, StructuredOutputError,
-        ToolSet, TypedPrompt,
+        RunEvents, StreamingChat, StreamingPrompt, StreamingResult, StructuredOutputError, ToolSet,
+        TypedPrompt,
     };
     pub use rig_core::prelude::*;
     // Default-transport construction traits: `Client::new(..)` / `from_env()` /

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,8 +145,8 @@ pub mod prelude {
     #[cfg(feature = "agent")]
     pub use rig_agent::prelude::{
         Agent, AgentClientExt, AgentModelExt, Chat, MultiTurnStreamItem, Prompt, PromptError,
-        StreamingChat, StreamingPrompt, StreamingResult, StructuredOutputError, ToolSet,
-        TypedPrompt,
+        RunEvents, StreamingChat, StreamingPrompt, StreamingResult, StructuredOutputError,
+        ToolSet, TypedPrompt,
     };
     pub use rig_core::prelude::*;
     // Default-transport construction traits: `Client::new(..)` / `from_env()` /

--- a/tests/core/dependency_graph.rs
+++ b/tests/core/dependency_graph.rs
@@ -1,0 +1,75 @@
+//! Dependency-graph invariants for the runtime/transport-agnostic split.
+//!
+//! The crate boundaries that keep rig usable from non-tokio hosts are
+//! enforced here rather than by convention: rig-core and rig-agent carry no
+//! runtime or transport, MCP is an rig-core-only leaf, and the facade with
+//! only `agent` + `derive` pulls in none of tokio / reqwest / rmcp. Each check
+//! asks Cargo for the resolved normal (non-dev, non-build) dependency graph of
+//! one package and asserts the forbidden crates are absent.
+
+use std::process::Command;
+
+/// `cargo tree -e normal --prefix none` for `package` with extra `args`,
+/// returned as the set of package names in the graph.
+fn normal_dependency_names(package: &str, args: &[&str]) -> Vec<String> {
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let output = Command::new(cargo)
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .args([
+            "tree", "--locked", "-p", package, "-e", "normal", "--prefix", "none",
+        ])
+        .args(args)
+        .output()
+        .expect("cargo tree runs");
+    assert!(
+        output.status.success(),
+        "cargo tree -p {package} failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("cargo tree output is utf-8")
+        .lines()
+        .filter_map(|line| line.split_whitespace().next())
+        .map(str::to_owned)
+        .collect()
+}
+
+fn assert_absent(package: &str, args: &[&str], forbidden: &[&str]) {
+    let names = normal_dependency_names(package, args);
+    for crate_name in forbidden {
+        assert!(
+            !names.iter().any(|name| name == crate_name),
+            "`{package}` ({}) must not depend on `{crate_name}` through its normal dependencies",
+            if args.is_empty() {
+                "default features".to_owned()
+            } else {
+                args.join(" ")
+            }
+        );
+    }
+}
+
+#[test]
+fn rig_core_is_runtime_and_transport_free() {
+    assert_absent("rig-core", &[], &["tokio", "reqwest"]);
+    assert_absent("rig-core", &["--all-features"], &["tokio", "reqwest"]);
+}
+
+#[test]
+fn rig_agent_carries_no_runtime_or_mcp() {
+    assert_absent("rig-agent", &[], &["tokio", "rmcp"]);
+}
+
+#[test]
+fn rig_rmcp_depends_on_rig_core_only() {
+    assert_absent("rig-rmcp", &[], &["rig-agent"]);
+}
+
+#[test]
+fn facade_agent_derive_is_runtime_transport_and_mcp_free() {
+    assert_absent(
+        "rig",
+        &["--no-default-features", "--features", "agent,derive"],
+        &["tokio", "reqwest", "rmcp"],
+    );
+}

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -1,3 +1,4 @@
+mod dependency_graph;
 #[cfg(feature = "derive")]
 mod embed_macro;
 mod loaders;


### PR DESCRIPTION
Sixth PR of the runtime/transport-agnostic series (after #2394, #2395, #2396, #2397, #2398). The agent loop gains a third shape that host runtimes without tokio can drive, and the split's guarantees become compile-time/test-time contracts.

## `AgentRunner::run_channel` + `RunEvents`

```rust
let (run, mut events) = agent.run_channel("…");           // or agent.stream_prompt("…").max_turns(3).run_channel()
pool.spawn(run);                                           // any executor: tokio, bevy_tasks, a thread
while let Some(ev) = events.try_next() { … }              // non-blocking, from a frame/tick loop
// or: events.next().await                                 // RunEvents: Stream + FusedStream
```

- Returns `(impl Future<Output = Result<PromptResponse, PromptError>> + WasmCompatSend, RunEvents)`; reuses the existing `stream()` engine, so hooks, tool execution, telemetry and fail-closed behaviour are identical to `run()`/`stream()`.
- `RunEvents` is a newtype over a **bounded** `futures::channel::mpsc::Receiver<MultiTurnStreamItem>` (`RUN_EVENTS_CAPACITY = 32`): a slow consumer applies back-pressure, nothing is dropped. `try_next()` / `is_done()` for synchronous hosts, `Stream` for async ones.
- Dropping the feed does not abort the run; the future still resolves with the `PromptResponse`. Stream errors surface on the future as `PromptError`.
- Also on `Agent` and on a configured `StreamingPromptRequest`; exported from `rig_agent::agent`, and `RunEvents` is in the rig-agent and `rig` preludes.
- Four unit tests on mock models: forwarding + final response, dropped receiver, `try_next` tick-loop drain, error propagation.

## Static `Send + Sync + 'static` pins

`const _: fn() = || { … }` assertions (native only) in rig-core (`PortableDynamicTool`, `ManagedToolToken`, `StreamedAssistantContent`; `StreamingCompletionResponse` is pinned `Send + 'static` — a live stream is owned by one poller), rig-agent (`Agent`, `AgentRunner`, `ModelHandle`, `MultiTurnStreamItem`, `RunEvents`, `PromptResponse`, `ToolServerHandle`), rig-reqwest (`ReqwestClient`), rig-rmcp (`McpTool`, `McpClientHandler<ToolServerHandle>`). Losing thread-safety now fails the owning crate's build.

## `examples/agent_no_tokio`

An OpenAI agent run spawned on `bevy_tasks::AsyncComputeTaskPool`, with the main thread acting as a frame loop that drains `RunEvents::try_next` and checks the task with `check_ready`. The manifest has no tokio/reqwest; tokio is only reached transitively through `rig-reqwest`'s private runtime:

```
$ cargo tree -p agent_no_tokio -e normal -i tokio
tokio v1.52.3
├── … (hyper/reqwest)
├── rig-reqwest v0.42.0
```

## `tests/core/dependency_graph.rs`

Facade guard running `cargo tree -e normal --prefix none` and asserting: rig-core (default and `--all-features`) ∌ {tokio, reqwest}; rig-agent ∌ {tokio, rmcp}; rig-rmcp ∌ rig-agent; `rig --no-default-features --features agent,derive` ∌ {tokio, reqwest, rmcp}.

## Verification

- `cargo clippy --workspace --all-targets --all-features` clean; `cargo fmt` clean
- `RUSTDOCFLAGS="-D warnings" cargo doc` for rig-core/rig-agent/rig-reqwest/rig-rmcp/rig
- `cargo nextest run -p rig-core -p rig-reqwest -p rig-agent -p rig-rmcp --all-features`: 2286 passed
- rig-agent doctests; `cargo test -p rig --test core dependency_graph`
- `cargo check --target wasm32-unknown-unknown -p rig-core -p rig-agent`

MIGRATING.md: additive entry under `0.41 → next`.
