### PR TITLE
feat!: transport middleware + run lifecycle hooks (on_run_start/on_run_settled, durable Scratchpad)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5526,6 +5526,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "http_middleware"
+version = "0.42.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "http 1.4.2",
+ "rig",
+ "tokio",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -806,6 +806,33 @@ handed back a silently short list.
 
 ## 0.41 → next
 
+### Run lifecycle hooks and transport middleware
+
+The agent hook surface gained a pre-run and a terminal event, and the erased
+HTTP transport gained a middleware seam. What breaks:
+
+- **`StepEventKind` gained `RunStart` and `RunSettled`.** Exhaustive `match`es
+  over `StepEventKind` (e.g. in an `AgentHook::observes` implementation) must
+  add the two arms. `AgentHook` itself is unaffected: the new `on_run_start`
+  and `on_run_settled` methods are default-implemented.
+- **`BoxedHttpClient` now applies attached `HttpMiddleware`** (new, opt-in via
+  `BoxedHttpClient::with_middleware`). Behavior without middleware is
+  unchanged. `BoxedHttpClient::ptr_eq` still compares the underlying transport
+  only, so two handles differing only in middleware compare equal.
+- **`AgentRun` gained an optional `hook_state` slot** (`hook_state`,
+  `set_hook_state`, `take_hook_state`, carrying the new serializable
+  `rig_run::ScratchpadSnapshot`) plus `initial_prompt`,
+  `rewrite_initial_prompt`, and `input_chat_history`. Runs serialized before
+  this release deserialize unchanged (the field defaults to absent). The agent
+  drivers restore a carried snapshot into the run's `Scratchpad` durable
+  entries at run start.
+
+New, non-breaking: `Scratchpad::{put_durable, get_durable, remove_durable,
+export, restore}` for hook state that must survive a serialized pause, and the
+`RunStart`/`RunStartAction`/`RunSettled`/`SettledOutcome` hook vocabulary. A
+`RunStartAction::Stop` terminates the run before any provider call with
+`PromptError::PromptCancelled`.
+
 ### The run protocol is its own crate: `rig-run` (`rig::run`)
 
 `AgentRun` — the sans-IO, serializable state machine behind every agent run —

--- a/crates/rig-agent/src/agent/hook.rs
+++ b/crates/rig-agent/src/agent/hook.rs
@@ -213,15 +213,88 @@ use crate::{
 
 pub use rig_core::id::RunId;
 
+pub use rig_run::ScratchpadSnapshot;
+
 /// Run-scoped typed storage shared by hooks.
+///
+/// # Durable hook state
+///
+/// The typed entries ([`insert`](Self::insert)/[`get`](Self::get)) live only
+/// as long as the run's process. Hooks whose state must survive a durable
+/// pause — an out-of-process approval, a serialized [`AgentRun`] resumed
+/// later, possibly elsewhere — store that state as **durable entries**
+/// instead: string-keyed JSON via [`put_durable`](Self::put_durable) /
+/// [`get_durable`](Self::get_durable). [`export`](Self::export) collects the
+/// durable entries into a serializable [`ScratchpadSnapshot`] to carry with
+/// the run (see [`AgentRun::set_hook_state`]), and the driver restores a
+/// carried snapshot into the live scratchpad at run start via
+/// [`restore`](Self::restore). Typed entries are deliberately not exported:
+/// a `TypeMap` has no serialization story, and durable state should be an
+/// explicit, named contract.
+///
+/// [`AgentRun`]: crate::agent::AgentRun
+/// [`AgentRun::set_hook_state`]: crate::agent::AgentRun::set_hook_state
 #[derive(Clone, Default)]
 pub struct Scratchpad {
     inner: Arc<std::sync::Mutex<TypeMap>>,
+    durable: Arc<std::sync::Mutex<std::collections::BTreeMap<String, serde_json::Value>>>,
 }
 
 impl Scratchpad {
     fn lock(&self) -> std::sync::MutexGuard<'_, TypeMap> {
         self.inner.lock().unwrap_or_else(|error| error.into_inner())
+    }
+
+    fn lock_durable(
+        &self,
+    ) -> std::sync::MutexGuard<'_, std::collections::BTreeMap<String, serde_json::Value>> {
+        self.durable
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+    }
+
+    /// Store a durable entry under `key`, replacing any previous value.
+    ///
+    /// Durable entries survive a serialized pause via [`export`](Self::export)
+    /// / [`restore`](Self::restore); see the type docs. Returns an error when
+    /// `value` cannot be represented as JSON.
+    pub fn put_durable<T: serde::Serialize>(
+        &self,
+        key: impl Into<String>,
+        value: &T,
+    ) -> Result<(), serde_json::Error> {
+        let value = serde_json::to_value(value)?;
+        self.lock_durable().insert(key.into(), value);
+        Ok(())
+    }
+
+    /// Read a durable entry, deserialized as `T`.
+    ///
+    /// `None` when the key is absent or its value does not deserialize as `T`.
+    pub fn get_durable<T: serde::de::DeserializeOwned>(&self, key: &str) -> Option<T> {
+        let value = self.lock_durable().get(key).cloned()?;
+        serde_json::from_value(value).ok()
+    }
+
+    /// Remove a durable entry, returning its raw JSON value.
+    pub fn remove_durable(&self, key: &str) -> Option<serde_json::Value> {
+        self.lock_durable().remove(key)
+    }
+
+    /// Collect the durable entries into a serializable snapshot.
+    pub fn export(&self) -> ScratchpadSnapshot {
+        ScratchpadSnapshot {
+            entries: self.lock_durable().clone(),
+        }
+    }
+
+    /// Merge a snapshot's entries into the durable store.
+    ///
+    /// Snapshot entries replace same-keyed existing entries; other existing
+    /// entries are kept. The driver calls this at run start with the snapshot
+    /// a resumed [`AgentRun`](crate::agent::AgentRun) carried.
+    pub fn restore(&self, snapshot: ScratchpadSnapshot) {
+        self.lock_durable().extend(snapshot.entries);
     }
 
     /// Insert a value.
@@ -751,9 +824,80 @@ pub struct StreamResponseFinish<'a> {
     pub raw: &'a serde_json::Value,
 }
 
+/// Pre-run event: the run's initial prompt, before any model call.
+///
+/// Fired exactly once per run, before the first completion-call hook. The
+/// composition rules mirror an input-transform chain: in a [`HookStack`],
+/// rewrites chain in registration order — each hook sees the prompt as
+/// rewritten by earlier hooks — and the first [`RunStartAction::Stop`] wins,
+/// short-circuiting the remaining hooks and terminating the run before any
+/// provider call.
+#[derive(Clone, Copy)]
+pub struct RunStart<'a> {
+    /// The prompt the run will send on its first model call, including
+    /// earlier hooks' rewrites.
+    pub prompt: &'a Message,
+    /// The input chat history preceding the prompt.
+    pub history: &'a [Message],
+}
+
+/// Action for the pre-run [`RunStart`] event.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RunStartAction {
+    /// Start the run with the current prompt.
+    Continue,
+    /// Replace the prompt and pass it to later hooks.
+    Rewrite(Message),
+    /// Stop the run before any model call, with a reason.
+    Stop(String),
+}
+
+impl RunStartAction {
+    /// Starts the run with the current prompt.
+    pub fn continue_run() -> Self {
+        Self::Continue
+    }
+
+    /// Replaces the prompt; later hooks in a [`HookStack`] see the rewrite.
+    pub fn rewrite(prompt: impl Into<Message>) -> Self {
+        Self::Rewrite(prompt.into())
+    }
+
+    /// Stops the run before any provider call.
+    pub fn stop(reason: impl Into<String>) -> Self {
+        Self::Stop(reason.into())
+    }
+}
+
+/// Terminal run event: the run has settled and nothing follows automatically.
+///
+/// Fired exactly once per run, after the outcome is decided — no retry,
+/// further turn, or tool execution will run. This is deliberately distinct
+/// from per-turn finishes ([`ModelTurnFinished`], [`StreamResponseFinish`]):
+/// those can be followed by hook-driven retries or tool turns, while
+/// `RunSettled` cannot. On the streaming surface the success case coincides
+/// with the run's `FinalResponse` stream item; `RunSettled` additionally
+/// covers error termination, which the stream reports as its `Err` item.
+#[derive(Clone, Copy)]
+pub struct RunSettled<'a> {
+    /// How the run ended.
+    pub outcome: SettledOutcome<'a>,
+}
+
+/// The outcome carried by [`RunSettled`].
+#[derive(Clone, Copy)]
+pub enum SettledOutcome<'a> {
+    /// The run completed with this final response.
+    Response(&'a rig_run::PromptResponse),
+    /// The run terminated with an error, rendered via its `Display` form.
+    Error(&'a str),
+}
+
 /// Hook event kind used only as an observation performance hint.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum StepEventKind {
+    RunStart,
+    RunSettled,
     CompletionCall,
     CompletionResponse,
     ModelTurnFinished,
@@ -930,6 +1074,31 @@ impl ObservationAction {
 
 /// Per-run lifecycle observer and steerer.
 pub trait AgentHook: WasmCompatSend + WasmCompatSync {
+    /// Runs once before the run's first model call, seeing the initial prompt.
+    ///
+    /// The hook may rewrite the prompt or stop the run before any provider
+    /// call. In a [`HookStack`], rewrites chain in registration order and the
+    /// first stop wins — see [`RunStart`]. The default action starts the run
+    /// with the current prompt.
+    fn on_run_start(
+        &self,
+        _ctx: &HookContext,
+        _event: RunStart<'_>,
+    ) -> impl Future<Output = RunStartAction> + WasmCompatSend {
+        async { RunStartAction::Continue }
+    }
+
+    /// Runs once after the run settles: its outcome — final response or
+    /// terminal error — is decided, and no retry, further turn, or tool
+    /// execution will follow. Observe-only; the run is already over.
+    fn on_run_settled(
+        &self,
+        _ctx: &HookContext,
+        _event: RunSettled<'_>,
+    ) -> impl Future<Output = ()> + WasmCompatSend {
+        async {}
+    }
+
     /// Selects the model for the pending model-call boundary.
     ///
     /// Selection is synchronous, local, and non-blocking: it operates only on
@@ -1158,6 +1327,16 @@ macro_rules! erased_hook_forward {
 }
 
 trait DynAgentHook: WasmCompatSend + WasmCompatSync {
+    fn run_start<'a>(
+        &'a self,
+        ctx: &'a HookContext,
+        event: RunStart<'a>,
+    ) -> WasmBoxedFuture<'a, RunStartAction>;
+    fn run_settled<'a>(
+        &'a self,
+        ctx: &'a HookContext,
+        event: RunSettled<'a>,
+    ) -> WasmBoxedFuture<'a, ()>;
     fn model_select(&self, ctx: &HookContext, event: ModelSelection<'_>) -> ModelSelectionAction;
     fn invalid_tool_call<'a>(
         &'a self,
@@ -1177,6 +1356,22 @@ impl<H> DynAgentHook for H
 where
     H: AgentHook,
 {
+    fn run_start<'a>(
+        &'a self,
+        ctx: &'a HookContext,
+        event: RunStart<'a>,
+    ) -> WasmBoxedFuture<'a, RunStartAction> {
+        Box::pin(self.on_run_start(ctx, event))
+    }
+
+    fn run_settled<'a>(
+        &'a self,
+        ctx: &'a HookContext,
+        event: RunSettled<'a>,
+    ) -> WasmBoxedFuture<'a, ()> {
+        Box::pin(self.on_run_settled(ctx, event))
+    }
+
     fn model_select(&self, ctx: &HookContext, event: ModelSelection<'_>) -> ModelSelectionAction {
         self.on_model_select(ctx, event)
     }
