### PR TITLE
chore: add rig-run placeholder crate (name reservation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10294,6 +10294,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "rig-run"
+version = "0.42.0"
+
+[[package]]
 name = "rig-s3vectors"
 version = "0.42.0"
 dependencies = [

--- a/crates/rig-run/Cargo.toml
+++ b/crates/rig-run/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rig-run"
+version.workspace = true
+edition = { workspace = true }
+license = "MIT"
+readme = "README.md"
+description = "Placeholder reserving the rig-run name for Rig's forthcoming agent-run host/runtime crate. Contains no code yet."
+repository = "https://github.com/0xPlaygrounds/rig"
+
+[lints]
+workspace = true
+
+[dependencies]

--- a/crates/rig-run/README.md
+++ b/crates/rig-run/README.md
@@ -1,0 +1,6 @@
+# rig-run
+
+Placeholder reserving the `rig-run` name for Rig's forthcoming agent-run
+host/runtime crate. It contains no code yet — see
+[rig](https://crates.io/crates/rig) and
+[rig-agent](https://crates.io/crates/rig-agent).

--- a/crates/rig-run/src/lib.rs
+++ b/crates/rig-run/src/lib.rs
@@ -1,0 +1,4 @@
+//! Placeholder crate reserving the `rig-run` name for Rig's forthcoming
+//! agent-run host/runtime crate. It contains no code yet; use
+//! [`rig`](https://crates.io/crates/rig) and
+//! [`rig-agent`](https://crates.io/crates/rig-agent) in the meantime.


### PR DESCRIPTION
Adds `crates/rig-run`, an empty placeholder crate reserving the `rig-run` name on crates.io for Rig's forthcoming agent-run host/runtime crate. Published manually as rig-run v0.42.0 (workspace version); it is a normal workspace member so release-plz will version it alongside the other crates going forward. No code, no dependencies.