### PR TITLE
feat!: event-sourced hook state — RunEntry log on AgentRun replaces the durable Scratchpad snapshot

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -819,19 +819,26 @@ HTTP transport gained a middleware seam. What breaks:
   `BoxedHttpClient::with_middleware`). Behavior without middleware is
   unchanged. `BoxedHttpClient::ptr_eq` still compares the underlying transport
   only, so two handles differing only in middleware compare equal.
-- **`AgentRun` gained an optional `hook_state` slot** (`hook_state`,
-  `set_hook_state`, `take_hook_state`, carrying the new serializable
-  `rig_run::ScratchpadSnapshot`) plus `initial_prompt`,
-  `rewrite_initial_prompt`, and `input_chat_history`. Runs serialized before
-  this release deserialize unchanged (the field defaults to absent). The agent
-  drivers restore a carried snapshot into the run's `Scratchpad` durable
-  entries at run start.
+- **`AgentRun` gained an append-only entry log** — `rig_run::RunEntry`
+  (`kind`/`turn`/`value`) with `append_entry`, `entries`, `entries_of`, and
+  `last_entry_of` — plus `initial_prompt`, `rewrite_initial_prompt`, and
+  `input_chat_history`. Runs serialized before this release deserialize
+  unchanged (the field defaults to empty). Entries are protocol data like
+  `TurnTools`: never interpreted by the run and never part of a provider
+  request.
 
-New, non-breaking: `Scratchpad::{put_durable, get_durable, remove_durable,
-export, restore}` for hook state that must survive a serialized pause, and the
+New, non-breaking: durable hook state is **event-sourced**. Hooks persist by
+appending entries to the run's record via `HookContext::append_entry` (stamped
+with the current turn, flushed into the `AgentRun` at each step boundary) and
+reconstruct by replaying `HookContext::entries(kind)` — the documented default
+pattern is snapshot + last-wins via `HookContext::last_entry`. State that
+rides the record travels, rewinds, and forks with the record. Also new: the
 `RunStart`/`RunStartAction`/`RunSettled`/`SettledOutcome` hook vocabulary. A
 `RunStartAction::Stop` terminates the run before any provider call with
-`PromptError::PromptCancelled`.
+`PromptError::PromptCancelled`. (A `Scratchpad::put_durable` /
+`ScratchpadSnapshot` / `AgentRun::hook_state` snapshot API existed briefly
+between two unreleased PRs and was replaced by the entry log before release;
+`Scratchpad` remains as the in-process, non-serialized cross-hook channel.)
 
 ### The run protocol is its own crate: `rig-run` (`rig::run`)
 

--- a/crates/rig-agent/src/agent/hook.rs
+++ b/crates/rig-agent/src/agent/hook.rs
@@ -213,88 +213,35 @@ use crate::{
 
 pub use rig_core::id::RunId;
 
-pub use rig_run::ScratchpadSnapshot;
+pub use rig_run::RunEntry;
 
-/// Run-scoped typed storage shared by hooks.
+/// Run-scoped typed storage shared by hooks — the in-process cross-hook
+/// channel.
 ///
-/// # Durable hook state
+/// # Where hook state belongs
 ///
-/// The typed entries ([`insert`](Self::insert)/[`get`](Self::get)) live only
-/// as long as the run's process. Hooks whose state must survive a durable
-/// pause — an out-of-process approval, a serialized [`AgentRun`] resumed
-/// later, possibly elsewhere — store that state as **durable entries**
-/// instead: string-keyed JSON via [`put_durable`](Self::put_durable) /
-/// [`get_durable`](Self::get_durable). [`export`](Self::export) collects the
-/// durable entries into a serializable [`ScratchpadSnapshot`] to carry with
-/// the run (see [`AgentRun::set_hook_state`]), and the driver restores a
-/// carried snapshot into the live scratchpad at run start via
-/// [`restore`](Self::restore). Typed entries are deliberately not exported:
-/// a `TypeMap` has no serialization story, and durable state should be an
-/// explicit, named contract.
+/// - **A hook's own private state** belongs in the hook's own fields
+///   (`Arc<AtomicUsize>`, `Arc<Mutex<…>>` — the pattern this crate's test
+///   probes use). Key by [`HookContext::run_id`] when one instance serves
+///   many runs.
+/// - **Transient cross-hook state** — one hook writing, another reading,
+///   within one run — goes here. Typed entries live only as long as the
+///   run's process; a `TypeMap` has no serialization story on purpose.
+/// - **Anything that must survive serialization** — an out-of-process
+///   approval, a run resumed later, possibly elsewhere — or that must rewind
+///   correctly when a host clones/forks a run, goes through
+///   [`HookContext::append_entry`]: state that rides the run's record
+///   travels, rewinds, and forks with the record; out-of-band state does not.
 ///
 /// [`AgentRun`]: crate::agent::AgentRun
-/// [`AgentRun::set_hook_state`]: crate::agent::AgentRun::set_hook_state
 #[derive(Clone, Default)]
 pub struct Scratchpad {
     inner: Arc<std::sync::Mutex<TypeMap>>,
-    durable: Arc<std::sync::Mutex<std::collections::BTreeMap<String, serde_json::Value>>>,
 }
 
 impl Scratchpad {
     fn lock(&self) -> std::sync::MutexGuard<'_, TypeMap> {
         self.inner.lock().unwrap_or_else(|error| error.into_inner())
-    }
-
-    fn lock_durable(
-        &self,
-    ) -> std::sync::MutexGuard<'_, std::collections::BTreeMap<String, serde_json::Value>> {
-        self.durable
-            .lock()
-            .unwrap_or_else(|error| error.into_inner())
-    }
-
-    /// Store a durable entry under `key`, replacing any previous value.
-    ///
-    /// Durable entries survive a serialized pause via [`export`](Self::export)
-    /// / [`restore`](Self::restore); see the type docs. Returns an error when
-    /// `value` cannot be represented as JSON.
-    pub fn put_durable<T: serde::Serialize>(
-        &self,
-        key: impl Into<String>,
-        value: &T,
-    ) -> Result<(), serde_json::Error> {
-        let value = serde_json::to_value(value)?;
-        self.lock_durable().insert(key.into(), value);
-        Ok(())
-    }
-
-    /// Read a durable entry, deserialized as `T`.
-    ///
-    /// `None` when the key is absent or its value does not deserialize as `T`.
-    pub fn get_durable<T: serde::de::DeserializeOwned>(&self, key: &str) -> Option<T> {
-        let value = self.lock_durable().get(key).cloned()?;
-        serde_json::from_value(value).ok()
-    }
-
-    /// Remove a durable entry, returning its raw JSON value.
-    pub fn remove_durable(&self, key: &str) -> Option<serde_json::Value> {
-        self.lock_durable().remove(key)
-    }
-
-    /// Collect the durable entries into a serializable snapshot.
-    pub fn export(&self) -> ScratchpadSnapshot {
-        ScratchpadSnapshot {
-            entries: self.lock_durable().clone(),
-        }
-    }
-
-    /// Merge a snapshot's entries into the durable store.
-    ///
-    /// Snapshot entries replace same-keyed existing entries; other existing
-    /// entries are kept. The driver calls this at run start with the snapshot
-    /// a resumed [`AgentRun`](crate::agent::AgentRun) carried.
-    pub fn restore(&self, snapshot: ScratchpadSnapshot) {
-        self.lock_durable().extend(snapshot.entries);
     }
 
     /// Insert a value.