@@ -1338,6 +1533,30 @@ macro_rules! stack_first_non_continue {
 }
 
 impl AgentHook for HookStack {
+    async fn on_run_start(&self, ctx: &HookContext, event: RunStart<'_>) -> RunStartAction {
+        let mut rewritten: Option<Message> = None;
+        for hook in &self.hooks {
+            let current = RunStart {
+                prompt: rewritten.as_ref().unwrap_or(event.prompt),
+                ..event
+            };
+            match hook.run_start(ctx, current).await {
+                RunStartAction::Continue => {}
+                RunStartAction::Rewrite(prompt) => rewritten = Some(prompt),
+                stop @ RunStartAction::Stop(_) => return stop,
+            }
+        }
+        rewritten.map_or(RunStartAction::Continue, RunStartAction::Rewrite)
+    }
+
+    async fn on_run_settled(&self, ctx: &HookContext, event: RunSettled<'_>) {
+        // Every hook observes the terminal event; there is nothing to
+        // short-circuit on since the run is already over.
+        for hook in &self.hooks {
+            hook.run_settled(ctx, event).await;
+        }
+    }
+
     fn on_model_select(
         &self,
         ctx: &HookContext,
@@ -1443,6 +1662,109 @@ impl AgentHook for HookStack {
 mod tests {
     use super::*;
     use crate::tool::{ToolErrorKind, ToolExecutionError};
+
+    /// Rewrites the run-start prompt by appending its tag; used to observe
+    /// rewrite chaining across a stack.
+    struct StartRewriter(&'static str);
+    impl AgentHook for StartRewriter {
+        async fn on_run_start(&self, _ctx: &HookContext, event: RunStart<'_>) -> RunStartAction {
+            let current = match event.prompt {
+                Message::User { .. } => event.prompt.rag_text().expect("test prompts carry text"),
+                _ => panic!("run-start prompts are user messages"),
+            };
+            RunStartAction::rewrite(Message::user(format!("{current}{}", self.0)))
+        }
+    }
+
+    struct StartStopper;
+    impl AgentHook for StartStopper {
+        async fn on_run_start(&self, _ctx: &HookContext, _event: RunStart<'_>) -> RunStartAction {
+            RunStartAction::stop("blocked at start")
+        }
+    }
+
+    #[tokio::test]
+    async fn run_start_rewrites_chain_in_registration_order() {
+        let mut stack = HookStack::with(StartRewriter("-a"));
+        stack.push(StartRewriter("-b"));
+        let ctx = HookContext::new(false, None);
+        let prompt = Message::user("p");
+        let action = stack
+            .on_run_start(
+                &ctx,
+                RunStart {
+                    prompt: &prompt,
+                    history: &[],
+                },
+            )
+            .await;
+        match action {
+            RunStartAction::Rewrite(message) => {
+                // The second hook saw the first hook's rewrite.
+                assert_eq!(message.rag_text().expect("text"), "p-a-b");
+            }
+            other => panic!("expected a chained rewrite, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_start_first_stop_wins_and_short_circuits() {
+        let mut stack = HookStack::with(StartRewriter("-a"));
+        stack.push(StartStopper);
+        // This rewriter must never run.
+        struct Panicker;
+        impl AgentHook for Panicker {
+            async fn on_run_start(
+                &self,
+                _ctx: &HookContext,
+                _event: RunStart<'_>,
+            ) -> RunStartAction {
+                panic!("a stop must short-circuit later hooks");
+            }
+        }
+        stack.push(Panicker);
+        let ctx = HookContext::new(false, None);
+        let prompt = Message::user("p");
+        let action = stack
+            .on_run_start(
+                &ctx,
+                RunStart {
+                    prompt: &prompt,
+                    history: &[],
+                },
+            )
+            .await;
+        assert_eq!(action, RunStartAction::Stop("blocked at start".into()));
+    }
+
+    #[test]
+    fn scratchpad_durable_entries_round_trip_through_snapshot() {
+        let pad = Scratchpad::default();
+        pad.put_durable("approvals", &vec!["tool-1".to_string()])
+            .expect("serializable");
+        pad.put_durable("retries", &2u32).expect("serializable");
+        // Typed entries never reach the snapshot.
+        pad.insert(42usize);
+
+        let snapshot = pad.export();
+        assert_eq!(snapshot.entries.len(), 2);
+        let serialized = serde_json::to_string(&snapshot).expect("snapshot serializes");
+        let restored: ScratchpadSnapshot =
+            serde_json::from_str(&serialized).expect("snapshot deserializes");
+
+        let fresh = Scratchpad::default();
+        fresh.put_durable("local", &true).expect("serializable");
+        fresh.restore(restored);
+        assert_eq!(
+            fresh.get_durable::<Vec<String>>("approvals").as_deref(),
+            Some(["tool-1".to_string()].as_slice())
+        );
+        assert_eq!(fresh.get_durable::<u32>("retries"), Some(2));
+        // Restore merges: unrelated existing entries survive.
+        assert_eq!(fresh.get_durable::<bool>("local"), Some(true));
+        // The typed entry stayed local to the original pad.
+        assert!(fresh.export().entries.len() == 3);
+    }
 
     struct Patcher(f64);
     impl AgentHook for Patcher {

--- a/crates/rig-agent/src/agent/mod.rs
+++ b/crates/rig-agent/src/agent/mod.rs
@@ -120,8 +120,9 @@ pub use hook::{
     AgentHook, CompletionCallAction, CompletionResponse as CompletionResponseEvent, HookContext,
     HookStack, InvalidToolCallAction, InvalidToolCallContext, ModelSelection, ModelSelectionAction,
     ModelTurnAction, ModelTurnFinished, ObservationAction, ReasoningDelta, RequestPatch,
-    RetryRequest, RunId, Scratchpad, StepEventKind, StreamResponseFinish, TextDelta, ToolCall,
-    ToolCallAction, ToolCallDelta, ToolResultAction, ToolResultEvent,
+    RetryRequest, RunId, RunSettled, RunStart, RunStartAction, Scratchpad, ScratchpadSnapshot,
+    SettledOutcome, StepEventKind, StreamResponseFinish, TextDelta, ToolCall, ToolCallAction,
+    ToolCallDelta, ToolResultAction, ToolResultEvent,
 };
 pub use prompt_request::streaming::{
     MultiTurnStreamItem, RUN_EVENTS_CAPACITY, RunEvents, StreamingError, StreamingPromptRequest,

--- a/crates/rig-agent/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-agent/src/agent/prompt_request/streaming.rs
@@ -8,8 +8,9 @@ use crate::{
     agent::completion::{PreparedCompletionRequest, build_prepared_completion_request},
     agent::hook::{
         AgentHook, HookContext, HookStack, InvalidToolCallAction, ModelSelection,
-        ModelSelectionAction, ModelTurnFinished, ReasoningDelta, StepEventKind,
-        StreamResponseFinish, TextDelta, ToolCallDelta,
+        ModelSelectionAction, ModelTurnFinished, ReasoningDelta, RunSettled, RunStart,
+        RunStartAction, SettledOutcome, StepEventKind, StreamResponseFinish, TextDelta,
+        ToolCallDelta,
     },
     agent::prompt_request::{assistant_text_from_choice, is_empty_assistant_turn},
     agent::run::{
@@ -123,6 +124,12 @@ pub enum MultiTurnStreamItem {
     },
     /// The final result from the stream: the unified [`PromptResponse`] shared
     /// with the blocking surface.
+    ///
+    /// Terminal for the run: nothing follows it automatically — no retry,
+    /// further turn, or tool execution — so this item is the stream-side
+    /// counterpart of the `on_run_settled` hook's success outcome. Error
+    /// termination surfaces as the stream's `Err` item instead, which is
+    /// equally terminal.
     FinalResponse(PromptResponse),
 }
 
@@ -461,6 +468,15 @@ where
         // both surfaces. `is_streaming` records which surface is driving; the
         // per-turn index is advanced on each `CallModel` step below.
         let hook_ctx = HookContext::new(is_streaming, runner.config.name.clone());
+        // Restore durable hook state a serialized run carried into this drive
+        // (see `Scratchpad`'s "Durable hook state" docs).
+        if let Some(snapshot) = run.take_hook_state() {
+            hook_ctx.scratchpad().restore(snapshot);
+        }
+        // Rendered terminal-error text, set on every error path before its
+        // yield so the run-settled hook below can report the outcome after
+        // the error itself has been moved into the stream.
+        let mut settled_error: Option<String> = None;
         // Set only after a model turn commits successfully and consumed by its
         // immediately following CallTools step. This keeps the sans-IO run state
         // serializable while pinning execution to the definitions sent that turn.
@@ -471,6 +487,58 @@ where
         // is invoked, so a completion-call stop, selection stop, or preparation
         // failure leaves it unchanged while a provider error still counts.
         let mut previous_model: Option<ModelHandle> = None;
+
+        // Pre-run hook: fired once with the initial prompt before any model
+        // call. Rewrites chain across the stack in registration order; the
+        // first stop wins and terminates the run before any provider work.
+        if runner.config.hooks.observes(StepEventKind::RunStart) {
+            let action = match run.initial_prompt() {
+                Some(prompt) => {
+                    runner
+                        .config
+                        .hooks
+                        .on_run_start(
+                            &hook_ctx,
+                            RunStart {
+                                prompt,
+                                history: run.input_chat_history(),
+                            },
+                        )
+                        .await
+                }
+                // A run resumed past its first model call has no pending
+                // initial prompt to steer.
+                None => RunStartAction::Continue,
+            };
+            let early_stop = match action {
+                RunStartAction::Continue => None,
+                RunStartAction::Rewrite(prompt) => run
+                    .rewrite_initial_prompt(prompt)
+                    .err()
+                    .map(|err| StreamingError::Prompt(Box::new(err))),
+                RunStartAction::Stop(reason) => {
+                    Some(StreamingError::Prompt(Box::new(run.cancel_error(reason))))
+                }
+            };
+            if let Some(err) = early_stop {
+                store_error_usage(&runner, &run);
+                let reason = err.to_string();
+                yield Err(err);
+                if runner.config.hooks.observes(StepEventKind::RunSettled) {
+                    runner
+                        .config
+                        .hooks
+                        .on_run_settled(
+                            &hook_ctx,
+                            RunSettled {
+                                outcome: SettledOutcome::Error(&reason),
+                            },
+                        )
+                        .await;
+                }
+                return;
+            }
+        }
 
         // Drive one medium-specific step stream: forward its items, and on the
         // first error store error usage, surface it, and end the run. A macro
@@ -492,6 +560,7 @@ where
                 drop(step_stream);
                 if let Some(err) = step_error {
                     store_error_usage(&runner, &run);
+                    settled_error = Some(err.to_string());
                     yield Err(err);
                     break $label;
                 }
@@ -503,7 +572,9 @@ where
                 Ok(step) => step,
                 Err(err) => {
                     store_error_usage(&runner, &run);
-                    yield Err(Box::new(err).into());
+                    let err: StreamingError = Box::new(err).into();
+                    settled_error = Some(err.to_string());
+                    yield Err(err);
                     break 'outer;
                 }
             };
@@ -523,7 +594,9 @@ where
                         match resolve_completion_call(&runner.config.hooks, &hook_ctx, &prompt, &history, turn).await {
                             CompletionCallOutcome::Terminate(reason) => {
                                 store_error_usage(&runner, &run);
-                                yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
+                                let err = StreamingError::Prompt(Box::new(run.cancel_error(reason)));
+                                settled_error = Some(err.to_string());
+                                yield Err(err);
                                 break 'outer;
                             }
                             CompletionCallOutcome::Proceed(request_patch) => request_patch,
@@ -549,7 +622,9 @@ where
                         ModelSelectionAction::Select(model) => model,
                         ModelSelectionAction::Stop(reason) => {
                             store_error_usage(&runner, &run);
-                            yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
+                            let err = StreamingError::Prompt(Box::new(run.cancel_error(reason)));
+                            settled_error = Some(err.to_string());
+                            yield Err(err);
                             break 'outer;
                         }
                     };
@@ -581,7 +656,9 @@ where
                         Ok(prepared) => prepared,
                         Err(err) => {
                             store_error_usage(&runner, &run);
-                            yield Err(err.into());
+                            let err: StreamingError = err.into();
+                            settled_error = Some(err.to_string());
+                            yield Err(err);
                             break 'outer;
                         }
                     };
@@ -619,10 +696,12 @@ where
                 AgentRunStep::CallTools { calls } => {
                     let Some(tool_snapshot) = pending_tool_snapshot.take() else {
                         store_error_usage(&runner, &run);
-                        yield Err(StreamingError::Completion(CompletionError::ResponseError(
+                        let err = StreamingError::Completion(CompletionError::ResponseError(
                             "agent requested tool execution without a prepared registry snapshot"
                                 .to_string(),
-                        )));
+                        ));
+                        settled_error = Some(err.to_string());
+                        yield Err(err);
                         break 'outer;
                     };
                     drive_step!('outer, source.run_tool_calls(
@@ -647,6 +726,20 @@ where
                         response.messages.as_deref().unwrap_or_default(),
                     )
                     .await;
+                    // The run has settled successfully: nothing follows this
+                    // response — the error endings settle after the loop.
+                    if runner.config.hooks.observes(StepEventKind::RunSettled) {
+                        runner
+                            .config
+                            .hooks
+                            .on_run_settled(
+                                &hook_ctx,
+                                RunSettled {
+                                    outcome: SettledOutcome::Response(&response),
+                                },
+                            )
+                            .await;
+                    }
                     // Build the final item only when the surface forwards it
                     // (streaming). The blocking fold discards it, so its source
                     // returns `None` and the extra full-response clone is skipped.
@@ -657,6 +750,23 @@ where
                     break 'outer;
                 }
             }
+        }
+
+        // Terminal settle for the error endings; the success ending settles in
+        // the `Done` arm above, so exactly one settle fires per run.
+        if let Some(reason) = settled_error
+            && runner.config.hooks.observes(StepEventKind::RunSettled)
+        {
+            runner
+                .config
+                .hooks
+                .on_run_settled(
+                    &hook_ctx,
+                    RunSettled {
+                        outcome: SettledOutcome::Error(&reason),
+                    },
+                )
+                .await;
         }
     }
 }

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -11427,4 +11427,179 @@ mod migrated_tests {
         assert_eq!(stop_calls.load(SeqCst), 1);
         assert_eq!(after_stop_calls.load(SeqCst), 0);
     }
+
+    mod run_lifecycle {
+        use super::*;
+        use crate::agent::hook::{RunSettled, RunStart, RunStartAction, SettledOutcome};
+
+        /// Records run-start firings, the prompt each completion call carried,
+        /// and every settle outcome — enough to pin the whole run lifecycle.
+        #[derive(Clone, Default)]
+        struct LifecycleProbe {
+            starts: Arc<AtomicU32>,
+            seen_prompts: Arc<Mutex<Vec<String>>>,
+            settles: Arc<Mutex<Vec<String>>>,
+            rewrite_on_start: bool,
+            stop_on_start: bool,
+        }
+
+        impl AgentHook for LifecycleProbe {
+            async fn on_run_start(
+                &self,
+                _ctx: &HookContext,
+                event: RunStart<'_>,
+            ) -> RunStartAction {
+                self.starts.fetch_add(1, SeqCst);
+                if self.stop_on_start {
+                    return RunStartAction::stop("vetoed at start");
+                }
+                if self.rewrite_on_start {
+                    let current = event.prompt.rag_text().unwrap_or_default();
+                    return RunStartAction::rewrite(Message::user(format!(
+                        "{current} (rewritten)"
+                    )));
+                }
+                RunStartAction::Continue
+            }
+
+            async fn on_completion_call(
+                &self,
+                _ctx: &HookContext,
+                event: CompletionCallEvent<'_>,
+            ) -> CompletionCallAction {
+                self.seen_prompts
+                    .lock()
+                    .expect("prompts")
+                    .push(event.prompt.rag_text().unwrap_or_default());
+                CompletionCallAction::Continue
+            }
+
+            async fn on_run_settled(&self, _ctx: &HookContext, event: RunSettled<'_>) {
+                let outcome = match event.outcome {
+                    SettledOutcome::Response(_) => "ok".to_string(),
+                    SettledOutcome::Error(reason) => format!("err:{reason}"),
+                };
+                self.settles.lock().expect("settles").push(outcome);
+            }
+        }
+
+        fn probe(rewrite_on_start: bool, stop_on_start: bool) -> LifecycleProbe {
+            LifecycleProbe {
+                rewrite_on_start,
+                stop_on_start,
+                ..LifecycleProbe::default()
+            }
+        }
+
+        #[tokio::test]
+        async fn streamed_run_fires_start_once_rewrites_prompt_and_settles_ok() {
+            let hook = probe(true, false);
+            let model = MockCompletionModel::from_stream_turns([vec![
+                MockStreamEvent::text("done"),
+                MockStreamEvent::final_response_with_total_tokens(0),
+            ]]);
+            let mut stream = AgentBuilder::new(model)
+                .add_hook(hook.clone())
+                .build()
+                .runner(Message::user("hi"))
+                .stream()
+                .await;
+            while let Some(item) = stream.next().await {
+                item.expect("stream item");
+            }
+
+            assert_eq!(hook.starts.load(SeqCst), 1);
+            // The model call carried the run-start rewrite.
+            assert_eq!(
+                hook.seen_prompts.lock().expect("prompts").as_slice(),
+                ["hi (rewritten)".to_string()]
+            );
+            assert_eq!(hook.settles.lock().expect("settles").as_slice(), ["ok"]);
+        }
+
+        #[tokio::test]
+        async fn blocking_run_fires_start_once_rewrites_prompt_and_settles_ok() {
+            let hook = probe(true, false);
+            let model = MockCompletionModel::from_turns([MockTurn::text("done")]);
+            let response = AgentBuilder::new(model)
+                .add_hook(hook.clone())
+                .build()
+                .prompt("hi")
+                .await
+                .expect("prompt succeeds");
+            assert_eq!(response, "done");
+
+            assert_eq!(hook.starts.load(SeqCst), 1);
+            assert_eq!(
+                hook.seen_prompts.lock().expect("prompts").as_slice(),
+                ["hi (rewritten)".to_string()]
+            );
+            assert_eq!(hook.settles.lock().expect("settles").as_slice(), ["ok"]);
+        }
+
+        #[tokio::test]
+        async fn run_start_stop_terminates_before_any_provider_call_and_settles_err() {
+            let hook = probe(false, true);
+            let model = MockCompletionModel::from_stream_turns([vec![
+                MockStreamEvent::text("never sent"),
+                MockStreamEvent::final_response_with_total_tokens(0),
+            ]]);
+            let mut stream = AgentBuilder::new(model)
+                .add_hook(hook.clone())
+                .build()
+                .runner(Message::user("hi"))
+                .stream()
+                .await;
+            let first = stream.next().await.expect("terminal item");
+            assert!(matches!(
+                first,
+                Err(StreamingError::Prompt(ref err))
+                    if matches!(**err, PromptError::PromptCancelled { .. })
+            ));
+            assert!(stream.next().await.is_none());
+
+            assert_eq!(hook.starts.load(SeqCst), 1);
+            // No completion call was ever issued.
+            assert!(hook.seen_prompts.lock().expect("prompts").is_empty());
+            let settles = hook.settles.lock().expect("settles").clone();
+            assert_eq!(settles.len(), 1, "settled exactly once");
+            assert!(
+                settles[0].starts_with("err:"),
+                "stop settles as an error outcome: {settles:?}"
+            );
+        }
+
+        #[tokio::test]
+        async fn error_termination_settles_exactly_once() {
+            let hook = probe(false, false);
+            // A tool-calling turn with a one-call budget: the run errors after
+            // the turn instead of finishing, exercising the error settle path.
+            let model = MockCompletionModel::from_stream_turns([vec![
+                MockStreamEvent::tool_call_name_delta("tc1", "add"),
+                MockStreamEvent::tool_call_arguments_delta("tc1", "{\"x\":2,\"y\":3}"),
+                MockStreamEvent::tool_call("tc1", "add", json!({"x": 2, "y": 3})),
+                MockStreamEvent::final_response_with_total_tokens(0),
+            ]]);
+            let mut stream = AgentBuilder::new(model)
+                .tool(crate::test_utils::MockAddTool)
+                .add_hook(hook.clone())
+                .build()
+                .runner(Message::user("add 2 and 3"))
+                .max_turns(1)
+                .stream()
+                .await;
+            let mut saw_error = false;
+            while let Some(item) = stream.next().await {
+                if item.is_err() {
+                    saw_error = true;
+                }
+            }
+            assert!(saw_error, "the exhausted budget surfaces as a stream error");
+
+            assert_eq!(hook.starts.load(SeqCst), 1);
+            let settles = hook.settles.lock().expect("settles").clone();
+            assert_eq!(settles.len(), 1, "settled exactly once: {settles:?}");
+            assert!(settles[0].starts_with("err:"), "error outcome: {settles:?}");
+        }
+    }
 }

--- a/crates/rig-core/src/http_client/erased.rs
+++ b/crates/rig-core/src/http_client/erased.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use http::{Request, Response};
 
+use super::middleware::HttpMiddleware;
 use super::{HttpClientExt, LazyBody, MultipartForm, Result, StreamingResponse};
 use crate::wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync};
 
@@ -95,10 +96,16 @@ where
 /// assert_serialize::<rig_core::http_client::BoxedHttpClient>();
 /// ```
 #[derive(Clone)]
-pub struct BoxedHttpClient(Arc<dyn ErasedHttpClient>);
+pub struct BoxedHttpClient {
+    inner: Arc<dyn ErasedHttpClient>,
+    /// Transport-boundary middleware, applied in attachment order around
+    /// every request this handle sends. Cloned handles share the same stack.
+    middleware: Vec<Arc<dyn HttpMiddleware>>,
+}
 
 impl BoxedHttpClient {
-    /// Erase `http`. If `http` is already a `BoxedHttpClient`, this is a clone.
+    /// Erase `http`. If `http` is already a `BoxedHttpClient`, this is a clone
+    /// (its attached middleware included).
     pub fn new<H>(http: H) -> Self
     where
         H: HttpClientExt + 'static,
@@ -106,12 +113,78 @@ impl BoxedHttpClient {
         if let Some(already) = (&http as &dyn Any).downcast_ref::<BoxedHttpClient>() {
             return already.clone();
         }
-        Self(Arc::new(http))
+        Self {
+            inner: Arc::new(http),
+            middleware: Vec::new(),
+        }
+    }
+
+    /// Attach a transport-boundary [`HttpMiddleware`] to this handle.
+    ///
+    /// Middlewares run in attachment order — see the
+    /// [`middleware`](super::middleware) module docs for the exact per-phase
+    /// ordering and error semantics. Attaching returns a new handle; existing
+    /// clones keep their previous stack. The underlying transport is shared,
+    /// so [`ptr_eq`](Self::ptr_eq) still reports the two as the same
+    /// transport.
+    pub fn with_middleware<M>(mut self, middleware: M) -> Self
+    where
+        M: HttpMiddleware + 'static,
+    {
+        self.middleware.push(Arc::new(middleware));
+        self
     }
 
     /// Whether two handles share the same underlying transport.
+    ///
+    /// Compares the transport only: handles that differ in attached
+    /// middleware but wrap the same transport still compare equal.
     pub fn ptr_eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.0, &other.0)
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
+    /// Run the request-side middleware phases: all header hooks in order,
+    /// then all body hooks in order (each seeing the final headers).
+    async fn apply_request_middleware(
+        &self,
+        parts: &mut http::request::Parts,
+        body: Bytes,
+    ) -> Result<Bytes> {
+        for mw in &self.middleware {
+            mw.before_request_headers(&parts.method, &parts.uri, &mut parts.headers)
+                .await?;
+        }
+        let mut body = body;
+        for mw in &self.middleware {
+            body = mw
+                .before_request_body(&parts.method, &parts.uri, &parts.headers, body)
+                .await?;
+        }
+        Ok(body)
+    }
+
+    /// Run only the header hooks (the multipart path, which has no single
+    /// serialized body to hand to the body hooks).
+    async fn apply_header_middleware(&self, parts: &mut http::request::Parts) -> Result<()> {
+        for mw in &self.middleware {
+            mw.before_request_headers(&parts.method, &parts.uri, &mut parts.headers)
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Run the response hooks in attachment order.
+    async fn apply_response_middleware(
+        &self,
+        method: &http::Method,
+        uri: &http::Uri,
+        status: http::StatusCode,
+        headers: &http::HeaderMap,
+    ) -> Result<()> {
+        for mw in &self.middleware {
+            mw.after_response(method, uri, status, headers).await?;
+        }
+        Ok(())
     }
 }
 
@@ -132,8 +205,19 @@ impl HttpClientExt for BoxedHttpClient {
         U: From<Bytes>,
         U: WasmCompatSend + 'static,
     {
-        let fut = self.0.send_bytes(req.map(Into::into));
-        async move { fut.await.map(convert_body::<U>) }
+        let this = self.clone();
+        let (mut parts, body) = req.map(Into::into).into_parts();
+        async move {
+            let body = this.apply_request_middleware(&mut parts, body).await?;
+            let (method, uri) = (parts.method.clone(), parts.uri.clone());
+            let response = this
+                .inner
+                .send_bytes(Request::from_parts(parts, body))
+                .await?;
+            this.apply_response_middleware(&method, &uri, response.status(), response.headers())
+                .await?;
+            Ok(convert_body::<U>(response))
+        }
     }
 
     fn send_multipart<U>(
@@ -144,8 +228,19 @@ impl HttpClientExt for BoxedHttpClient {
         U: From<Bytes>,
         U: WasmCompatSend + 'static,
     {
-        let fut = self.0.send_multipart_bytes(req);
-        async move { fut.await.map(convert_body::<U>) }
+        let this = self.clone();
+        let (mut parts, body) = req.into_parts();
+        async move {
+            this.apply_header_middleware(&mut parts).await?;
+            let (method, uri) = (parts.method.clone(), parts.uri.clone());
+            let response = this
+                .inner
+                .send_multipart_bytes(Request::from_parts(parts, body))
+                .await?;
+            this.apply_response_middleware(&method, &uri, response.status(), response.headers())
+                .await?;
+            Ok(convert_body::<U>(response))
+        }
     }
 
     fn send_streaming<T>(
@@ -155,7 +250,20 @@ impl HttpClientExt for BoxedHttpClient {
     where
         T: Into<Bytes> + WasmCompatSend,
     {
-        self.0.send_streaming_bytes(req.map(Into::into))
+        let (mut parts, body) = req.map(Into::into).into_parts();
+        async move {
+            let body = self.apply_request_middleware(&mut parts, body).await?;
+            let (method, uri) = (parts.method.clone(), parts.uri.clone());
+            let response = self
+                .inner
+                .send_streaming_bytes(Request::from_parts(parts, body))
+                .await?;
+            // The response hooks run before any of the body stream is
+            // consumed — the point of `after_response` for streaming calls.
+            self.apply_response_middleware(&method, &uri, response.status(), response.headers())
+                .await?;
+            Ok(response)
+        }
     }
 }
 
@@ -213,6 +321,254 @@ mod tests {
     fn debug_never_prints_the_inner_transport() {
         let boxed = BoxedHttpClient::new(RecordingHttpClient::new("secret-bearing config"));
         assert_eq!(format!("{boxed:?}"), "BoxedHttpClient");
+    }
+
+    mod middleware {
+        use super::*;
+        use crate::http_client::middleware::HttpMiddleware;
+        use crate::test_utils::MockStreamingClient;
+        use crate::wasm_compat::WasmBoxedFuture;
+        use http::{HeaderMap, HeaderValue, Method, StatusCode, Uri};
+        use std::sync::{Arc, Mutex};
+
+        /// Appends its tag to a header, to the body, and to a shared log —
+        /// making phase ordering across a stack observable.
+        struct Tagger {
+            tag: &'static str,
+            log: Arc<Mutex<Vec<String>>>,
+        }
+
+        impl Tagger {
+            fn log(&self, phase: &str) {
+                self.log
+                    .lock()
+                    .expect("log")
+                    .push(format!("{}:{}", self.tag, phase));
+            }
+        }
+
+        impl HttpMiddleware for Tagger {
+            fn before_request_headers<'a>(
+                &'a self,
+                _method: &'a Method,
+                _uri: &'a Uri,
+                headers: &'a mut HeaderMap,
+            ) -> WasmBoxedFuture<'a, Result<()>> {
+                Box::pin(async move {
+                    self.log("headers");
+                    headers.append("x-tag", HeaderValue::from_static(self.tag));
+                    Ok(())
+                })
+            }
+
+            fn before_request_body<'a>(
+                &'a self,
+                _method: &'a Method,
+                _uri: &'a Uri,
+                headers: &'a HeaderMap,
+                body: Bytes,
+            ) -> WasmBoxedFuture<'a, Result<Bytes>> {
+                Box::pin(async move {
+                    self.log("body");
+                    // Every body hook sees the fully mutated headers: its own
+                    // tag was already appended by the headers phase.
+                    assert!(
+                        headers
+                            .get_all("x-tag")
+                            .iter()
+                            .any(|v| v.as_bytes() == self.tag.as_bytes()),
+                        "body hooks run after all header hooks"
+                    );
+                    let mut bytes = body.to_vec();
+                    bytes.extend_from_slice(self.tag.as_bytes());
+                    Ok(Bytes::from(bytes))
+                })
+            }
+
+            fn after_response<'a>(
+                &'a self,
+                _method: &'a Method,
+                _uri: &'a Uri,
+                status: StatusCode,
+                _headers: &'a HeaderMap,
+            ) -> WasmBoxedFuture<'a, Result<()>> {
+                Box::pin(async move {
+                    self.log(&format!("response:{}", status.as_u16()));
+                    Ok(())
+                })
+            }
+        }
+
+        #[test]
+        fn phases_run_in_attachment_order_and_mutations_chain() {
+            let inner = RecordingHttpClient::new("ok");
+            let log = Arc::new(Mutex::new(Vec::new()));
+            let boxed = BoxedHttpClient::new(inner.clone())
+                .with_middleware(Tagger {
+                    tag: "a",
+                    log: log.clone(),
+                })
+                .with_middleware(Tagger {
+                    tag: "b",
+                    log: log.clone(),
+                });
+
+            block_on(boxed.send::<_, Bytes>(request("body-"))).expect("send");
+
+            let captured = inner.requests();
+            assert_eq!(captured.len(), 1);
+            // Header mutations chain in attachment order.
+            let tags: Vec<_> = captured[0]
+                .headers
+                .get_all("x-tag")
+                .iter()
+                .map(|v| v.to_str().expect("ascii"))
+                .collect();
+            assert_eq!(tags, ["a", "b"]);
+            // Body replacements chain in attachment order.
+            assert_eq!(captured[0].body, Bytes::from_static(b"body-ab"));
+            // All header hooks run before any body hook; response hooks last.
+            assert_eq!(
+                log.lock().expect("log").as_slice(),
+                [
+                    "a:headers",
+                    "b:headers",
+                    "a:body",
+                    "b:body",
+                    "a:response:200",
+                    "b:response:200"
+                ]
+            );
+        }
+
+        /// A middleware that fails the given phase.
+        struct FailAt(&'static str);
+
+        impl HttpMiddleware for FailAt {
+            fn before_request_headers<'a>(
+                &'a self,
+                _method: &'a Method,
+                _uri: &'a Uri,
+                _headers: &'a mut HeaderMap,
+            ) -> WasmBoxedFuture<'a, Result<()>> {
+                let fail = self.0 == "headers";
+                Box::pin(async move {
+                    if fail {
+                        return Err(crate::http_client::Error::InvalidStatusCodeWithMessage(
+                            StatusCode::BAD_REQUEST,
+                            "rejected headers".into(),
+                        ));
+                    }
+                    Ok(())
+                })
+            }
+
+            fn after_response<'a>(
+                &'a self,
+                _method: &'a Method,
+                _uri: &'a Uri,
+                _status: StatusCode,
+                _headers: &'a HeaderMap,
+            ) -> WasmBoxedFuture<'a, Result<()>> {
+                let fail = self.0 == "response";
+                Box::pin(async move {
+                    if fail {
+                        return Err(crate::http_client::Error::InvalidStatusCodeWithMessage(
+                            StatusCode::TOO_MANY_REQUESTS,
+                            "rejected response".into(),
+                        ));
+                    }
+                    Ok(())
+                })
+            }
+        }
+
+        #[test]
+        fn request_side_failure_aborts_before_sending() {
+            let inner = RecordingHttpClient::new("ok");
+            let boxed = BoxedHttpClient::new(inner.clone()).with_middleware(FailAt("headers"));
+            let err = match block_on(boxed.send::<_, Bytes>(request("hello"))) {
+                Ok(_) => panic!("must abort"),
+                Err(err) => err,
+            };
+            assert_eq!(err.non_success_status(), Some(StatusCode::BAD_REQUEST));
+            assert!(inner.requests().is_empty(), "nothing reached the transport");
+        }
+
+        #[test]
+        fn response_hook_failure_surfaces_as_the_request_error() {
+            let inner = RecordingHttpClient::new("ok");
+            let boxed = BoxedHttpClient::new(inner.clone()).with_middleware(FailAt("response"));
+            let err = match block_on(boxed.send::<_, Bytes>(request("hello"))) {
+                Ok(_) => panic!("must fail"),
+                Err(err) => err,
+            };
+            assert_eq!(
+                err.non_success_status(),
+                Some(StatusCode::TOO_MANY_REQUESTS)
+            );
+            // The request itself was sent; only acceptance was refused.
+            assert_eq!(inner.requests().len(), 1);
+        }
+
+        #[test]
+        fn streaming_response_hook_sees_status_and_headers_before_consumption() {
+            let seen = Arc::new(Mutex::new(None));
+
+            struct CaptureContentType(Arc<Mutex<Option<String>>>);
+            impl HttpMiddleware for CaptureContentType {
+                fn after_response<'a>(
+                    &'a self,
+                    _method: &'a Method,
+                    _uri: &'a Uri,
+                    status: StatusCode,
+                    headers: &'a HeaderMap,
+                ) -> WasmBoxedFuture<'a, Result<()>> {
+                    Box::pin(async move {
+                        let content_type = headers
+                            .get(http::header::CONTENT_TYPE)
+                            .and_then(|v| v.to_str().ok())
+                            .map(str::to_owned);
+                        *self.0.lock().expect("seen") = Some(format!(
+                            "{}:{}",
+                            status.as_u16(),
+                            content_type.unwrap_or_default()
+                        ));
+                        Ok(())
+                    })
+                }
+            }
+
+            let inner = MockStreamingClient {
+                sse_bytes: Bytes::from_static(b"data: hi\n\n"),
+            };
+            let boxed =
+                BoxedHttpClient::new(inner).with_middleware(CaptureContentType(seen.clone()));
+            // The hook has run by the time `send_streaming` resolves — before
+            // any of the body stream is polled.
+            let response = block_on(boxed.send_streaming(request(""))).expect("stream");
+            assert_eq!(
+                seen.lock().expect("seen").as_deref(),
+                Some("200:text/event-stream")
+            );
+            drop(response);
+        }
+
+        #[test]
+        fn boxing_preserves_middleware_and_ptr_eq_ignores_it() {
+            let log = Arc::new(Mutex::new(Vec::new()));
+            let plain = BoxedHttpClient::new(RecordingHttpClient::new("ok"));
+            let layered = plain.clone().with_middleware(Tagger {
+                tag: "a",
+                log: log.clone(),
+            });
+            // Same transport, so ptr_eq holds despite differing middleware.
+            assert!(plain.ptr_eq(&layered));
+            // Re-boxing clones the handle, middleware included.
+            let reboxed = BoxedHttpClient::new(layered);
+            block_on(reboxed.send::<_, Bytes>(request("x"))).expect("send");
+            assert!(!log.lock().expect("log").is_empty());
+        }
     }
 
     #[test]

--- a/crates/rig-core/src/http_client/middleware.rs
+++ b/crates/rig-core/src/http_client/middleware.rs
@@ -1,0 +1,102 @@
+//! Transport-boundary middleware for [`BoxedHttpClient`](super::BoxedHttpClient).
+//!
+//! Agent-level hooks (`AgentHook` in rig-agent) stop at the semantic layer:
+//! they patch a request's *meaning* (preamble, temperature, history) but never
+//! see the serialized provider payload, the HTTP headers, or the raw HTTP
+//! response. [`HttpMiddleware`] is the seam below that: it runs inside the
+//! erased transport, so one implementation observes and shapes every provider's
+//! wire traffic — unary, streaming, and multipart — without touching provider
+//! code.
+//!
+//! The three methods mirror the three moments a transport-level extension
+//! cares about:
+//!
+//! - [`before_request_headers`](HttpMiddleware::before_request_headers)
+//!   mutates the outgoing [`HeaderMap`] in place (per-request beta or feature
+//!   headers, auth decoration).
+//! - [`before_request_body`](HttpMiddleware::before_request_body) sees the
+//!   serialized body and may replace it (logging/replay capture, payload
+//!   patching that no semantic knob covers).
+//! - [`after_response`](HttpMiddleware::after_response) sees the response
+//!   status and headers as soon as they arrive — for a streaming call this is
+//!   **before stream consumption**, so rate-limit headers and request ids are
+//!   readable without buffering the body.
+//!
+//! Middlewares attach with
+//! [`BoxedHttpClient::with_middleware`](super::BoxedHttpClient::with_middleware)
+//! and compose in attachment order:
+//!
+//! - all `before_request_headers` run first, in order, each seeing the
+//!   previous one's mutations;
+//! - then all `before_request_body` run in order, each seeing the previous
+//!   one's replacement body (and the final headers);
+//! - after the transport returns, all `after_response` run in order.
+//!
+//! `after_response` is observe-only for the response itself, but any method
+//! may *fail* the request by returning an error, which surfaces through the
+//! normal [`Error`](super::Error) path — a middleware can reject a response it
+//! refuses to accept, but cannot silently swallow or alter one.
+//!
+//! Multipart requests run the header and response methods; the body method is
+//! **not** invoked for them (the form is encoded transport-side and carries no
+//! single serialized payload to replace).
+//!
+//! Middleware failures on the request side abort before any bytes are sent.
+//! A middleware must not block; it runs on the request's own future.
+
+use bytes::Bytes;
+use http::{HeaderMap, Method, StatusCode, Uri};
+
+use super::Result;
+use crate::wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync};
+
+/// Transport-boundary hooks applied by
+/// [`BoxedHttpClient`](super::BoxedHttpClient) around every request.
+///
+/// All methods are default no-ops; implement only the moments you need. See
+/// the [module docs](self) for ordering, composition, and error semantics.
+pub trait HttpMiddleware: WasmCompatSend + WasmCompatSync {
+    /// Mutate the outgoing request headers in place.
+    ///
+    /// Runs before [`before_request_body`](Self::before_request_body). An
+    /// error aborts the request before it is sent.
+    fn before_request_headers<'a>(
+        &'a self,
+        _method: &'a Method,
+        _uri: &'a Uri,
+        _headers: &'a mut HeaderMap,
+    ) -> WasmBoxedFuture<'a, Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    /// Observe the serialized request body, returning the body to send.
+    ///
+    /// Return `body` unchanged to pass through, or a replacement to rewrite
+    /// the payload. `headers` reflects every middleware's header mutations.
+    /// Not invoked for multipart requests. An error aborts the request before
+    /// it is sent.
+    fn before_request_body<'a>(
+        &'a self,
+        _method: &'a Method,
+        _uri: &'a Uri,
+        _headers: &'a HeaderMap,
+        body: Bytes,
+    ) -> WasmBoxedFuture<'a, Result<Bytes>> {
+        Box::pin(async move { Ok(body) })
+    }
+
+    /// Observe the response status and headers as soon as they arrive.
+    ///
+    /// For streaming responses this runs before any of the body stream is
+    /// consumed. Observe-only: the response cannot be modified, but returning
+    /// an error fails the request with that error.
+    fn after_response<'a>(
+        &'a self,
+        _method: &'a Method,
+        _uri: &'a Uri,
+        _status: StatusCode,
+        _headers: &'a HeaderMap,
+    ) -> WasmBoxedFuture<'a, Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+}