@@ -441,6 +388,13 @@ pub struct HookContext {
     agent_name: Option<String>,
     scratchpad: Scratchpad,
     tool_call_rewrite_frames: ToolCallRewriteFrames,
+    /// Every [`RunEntry`] visible to this run — the entries the run carried
+    /// in (seeded by the driver at run start) followed by this run's appends,
+    /// in append order.
+    entries: std::sync::Mutex<Vec<RunEntry>>,
+    /// Appends not yet flushed into the [`AgentRun`](crate::agent::AgentRun)
+    /// by the driver.
+    pending_entries: std::sync::Mutex<Vec<RunEntry>>,
 }
 
 impl HookContext {
@@ -452,7 +406,29 @@ impl HookContext {
             agent_name,
             scratchpad: Scratchpad::default(),
             tool_call_rewrite_frames: ToolCallRewriteFrames::default(),
+            entries: std::sync::Mutex::new(Vec::new()),
+            pending_entries: std::sync::Mutex::new(Vec::new()),
         }
+    }
+
+    /// Seed the entries a resumed run carried; called by the driver at run
+    /// start, before any hook fires.
+    pub(crate) fn seed_entries(&self, entries: &[RunEntry]) {
+        self.entries
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .extend_from_slice(entries);
+    }
+
+    /// Drain the appends not yet flushed into the run; called by the driver
+    /// at each step boundary.
+    pub(crate) fn drain_pending_entries(&self) -> Vec<RunEntry> {
+        std::mem::take(
+            &mut *self
+                .pending_entries
+                .lock()
+                .unwrap_or_else(|error| error.into_inner()),
+        )
     }
 
     pub(crate) fn set_turn(&self, turn: usize) {
@@ -482,6 +458,73 @@ impl HookContext {
     /// Shared run scratchpad.
     pub fn scratchpad(&self) -> &Scratchpad {
         &self.scratchpad
+    }
+
+    /// Append a durable entry to the run's record.
+    ///
+    /// The entry is stamped with the current [`turn`](Self::turn) and lands
+    /// in the serializable [`AgentRun`](crate::agent::AgentRun) at the next
+    /// step boundary — durability holds by construction, with no snapshot or
+    /// export moment. Serialization failures surface immediately; nothing is
+    /// silently dropped. Fire-and-forget beyond that: no id or handle comes
+    /// back.
+    ///
+    /// The intended default pattern is **snapshot + last-wins**: append a
+    /// full state snapshot whenever your state changes, and reconstruct by
+    /// reading the most recent one with [`last_entry`](Self::last_entry).
+    /// Delta entries folded over [`entries`](Self::entries) fit genuinely
+    /// event-shaped state (an approval ledger); the snapshot pattern needs no
+    /// fold logic and tolerates replay trivially.
+    ///
+    /// An entry appended inside `on_run_settled` is not persisted — the run
+    /// is already finished; it remains visible to same-process reads only.
+    pub fn append_entry<T: serde::Serialize>(
+        &self,
+        kind: impl Into<String>,
+        value: &T,
+    ) -> Result<(), serde_json::Error> {
+        let entry = RunEntry {
+            kind: kind.into(),
+            turn: self.turn(),
+            value: serde_json::to_value(value)?,
+        };
+        self.entries
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .push(entry.clone());
+        self.pending_entries
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .push(entry);
+        Ok(())
+    }
+
+    /// All entries of `kind` visible to this run: the entries a resumed run
+    /// carried in, followed by this run's appends, in append order.
+    ///
+    /// This *is* the replay: a hook reconstructs state by folding over this
+    /// list — and because every read traverses the full list, re-reading is
+    /// idempotent by construction.
+    pub fn entries(&self, kind: &str) -> Vec<RunEntry> {
+        self.entries
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .iter()
+            .filter(|entry| entry.kind == kind)
+            .cloned()
+            .collect()
+    }
+
+    /// The most recent entry of `kind`, if any — the read for the
+    /// snapshot-and-read-the-last pattern.
+    pub fn last_entry(&self, kind: &str) -> Option<RunEntry> {
+        self.entries
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .iter()
+            .rev()
+            .find(|entry| entry.kind == kind)
+            .cloned()
     }
 
     fn begin_tool_call_resolution(&self, internal_call_id: &str) -> ToolCallResolutionFrame<'_> {
@@ -1091,6 +1134,10 @@ pub trait AgentHook: WasmCompatSend + WasmCompatSync {
     /// Runs once after the run settles: its outcome — final response or
     /// terminal error — is decided, and no retry, further turn, or tool
     /// execution will follow. Observe-only; the run is already over.
+    ///
+    /// [`HookContext::entries`] sees every entry appended during the run
+    /// (the driver flushes before settling), but an entry appended *inside*
+    /// this hook is not persisted — the run is finished.
     fn on_run_settled(
         &self,
         _ctx: &HookContext,
@@ -1738,32 +1785,41 @@ mod tests {
     }
 
     #[test]
-    fn scratchpad_durable_entries_round_trip_through_snapshot() {
-        let pad = Scratchpad::default();
-        pad.put_durable("approvals", &vec!["tool-1".to_string()])
-            .expect("serializable");
-        pad.put_durable("retries", &2u32).expect("serializable");
-        // Typed entries never reach the snapshot.
-        pad.insert(42usize);
+    fn append_entry_stamps_the_current_turn_and_reads_replay_in_order() {
+        let ctx = HookContext::new(false, None);
+        // A resumed run's carried entries come first.
+        ctx.seed_entries(&[RunEntry {
+            kind: "counter".into(),
+            turn: 2,
+            value: serde_json::json!(2),
+        }]);
 
-        let snapshot = pad.export();
-        assert_eq!(snapshot.entries.len(), 2);
-        let serialized = serde_json::to_string(&snapshot).expect("snapshot serializes");
-        let restored: ScratchpadSnapshot =
-            serde_json::from_str(&serialized).expect("snapshot deserializes");
+        ctx.set_turn(3);
+        ctx.append_entry("counter", &3u64).expect("serializable");
+        ctx.append_entry("other", &()).expect("null marker");
 
-        let fresh = Scratchpad::default();
-        fresh.put_durable("local", &true).expect("serializable");
-        fresh.restore(restored);
+        let counters = ctx.entries("counter");
         assert_eq!(
-            fresh.get_durable::<Vec<String>>("approvals").as_deref(),
-            Some(["tool-1".to_string()].as_slice())
+            counters.iter().map(|e| e.turn).collect::<Vec<_>>(),
+            [2, 3],
+            "seeded entries precede this run's appends"
         );
-        assert_eq!(fresh.get_durable::<u32>("retries"), Some(2));
-        // Restore merges: unrelated existing entries survive.
-        assert_eq!(fresh.get_durable::<bool>("local"), Some(true));
-        // The typed entry stayed local to the original pad.
-        assert!(fresh.export().entries.len() == 3);
+        // Last-wins snapshot read.
+        let last = ctx.last_entry("counter").expect("appended");
+        assert_eq!(last.turn, 3);
+        assert_eq!(last.value, serde_json::json!(3));
+        assert!(ctx.last_entry("absent").is_none());
+
+        // Only this run's appends are pending for the driver to flush —
+        // seeded entries are already in the run.
+        let pending = ctx.drain_pending_entries();
+        assert_eq!(
+            pending.iter().map(|e| e.kind.as_str()).collect::<Vec<_>>(),
+            ["counter", "other"]
+        );
+        // Draining does not affect reads, and is not repeatable.
+        assert_eq!(ctx.entries("counter").len(), 2);
+        assert!(ctx.drain_pending_entries().is_empty());
     }
 
     struct Patcher(f64);

--- a/crates/rig-agent/src/agent/mod.rs
+++ b/crates/rig-agent/src/agent/mod.rs
@@ -120,7 +120,7 @@ pub use hook::{
     AgentHook, CompletionCallAction, CompletionResponse as CompletionResponseEvent, HookContext,
     HookStack, InvalidToolCallAction, InvalidToolCallContext, ModelSelection, ModelSelectionAction,
     ModelTurnAction, ModelTurnFinished, ObservationAction, ReasoningDelta, RequestPatch,
-    RetryRequest, RunId, RunSettled, RunStart, RunStartAction, Scratchpad, ScratchpadSnapshot,
+    RetryRequest, RunEntry, RunId, RunSettled, RunStart, RunStartAction, Scratchpad,
     SettledOutcome, StepEventKind, StreamResponseFinish, TextDelta, ToolCall, ToolCallAction,
     ToolCallDelta, ToolResultAction, ToolResultEvent,
 };

--- a/crates/rig-agent/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-agent/src/agent/prompt_request/streaming.rs
@@ -468,10 +468,19 @@ where
         // both surfaces. `is_streaming` records which surface is driving; the
         // per-turn index is advanced on each `CallModel` step below.
         let hook_ctx = HookContext::new(is_streaming, runner.config.name.clone());
-        // Restore durable hook state a serialized run carried into this drive
-        // (see `Scratchpad`'s "Durable hook state" docs).
-        if let Some(snapshot) = run.take_hook_state() {
-            hook_ctx.scratchpad().restore(snapshot);
+        // Seed the entries a resumed run carried, so `HookContext::entries`
+        // replays the full record from the first hook event on.
+        hook_ctx.seed_entries(run.entries());
+        // Flush hook appends into the run's record. Called at every step
+        // boundary and in the Done arm, so the run — the serializable record
+        // — is current whenever it can be observed. Entries appended by the
+        // terminal `on_run_settled` hook are documented as not persisted.
+        macro_rules! flush_entries {
+            () => {
+                for entry in hook_ctx.drain_pending_entries() {
+                    run.append_entry(entry);
+                }
+            };
         }
         // Rendered terminal-error text, set on every error path before its
         // yield so the run-settled hook below can report the outcome after
@@ -568,6 +577,7 @@ where
         }
 
         'outer: loop {
+            flush_entries!();
             let step = match run.next_step() {
                 Ok(step) => step,
                 Err(err) => {
@@ -713,6 +723,7 @@ where
                     ));
                 }
                 AgentRunStep::Done(response) => {
+                    flush_entries!();
                     // Run-completion marker, unifying the blocking and streaming
                     // drivers' run-finished logs into one shared event.
                     tracing::info!(

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -11601,5 +11601,76 @@ mod migrated_tests {
             assert_eq!(settles.len(), 1, "settled exactly once: {settles:?}");
             assert!(settles[0].starts_with("err:"), "error outcome: {settles:?}");
         }
+
+        /// Appends a per-call snapshot entry and captures what the record
+        /// shows at settle — proving appends are flushed into the run and
+        /// replayable through `HookContext::entries` with no export step.
+        #[derive(Clone, Default)]
+        struct EntryProbe {
+            settled: Arc<Mutex<Vec<crate::agent::RunEntry>>>,
+        }
+
+        impl AgentHook for EntryProbe {
+            async fn on_completion_call(
+                &self,
+                ctx: &HookContext,
+                _event: CompletionCallEvent<'_>,
+            ) -> CompletionCallAction {
+                let calls = ctx
+                    .last_entry("calls")
+                    .and_then(|entry| entry.value.as_u64())
+                    .unwrap_or(0)
+                    + 1;
+                ctx.append_entry("calls", &calls).expect("serializable");
+                CompletionCallAction::Continue
+            }
+
+            async fn on_run_settled(
+                &self,
+                ctx: &HookContext,
+                _event: crate::agent::RunSettled<'_>,
+            ) {
+                *self.settled.lock().expect("settled") = ctx.entries("calls");
+            }
+        }
+
+        #[tokio::test]
+        async fn entries_appended_per_turn_are_visible_at_settle() {
+            let probe = EntryProbe::default();
+            let model = MockCompletionModel::from_stream_turns([
+                vec![
+                    MockStreamEvent::tool_call_name_delta("tc1", "add"),
+                    MockStreamEvent::tool_call_arguments_delta("tc1", "{\"x\":2,\"y\":3}"),
+                    MockStreamEvent::tool_call("tc1", "add", json!({"x": 2, "y": 3})),
+                    MockStreamEvent::final_response_with_total_tokens(0),
+                ],
+                vec![
+                    MockStreamEvent::text("5"),
+                    MockStreamEvent::final_response_with_total_tokens(0),
+                ],
+            ]);
+            let mut stream = AgentBuilder::new(model)
+                .tool(crate::test_utils::MockAddTool)
+                .add_hook(probe.clone())
+                .build()
+                .runner(Message::user("add 2 and 3"))
+                .max_turns(3)
+                .stream()
+                .await;
+            while let Some(item) = stream.next().await {
+                item.expect("stream item");
+            }
+
+            let settled = probe.settled.lock().expect("settled").clone();
+            // One snapshot per model call, turn-stamped, in append order;
+            // the last-wins read reports the final count.
+            assert_eq!(
+                settled
+                    .iter()
+                    .map(|entry| (entry.turn, entry.value.as_u64()))
+                    .collect::<Vec<_>>(),
+                [(1, Some(1)), (2, Some(2))]
+            );
+        }
     }
 }

--- a/crates/rig-run/src/lib.rs
+++ b/crates/rig-run/src/lib.rs
@@ -40,7 +40,7 @@ pub use response::{CompletionCall, PromptResponse};
 pub use rig_core::id::RunId;
 pub use run::{
     AgentRun, AgentRunStep, DEFAULT_OUTPUT_RETRIES, ModelTurn, ModelTurnOutcome, PendingToolCall,
-    ScratchpadSnapshot, TurnTools,
+    RunEntry, TurnTools,
 };
 pub use spec::RunSpec;
 pub use streamed::{
@@ -65,6 +65,7 @@ const _: fn() = || {
     assert_send_sync_static::<PromptError>();
     assert_send_sync_static::<RunSpec>();
     assert_send_sync_static::<TurnTools>();
+    assert_send_sync_static::<RunEntry>();
     assert_send_sync_static::<RequestPatch>();
     assert_send_sync_static::<PreparedRequest>();
 };

--- a/crates/rig-run/src/run.rs
+++ b/crates/rig-run/src/run.rs
@@ -426,33 +426,38 @@ pub struct AgentRun {
     /// driver (or a resumed run) can re-pair tool calls with what was offered.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     turn_tools: Option<TurnTools>,
-    /// Serialized hook state carried with the run — see [`ScratchpadSnapshot`].
-    /// Protocol data like [`TurnTools`]: the run does not interpret it, but a
-    /// driver that pauses a run out of process can round-trip its hooks' state
-    /// through it.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    hook_state: Option<ScratchpadSnapshot>,
+    /// Hook- and driver-appended records — see [`RunEntry`]. Protocol data
+    /// like [`TurnTools`]: append-only, stored verbatim, never interpreted by
+    /// the run and never part of a provider request. Vec order is append
+    /// order, which is also the replay order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    entries: Vec<RunEntry>,
     state: RunState,
 }
 
-/// Serializable hook state carried by an [`AgentRun`].
+/// One hook- or driver-appended record in an [`AgentRun`]'s log.
 ///
-/// A driver with stateful hooks (a retry counter, an approval ledger) stores
-/// their durable entries here before serializing the run, and restores them
-/// into the live hook context when the run resumes — possibly in another
-/// process. The run itself never reads the entries; they are opaque
-/// driver/hook data keyed by string.
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-pub struct ScratchpadSnapshot {
-    /// Durable entries, keyed by the name each hook chose.
-    pub entries: BTreeMap<String, serde_json::Value>,
-}
-
-impl ScratchpadSnapshot {
-    /// Whether the snapshot carries no entries.
-    pub fn is_empty(&self) -> bool {
-        self.entries.is_empty()
-    }
+/// Protocol data like [`TurnTools`]: the run stores it verbatim and never
+/// interprets it, and it never reaches a provider request — state in the
+/// record is invisible to the model. Durability holds by construction:
+/// whatever the run's serialized form is, the entries appended so far are in
+/// it, and a driver rebuilds hook state on resume by replaying them (the
+/// usual pattern is *snapshot + last-wins*: append a full state snapshot per
+/// change, read back the most recent one with [`AgentRun::last_entry_of`]).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RunEntry {
+    /// Hook-chosen namespace (e.g. `"approval"`, `"retry_budget"`).
+    /// Unregistered and unvalidated: the kind string is the whole contract
+    /// and the collision boundary, so hooks should pick specific names.
+    pub kind: String,
+    /// One-based model-call index current when the entry was appended
+    /// (0 before the first call). Deliberately not a wall-clock timestamp:
+    /// [`AgentRun`] is deterministic, serializable state — no clocks in
+    /// rig-run. A host that wants timestamps puts them in [`value`](Self::value).
+    pub turn: usize,
+    /// The appended value, verbatim JSON. `Value::Null` marker entries are
+    /// legitimate.
+    pub value: serde_json::Value,
 }
 
 /// The tools advertised to the model for one turn — what the request carried,
@@ -497,7 +502,7 @@ impl AgentRun {
             rollback_pending: false,
             streamed_completion_call_recorded: false,
             turn_tools: None,
-            hook_state: None,
+            entries: Vec::new(),
             state: RunState::PreparingRequest,
         }
     }
@@ -536,21 +541,26 @@ impl AgentRun {
         }
     }
 
-    /// Serialized hook state carried by this run, if any. See
-    /// [`ScratchpadSnapshot`].
-    pub fn hook_state(&self) -> Option<&ScratchpadSnapshot> {
-        self.hook_state.as_ref()
+    /// Append one [`RunEntry`] to the run's record. Append-only: the log has
+    /// no removal or mutation API — the log is the record.
+    pub fn append_entry(&mut self, entry: RunEntry) {
+        self.entries.push(entry);
     }
 
-    /// Attach serialized hook state to carry with the run. `None` clears it.
-    pub fn set_hook_state(&mut self, state: Option<ScratchpadSnapshot>) {
-        self.hook_state = state;
+    /// Every appended [`RunEntry`], in append order.
+    pub fn entries(&self) -> &[RunEntry] {
+        &self.entries
     }
 
-    /// Remove and return the carried hook state, if any. Drivers call this at
-    /// run start to restore the state into their live hook context.
-    pub fn take_hook_state(&mut self) -> Option<ScratchpadSnapshot> {
-        self.hook_state.take()
+    /// The entries of one `kind`, in append order.
+    pub fn entries_of<'a>(&'a self, kind: &'a str) -> impl Iterator<Item = &'a RunEntry> {
+        self.entries.iter().filter(move |entry| entry.kind == kind)
+    }
+
+    /// The most recent entry of `kind`, if any — the read for the
+    /// snapshot-and-read-the-last pattern that most durable state uses.
+    pub fn last_entry_of(&self, kind: &str) -> Option<&RunEntry> {
+        self.entries.iter().rev().find(|entry| entry.kind == kind)
     }
 
     /// Record the tool definitions advertised to the model for `turn` (the
@@ -1837,31 +1847,79 @@ mod tests {
         assert_eq!(run.input_chat_history(), [Message::user("earlier")]);
     }
 
-    #[test]
-    fn hook_state_round_trips_through_serialization_and_take() {
-        let mut run = AgentRun::new("p");
-        assert!(run.hook_state().is_none());
-        let mut snapshot = ScratchpadSnapshot::default();
-        snapshot
-            .entries
-            .insert("approvals".into(), json!(["tool-1"]));
-        run.set_hook_state(Some(snapshot.clone()));
-
-        let serialized = serde_json::to_string(&run).expect("run serializes");
-        let mut restored: AgentRun = serde_json::from_str(&serialized).expect("run deserializes");
-        assert_eq!(restored.hook_state(), Some(&snapshot));
-        assert_eq!(restored.take_hook_state(), Some(snapshot));
-        assert!(restored.hook_state().is_none());
+    fn entry(kind: &str, turn: usize, value: serde_json::Value) -> RunEntry {
+        RunEntry {
+            kind: kind.to_string(),
+            turn,
+            value,
+        }
     }
 
     #[test]
-    fn runs_serialized_without_hook_state_still_deserialize() {
+    fn entries_round_trip_through_serialization_in_append_order() {
+        let mut run = AgentRun::new("p");
+        run.append_entry(entry("approval", 1, json!({"tool": "add"})));
+        run.append_entry(entry("counter", 1, json!(1)));
+        run.append_entry(entry("counter", 2, json!(2)));
+
+        let serialized = serde_json::to_string(&run).expect("run serializes");
+        let restored: AgentRun = serde_json::from_str(&serialized).expect("run deserializes");
+        assert_eq!(restored.entries(), run.entries());
+        assert_eq!(
+            restored.entries_of("counter").count(),
+            2,
+            "kind filter sees both counter snapshots"
+        );
+        // Last-wins: the snapshot pattern reads the most recent entry.
+        assert_eq!(
+            restored.last_entry_of("counter"),
+            Some(&entry("counter", 2, json!(2)))
+        );
+        assert_eq!(restored.last_entry_of("absent"), None);
+
+        // A cloned ("forked") run carries the entries verbatim.
+        assert_eq!(restored.clone().entries(), run.entries());
+    }
+
+    #[test]
+    fn runs_serialized_without_entries_still_deserialize() {
         let run = AgentRun::new("p");
         let mut value = serde_json::to_value(&run).expect("serializes");
         let object = value.as_object_mut().expect("object");
-        assert!(!object.contains_key("hook_state"), "absent when unset");
+        assert!(!object.contains_key("entries"), "absent when empty");
         let restored: AgentRun = serde_json::from_value(value).expect("deserializes");
-        assert!(restored.hook_state().is_none());
+        assert!(restored.entries().is_empty());
+    }
+
+    #[test]
+    fn entries_never_reach_the_protocol_steps() {
+        // The no-context-leakage guarantee at the protocol level: two
+        // identical runs, one carrying entries, emit identical CallModel
+        // steps — entries are storage, not context.
+        let mut plain = AgentRun::new("p").max_turns(2);
+        let mut logged = AgentRun::new("p").max_turns(2);
+        logged.append_entry(entry("state", 0, json!({"visible": "never"})));
+
+        let plain_step = plain.next_step().expect("step");
+        let logged_step = logged.next_step().expect("step");
+        let (
+            AgentRunStep::CallModel {
+                prompt: plain_prompt,
+                history: plain_history,
+                turn: plain_turn,
+            },
+            AgentRunStep::CallModel {
+                prompt: logged_prompt,
+                history: logged_history,
+                turn: logged_turn,
+            },
+        ) = (plain_step, logged_step)
+        else {
+            panic!("both runs emit CallModel first");
+        };
+        assert_eq!(plain_prompt, logged_prompt);
+        assert_eq!(plain_history, logged_history);
+        assert_eq!(plain_turn, logged_turn);
     }
 
     fn tool_names(names: &[&str]) -> BTreeSet<String> {

--- a/tests/cassettes/anthropic/lifecycle_matrix/entry_log_order.yaml
+++ b/tests/cassettes/anthropic/lifecycle_matrix/entry_log_order.yaml
@@ -1,0 +1,92 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":64000,"messages":[{"content":[{"text":"What is 9 + 16? Use the add tool, then reply with just the number.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You are a calculator. Use the add tool for arithmetic.","type":"text"}],"tool_choice":{"type":"auto"},"tools":[{"description":"Add x and y together","input_schema":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"name":"add"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  - name: request-id
+    value: req_REDACTED_1
+  body: |+
+    event: message_start
+    data: {"message":{"content":[],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":622,"output_tokens":22,"service_tier":"standard"}},"type":"message_start"}
+
+    event: content_block_start
+    data: {"content_block":{"caller":{"type":"direct"},"id":"toolu_REDACTED_1","input":{},"name":"add","type":"tool_use"},"index":0,"type":"content_block_start"}
+
+    event: ping
+    data: {"type":"ping"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"","type":"input_json_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"{\"x\": 9","type":"input_json_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":", \"y\": ","type":"input_json_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"16}","type":"input_json_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":0,"type":"content_block_stop"}
+
+    event: message_delta
+    data: {"delta":{"stop_details":null,"stop_reason":"tool_use","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":622,"output_tokens":69}}
+
+    event: message_stop
+    data: {"type":"message_stop"}
+
+---
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":64000,"messages":[{"content":[{"text":"What is 9 + 16? Use the add tool, then reply with just the number.","type":"text"}],"role":"user"},{"content":[{"id":"toolu_REDACTED_1","input":{"x":9,"y":16},"name":"add","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"25","type":"text"}],"tool_use_id":"toolu_REDACTED_1","type":"tool_result"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You are a calculator. Use the add tool for arithmetic.","type":"text"}],"tool_choice":{"type":"auto"},"tools":[{"description":"Add x and y together","input_schema":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"name":"add"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  - name: request-id
+    value: req_REDACTED_2
+  body: |+
+    event: message_start
+    data: {"message":{"content":[],"id":"msg_REDACTED_2","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":704,"output_tokens":1,"service_tier":"standard"}},"type":"message_start"}
+
+    event: content_block_start
+    data: {"content_block":{"text":"","type":"text"},"index":0,"type":"content_block_start"}
+
+    event: ping
+    data: {"type":"ping"}
+
+    event: content_block_delta
+    data: {"delta":{"text":"25","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":0,"type":"content_block_stop"}
+
+    event: message_delta
+    data: {"delta":{"stop_details":null,"stop_reason":"end_turn","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":704,"output_tokens":4}}
+
+    event: message_stop
+    data: {"type":"message_stop"}
+

--- a/tests/cassettes/gemini/agent_run_stepping/entries_survive_midrun_serialization.yaml
+++ b/tests/cassettes/gemini/agent_run_stepping/entries_survive_midrun_serialization.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to compute 6 + 7, then state the final result.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":6,"y":7},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":18,"promptTokenCount":112,"promptTokensDetails":[{"modality":"TEXT","tokenCount":112}],"serviceTier":"standard","thoughtsTokenCount":53,"totalTokenCount":183}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to compute 6 + 7, then state the final result.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":6,"y":7},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":13}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"13"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":2,"promptTokenCount":144,"promptTokensDetails":[{"modality":"TEXT","tokenCount":144}],"serviceTier":"standard","totalTokenCount":146}}'

--- a/tests/cassettes/gemini/lifecycle_matrix/entry_log_order.yaml
+++ b/tests/cassettes/gemini/lifecycle_matrix/entry_log_order.yaml
@@ -1,0 +1,41 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 9 + 16? Use the add tool, then reply with just the number.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator. Use the add tool for arithmetic.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":9,\"y\":16},\"name\":\"add\"},\"thoughtSignature\":\"signature_REDACTED_1\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":19,\"promptTokenCount\":89,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":89}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":64,\"totalTokenCount\":172}}\r\n\r\n"
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 9 + 16? Use the add tool, then reply with just the number.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":9,"y":16},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":25}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator. Use the add tool for arithmetic.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"2\"}],\"role\":\"model\"},\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":1,\"promptTokenCount\":186,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":186}],\"serviceTier\":\"standard\",\"totalTokenCount\":187}}\r\n\r\ndata: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"5\"}],\"role\":\"model\"},\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":2,\"promptTokenCount\":186,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":186}],\"serviceTier\":\"standard\",\"totalTokenCount\":188}}\r\n\r\n"

--- a/tests/cassettes/openai/lifecycle_matrix/entry_log_order.yaml
+++ b/tests/cassettes/openai/lifecycle_matrix/entry_log_order.yaml
@@ -1,0 +1,109 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"input":[{"content":[{"text":"What is 9 + 16? Use the add tool, then reply with just the number.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a calculator. Use the add tool for arithmetic.","model":"gpt-4o","stream":true,"tools":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  - name: x-request-id
+    value: req_REDACTED_1
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator. Use the add tool for arithmetic.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-4o-2024-08-06","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator. Use the add tool for arithmetic.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-4o-2024-08-06","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"x","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_2","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":5,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"9","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":6,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":",\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":7,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"y","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_6","output_index":0,"sequence_number":8,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_7","output_index":0,"sequence_number":9,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"16","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_8","output_index":0,"sequence_number":10,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_9","output_index":0,"sequence_number":11,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{\"x\":9,\"y\":16}","item_id":"fc_REDACTED_1","output_index":0,"sequence_number":12,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{\"x\":9,\"y\":16}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"completed","type":"function_call"},"output_index":0,"sequence_number":13,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator. Use the add tool for arithmetic.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-4o-2024-08-06","moderation":null,"object":"response","output":[{"arguments":"{\"x\":9,\"y\":16}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"completed","type":"function_call"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":89,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":18,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":107},"user":null},"sequence_number":14,"type":"response.completed"}
+
+---
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"input":[{"content":[{"text":"What is 9 + 16? Use the add tool, then reply with just the number.","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"x\":9,\"y\":16}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"completed","type":"function_call"},{"call_id":"call_REDACTED_1","output":"25","status":"completed","type":"function_call_output"}],"instructions":"You are a calculator. Use the add tool for arithmetic.","model":"gpt-4o","stream":true,"tools":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  - name: x-request-id
+    value: req_REDACTED_2
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a calculator. Use the add tool for arithmetic.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-4o-2024-08-06","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a calculator. Use the add tool for arithmetic.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-4o-2024-08-06","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_1","role":"assistant","status":"in_progress","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"25","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_10","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","logprobs":[],"output_index":0,"sequence_number":5,"text":"25","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"25","type":"output_text"},"sequence_number":6,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"25","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":7,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a calculator. Use the add tool for arithmetic.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-4o-2024-08-06","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"25","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","output_schema":null,"parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":115,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":3,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":118},"user":null},"sequence_number":8,"type":"response.completed"}
+

--- a/tests/common/support.rs
+++ b/tests/common/support.rs
@@ -1483,7 +1483,7 @@ impl EntryLogProbe {
     pub(crate) fn assert_phases(&self, min_calls: usize) {
         let phases = self.settled_phases();
         assert!(
-            phases.len() >= 1 + min_calls,
+            phases.len() > min_calls,
             "expected run_start plus at least {min_calls} completion calls: {phases:?}"
         );
         assert_eq!(

--- a/tests/common/support.rs
+++ b/tests/common/support.rs
@@ -1448,6 +1448,89 @@ impl WireProbe {
     }
 }
 
+/// Entry-log probe for the run-lifecycle cassette matrix: appends one
+/// `"phase"` entry per lifecycle event — `"run_start"` at `on_run_start`
+/// (turn 0, before any model call) and `"completion_call"` per model call —
+/// and captures the full replayed log at settle. What it pins on real
+/// provider traffic: append order across lifecycle events, turn stamping
+/// (0 pre-run, then the one-based call index), and that the entry log is
+/// storage, not context — the replay server matches request bodies
+/// byte-exactly, so replay staying green proves entries never reach the wire.
+#[derive(Clone, Default)]
+pub(crate) struct EntryLogProbe {
+    pub(crate) settled: std::sync::Arc<std::sync::Mutex<Vec<rig::agent::RunEntry>>>,
+}
+
+impl EntryLogProbe {
+    /// The settled `"phase"` log as `(turn, value)` pairs.
+    pub(crate) fn settled_phases(&self) -> Vec<(usize, String)> {
+        self.settled
+            .lock()
+            .expect("settled")
+            .iter()
+            .map(|entry| {
+                (
+                    entry.turn,
+                    entry.value.as_str().unwrap_or_default().to_string(),
+                )
+            })
+            .collect()
+    }
+
+    /// Assert the settled log of a completed run: a turn-0 `run_start` first,
+    /// then one `completion_call` per model call with consecutive one-based
+    /// turn stamps, at least `min_calls` of them.
+    pub(crate) fn assert_phases(&self, min_calls: usize) {
+        let phases = self.settled_phases();
+        assert!(
+            phases.len() >= 1 + min_calls,
+            "expected run_start plus at least {min_calls} completion calls: {phases:?}"
+        );
+        assert_eq!(
+            phases[0],
+            (0, "run_start".to_string()),
+            "the pre-run append is stamped turn 0: {phases:?}"
+        );
+        for (index, (turn, value)) in phases[1..].iter().enumerate() {
+            assert_eq!(
+                (*turn, value.as_str()),
+                (index + 1, "completion_call"),
+                "per-call snapshots are turn-stamped in call order: {phases:?}"
+            );
+        }
+    }
+}
+
+impl rig::agent::AgentHook for EntryLogProbe {
+    async fn on_run_start(
+        &self,
+        ctx: &rig::agent::HookContext,
+        _event: rig::agent::RunStart<'_>,
+    ) -> rig::agent::RunStartAction {
+        ctx.append_entry("phase", &"run_start")
+            .expect("a str serializes");
+        rig::agent::RunStartAction::Continue
+    }
+
+    async fn on_completion_call(
+        &self,
+        ctx: &rig::agent::HookContext,
+        _event: rig::agent::CompletionCallEvent<'_>,
+    ) -> rig::agent::CompletionCallAction {
+        ctx.append_entry("phase", &"completion_call")
+            .expect("a str serializes");
+        rig::agent::CompletionCallAction::Continue
+    }
+
+    async fn on_run_settled(
+        &self,
+        ctx: &rig::agent::HookContext,
+        _event: rig::agent::RunSettled<'_>,
+    ) {
+        *self.settled.lock().expect("settled") = ctx.entries("phase");
+    }
+}
+
 /// Agent-hook probe for the run-lifecycle cassette matrix: counts
 /// `on_run_start` firings (optionally rewriting the prompt), appends one
 /// `"completion_calls"` snapshot entry to the run's record per model call,

--- a/tests/common/support.rs
+++ b/tests/common/support.rs
@@ -1449,15 +1449,16 @@ impl WireProbe {
 }
 
 /// Agent-hook probe for the run-lifecycle cassette matrix: counts
-/// `on_run_start` firings (optionally rewriting the prompt), counts
-/// completion calls into a durable scratchpad entry, and records every
-/// `on_run_settled` outcome plus the settled scratchpad export.
+/// `on_run_start` firings (optionally rewriting the prompt), appends one
+/// `"completion_calls"` snapshot entry to the run's record per model call,
+/// and records every `on_run_settled` outcome plus the entries visible at
+/// settle time.
 #[derive(Clone, Default)]
 pub(crate) struct LifecycleHookProbe {
     pub(crate) rewrite_to: Option<String>,
     pub(crate) starts: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     pub(crate) settles: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
-    pub(crate) exported: std::sync::Arc<std::sync::Mutex<Option<rig::agent::ScratchpadSnapshot>>>,
+    pub(crate) settled_entries: std::sync::Arc<std::sync::Mutex<Vec<rig::agent::RunEntry>>>,
 }
 
 impl LifecycleHookProbe {
@@ -1473,13 +1474,17 @@ impl LifecycleHookProbe {
         self.settles.lock().expect("settles").clone()
     }
 
-    /// The durable completion-call counter the settled export carried.
+    /// The durable completion-call counter as seen at settle time: the
+    /// last-wins read of the `"completion_calls"` snapshot entries the hook
+    /// appended to the run's record.
     pub(crate) fn exported_completion_calls(&self) -> Option<u64> {
-        let snapshot = self.exported.lock().expect("export").clone()?;
-        snapshot
-            .entries
-            .get("completion_calls")
-            .and_then(serde_json::Value::as_u64)
+        self.settled_entries
+            .lock()
+            .expect("entries")
+            .iter()
+            .rev()
+            .find(|entry| entry.kind == "completion_calls")
+            .and_then(|entry| entry.value.as_u64())
     }
 }
 
@@ -1504,13 +1509,17 @@ impl rig::agent::AgentHook for LifecycleHookProbe {
         ctx: &rig::agent::HookContext,
         _event: rig::agent::CompletionCallEvent<'_>,
     ) -> rig::agent::CompletionCallAction {
+        // Snapshot + last-wins: append the running count per model call; the
+        // settle-time read takes the most recent snapshot. Entries land in
+        // the run's serializable record — and never on the wire, which the
+        // cassette replay proves byte-exactly (the replay server matches
+        // request bodies).
         let calls = ctx
-            .scratchpad()
-            .get_durable::<u64>("completion_calls")
+            .last_entry("completion_calls")
+            .and_then(|entry| entry.value.as_u64())
             .unwrap_or(0)
             + 1;
-        ctx.scratchpad()
-            .put_durable("completion_calls", &calls)
+        ctx.append_entry("completion_calls", &calls)
             .expect("a u64 serializes");
         rig::agent::CompletionCallAction::Continue
     }
@@ -1520,7 +1529,7 @@ impl rig::agent::AgentHook for LifecycleHookProbe {
         ctx: &rig::agent::HookContext,
         event: rig::agent::RunSettled<'_>,
     ) {
-        *self.exported.lock().expect("export") = Some(ctx.scratchpad().export());
+        *self.settled_entries.lock().expect("entries") = ctx.entries("completion_calls");
         let outcome = match event.outcome {
             rig::agent::SettledOutcome::Response(_) => "response".to_string(),
             rig::agent::SettledOutcome::Error(reason) => format!("error:{reason}"),

--- a/tests/providers/anthropic/cassette/lifecycle_matrix.rs
+++ b/tests/providers/anthropic/cassette/lifecycle_matrix.rs
@@ -103,6 +103,40 @@ async fn run_start_rewrite_reaches_the_provider() {
 }
 
 #[tokio::test]
+async fn entry_log_orders_and_turn_stamps_across_a_streamed_tool_run() {
+    let probe = crate::support::EntryLogProbe::default();
+    let agent_hook = probe.clone();
+    with_anthropic_lifecycle_cassette(
+        "lifecycle_matrix/entry_log_order",
+        WireProbe::default(),
+        |client| async move {
+            let agent = client
+                .agent(MODEL)
+                .preamble("You are a calculator. Use the add tool for arithmetic.")
+                .tool(Adder)
+                .add_hook(agent_hook)
+                .build();
+            let mut stream = agent
+                .stream_prompt("What is 9 + 16? Use the add tool, then reply with just the number.")
+                .max_turns(3)
+                .await;
+            let (response, _final): (_, rig::streaming::StreamFinal) =
+                collect_stream_final_response_and_provider_final(&mut stream)
+                    .await
+                    .expect("streamed tool run should succeed");
+            assert!(
+                response.contains("25"),
+                "the tool result reached the final answer: {response:?}"
+            );
+        },
+    )
+    .await;
+    // Turn-0 run_start append, then one turn-stamped snapshot per model call
+    // (a tool run makes at least two), replayed in append order at settle.
+    probe.assert_phases(2);
+}
+
+#[tokio::test]
 async fn run_settles_once_across_a_multi_turn_tool_run_with_durable_state() {
     let hook = LifecycleHookProbe::default();
     let agent_hook = hook.clone();

--- a/tests/providers/gemini/cassette/agent_run_stepping.rs
+++ b/tests/providers/gemini/cassette/agent_run_stepping.rs
@@ -327,3 +327,86 @@ async fn max_turns_error_carries_pending_tool_results_message() {
     )
     .await;
 }
+
+/// Host-side entry log across a mid-run serialize/resume (PR #2408): a driver
+/// pausing at the tool boundary appends its state to the run's record, ships
+/// the serialized run across a process boundary, and the resumed run carries
+/// the entries — no export step, and (proven by this cassette replaying
+/// byte-exactly) no effect on the wire.
+#[tokio::test]
+async fn hand_driven_entries_survive_midrun_serialization() {
+    with_gemini_cassette(
+        "agent_run_stepping/entries_survive_midrun_serialization",
+        |client| async move {
+            let agent = GeminiAgent::new(
+                client.completion_model(gemini::completion::GEMINI_2_5_FLASH),
+                FORCE_TOOLS_PREAMBLE,
+                &["add"],
+                None,
+            );
+            let names = tool_names(&["add"]);
+
+            let mut run =
+                AgentRun::new("Use the add tool to compute 6 + 7, then state the final result.")
+                    .max_turns(4);
+            run.append_entry(rig::run::RunEntry {
+                kind: "driver_note".into(),
+                turn: 0,
+                value: serde_json::json!("created"),
+            });
+
+            let response = loop {
+                match run.next_step().expect("run should advance") {
+                    AgentRunStep::CallModel {
+                        prompt,
+                        history,
+                        turn,
+                    } => {
+                        run.model_response(
+                            call_model(&agent, prompt, history, &names, &names).await,
+                        )
+                        .expect("model turn should be accepted");
+                        run.append_entry(rig::run::RunEntry {
+                            kind: "driver_note".into(),
+                            turn,
+                            value: serde_json::json!(format!("model_call_{turn}")),
+                        });
+                    }
+                    AgentRunStep::CallTools { calls } => {
+                        // Pause at the tool boundary: serialize, cross a
+                        // "process boundary", resume. The entries ride along
+                        // with no export step.
+                        let serialized =
+                            serde_json::to_string(&run).expect("run serializes mid-run");
+                        run = serde_json::from_str(&serialized).expect("run deserializes");
+                        assert_eq!(
+                            run.entries_of("driver_note").count(),
+                            2,
+                            "created + first model call survived the round trip"
+                        );
+
+                        run.tool_results(execute_pending_calls(&calls))
+                            .expect("tool results should be accepted");
+                    }
+                    AgentRunStep::Done(response) => break response,
+                }
+            };
+
+            assert_mentions_expected_number(&response.output, 13);
+            // The full log is on the finished run, in append order, last-wins
+            // readable.
+            let notes: Vec<_> = run
+                .entries_of("driver_note")
+                .map(|entry| (entry.turn, entry.value.clone()))
+                .collect();
+            assert_eq!(notes.first(), Some(&(0, serde_json::json!("created"))));
+            assert!(
+                notes.len() >= 3,
+                "created + at least two model calls: {notes:?}"
+            );
+            let last = run.last_entry_of("driver_note").expect("appends recorded");
+            assert_eq!(last.turn, run.turn(), "last note is the final model call's");
+        },
+    )
+    .await;
+}

--- a/tests/providers/gemini/cassette/lifecycle_matrix.rs
+++ b/tests/providers/gemini/cassette/lifecycle_matrix.rs
@@ -103,6 +103,40 @@ async fn run_start_rewrite_reaches_the_provider() {
 }
 
 #[tokio::test]
+async fn entry_log_orders_and_turn_stamps_across_a_streamed_tool_run() {
+    let probe = crate::support::EntryLogProbe::default();
+    let agent_hook = probe.clone();
+    with_gemini_lifecycle_cassette(
+        "lifecycle_matrix/entry_log_order",
+        WireProbe::default(),
+        |client| async move {
+            let agent = client
+                .agent(MODEL)
+                .preamble("You are a calculator. Use the add tool for arithmetic.")
+                .tool(Adder)
+                .add_hook(agent_hook)
+                .build();
+            let mut stream = agent
+                .stream_prompt("What is 9 + 16? Use the add tool, then reply with just the number.")
+                .max_turns(3)
+                .await;
+            let (response, _final): (_, rig::streaming::StreamFinal) =
+                collect_stream_final_response_and_provider_final(&mut stream)
+                    .await
+                    .expect("streamed tool run should succeed");
+            assert!(
+                response.contains("25"),
+                "the tool result reached the final answer: {response:?}"
+            );
+        },
+    )
+    .await;
+    // Turn-0 run_start append, then one turn-stamped snapshot per model call
+    // (a tool run makes at least two), replayed in append order at settle.
+    probe.assert_phases(2);
+}
+
+#[tokio::test]
 async fn run_settles_once_across_a_multi_turn_tool_run_with_durable_state() {
     let hook = LifecycleHookProbe::default();
     let agent_hook = hook.clone();

--- a/tests/providers/openai/cassette/lifecycle_matrix.rs
+++ b/tests/providers/openai/cassette/lifecycle_matrix.rs
@@ -103,6 +103,40 @@ async fn run_start_rewrite_reaches_the_provider() {
 }
 
 #[tokio::test]
+async fn entry_log_orders_and_turn_stamps_across_a_streamed_tool_run() {
+    let probe = crate::support::EntryLogProbe::default();
+    let agent_hook = probe.clone();
+    with_openai_lifecycle_cassette(
+        "lifecycle_matrix/entry_log_order",
+        WireProbe::default(),
+        |client| async move {
+            let agent = client
+                .agent(MODEL)
+                .preamble("You are a calculator. Use the add tool for arithmetic.")
+                .tool(Adder)
+                .add_hook(agent_hook)
+                .build();
+            let mut stream = agent
+                .stream_prompt("What is 9 + 16? Use the add tool, then reply with just the number.")
+                .max_turns(3)
+                .await;
+            let (response, _final): (_, rig::streaming::StreamFinal) =
+                collect_stream_final_response_and_provider_final(&mut stream)
+                    .await
+                    .expect("streamed tool run should succeed");
+            assert!(
+                response.contains("25"),
+                "the tool result reached the final answer: {response:?}"
+            );
+        },
+    )
+    .await;
+    // Turn-0 run_start append, then one turn-stamped snapshot per model call
+    // (a tool run makes at least two), replayed in append order at settle.
+    probe.assert_phases(2);
+}
+
+#[tokio::test]
 async fn run_settles_once_across_a_multi_turn_tool_run_with_durable_state() {
     let hook = LifecycleHookProbe::default();
     let agent_hook = hook.clone();


### PR DESCRIPTION
Replaces #2407's durable-Scratchpad snapshot with an event-sourced design mirrored from pi's extension state model (verified against pi's source: `appendEntry`/`CustomEntry`, `getBranch()` replay, and its docs' "State Management" guidance).

## Why the snapshot design lost

The KV-plus-snapshot shape (`put_durable`/`get_durable` → `export()` → `AgentRun::hook_state` → driver `restore()`) required a manual export at exactly the right moment — the "auto write-back" gap — and mixed two key models (type-keyed transient vs string-keyed durable) with silent deserialize-to-`None` reads.

## The replacement

**Hooks persist by appending entries to the run's record; durability holds by construction.**

- `rig_run::RunEntry { kind, turn, value }` — protocol data like `TurnTools`. `AgentRun` gains an append-only `entries: Vec<RunEntry>` (serde-default; pre-existing serialized runs load unchanged) with `append_entry` / `entries` / `entries_of` / `last_entry_of`. `turn` deliberately replaces pi's wall-clock timestamp: rig-run is deterministic sans-IO state, no clocks.
- `HookContext::append_entry(kind, &T)` (turn-stamped, fail-loud serialization, fire-and-forget like pi's `appendEntry`), `entries(kind)` (carried-in entries + this run's appends, in order — the replay), and `last_entry(kind)`. The documented default pattern is **snapshot + last-wins**, which pi's extensions use unanimously.
- The driver seeds the context from `run.entries()` at run start (replacing `restore()`) and **flushes pending appends into the run at every step boundary and in the Done arm** — the serialized run is always current; there is no export moment. Entries appended inside `on_run_settled` are documented as not persisted (the run is finished).
- Mirroring pi's storage-vs-context split: entries are storage, never context — they never reach a provider request, pinned two ways: a rig-run test that a run with entries emits identical `CallModel` steps, and the cassette matrix, whose replay server matches request bodies byte-exactly — replay staying green with the probe now appending entries **is** wire-level proof (no re-recording was needed; fixtures are untouched).
- rig-run stays hook-free (dependency-graph guard unchanged); out-of-process hosts append/read directly on `AgentRun`.

## Deleted (shipped unreleased in #2407, no shims per repo policy)

`Scratchpad::{put_durable, get_durable, remove_durable, export, restore}` and its `durable` field; `rig_run::ScratchpadSnapshot`; `AgentRun::{hook_state, set_hook_state, take_hook_state}`. `Scratchpad` remains as the in-process cross-hook channel, with new docs giving the three-way guidance (hook fields / scratchpad / entry log) and pi's branch-correctness rationale.

## Non-goals (possible follow-ups)

No entry tree (cloning the run is rig's branch), no log compaction (pi has none; runs are `max_turns`-bounded), no `RunEvents` entry-appended notification (pi's `entry_appended` analog, for UI hosts), no `Scratchpad` rename.

## Tests

RunEntry serde + append-order + last-wins + clone-carries-entries; old-run-without-entries deserializes; protocol no-leakage (`CallModel` identity); `HookContext` turn-stamping, seed-precedes-appends ordering, drain semantics; end-to-end runner test that per-turn appends are flushed and visible at settle with correct turn stamps; cassette matrix re-pointed to the entry log (replay green, fixtures unchanged). MIGRATING.md's 0.41→next entry amended to describe the final shape. Full suite 5767 passed, provider replay 1200 passed, clippy `-D warnings` clean, doctests green.