--- a/crates/rig-core/src/http_client/mod.rs
+++ b/crates/rig-core/src/http_client/mod.rs
@@ -3,11 +3,13 @@ use bytes::Bytes;
 pub use http::{HeaderMap, HeaderValue, Method, Request, Response, Uri, request::Builder};
 use http::{HeaderName, StatusCode};
 mod erased;
+pub mod middleware;
 pub mod multipart;
 pub mod retry;
 pub mod sse;
 use crate::wasm_compat::*;
 pub use erased::BoxedHttpClient;
+pub use middleware::HttpMiddleware;
 pub use multipart::MultipartForm;
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/rig-core/src/http_client/mod.rs
+++ b/crates/rig-core/src/http_client/mod.rs
@@ -1,7 +1,9 @@
 use crate::http_client::sse::BoxedStream;
 use bytes::Bytes;
-pub use http::{HeaderMap, HeaderValue, Method, Request, Response, Uri, request::Builder};
-use http::{HeaderName, StatusCode};
+use http::HeaderName;
+pub use http::{
+    HeaderMap, HeaderValue, Method, Request, Response, StatusCode, Uri, request::Builder,
+};
 mod erased;
 pub mod middleware;
 pub mod multipart;

--- a/crates/rig-run/src/lib.rs
+++ b/crates/rig-run/src/lib.rs
@@ -40,7 +40,7 @@ pub use response::{CompletionCall, PromptResponse};
 pub use rig_core::id::RunId;
 pub use run::{
     AgentRun, AgentRunStep, DEFAULT_OUTPUT_RETRIES, ModelTurn, ModelTurnOutcome, PendingToolCall,
-    TurnTools,
+    ScratchpadSnapshot, TurnTools,
 };
 pub use spec::RunSpec;
 pub use streamed::{

--- a/crates/rig-run/src/run.rs
+++ b/crates/rig-run/src/run.rs
@@ -426,7 +426,33 @@ pub struct AgentRun {
     /// driver (or a resumed run) can re-pair tool calls with what was offered.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     turn_tools: Option<TurnTools>,
+    /// Serialized hook state carried with the run — see [`ScratchpadSnapshot`].
+    /// Protocol data like [`TurnTools`]: the run does not interpret it, but a
+    /// driver that pauses a run out of process can round-trip its hooks' state
+    /// through it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    hook_state: Option<ScratchpadSnapshot>,
     state: RunState,
+}
+
+/// Serializable hook state carried by an [`AgentRun`].
+///
+/// A driver with stateful hooks (a retry counter, an approval ledger) stores
+/// their durable entries here before serializing the run, and restores them
+/// into the live hook context when the run resumes — possibly in another
+/// process. The run itself never reads the entries; they are opaque
+/// driver/hook data keyed by string.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ScratchpadSnapshot {
+    /// Durable entries, keyed by the name each hook chose.
+    pub entries: BTreeMap<String, serde_json::Value>,
+}
+
+impl ScratchpadSnapshot {
+    /// Whether the snapshot carries no entries.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
 }
 
 /// The tools advertised to the model for one turn — what the request carried,
@@ -471,8 +497,60 @@ impl AgentRun {
             rollback_pending: false,
             streamed_completion_call_recorded: false,
             turn_tools: None,
+            hook_state: None,
             state: RunState::PreparingRequest,
         }
+    }
+
+    /// The prompt this run will send on its first model call, while the run
+    /// has not yet started. `None` once the first
+    /// [`AgentRunStep::CallModel`] has been emitted (the prompt is then run
+    /// history, no longer pending input).
+    pub fn initial_prompt(&self) -> Option<&Message> {
+        (self.current_turn == 0 && matches!(self.state, RunState::PreparingRequest))
+            .then(|| self.new_messages.last())
+            .flatten()
+    }
+
+    /// Replace the pending prompt before the run starts.
+    ///
+    /// This is the run-start steering point: a driver's pre-run hook may
+    /// rewrite the user prompt here, before any model call. Valid only while
+    /// [`initial_prompt`](Self::initial_prompt) is `Some`; once the first
+    /// [`AgentRunStep::CallModel`] has been emitted the prompt is committed
+    /// and rewriting returns [`PromptError::PromptCancelled`].
+    pub fn rewrite_initial_prompt(
+        &mut self,
+        prompt: impl Into<Message>,
+    ) -> Result<(), PromptError> {
+        let started = self.current_turn != 0 || !matches!(self.state, RunState::PreparingRequest);
+        match self.new_messages.last_mut() {
+            Some(slot) if !started => {
+                *slot = prompt.into();
+                Ok(())
+            }
+            _ => Err(PromptError::prompt_cancelled(
+                self.full_history(),
+                "the initial prompt can only be rewritten before the run starts",
+            )),
+        }
+    }
+
+    /// Serialized hook state carried by this run, if any. See
+    /// [`ScratchpadSnapshot`].
+    pub fn hook_state(&self) -> Option<&ScratchpadSnapshot> {
+        self.hook_state.as_ref()
+    }
+
+    /// Attach serialized hook state to carry with the run. `None` clears it.
+    pub fn set_hook_state(&mut self, state: Option<ScratchpadSnapshot>) {
+        self.hook_state = state;
+    }
+
+    /// Remove and return the carried hook state, if any. Drivers call this at
+    /// run start to restore the state into their live hook context.
+    pub fn take_hook_state(&mut self) -> Option<ScratchpadSnapshot> {
+        self.hook_state.take()
     }
 
     /// Record the tool definitions advertised to the model for `turn` (the
@@ -550,6 +628,13 @@ impl AgentRun {
         serde_json::from_str::<serde_json::Value>(text.trim())
             .ok()
             .is_some_and(|value| self.missing_required_output_fields(&value).is_empty())
+    }
+
+    /// The input chat history this run was created with, empty when none was
+    /// set. This is the history preceding the initial prompt, not the run's
+    /// accumulated messages.
+    pub fn input_chat_history(&self) -> &[Message] {
+        self.chat_history.as_deref().unwrap_or_default()
     }
 
     /// Whether the run may re-prompt for valid Tool-mode output: both the
@@ -1721,6 +1806,63 @@ mod tests {
     use super::*;
     use rig_core::message::{ToolFunction, ToolResultContent};
     use serde_json::json;
+
+    #[test]
+    fn initial_prompt_is_rewritable_only_before_the_run_starts() {
+        let mut run = AgentRun::new("original").max_turns(2);
+        assert!(run.initial_prompt().is_some());
+        run.rewrite_initial_prompt("rewritten")
+            .expect("rewrite before start");
+
+        let step = run.next_step().expect("first step");
+        let AgentRunStep::CallModel {
+            prompt, history, ..
+        } = step
+        else {
+            panic!("expected CallModel");
+        };
+        assert_eq!(prompt, Message::user("rewritten"));
+        assert!(history.is_empty());
+
+        // Once the run has started, the prompt is committed.
+        assert!(run.initial_prompt().is_none());
+        assert!(run.rewrite_initial_prompt("too late").is_err());
+    }
+
+    #[test]
+    fn input_chat_history_reflects_the_configured_history() {
+        let run = AgentRun::new("p");
+        assert!(run.input_chat_history().is_empty());
+        let run = AgentRun::new("p").with_history(vec![Message::user("earlier")]);
+        assert_eq!(run.input_chat_history(), [Message::user("earlier")]);
+    }
+
+    #[test]
+    fn hook_state_round_trips_through_serialization_and_take() {
+        let mut run = AgentRun::new("p");
+        assert!(run.hook_state().is_none());
+        let mut snapshot = ScratchpadSnapshot::default();
+        snapshot
+            .entries
+            .insert("approvals".into(), json!(["tool-1"]));
+        run.set_hook_state(Some(snapshot.clone()));
+
+        let serialized = serde_json::to_string(&run).expect("run serializes");
+        let mut restored: AgentRun = serde_json::from_str(&serialized).expect("run deserializes");
+        assert_eq!(restored.hook_state(), Some(&snapshot));
+        assert_eq!(restored.take_hook_state(), Some(snapshot));
+        assert!(restored.hook_state().is_none());
+    }
+
+    #[test]
+    fn runs_serialized_without_hook_state_still_deserialize() {
+        let run = AgentRun::new("p");
+        let mut value = serde_json::to_value(&run).expect("serializes");
+        let object = value.as_object_mut().expect("object");
+        assert!(!object.contains_key("hook_state"), "absent when unset");
+        let restored: AgentRun = serde_json::from_value(value).expect("deserializes");
+        assert!(restored.hook_state().is_none());
+    }
 
     fn tool_names(names: &[&str]) -> BTreeSet<String> {
         names.iter().map(|name| (*name).to_string()).collect()

--- a/examples/http_middleware/Cargo.toml
+++ b/examples/http_middleware/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "http_middleware"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+rig = { workspace = true }
+anyhow = { workspace = true }
+bytes = { workspace = true }
+http = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/examples/http_middleware/src/main.rs
+++ b/examples/http_middleware/src/main.rs
@@ -1,0 +1,95 @@
+//! Transport-boundary middleware on the erased HTTP client.
+//!
+//! Demonstrates the three `HttpMiddleware` moments on a real provider call:
+//! injecting a per-request `anthropic-beta` header, logging the serialized
+//! request body, and reading rate-limit / request-id response headers — on a
+//! streaming call, before the stream is consumed. Requires `ANTHROPIC_API_KEY`.
+
+use anyhow::{Context, Result};
+use rig::http_client::{BoxedHttpClient, HeaderMap, HeaderValue, HttpMiddleware, Method, Uri};
+use rig::prelude::*;
+use rig::providers::anthropic;
+use rig::wasm_compat::WasmBoxedFuture;
+
+/// Adds a beta header to every outgoing request and prints the wire traffic
+/// the semantic layer never shows: the serialized body and the response's
+/// transport metadata.
+struct WireLogger;
+
+impl HttpMiddleware for WireLogger {
+    fn before_request_headers<'a>(
+        &'a self,
+        _method: &'a Method,
+        _uri: &'a Uri,
+        headers: &'a mut HeaderMap,
+    ) -> WasmBoxedFuture<'a, rig::http_client::Result<()>> {
+        Box::pin(async move {
+            headers.insert(
+                "anthropic-beta",
+                HeaderValue::from_static("token-efficient-tools-2025-02-19"),
+            );
+            Ok(())
+        })
+    }
+
+    fn before_request_body<'a>(
+        &'a self,
+        method: &'a Method,
+        uri: &'a Uri,
+        _headers: &'a HeaderMap,
+        body: bytes::Bytes,
+    ) -> WasmBoxedFuture<'a, rig::http_client::Result<bytes::Bytes>> {
+        Box::pin(async move {
+            println!("→ {method} {uri} ({} byte payload)", body.len());
+            Ok(body)
+        })
+    }
+
+    fn after_response<'a>(
+        &'a self,
+        _method: &'a Method,
+        _uri: &'a Uri,
+        status: http::StatusCode,
+        headers: &'a HeaderMap,
+    ) -> WasmBoxedFuture<'a, rig::http_client::Result<()>> {
+        Box::pin(async move {
+            // Runs before any of the (possibly streaming) body is consumed.
+            let request_id = headers
+                .get("request-id")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("<none>");
+            println!("← {status}, request-id: {request_id}");
+            for (name, value) in headers {
+                if name.as_str().starts_with("anthropic-ratelimit-") {
+                    println!("  {name}: {}", value.to_str().unwrap_or("<binary>"));
+                }
+            }
+            Ok(())
+        })
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let api_key = std::env::var("ANTHROPIC_API_KEY").context("ANTHROPIC_API_KEY is not set")?;
+
+    // Erase the default transport, then attach the middleware — no provider
+    // code involved; the same handle could back every provider a host builds.
+    let http_client = BoxedHttpClient::new(rig::http_client::ReqwestClient::default())
+        .with_middleware(WireLogger);
+
+    let client = anthropic::Client::builder()
+        .http_client(http_client)
+        .api_key(api_key)
+        .build()?;
+
+    let agent = client
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
+        .preamble("You are a helpful assistant.")
+        .build();
+
+    let response = agent.prompt("What is 2 + 2?").await?;
+    println!("Response: {response}");
+
+    Ok(())
+}

--- a/tests/cassettes/anthropic/lifecycle_matrix/middleware_streaming.yaml
+++ b/tests/cassettes/anthropic/lifecycle_matrix/middleware_streaming.yaml
@@ -1,0 +1,68 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":64000,"messages":[{"content":[{"text":"In one short paragraph, explain what a solar eclipse is.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You are a concise assistant. Answer directly in plain text.","type":"text"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  - name: request-id
+    value: req_REDACTED_1
+  body: |+
+    event: message_start
+    data: {"message":{"content":[],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":33,"output_tokens":4,"service_tier":"standard"}},"type":"message_start"}
+
+    event: content_block_start
+    data: {"content_block":{"text":"","type":"text"},"index":0,"type":"content_block_start"}
+
+    event: ping
+    data: {"type":"ping"}
+
+    event: content_block_delta
+    data: {"delta":{"text":"A solar eclipse occurs","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"text":" when the Moon","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"text":" passes directly","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"text":" between the Earth","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"text":" and the Sun, blocking","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"text":" some or all of the Sun's light from reaching Earth. During a total solar eclipse, the Moon completely covers the Sun's disk, briefly turning day into an e","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"text":"erie darkness and allowing the Sun's outer atmosphere, called the corona, to become visible. A partial eclipse occurs when only a","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"text":" portion of the Sun is obscured, while an annular eclipse happens when the Moon is slightly farther from Earth and appears smaller, leaving","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"text":" a bright ring of sunlight visible around its edges. Solar eclipses can only happen during a new moon and","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"text":" are only visible from specific locations on Earth's surface.","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":0,"type":"content_block_stop"}
+
+    event: message_delta
+    data: {"delta":{"stop_details":null,"stop_reason":"end_turn","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":33,"output_tokens":140}}
+
+    event: message_stop
+    data: {"type":"message_stop"}
+

--- a/tests/cassettes/anthropic/lifecycle_matrix/middleware_unary.yaml
+++ b/tests/cassettes/anthropic/lifecycle_matrix/middleware_unary.yaml
@@ -1,0 +1,20 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":64000,"messages":[{"content":[{"text":"In one or two sentences, explain what Rust programming language is and why memory safety matters.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"You are a concise assistant. Answer directly.","type":"text"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: request-id
+    value: req_REDACTED_1
+  body: '{"content":[{"text":"Rust is a systems programming language designed for performance, reliability, and productivity, with a unique ownership system that enforces memory safety at compile time without needing a garbage collector. Memory safety matters because bugs like null pointer dereferences, buffer overflows, and use-after-free errors are leading causes of security vulnerabilities and crashes in software.","type":"text"}],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"end_turn","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":37,"output_tokens":74,"service_tier":"standard"}}'

--- a/tests/cassettes/anthropic/lifecycle_matrix/run_settled_tool_run.yaml
+++ b/tests/cassettes/anthropic/lifecycle_matrix/run_settled_tool_run.yaml
@@ -1,0 +1,41 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":64000,"messages":[{"content":[{"text":"What is 7 + 15? Use the add tool, then reply with just the number.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"You are a calculator. Use the add tool for arithmetic.","type":"text"}],"tools":[{"description":"Add x and y together","input_schema":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"name":"add"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: request-id
+    value: req_REDACTED_1
+  body: '{"content":[{"caller":{"type":"direct"},"id":"toolu_REDACTED_1","input":{"x":7,"y":15},"name":"add","type":"tool_use"}],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"tool_use","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":622,"output_tokens":69,"service_tier":"standard"}}'
+---
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":64000,"messages":[{"content":[{"text":"What is 7 + 15? Use the add tool, then reply with just the number.","type":"text"}],"role":"user"},{"content":[{"id":"toolu_REDACTED_1","input":{"x":7,"y":15},"name":"add","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"22","type":"text"}],"tool_use_id":"toolu_REDACTED_1","type":"tool_result"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"You are a calculator. Use the add tool for arithmetic.","type":"text"}],"tools":[{"description":"Add x and y together","input_schema":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"name":"add"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: request-id
+    value: req_REDACTED_2
+  body: '{"content":[{"text":"22","type":"text"}],"id":"msg_REDACTED_2","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"end_turn","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":704,"output_tokens":4,"service_tier":"standard"}}'

--- a/tests/cassettes/anthropic/lifecycle_matrix/run_start_rewrite.yaml
+++ b/tests/cassettes/anthropic/lifecycle_matrix/run_start_rewrite.yaml
@@ -1,0 +1,20 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":64000,"messages":[{"content":[{"text":"Reply with exactly the single word PINEAPPLE and nothing else.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"You are a concise assistant. Answer directly.","type":"text"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: request-id
+    value: req_REDACTED_1
+  body: '{"content":[{"text":"PINEAPPLE","type":"text"}],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"end_turn","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":33,"output_tokens":8,"service_tier":"standard"}}'

--- a/tests/cassettes/gemini/lifecycle_matrix/middleware_streaming.yaml
+++ b/tests/cassettes/gemini/lifecycle_matrix/middleware_streaming.yaml
@@ -1,0 +1,20 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"In one short paragraph, explain what a solar eclipse is.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a concise assistant. Answer directly in plain text.","thought":false}],"role":"model"},"toolConfig":null}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"A solar eclipse occurs when the Moon passes directly between the Sun and Earth, casting a shadow on Earth and blocking all or part of the Sun's light\"}],\"role\":\"model\"},\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":31,\"promptTokenCount\":26,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":26}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":82,\"totalTokenCount\":139}}\r\n\r\ndata: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\". This alignment causes the Moon to temporarily obscure the Sun from view, turning day into a brief twilight or darkness for those in the path of the Moon's shadow.\"}],\"role\":\"model\"},\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":65,\"promptTokenCount\":26,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":26}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":82,\"totalTokenCount\":173}}\r\n\r\n"

--- a/tests/cassettes/gemini/lifecycle_matrix/middleware_unary.yaml
+++ b/tests/cassettes/gemini/lifecycle_matrix/middleware_unary.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"In one or two sentences, explain what Rust programming language is and why memory safety matters.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a concise assistant. Answer directly.","thought":false}],"role":"model"},"toolConfig":null}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"Rust is a systems programming language known for its performance, reliability, and productivity, achieving memory safety without a garbage collector. Memory safety is crucial as it prevents common, critical bugs like data races and buffer overflows that lead to crashes and security vulnerabilities."}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":49,"promptTokenCount":29,"promptTokensDetails":[{"modality":"TEXT","tokenCount":29}],"serviceTier":"standard","thoughtsTokenCount":165,"totalTokenCount":243}}'

--- a/tests/cassettes/gemini/lifecycle_matrix/run_settled_tool_run.yaml
+++ b/tests/cassettes/gemini/lifecycle_matrix/run_settled_tool_run.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 7 + 15? Use the add tool, then reply with just the number.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator. Use the add tool for arithmetic.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":7,"y":15},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":19,"promptTokenCount":89,"promptTokensDetails":[{"modality":"TEXT","tokenCount":89}],"serviceTier":"standard","thoughtsTokenCount":59,"totalTokenCount":167}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 7 + 15? Use the add tool, then reply with just the number.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":7,"y":15},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":22}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator. Use the add tool for arithmetic.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"22","thoughtSignature":"signature_REDACTED_2"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":2,"promptTokenCount":122,"promptTokensDetails":[{"modality":"TEXT","tokenCount":122}],"serviceTier":"standard","thoughtsTokenCount":31,"totalTokenCount":155}}'

--- a/tests/cassettes/gemini/lifecycle_matrix/run_start_rewrite.yaml
+++ b/tests/cassettes/gemini/lifecycle_matrix/run_start_rewrite.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Reply with exactly the single word PINEAPPLE and nothing else.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a concise assistant. Answer directly.","thought":false}],"role":"model"},"toolConfig":null}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"PINEAPPLE"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":3,"promptTokenCount":24,"promptTokensDetails":[{"modality":"TEXT","tokenCount":24}],"serviceTier":"standard","thoughtsTokenCount":25,"totalTokenCount":52}}'

--- a/tests/cassettes/openai/lifecycle_matrix/middleware_streaming.yaml
+++ b/tests/cassettes/openai/lifecycle_matrix/middleware_streaming.yaml
@@ -1,0 +1,270 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"input":[{"content":[{"text":"In one short paragraph, explain what a solar eclipse is.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a concise assistant. Answer directly in plain text.","model":"gpt-4o","stream":true}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  - name: x-request-id
+    value: req_REDACTED_1
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a concise assistant. Answer directly in plain text.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-4o-2024-08-06","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a concise assistant. Answer directly in plain text.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-4o-2024-08-06","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_1","role":"assistant","status":"in_progress","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"A","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" solar","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_2","output_index":0,"sequence_number":5,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" eclipse","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":6,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" occurs","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":7,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" when","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":8,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" the","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_6","output_index":0,"sequence_number":9,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" Moon","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_7","output_index":0,"sequence_number":10,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" passes","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_8","output_index":0,"sequence_number":11,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" between","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_9","output_index":0,"sequence_number":12,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" the","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_10","output_index":0,"sequence_number":13,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" Earth","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_11","output_index":0,"sequence_number":14,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" and","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_12","output_index":0,"sequence_number":15,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" the","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_13","output_index":0,"sequence_number":16,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" Sun","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_14","output_index":0,"sequence_number":17,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":",","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_15","output_index":0,"sequence_number":18,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" temporarily","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_16","output_index":0,"sequence_number":19,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" blocking","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_17","output_index":0,"sequence_number":20,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" the","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_18","output_index":0,"sequence_number":21,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" Sun","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_19","output_index":0,"sequence_number":22,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"'s","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_20","output_index":0,"sequence_number":23,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" light","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_21","output_index":0,"sequence_number":24,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":".","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_22","output_index":0,"sequence_number":25,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" This","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_23","output_index":0,"sequence_number":26,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" alignment","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_24","output_index":0,"sequence_number":27,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" can","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_25","output_index":0,"sequence_number":28,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" cause","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_26","output_index":0,"sequence_number":29,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" partial","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_27","output_index":0,"sequence_number":30,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":",","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_28","output_index":0,"sequence_number":31,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" total","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_29","output_index":0,"sequence_number":32,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":",","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_30","output_index":0,"sequence_number":33,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" or","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_31","output_index":0,"sequence_number":34,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" ann","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_32","output_index":0,"sequence_number":35,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ular","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_33","output_index":0,"sequence_number":36,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" eclips","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_34","output_index":0,"sequence_number":37,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"es","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_35","output_index":0,"sequence_number":38,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":",","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_36","output_index":0,"sequence_number":39,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" depending","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_37","output_index":0,"sequence_number":40,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" on","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_38","output_index":0,"sequence_number":41,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" the","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_39","output_index":0,"sequence_number":42,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" distances","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_40","output_index":0,"sequence_number":43,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" between","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_41","output_index":0,"sequence_number":44,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" these","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_42","output_index":0,"sequence_number":45,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" celestial","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_43","output_index":0,"sequence_number":46,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" bodies","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_44","output_index":0,"sequence_number":47,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":".","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_45","output_index":0,"sequence_number":48,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" During","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_46","output_index":0,"sequence_number":49,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" a","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_47","output_index":0,"sequence_number":50,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" total","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_48","output_index":0,"sequence_number":51,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" solar","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_49","output_index":0,"sequence_number":52,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" eclipse","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_50","output_index":0,"sequence_number":53,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":",","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_51","output_index":0,"sequence_number":54,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" the","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_52","output_index":0,"sequence_number":55,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" Sun","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_53","output_index":0,"sequence_number":56,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" is","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_54","output_index":0,"sequence_number":57,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" completely","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_55","output_index":0,"sequence_number":58,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" obsc","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_56","output_index":0,"sequence_number":59,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ured","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_57","output_index":0,"sequence_number":60,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" by","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_58","output_index":0,"sequence_number":61,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" the","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_59","output_index":0,"sequence_number":62,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" Moon","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_60","output_index":0,"sequence_number":63,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":",","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_61","output_index":0,"sequence_number":64,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" casting","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_62","output_index":0,"sequence_number":65,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" a","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_63","output_index":0,"sequence_number":66,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" shadow","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_64","output_index":0,"sequence_number":67,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" on","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_65","output_index":0,"sequence_number":68,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" parts","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_66","output_index":0,"sequence_number":69,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" of","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_67","output_index":0,"sequence_number":70,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" the","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_68","output_index":0,"sequence_number":71,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" Earth","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_69","output_index":0,"sequence_number":72,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" and","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_70","output_index":0,"sequence_number":73,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" briefly","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_71","output_index":0,"sequence_number":74,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" turning","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_72","output_index":0,"sequence_number":75,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" day","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_73","output_index":0,"sequence_number":76,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" into","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_74","output_index":0,"sequence_number":77,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" night","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_75","output_index":0,"sequence_number":78,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":".","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_76","output_index":0,"sequence_number":79,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","logprobs":[],"output_index":0,"sequence_number":80,"text":"A solar eclipse occurs when the Moon passes between the Earth and the Sun, temporarily blocking the Sun's light. This alignment can cause partial, total, or annular eclipses, depending on the distances between these celestial bodies. During a total solar eclipse, the Sun is completely obscured by the Moon, casting a shadow on parts of the Earth and briefly turning day into night.","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"A solar eclipse occurs when the Moon passes between the Earth and the Sun, temporarily blocking the Sun's light. This alignment can cause partial, total, or annular eclipses, depending on the distances between these celestial bodies. During a total solar eclipse, the Sun is completely obscured by the Moon, casting a shadow on parts of the Earth and briefly turning day into night.","type":"output_text"},"sequence_number":81,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"A solar eclipse occurs when the Moon passes between the Earth and the Sun, temporarily blocking the Sun's light. This alignment can cause partial, total, or annular eclipses, depending on the distances between these celestial bodies. During a total solar eclipse, the Sun is completely obscured by the Moon, casting a shadow on parts of the Earth and briefly turning day into night.","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":82,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a concise assistant. Answer directly in plain text.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-4o-2024-08-06","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"A solar eclipse occurs when the Moon passes between the Earth and the Sun, temporarily blocking the Sun's light. This alignment can cause partial, total, or annular eclipses, depending on the distances between these celestial bodies. During a total solar eclipse, the Sun is completely obscured by the Moon, casting a shadow on parts of the Earth and briefly turning day into night.","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":35,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":77,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":112},"user":null},"sequence_number":83,"type":"response.completed"}
+

--- a/tests/cassettes/openai/lifecycle_matrix/middleware_unary.yaml
+++ b/tests/cassettes/openai/lifecycle_matrix/middleware_unary.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"input":[{"content":[{"text":"In one or two sentences, explain what Rust programming language is and why memory safety matters.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a concise assistant. Answer directly.","model":"gpt-4o"}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: x-request-id
+    value: req_REDACTED_1
+  body: '{"background":false,"billing":{"payer":"developer"},"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a concise assistant. Answer directly.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-4o-2024-08-06","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"Rust is a systems programming language focused on safety, performance, and concurrency, with features that prevent common programming errors. Memory safety matters because it helps prevent issues like buffer overflows and null pointer dereferences, reducing vulnerabilities and improving program reliability.","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":38,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":49,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":87},"user":null}'

--- a/tests/cassettes/openai/lifecycle_matrix/run_settled_tool_run.yaml
+++ b/tests/cassettes/openai/lifecycle_matrix/run_settled_tool_run.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"input":[{"content":[{"text":"What is 7 + 15? Use the add tool, then reply with just the number.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a calculator. Use the add tool for arithmetic.","model":"gpt-4o","tools":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: x-request-id
+    value: req_REDACTED_1
+  body: '{"background":false,"billing":{"payer":"developer"},"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator. Use the add tool for arithmetic.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-4o-2024-08-06","moderation":null,"object":"response","output":[{"arguments":"{\"x\":7,\"y\":15}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"completed","type":"function_call"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":89,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":18,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":107},"user":null}'
+---
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"input":[{"content":[{"text":"What is 7 + 15? Use the add tool, then reply with just the number.","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"x\":7,\"y\":15}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"completed","type":"function_call"},{"call_id":"call_REDACTED_1","output":"22","status":"completed","type":"function_call_output"}],"instructions":"You are a calculator. Use the add tool for arithmetic.","model":"gpt-4o","tools":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: x-request-id
+    value: req_REDACTED_2
+  body: '{"background":false,"billing":{"payer":"developer"},"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a calculator. Use the add tool for arithmetic.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-4o-2024-08-06","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"22","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":115,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":3,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":118},"user":null}'

--- a/tests/cassettes/openai/lifecycle_matrix/run_start_rewrite.yaml
+++ b/tests/cassettes/openai/lifecycle_matrix/run_start_rewrite.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"input":[{"content":[{"text":"Reply with exactly the single word PINEAPPLE and nothing else.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a concise assistant. Answer directly.","model":"gpt-4o"}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: x-request-id
+    value: req_REDACTED_1
+  body: '{"background":false,"billing":{"payer":"developer"},"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a concise assistant. Answer directly.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-4o-2024-08-06","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"PINEAPPLE","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":33,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":4,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":37},"user":null}'

--- a/tests/common/cassette_safety.rs
+++ b/tests/common/cassette_safety.rs
@@ -22,6 +22,7 @@ const PROVIDER_CASSETTE_SUITES: &[ProviderCassetteSuite] = &[
         source_dir: "tests/providers/openai/cassette",
         wrapper_names: &[
             "with_openai_cassette",
+            "with_openai_lifecycle_cassette",
             "with_openai_prompt_caching_cassette",
             "with_openai_completions_prompt_caching_cassette",
             "with_openai_turn_metadata_cassette",
@@ -68,6 +69,7 @@ const PROVIDER_CASSETTE_SUITES: &[ProviderCassetteSuite] = &[
         source_dir: "tests/providers/anthropic/cassette",
         wrapper_names: &[
             "with_anthropic_cassette",
+            "with_anthropic_lifecycle_cassette",
             "with_anthropic_turn_metadata_cassette",
             "with_anthropic_cassette_result",
             "with_anthropic_cassette_bogus_key",
@@ -118,6 +120,7 @@ const PROVIDER_CASSETTE_SUITES: &[ProviderCassetteSuite] = &[
         wrapper_names: &[
             "with_gemini_prompt_caching_cassette",
             "with_gemini_cassette",
+            "with_gemini_lifecycle_cassette",
             "with_gemini_turn_metadata_cassette",
             "with_gemini_cassette_bogus_key",
             "with_gemini_code_execution_cassette",

--- a/tests/common/support.rs
+++ b/tests/common/support.rs
@@ -1355,3 +1355,176 @@ pub(crate) fn assert_normalized_embedding_response(
         "every HTTP provider seam populates `raw`"
     );
 }
+
+/// Wire-level probe middleware for the run-lifecycle cassette matrix.
+///
+/// Counts each `HttpMiddleware` phase, records the last observed response
+/// status and request-body length, and injects a benign
+/// `x-rig-lifecycle-probe` header (deliberately outside the harness's
+/// recorded-header allowlist, so cassette matching is identical with and
+/// without it). Everything it observes holds in both cassette modes: on
+/// replay the same phases fire against the replay server.
+#[derive(Clone, Default)]
+pub(crate) struct WireProbe {
+    pub(crate) header_phases: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    pub(crate) body_phases: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    pub(crate) response_phases: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    pub(crate) last_status: std::sync::Arc<std::sync::atomic::AtomicU16>,
+    pub(crate) last_body_len: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl rig::http_client::HttpMiddleware for WireProbe {
+    fn before_request_headers<'a>(
+        &'a self,
+        _method: &'a rig::http_client::Method,
+        _uri: &'a rig::http_client::Uri,
+        headers: &'a mut rig::http_client::HeaderMap,
+    ) -> rig::wasm_compat::WasmBoxedFuture<'a, rig::http_client::Result<()>> {
+        Box::pin(async move {
+            self.header_phases
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            headers.insert(
+                "x-rig-lifecycle-probe",
+                rig::http_client::HeaderValue::from_static("1"),
+            );
+            Ok(())
+        })
+    }
+
+    fn before_request_body<'a>(
+        &'a self,
+        _method: &'a rig::http_client::Method,
+        _uri: &'a rig::http_client::Uri,
+        headers: &'a rig::http_client::HeaderMap,
+        body: bytes::Bytes,
+    ) -> rig::wasm_compat::WasmBoxedFuture<'a, rig::http_client::Result<bytes::Bytes>> {
+        Box::pin(async move {
+            self.body_phases
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            // The body phase runs after the header phase mutated the map.
+            assert!(
+                headers.contains_key("x-rig-lifecycle-probe"),
+                "body hooks see the final headers"
+            );
+            self.last_body_len
+                .store(body.len(), std::sync::atomic::Ordering::SeqCst);
+            Ok(body)
+        })
+    }
+
+    fn after_response<'a>(
+        &'a self,
+        _method: &'a rig::http_client::Method,
+        _uri: &'a rig::http_client::Uri,
+        status: rig::http_client::StatusCode,
+        _headers: &'a rig::http_client::HeaderMap,
+    ) -> rig::wasm_compat::WasmBoxedFuture<'a, rig::http_client::Result<()>> {
+        Box::pin(async move {
+            self.response_phases
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.last_status
+                .store(status.as_u16(), std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        })
+    }
+}
+
+impl WireProbe {
+    /// Assert the counters of a completed single-request exchange.
+    pub(crate) fn assert_single_exchange(&self) {
+        use std::sync::atomic::Ordering::SeqCst;
+        assert_eq!(self.header_phases.load(SeqCst), 1, "one header phase");
+        assert_eq!(self.body_phases.load(SeqCst), 1, "one body phase");
+        assert_eq!(self.response_phases.load(SeqCst), 1, "one response phase");
+        assert_eq!(
+            self.last_status.load(SeqCst),
+            200,
+            "success status observed"
+        );
+        assert!(
+            self.last_body_len.load(SeqCst) > 0,
+            "the serialized provider payload was visible to the body phase"
+        );
+    }
+}
+
+/// Agent-hook probe for the run-lifecycle cassette matrix: counts
+/// `on_run_start` firings (optionally rewriting the prompt), counts
+/// completion calls into a durable scratchpad entry, and records every
+/// `on_run_settled` outcome plus the settled scratchpad export.
+#[derive(Clone, Default)]
+pub(crate) struct LifecycleHookProbe {
+    pub(crate) rewrite_to: Option<String>,
+    pub(crate) starts: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    pub(crate) settles: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    pub(crate) exported: std::sync::Arc<std::sync::Mutex<Option<rig::agent::ScratchpadSnapshot>>>,
+}
+
+impl LifecycleHookProbe {
+    pub(crate) fn rewriting_to(prompt: &str) -> Self {
+        Self {
+            rewrite_to: Some(prompt.to_string()),
+            ..Self::default()
+        }
+    }
+
+    /// The settle outcomes observed so far ("response" or "error:…").
+    pub(crate) fn settle_outcomes(&self) -> Vec<String> {
+        self.settles.lock().expect("settles").clone()
+    }
+
+    /// The durable completion-call counter the settled export carried.
+    pub(crate) fn exported_completion_calls(&self) -> Option<u64> {
+        let snapshot = self.exported.lock().expect("export").clone()?;
+        snapshot
+            .entries
+            .get("completion_calls")
+            .and_then(serde_json::Value::as_u64)
+    }
+}
+
+impl rig::agent::AgentHook for LifecycleHookProbe {
+    async fn on_run_start(
+        &self,
+        _ctx: &rig::agent::HookContext,
+        _event: rig::agent::RunStart<'_>,
+    ) -> rig::agent::RunStartAction {
+        self.starts
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        match &self.rewrite_to {
+            Some(prompt) => {
+                rig::agent::RunStartAction::rewrite(rig::completion::Message::user(prompt))
+            }
+            None => rig::agent::RunStartAction::Continue,
+        }
+    }
+
+    async fn on_completion_call(
+        &self,
+        ctx: &rig::agent::HookContext,
+        _event: rig::agent::CompletionCallEvent<'_>,
+    ) -> rig::agent::CompletionCallAction {
+        let calls = ctx
+            .scratchpad()
+            .get_durable::<u64>("completion_calls")
+            .unwrap_or(0)
+            + 1;
+        ctx.scratchpad()
+            .put_durable("completion_calls", &calls)
+            .expect("a u64 serializes");
+        rig::agent::CompletionCallAction::Continue
+    }
+
+    async fn on_run_settled(
+        &self,
+        ctx: &rig::agent::HookContext,
+        event: rig::agent::RunSettled<'_>,
+    ) {
+        *self.exported.lock().expect("export") = Some(ctx.scratchpad().export());
+        let outcome = match event.outcome {
+            rig::agent::SettledOutcome::Response(_) => "response".to_string(),
+            rig::agent::SettledOutcome::Error(reason) => format!("error:{reason}"),
+        };
+        self.settles.lock().expect("settles").push(outcome);
+    }
+}

--- a/tests/providers/anthropic/cassette/lifecycle_matrix.rs
+++ b/tests/providers/anthropic/cassette/lifecycle_matrix.rs
@@ -1,0 +1,141 @@
+//! Run-lifecycle matrix (PR #2407): transport middleware, `on_run_start`,
+//! `on_run_settled`, and durable scratchpad state, recorded against the live
+//! Anthropic API.
+//!
+//! Every cell sends through a `BoxedHttpClient` carrying a `WireProbe`
+//! middleware, so one recorded exchange proves both the transport seam (the
+//! phases fired, the serialized body and response status were visible) and
+//! the hook-level lifecycle claims. All assertions hold in both cassette
+//! modes: on replay the same code paths run against the replay server.
+
+use rig::completion::Prompt;
+use rig::prelude::*;
+use rig::providers::anthropic;
+use rig::streaming::StreamingPrompt;
+
+use super::super::support::with_anthropic_lifecycle_cassette;
+use crate::support::{
+    Adder, BASIC_PREAMBLE, BASIC_PROMPT, LifecycleHookProbe, STREAMING_PREAMBLE, STREAMING_PROMPT,
+    WireProbe, assert_nonempty_response, collect_stream_final_response_and_provider_final,
+};
+
+const MODEL: &str = anthropic::completion::CLAUDE_SONNET_4_6;
+
+#[tokio::test]
+async fn middleware_phases_observe_a_unary_completion() {
+    let probe = WireProbe::default();
+    with_anthropic_lifecycle_cassette(
+        "lifecycle_matrix/middleware_unary",
+        probe.clone(),
+        |client| async move {
+            let agent = client.agent(MODEL).preamble(BASIC_PREAMBLE).build();
+            let response = agent
+                .prompt(BASIC_PROMPT)
+                .await
+                .expect("completion should succeed");
+            assert_nonempty_response(&response);
+        },
+    )
+    .await;
+    probe.assert_single_exchange();
+}
+
+#[tokio::test]
+async fn middleware_response_phase_precedes_stream_consumption() {
+    let probe = WireProbe::default();
+    let hook = LifecycleHookProbe::default();
+    let settle_hook = hook.clone();
+    with_anthropic_lifecycle_cassette(
+        "lifecycle_matrix/middleware_streaming",
+        probe.clone(),
+        |client| async move {
+            let agent = client
+                .agent(MODEL)
+                .preamble(STREAMING_PREAMBLE)
+                .add_hook(settle_hook)
+                .build();
+            let mut stream = agent.stream_prompt(STREAMING_PROMPT).await;
+            let (response, provider_final): (_, rig::streaming::StreamFinal) =
+                collect_stream_final_response_and_provider_final(&mut stream)
+                    .await
+                    .expect("streaming prompt should succeed");
+            assert_nonempty_response(&response);
+            assert!(provider_final.usage.total_tokens > 0);
+        },
+    )
+    .await;
+    probe.assert_single_exchange();
+    // The streamed run settled exactly once, with a response.
+    assert_eq!(hook.settle_outcomes(), ["response"]);
+    assert_eq!(hook.starts.load(std::sync::atomic::Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn run_start_rewrite_reaches_the_provider() {
+    let hook = LifecycleHookProbe::rewriting_to(
+        "Reply with exactly the single word PINEAPPLE and nothing else.",
+    );
+    let agent_hook = hook.clone();
+    with_anthropic_lifecycle_cassette(
+        "lifecycle_matrix/run_start_rewrite",
+        WireProbe::default(),
+        |client| async move {
+            let agent = client
+                .agent(MODEL)
+                .preamble(BASIC_PREAMBLE)
+                .add_hook(agent_hook)
+                .build();
+            // The original prompt says nothing about pineapples; only the
+            // pre-run rewrite can put the marker into the model's reply.
+            let response = agent
+                .prompt("Tell me about the Rust borrow checker.")
+                .await
+                .expect("completion should succeed");
+            assert!(
+                response.to_uppercase().contains("PINEAPPLE"),
+                "the provider answered the rewritten prompt, not the original: {response:?}"
+            );
+        },
+    )
+    .await;
+    assert_eq!(hook.starts.load(std::sync::atomic::Ordering::SeqCst), 1);
+    assert_eq!(hook.settle_outcomes(), ["response"]);
+}
+
+#[tokio::test]
+async fn run_settles_once_across_a_multi_turn_tool_run_with_durable_state() {
+    let hook = LifecycleHookProbe::default();
+    let agent_hook = hook.clone();
+    with_anthropic_lifecycle_cassette(
+        "lifecycle_matrix/run_settled_tool_run",
+        WireProbe::default(),
+        |client| async move {
+            let agent = client
+                .agent(MODEL)
+                .preamble("You are a calculator. Use the add tool for arithmetic.")
+                .tool(Adder)
+                .add_hook(agent_hook)
+                .build();
+            let response = agent
+                .prompt("What is 7 + 15? Use the add tool, then reply with just the number.")
+                .max_turns(3)
+                .await
+                .expect("tool run should succeed");
+            assert!(
+                response.contains("22"),
+                "the tool result reached the final answer: {response:?}"
+            );
+        },
+    )
+    .await;
+    assert_eq!(hook.starts.load(std::sync::atomic::Ordering::SeqCst), 1);
+    // Terminal, not per-turn: two model calls, one settle.
+    assert_eq!(hook.settle_outcomes(), ["response"]);
+    let calls = hook
+        .exported_completion_calls()
+        .expect("the settle export carries the durable counter");
+    assert!(
+        calls >= 2,
+        "a tool run makes at least two model calls; durable counter was {calls}"
+    );
+}

--- a/tests/providers/anthropic/mod.rs
+++ b/tests/providers/anthropic/mod.rs
@@ -10,6 +10,7 @@ mod cassette {
     mod error_envelope;
     mod error_identity_edge;
     mod image;
+    mod lifecycle_matrix;
     mod messages_behaviors;
     mod messages_sessions;
     mod messages_strict_tools;

--- a/tests/providers/anthropic/support.rs
+++ b/tests/providers/anthropic/support.rs
@@ -48,6 +48,31 @@ pub(super) async fn with_anthropic_boxed_cassette<F, Fut>(
     cassette.finish_after_test(result).await;
 }
 
+/// Cassette wrapper for the run-lifecycle matrix (PR #2407): the client sends
+/// through a [`BoxedHttpClient`] carrying the supplied [`HttpMiddleware`], so
+/// the same recorded exchange exercises the transport middleware seam and the
+/// run lifecycle hooks together (see
+/// `tests/cassettes/anthropic/lifecycle_matrix/`).
+pub(super) async fn with_anthropic_lifecycle_cassette<M, F, Fut>(
+    spec: impl Into<CassetteSpec>,
+    middleware: M,
+    test_body: F,
+) where
+    M: rig::http_client::HttpMiddleware + 'static,
+    F: FnOnce(anthropic::Client<BoxedHttpClient>) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let cassette = ProviderCassette::start("anthropic", spec, "https://api.anthropic.com").await;
+    let client = anthropic::Client::builder()
+        .api_key(cassette.api_key("ANTHROPIC_API_KEY"))
+        .base_url(cassette.base_url())
+        .http_client(ReqwestClient::default().boxed().with_middleware(middleware))
+        .build()
+        .expect("client should build");
+    let result = AssertUnwindSafe(test_body(client)).catch_unwind().await;
+    cassette.finish_after_test(result).await;
+}
+
 pub(super) async fn with_anthropic_cassette<F, Fut>(spec: impl Into<CassetteSpec>, test_body: F)
 where
     F: FnOnce(anthropic::Client) -> Fut,

--- a/tests/providers/gemini/cassette/lifecycle_matrix.rs
+++ b/tests/providers/gemini/cassette/lifecycle_matrix.rs
@@ -1,0 +1,141 @@
+//! Run-lifecycle matrix (PR #2407): transport middleware, `on_run_start`,
+//! `on_run_settled`, and durable scratchpad state, recorded against the live
+//! Gemini API.
+//!
+//! Every cell sends through a `BoxedHttpClient` carrying a `WireProbe`
+//! middleware, so one recorded exchange proves both the transport seam (the
+//! phases fired, the serialized body and response status were visible) and
+//! the hook-level lifecycle claims. All assertions hold in both cassette
+//! modes: on replay the same code paths run against the replay server.
+
+use rig::completion::Prompt;
+use rig::prelude::*;
+use rig::providers::gemini;
+use rig::streaming::StreamingPrompt;
+
+use super::super::support::with_gemini_lifecycle_cassette;
+use crate::support::{
+    Adder, BASIC_PREAMBLE, BASIC_PROMPT, LifecycleHookProbe, STREAMING_PREAMBLE, STREAMING_PROMPT,
+    WireProbe, assert_nonempty_response, collect_stream_final_response_and_provider_final,
+};
+
+const MODEL: &str = gemini::completion::GEMINI_2_5_FLASH;
+
+#[tokio::test]
+async fn middleware_phases_observe_a_unary_completion() {
+    let probe = WireProbe::default();
+    with_gemini_lifecycle_cassette(
+        "lifecycle_matrix/middleware_unary",
+        probe.clone(),
+        |client| async move {
+            let agent = client.agent(MODEL).preamble(BASIC_PREAMBLE).build();
+            let response = agent
+                .prompt(BASIC_PROMPT)
+                .await
+                .expect("completion should succeed");
+            assert_nonempty_response(&response);
+        },
+    )
+    .await;
+    probe.assert_single_exchange();
+}
+
+#[tokio::test]
+async fn middleware_response_phase_precedes_stream_consumption() {
+    let probe = WireProbe::default();
+    let hook = LifecycleHookProbe::default();
+    let settle_hook = hook.clone();
+    with_gemini_lifecycle_cassette(
+        "lifecycle_matrix/middleware_streaming",
+        probe.clone(),
+        |client| async move {
+            let agent = client
+                .agent(MODEL)
+                .preamble(STREAMING_PREAMBLE)
+                .add_hook(settle_hook)
+                .build();
+            let mut stream = agent.stream_prompt(STREAMING_PROMPT).await;
+            let (response, provider_final): (_, rig::streaming::StreamFinal) =
+                collect_stream_final_response_and_provider_final(&mut stream)
+                    .await
+                    .expect("streaming prompt should succeed");
+            assert_nonempty_response(&response);
+            assert!(provider_final.usage.total_tokens > 0);
+        },
+    )
+    .await;
+    probe.assert_single_exchange();
+    // The streamed run settled exactly once, with a response.
+    assert_eq!(hook.settle_outcomes(), ["response"]);
+    assert_eq!(hook.starts.load(std::sync::atomic::Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn run_start_rewrite_reaches_the_provider() {
+    let hook = LifecycleHookProbe::rewriting_to(
+        "Reply with exactly the single word PINEAPPLE and nothing else.",
+    );
+    let agent_hook = hook.clone();
+    with_gemini_lifecycle_cassette(
+        "lifecycle_matrix/run_start_rewrite",
+        WireProbe::default(),
+        |client| async move {
+            let agent = client
+                .agent(MODEL)
+                .preamble(BASIC_PREAMBLE)
+                .add_hook(agent_hook)
+                .build();
+            // The original prompt says nothing about pineapples; only the
+            // pre-run rewrite can put the marker into the model's reply.
+            let response = agent
+                .prompt("Tell me about the Rust borrow checker.")
+                .await
+                .expect("completion should succeed");
+            assert!(
+                response.to_uppercase().contains("PINEAPPLE"),
+                "the provider answered the rewritten prompt, not the original: {response:?}"
+            );
+        },
+    )
+    .await;
+    assert_eq!(hook.starts.load(std::sync::atomic::Ordering::SeqCst), 1);
+    assert_eq!(hook.settle_outcomes(), ["response"]);
+}
+
+#[tokio::test]
+async fn run_settles_once_across_a_multi_turn_tool_run_with_durable_state() {
+    let hook = LifecycleHookProbe::default();
+    let agent_hook = hook.clone();
+    with_gemini_lifecycle_cassette(
+        "lifecycle_matrix/run_settled_tool_run",
+        WireProbe::default(),
+        |client| async move {
+            let agent = client
+                .agent(MODEL)
+                .preamble("You are a calculator. Use the add tool for arithmetic.")
+                .tool(Adder)
+                .add_hook(agent_hook)
+                .build();
+            let response = agent
+                .prompt("What is 7 + 15? Use the add tool, then reply with just the number.")
+                .max_turns(3)
+                .await
+                .expect("tool run should succeed");
+            assert!(
+                response.contains("22"),
+                "the tool result reached the final answer: {response:?}"
+            );
+        },
+    )
+    .await;
+    assert_eq!(hook.starts.load(std::sync::atomic::Ordering::SeqCst), 1);
+    // Terminal, not per-turn: two model calls, one settle.
+    assert_eq!(hook.settle_outcomes(), ["response"]);
+    let calls = hook
+        .exported_completion_calls()
+        .expect("the settle export carries the durable counter");
+    assert!(
+        calls >= 2,
+        "a tool run makes at least two model calls; durable counter was {calls}"
+    );
+}

--- a/tests/providers/gemini/mod.rs
+++ b/tests/providers/gemini/mod.rs
@@ -33,6 +33,7 @@ mod cassette {
     mod interactions_api;
     mod interactions_raw_capture_matrix;
     mod interactions_raw_stream_capture_matrix;
+    mod lifecycle_matrix;
     mod models;
     mod multi_turn_streaming;
     mod prompt_caching;

--- a/tests/providers/gemini/support.rs
+++ b/tests/providers/gemini/support.rs
@@ -304,6 +304,36 @@ async fn gemini_interactions_cassette(
     (cassette, client.interactions_api())
 }
 
+/// Cassette wrapper for the run-lifecycle matrix (PR #2407): the client sends
+/// through a [`rig::http_client::BoxedHttpClient`] carrying the supplied
+/// [`rig::http_client::HttpMiddleware`], so the same recorded exchange
+/// exercises the transport middleware seam and the run lifecycle hooks
+/// together (see `tests/cassettes/gemini/lifecycle_matrix/`).
+pub(super) async fn with_gemini_lifecycle_cassette<M, F, Fut>(
+    spec: impl Into<CassetteSpec>,
+    middleware: M,
+    test_body: F,
+) where
+    M: rig::http_client::HttpMiddleware + 'static,
+    F: FnOnce(gemini::Client<rig::http_client::BoxedHttpClient>) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let cassette =
+        ProviderCassette::start("gemini", spec, "https://generativelanguage.googleapis.com").await;
+    let client = gemini::Client::builder()
+        .api_key(cassette.api_key("GEMINI_API_KEY"))
+        .base_url(cassette.base_url())
+        .http_client(
+            rig::http_client::ReqwestClient::default()
+                .boxed()
+                .with_middleware(middleware),
+        )
+        .build()
+        .expect("client should build");
+    let result = AssertUnwindSafe(test_body(client)).catch_unwind().await;
+    cassette.finish_after_test(result).await;
+}
+
 pub(super) async fn with_gemini_cassette<F, Fut>(spec: impl Into<CassetteSpec>, test_body: F)
 where
     F: FnOnce(gemini::Client) -> Fut,

--- a/tests/providers/openai/cassette/lifecycle_matrix.rs
+++ b/tests/providers/openai/cassette/lifecycle_matrix.rs
@@ -1,0 +1,141 @@
+//! Run-lifecycle matrix (PR #2407): transport middleware, `on_run_start`,
+//! `on_run_settled`, and durable scratchpad state, recorded against the live
+//! OpenAI API.
+//!
+//! Every cell sends through a `BoxedHttpClient` carrying a `WireProbe`
+//! middleware, so one recorded exchange proves both the transport seam (the
+//! phases fired, the serialized body and response status were visible) and
+//! the hook-level lifecycle claims. All assertions hold in both cassette
+//! modes: on replay the same code paths run against the replay server.
+
+use rig::completion::Prompt;
+use rig::prelude::*;
+use rig::providers::openai;
+use rig::streaming::StreamingPrompt;
+
+use super::super::support::with_openai_lifecycle_cassette;
+use crate::support::{
+    Adder, BASIC_PREAMBLE, BASIC_PROMPT, LifecycleHookProbe, STREAMING_PREAMBLE, STREAMING_PROMPT,
+    WireProbe, assert_nonempty_response, collect_stream_final_response_and_provider_final,
+};
+
+const MODEL: &str = openai::GPT_4O;
+
+#[tokio::test]
+async fn middleware_phases_observe_a_unary_completion() {
+    let probe = WireProbe::default();
+    with_openai_lifecycle_cassette(
+        "lifecycle_matrix/middleware_unary",
+        probe.clone(),
+        |client| async move {
+            let agent = client.agent(MODEL).preamble(BASIC_PREAMBLE).build();
+            let response = agent
+                .prompt(BASIC_PROMPT)
+                .await
+                .expect("completion should succeed");
+            assert_nonempty_response(&response);
+        },
+    )
+    .await;
+    probe.assert_single_exchange();
+}
+
+#[tokio::test]
+async fn middleware_response_phase_precedes_stream_consumption() {
+    let probe = WireProbe::default();
+    let hook = LifecycleHookProbe::default();
+    let settle_hook = hook.clone();
+    with_openai_lifecycle_cassette(
+        "lifecycle_matrix/middleware_streaming",
+        probe.clone(),
+        |client| async move {
+            let agent = client
+                .agent(MODEL)
+                .preamble(STREAMING_PREAMBLE)
+                .add_hook(settle_hook)
+                .build();
+            let mut stream = agent.stream_prompt(STREAMING_PROMPT).await;
+            let (response, provider_final): (_, rig::streaming::StreamFinal) =
+                collect_stream_final_response_and_provider_final(&mut stream)
+                    .await
+                    .expect("streaming prompt should succeed");
+            assert_nonempty_response(&response);
+            assert!(provider_final.usage.total_tokens > 0);
+        },
+    )
+    .await;
+    probe.assert_single_exchange();
+    // The streamed run settled exactly once, with a response.
+    assert_eq!(hook.settle_outcomes(), ["response"]);
+    assert_eq!(hook.starts.load(std::sync::atomic::Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn run_start_rewrite_reaches_the_provider() {
+    let hook = LifecycleHookProbe::rewriting_to(
+        "Reply with exactly the single word PINEAPPLE and nothing else.",
+    );
+    let agent_hook = hook.clone();
+    with_openai_lifecycle_cassette(
+        "lifecycle_matrix/run_start_rewrite",
+        WireProbe::default(),
+        |client| async move {
+            let agent = client
+                .agent(MODEL)
+                .preamble(BASIC_PREAMBLE)
+                .add_hook(agent_hook)
+                .build();
+            // The original prompt says nothing about pineapples; only the
+            // pre-run rewrite can put the marker into the model's reply.
+            let response = agent
+                .prompt("Tell me about the Rust borrow checker.")
+                .await
+                .expect("completion should succeed");
+            assert!(
+                response.to_uppercase().contains("PINEAPPLE"),
+                "the provider answered the rewritten prompt, not the original: {response:?}"
+            );
+        },
+    )
+    .await;
+    assert_eq!(hook.starts.load(std::sync::atomic::Ordering::SeqCst), 1);
+    assert_eq!(hook.settle_outcomes(), ["response"]);
+}
+
+#[tokio::test]
+async fn run_settles_once_across_a_multi_turn_tool_run_with_durable_state() {
+    let hook = LifecycleHookProbe::default();
+    let agent_hook = hook.clone();
+    with_openai_lifecycle_cassette(
+        "lifecycle_matrix/run_settled_tool_run",
+        WireProbe::default(),
+        |client| async move {
+            let agent = client
+                .agent(MODEL)
+                .preamble("You are a calculator. Use the add tool for arithmetic.")
+                .tool(Adder)
+                .add_hook(agent_hook)
+                .build();
+            let response = agent
+                .prompt("What is 7 + 15? Use the add tool, then reply with just the number.")
+                .max_turns(3)
+                .await
+                .expect("tool run should succeed");
+            assert!(
+                response.contains("22"),
+                "the tool result reached the final answer: {response:?}"
+            );
+        },
+    )
+    .await;
+    assert_eq!(hook.starts.load(std::sync::atomic::Ordering::SeqCst), 1);
+    // Terminal, not per-turn: two model calls, one settle.
+    assert_eq!(hook.settle_outcomes(), ["response"]);
+    let calls = hook
+        .exported_completion_calls()
+        .expect("the settle export carries the durable counter");
+    assert!(
+        calls >= 2,
+        "a tool run makes at least two model calls; durable counter was {calls}"
+    );
+}

--- a/tests/providers/openai/mod.rs
+++ b/tests/providers/openai/mod.rs
@@ -24,6 +24,7 @@ mod cassette {
     mod gpt_5_6_reasoning;
     #[cfg(feature = "image")]
     mod image_params_matrix;
+    mod lifecycle_matrix;
     mod max_completion_tokens_matrix;
     mod models;
     mod multi_extract;

--- a/tests/providers/openai/support.rs
+++ b/tests/providers/openai/support.rs
@@ -52,6 +52,31 @@ where
     cassette.finish_after_test(result).await;
 }
 
+/// Cassette wrapper for the run-lifecycle matrix (PR #2407): the client sends
+/// through a [`BoxedHttpClient`] carrying the supplied [`HttpMiddleware`], so
+/// the same recorded exchange exercises the transport middleware seam and the
+/// run lifecycle hooks together (see
+/// `tests/cassettes/openai/lifecycle_matrix/`).
+pub(super) async fn with_openai_lifecycle_cassette<M, F, Fut>(
+    spec: impl Into<CassetteSpec>,
+    middleware: M,
+    test_body: F,
+) where
+    M: rig::http_client::HttpMiddleware + 'static,
+    F: FnOnce(openai::Client<BoxedHttpClient>) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let cassette = ProviderCassette::start("openai", spec, "https://api.openai.com/v1").await;
+    let client = openai::Client::builder()
+        .api_key(cassette.api_key("OPENAI_API_KEY"))
+        .base_url(cassette.base_url())
+        .http_client(ReqwestClient::default().boxed().with_middleware(middleware))
+        .build()
+        .expect("client should build");
+    let result = AssertUnwindSafe(test_body(client)).catch_unwind().await;
+    cassette.finish_after_test(result).await;
+}
+
 pub(super) async fn with_openai_cassette<F, Fut>(spec: impl Into<CassetteSpec>, test_body: F)
 where
     F: FnOnce(openai::Client) -> Fut,


### PR DESCRIPTION
Completes the agent lifecycle with the seams that stopped at the semantic layer, inspired by [Pi's extension lifecycle](https://pi.dev/docs/latest/extensions#lifecycle-overview).

## 1. Transport-boundary middleware (`HttpMiddleware`)

Agent hooks patch a request's *meaning* (`RequestPatch`) but never see the serialized provider payload, the HTTP headers, or the raw HTTP response — that required implementing `HttpClientExt` yourself. New `rig_core::http_client::HttpMiddleware` runs inside `BoxedHttpClient` (#2401), so one implementation covers every provider and all three paths (unary, streaming, multipart):

- `before_request_headers` — mutates the outgoing `HeaderMap` in place (per-request beta headers, auth decoration)
- `before_request_body` — sees the serialized body, may replace it (logging/replay, payload patching); skipped for multipart, which has no single serialized payload
- `after_response` — status + headers as soon as they arrive, **before stream consumption** for streaming calls (rate-limit headers, request ids)

Attach with `BoxedHttpClient::with_middleware(..)`; middlewares compose in attachment order (all header hooks, then all body hooks seeing the final headers, then response hooks). Observe-only on the response, but any phase can *fail* the request through the normal `http_client::Error` path — nothing can be silently swallowed. `examples/http_middleware` demonstrates all three on a live Anthropic call.

## 2. `on_run_start` — pre-run prompt hook

The earliest interception used to be `on_completion_call`; nothing could rewrite or veto the user prompt itself. `AgentHook::on_run_start` fires once before the first model call with the initial prompt + input history. `RunStartAction::{Continue, Rewrite, Stop}` — rewrites chain in registration order (each hook sees the previous rewrite), first stop wins and terminates the run before any provider work with `PromptError::PromptCancelled`. Backed by `AgentRun::{initial_prompt, rewrite_initial_prompt, input_chat_history}` in rig-run so the rewrite is protocol data, not driver trickery.

## 3. `on_run_settled` — terminal event

Per-turn finishes (`ModelTurnFinished`, `StreamResponseFinish`) can be followed by hook-driven retries or tool turns; nothing distinguished "a turn ended" from "nothing follows automatically". `on_run_settled` fires exactly once per run with `SettledOutcome::{Response, Error}`, covering success and every error termination path (including a run-start stop). Every hook in a stack observes it (no short-circuit).

**Finding on the stream side** (the prompt asked for an explicit call): `MultiTurnStreamItem::FinalResponse` already *is* the settled signal on the success path, and error termination is the stream's terminal `Err` item — so no new stream variant is added; the docs on `FinalResponse` now state the equivalence instead of duplicating the event.

## 4. Durable hook state

`Scratchpad` gains string-keyed durable JSON entries (`put_durable`/`get_durable`/`remove_durable`) plus `export()`/`restore()` over a new serializable `rig_run::ScratchpadSnapshot`. `AgentRun` carries an optional `hook_state` slot (`set_hook_state`/`take_hook_state`; serde-default, so old serialized runs load unchanged), and both agent drivers restore a carried snapshot into the live scratchpad at run start. Typed `TypeMap` entries are deliberately not exported — durable state is an explicit, named contract.

## Breaking

- `StepEventKind` gained `RunStart` and `RunSettled` — exhaustive matches must add arms (`AgentHook` itself is unaffected; the new methods are default-implemented).
- MIGRATING.md updated under *0.41 → next*.

## Notes / follow-ups

- No cassette tests were added: the transport hooks are opt-in on `BoxedHttpClient` and provider request paths are unchanged (the middleware unit tests cover unary, streaming, multipart, ordering, and error propagation against the recorded test transports).
- `HookContext` write-back of durable state into `AgentRun` at settle time (fully automatic round-tripping through the futures driver) is left as a follow-up; the manual `export()` → `set_hook_state` path is documented on `Scratchpad`.

Tests: 4 middleware + 1 boxing test (rig-core), run-start chaining / first-stop-wins / scratchpad round-trip (hook.rs), rewrite-validity + hook-state serde (rig-run), and 4 end-to-end lifecycle tests on both surfaces (runner.rs). Full workspace: 5753 passed, clippy `-D warnings` clean, doctests green.