### PR TITLE
refactor: idiomatic Rust sweep, round 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(openai-compatible)* `OpenAICompatibleProvider::SUPPORTS_IMAGE_TOOL_RESULTS`, letting a server that honours an image inside a `role:"tool"` message receive one; enabled for llama.cpp (`providers::llamacpp`), off everywhere else because official OpenAI refuses it on Chat Completions (by [gold-silver-copper](https://github.com/gold-silver-copper))
 - *(gemini)* explicit context caching (`cachedContents`) — create, reuse and delete a server-side cache that hits from the first request ([#2375](https://github.com/0xPlaygrounds/rig/pull/2375)) (by [gold-silver-copper](https://github.com/gold-silver-copper))
 
+### Changed
+
+- *(core, agent, bedrock, vertexai)* [**breaking**] accessors drop their `get_` prefix per Rust naming convention: `ToolCatalog`-side `get_tool_definitions` → `tool_definitions` (rig-core contextual tools), `ToolServerHandle::get_tool_defs` → `tool_defs` (rig-agent), and `Client::get_inner` → `inner` (rig-bedrock, rig-vertexai)
+
 ### Fixed
+
+- *(milvus)* `Filter` and `MilvusValue` are now re-exported from the crate root — `VectorStoreIndex::Filter` named them in public signatures, but their constructors were unreachable outside the crate
 
 - *(llamacpp)* refuse a specific-function `tool_choice` instead of sending one llama.cpp silently reads as `auto` — `llama-server` parses the field as a string and knows only `auto`/`none`/`required`, so a request naming one tool returned whichever tool the model picked (by [gold-silver-copper](https://github.com/gold-silver-copper))
 - *(llamacpp)* `EMITS_COMPLETE_SINGLE_CHUNK_TOOL_CALLS` is `false`, which is what llama.cpp measurably does: it streams tool-call arguments one token at a time on every chat template tested (Qwen3, Llama 3.2, Mistral Small 3.2), including for zero-argument calls (by [gold-silver-copper](https://github.com/gold-silver-copper))

--- a/crates/rig-agent/src/agent/builder.rs
+++ b/crates/rig-agent/src/agent/builder.rs
@@ -608,7 +608,7 @@ mod tests {
                 .tool(NamedTool::new())
                 .build(),
         ] {
-            let definitions = agent.tool_server_handle.get_tool_defs(None).await.unwrap();
+            let definitions = agent.tool_server_handle.tool_defs(None).await.unwrap();
             assert!(
                 definitions
                     .iter()
@@ -638,7 +638,7 @@ mod tests {
         assert!(
             retrieval_only
                 .tool_server_handle
-                .get_tool_defs(None)
+                .tool_defs(None)
                 .await
                 .unwrap()
                 .is_empty()
@@ -653,7 +653,7 @@ mod tests {
             )
             .build();
 
-        let always = agent.tool_server_handle.get_tool_defs(None).await.unwrap();
+        let always = agent.tool_server_handle.tool_defs(None).await.unwrap();
         assert_eq!(
             always
                 .iter()
@@ -664,7 +664,7 @@ mod tests {
 
         let with_retrieval = agent
             .tool_server_handle
-            .get_tool_defs(Some("add two numbers".to_string()))
+            .tool_defs(Some("add two numbers".to_string()))
             .await
             .unwrap();
         assert_eq!(

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -270,10 +270,11 @@ impl AgentConfig {
         self.temperature = spec.temperature;
         self.tool_choice = spec.tool_choice.clone();
         self.max_turns = spec.effective_max_turns();
-        self.output_schema = match &spec.output_schema {
-            Some(value) => Some(schemars::Schema::try_from(value.clone())?),
-            None => None,
-        };
+        self.output_schema = spec
+            .output_schema
+            .clone()
+            .map(schemars::Schema::try_from)
+            .transpose()?;
         self.output_mode = spec.output_mode.clone();
         Ok(())
     }

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -366,7 +366,7 @@ impl Agent {
         &self,
         prompt: Option<String>,
     ) -> Result<Vec<ToolDefinition>, ToolServerError> {
-        self.tool_server_handle.get_tool_defs(prompt).await
+        self.tool_server_handle.tool_defs(prompt).await
     }
 }
 

--- a/crates/rig-agent/src/tool/mod.rs
+++ b/crates/rig-agent/src/tool/mod.rs
@@ -140,10 +140,7 @@ mod toolset_clone_tests {
 
         let mut clone = original.clone();
         assert_eq!(erased_ptr(&original, "add"), erased_ptr(&clone, "add"));
-        assert_eq!(
-            original.get_tool_definitions(),
-            clone.get_tool_definitions()
-        );
+        assert_eq!(original.tool_definitions(), clone.tool_definitions());
 
         clone.add_tool(MockSubtractTool);
         assert!(clone.contains("subtract"));
@@ -333,7 +330,7 @@ mod migrated_tests {
     #[test]
     fn test_get_tool_definitions() {
         let toolset = get_test_toolset();
-        let tools = toolset.get_tool_definitions();
+        let tools = toolset.tool_definitions();
         assert_eq!(tools.len(), 2);
         assert_eq!(
             tools
@@ -419,7 +416,7 @@ mod migrated_tests {
             toolset.add_dynamic_tool(named_tool(name, "test tool"));
         }
 
-        let defs = toolset.get_tool_definitions();
+        let defs = toolset.tool_definitions();
         let def_names: Vec<String> = defs.into_iter().map(|def| def.name).collect();
         assert_eq!(def_names, names);
 
@@ -456,7 +453,7 @@ mod migrated_tests {
         let mut toolset = ToolSet::default();
         toolset.add_tool(NamedTool);
 
-        let defs = toolset.get_tool_definitions();
+        let defs = toolset.tool_definitions();
         assert_eq!(defs[0].name, NamedTool::NAME);
 
         let docs = toolset.documents();
@@ -541,7 +538,7 @@ mod migrated_tests {
             )
             .run();
         let definitions = handle
-            .get_tool_defs(Some("find the shared portable tool".to_string()))
+            .tool_defs(Some("find the shared portable tool".to_string()))
             .await
             .unwrap();
 
@@ -603,7 +600,7 @@ mod migrated_tests {
         assert_eq!(registered_name, "portable_runtime_name");
         assert_eq!(
             toolset
-                .get_tool_definitions()
+                .tool_definitions()
                 .iter()
                 .map(|definition| definition.name.as_str())
                 .collect::<Vec<_>>(),
@@ -647,7 +644,7 @@ mod migrated_tests {
         toolset.add_dynamic_tool(named_tool("beta", "beta"));
         toolset.add_dynamic_tool(named_tool("alpha", "second alpha"));
 
-        let defs = toolset.get_tool_definitions();
+        let defs = toolset.tool_definitions();
         assert_eq!(
             defs.iter().map(|def| def.name.as_str()).collect::<Vec<_>>(),
             vec!["alpha", "beta"],
@@ -678,7 +675,7 @@ mod migrated_tests {
 
         base.add_tools(incoming);
 
-        let defs = base.get_tool_definitions();
+        let defs = base.tool_definitions();
         assert_eq!(
             defs.iter().map(|def| def.name.as_str()).collect::<Vec<_>>(),
             vec!["alpha", "beta", "gamma"],

--- a/crates/rig-agent/src/tool/server.rs
+++ b/crates/rig-agent/src/tool/server.rs
@@ -368,7 +368,7 @@ impl ToolServerHandle {
     /// so a tick-driven host can call it every frame.
     ///
     /// For the retrieval-aware view that also selects dynamic tools for a
-    /// prompt, use the async [`get_tool_defs`](Self::get_tool_defs).
+    /// prompt, use the async [`tool_defs`](Self::tool_defs).
     pub fn snapshot(&self) -> ToolRegistrySnapshot {
         let tools = self.with_registry(|state| snapshot_registered_tools(state, &[]));
         ToolCatalog::from_registered(tools)
@@ -376,7 +376,7 @@ impl ToolServerHandle {
 
     /// Provider definitions of the registry as it stands — the definitions of
     /// [`snapshot`](Self::snapshot), synchronously. Equivalent to
-    /// `get_tool_defs(None)` without the future.
+    /// `tool_defs(None)` without the future.
     pub fn static_tool_defs(&self) -> Vec<ToolDefinition> {
         let mut snapshot = self.snapshot();
         snapshot.take_definitions()
@@ -399,7 +399,7 @@ impl ToolServerHandle {
     /// the registry as it stands, [`static_tool_defs`](Self::static_tool_defs)
     /// / [`snapshot`](Self::snapshot) give the same always-exposed definitions
     /// synchronously.
-    pub async fn get_tool_defs(
+    pub async fn tool_defs(
         &self,
         prompt: Option<String>,
     ) -> Result<Vec<ToolDefinition>, ToolServerError> {
@@ -589,7 +589,7 @@ mod tests {
         .with_liveness(move || live.load(Ordering::SeqCst))
     }
 
-    /// The sync snapshot and the async, prompt-less `get_tool_defs` read the
+    /// The sync snapshot and the async, prompt-less `tool_defs` read the
     /// same always-exposed registry in the same order.
     #[tokio::test]
     async fn sync_snapshot_matches_async_prompt_less_read() {
@@ -599,7 +599,7 @@ mod tests {
             .run();
 
         let sync_defs = handle.static_tool_defs();
-        let async_defs = handle.get_tool_defs(None).await.unwrap();
+        let async_defs = handle.tool_defs(None).await.unwrap();
         assert_eq!(sync_defs.len(), 2);
         assert_eq!(sync_defs, async_defs);
 
@@ -632,7 +632,7 @@ mod tests {
         assert_eq!(handle.snapshot().names().collect::<Vec<_>>(), vec!["add"]);
         assert_eq!(handle.static_tool_defs().len(), 1);
         assert!(!handle.toolset().contains("remote"));
-        assert_eq!(handle.get_tool_defs(None).await.unwrap().len(), 1);
+        assert_eq!(handle.tool_defs(None).await.unwrap().len(), 1);
     }
 
     /// A snapshot pins implementations: it keeps executing the tool it was
@@ -798,7 +798,7 @@ mod tests {
         let handle = server.run();
 
         handle.add_tool(MockAddTool);
-        let res = handle.get_tool_defs(None).await.unwrap();
+        let res = handle.tool_defs(None).await.unwrap();
 
         assert_eq!(res.len(), 1);
 
@@ -810,7 +810,7 @@ mod tests {
         assert_eq!(res, "7");
 
         handle.remove_tool("add");
-        let res = handle.get_tool_defs(None).await.unwrap();
+        let res = handle.tool_defs(None).await.unwrap();
 
         assert_eq!(res.len(), 0);
     }
@@ -855,7 +855,7 @@ mod tests {
             let handle = ToolServer::new().run();
             handle.add_tool(MockAddTool);
             handle.add_tool(MockSubtractTool);
-            handle.get_tool_defs(None).await.unwrap()
+            handle.tool_defs(None).await.unwrap()
         };
         via_add_tool.sort_by(|a, b| a.name.cmp(&b.name));
 
@@ -865,7 +865,7 @@ mod tests {
             toolset.add_tool(MockAddTool);
             toolset.add_tool(MockSubtractTool);
             handle.append_toolset(toolset);
-            handle.get_tool_defs(None).await.unwrap()
+            handle.tool_defs(None).await.unwrap()
         };
         via_append_toolset.sort_by(|a, b| a.name.cmp(&b.name));
 
@@ -883,7 +883,7 @@ mod tests {
     pub async fn builder_tool_uses_canonical_static_name() {
         let handle = ToolServer::new().tool(NamedTool::new()).run();
 
-        let defs = handle.get_tool_defs(None).await.unwrap();
+        let defs = handle.tool_defs(None).await.unwrap();
         assert_eq!(defs.len(), 1);
         assert_eq!(defs[0].name, NamedTool::NAME);
     }
@@ -893,7 +893,7 @@ mod tests {
         let handle = ToolServer::new().run();
         handle.add_tool(NamedTool::new());
 
-        let defs = handle.get_tool_defs(None).await.unwrap();
+        let defs = handle.tool_defs(None).await.unwrap();
         assert_eq!(defs.len(), 1);
         assert_eq!(defs[0].name, NamedTool::NAME);
     }
@@ -907,7 +907,7 @@ mod tests {
             .run();
 
         let defs = handle
-            .get_tool_defs(Some("use the changing tool".to_string()))
+            .tool_defs(Some("use the changing tool".to_string()))
             .await
             .unwrap();
         assert_eq!(defs.len(), 1);
@@ -920,7 +920,7 @@ mod tests {
         handle.add_tool(MockSubtractTool);
         handle.add_tool(MockAddTool);
 
-        let defs = handle.get_tool_defs(None).await.unwrap();
+        let defs = handle.tool_defs(None).await.unwrap();
         assert_eq!(
             defs.iter().map(|def| def.name.as_str()).collect::<Vec<_>>(),
             vec!["subtract", "add"]
@@ -937,7 +937,7 @@ mod tests {
             .run();
 
         let defs = handle
-            .get_tool_defs(Some("add two numbers".to_string()))
+            .tool_defs(Some("add two numbers".to_string()))
             .await
             .unwrap();
         assert_eq!(
@@ -960,7 +960,7 @@ mod tests {
             )
             .run();
 
-        let defs = handle.get_tool_defs(None).await.unwrap();
+        let defs = handle.tool_defs(None).await.unwrap();
         assert_eq!(
             defs.iter()
                 .map(|definition| definition.name.as_str())
@@ -979,7 +979,7 @@ mod tests {
         toolset.add_tool(MockAddTool);
         handle.append_toolset(toolset);
 
-        let defs = handle.get_tool_defs(None).await.unwrap();
+        let defs = handle.tool_defs(None).await.unwrap();
         assert_eq!(
             defs.len(),
             1,
@@ -1008,13 +1008,13 @@ mod tests {
         let handle = server.run();
 
         // Test with None prompt - should only return static tools
-        let res = handle.get_tool_defs(None).await.unwrap();
+        let res = handle.tool_defs(None).await.unwrap();
         assert_eq!(res.len(), 1);
         assert_eq!(res[0].name, "add");
 
         // Test with Some prompt - should return both static and dynamic tools
         let res = handle
-            .get_tool_defs(Some("calculate difference".to_string()))
+            .tool_defs(Some("calculate difference".to_string()))
             .await
             .unwrap();
         assert_eq!(res.len(), 2);
@@ -1040,7 +1040,7 @@ mod tests {
 
         // Test with Some prompt - should only return static tool since dynamic tool is missing
         let res = handle
-            .get_tool_defs(Some("some query".to_string()))
+            .tool_defs(Some("some query".to_string()))
             .await
             .unwrap();
         assert_eq!(res.len(), 1);
@@ -1130,7 +1130,7 @@ mod tests {
         // If fetched sequentially, the first index will wait at the barrier forever.
         let get_defs = tokio::time::timeout(
             std::time::Duration::from_secs(1),
-            handle.get_tool_defs(Some("do math".to_string())),
+            handle.tool_defs(Some("do math".to_string())),
         )
         .await;
 

--- a/crates/rig-bedrock/src/client.rs
+++ b/crates/rig-bedrock/src/client.rs
@@ -77,7 +77,7 @@ impl Client {
         }
     }
 
-    pub async fn get_inner(&self) -> &aws_sdk_bedrockruntime::Client {
+    pub async fn inner(&self) -> &aws_sdk_bedrockruntime::Client {
         self.aws_client
             .get_or_init(|| async {
                 let config = if let Some(profile_name) = &self.profile_name {

--- a/crates/rig-bedrock/src/completion.rs
+++ b/crates/rig-bedrock/src/completion.rs
@@ -228,7 +228,7 @@ impl CompletionModel {
 
         let mut converse_builder = self
             .client
-            .get_inner()
+            .inner()
             .await
             .converse()
             .model_id(request_model.clone());

--- a/crates/rig-bedrock/src/embedding.rs
+++ b/crates/rig-bedrock/src/embedding.rs
@@ -54,7 +54,7 @@ impl EmbeddingModel {
 
         let model_response = self
             .client
-            .get_inner()
+            .inner()
             .await
             .invoke_model()
             .model_id(self.model.as_str())

--- a/crates/rig-bedrock/src/image.rs
+++ b/crates/rig-bedrock/src/image.rs
@@ -60,7 +60,7 @@ impl ImageGenerationModel {
         let body = serde_json::to_string(&request)?;
         let model_response = self
             .client
-            .get_inner()
+            .inner()
             .await
             .invoke_model()
             .model_id(self.model.as_str())

--- a/crates/rig-bedrock/src/streaming.rs
+++ b/crates/rig-bedrock/src/streaming.rs
@@ -424,7 +424,7 @@ impl CompletionModel {
 
         let mut converse_builder = self
             .client
-            .get_inner()
+            .inner()
             .await
             .converse_stream()
             .model_id(request_model);

--- a/crates/rig-bedrock/src/types/errors.rs
+++ b/crates/rig-bedrock/src/types/errors.rs
@@ -87,10 +87,7 @@ fn gated<E>(
     from_body: impl FnOnce(String) -> E,
     provider_error: impl FnOnce(String) -> E,
 ) -> E {
-    match message {
-        Some(msg) => from_body(msg),
-        None => provider_error(fallback),
-    }
+    message.map_or_else(|| provider_error(fallback), from_body)
 }
 
 const UNEXPECTED: &str = "An unexpected error occurred. Verify Internet connection or AWS keys";

--- a/crates/rig-candle/src/generation.rs
+++ b/crates/rig-candle/src/generation.rs
@@ -82,13 +82,6 @@ struct RequestGenerationOverrides {
     repeat_last_n: Option<usize>,
 }
 
-fn override_or<T>(value: Option<T>, default: T) -> T {
-    match value {
-        Some(value) => value,
-        None => default,
-    }
-}
-
 pub(crate) fn effective_generation(
     request: &CompletionRequest,
     defaults: &GenerationConfig,
@@ -100,13 +93,13 @@ pub(crate) fn effective_generation(
         None => RequestGenerationOverrides::default(),
     };
     let generation = GenerationConfig {
-        max_tokens: override_or(request.max_tokens, defaults.max_tokens),
-        temperature: override_or(request.temperature, defaults.temperature),
+        max_tokens: request.max_tokens.unwrap_or(defaults.max_tokens),
+        temperature: request.temperature.unwrap_or(defaults.temperature),
         top_k: overrides.top_k.resolve(defaults.top_k),
         top_p: overrides.top_p.resolve(defaults.top_p),
-        seed: override_or(overrides.seed, defaults.seed),
-        repeat_penalty: override_or(overrides.repeat_penalty, defaults.repeat_penalty),
-        repeat_last_n: override_or(overrides.repeat_last_n, defaults.repeat_last_n),
+        seed: overrides.seed.unwrap_or(defaults.seed),
+        repeat_penalty: overrides.repeat_penalty.unwrap_or(defaults.repeat_penalty),
+        repeat_last_n: overrides.repeat_last_n.unwrap_or(defaults.repeat_last_n),
     };
     validate_generation(&generation, Some(vocab_size))?;
     Ok(generation)

--- a/crates/rig-candle/src/profile.rs
+++ b/crates/rig-candle/src/profile.rs
@@ -7,14 +7,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::CandleError;
 
-pub const BEGIN_OF_TEXT: &str = "<|begin_of_text|>";
-pub const START_HEADER: &str = "<|start_header_id|>";
-pub const END_HEADER: &str = "<|end_header_id|>";
-pub const END_OF_TURN: &str = "<|eot_id|>";
-pub const IM_START: &str = "<|im_start|>";
-pub const IM_END: &str = "<|im_end|>";
+pub(crate) const BEGIN_OF_TEXT: &str = "<|begin_of_text|>";
+pub(crate) const START_HEADER: &str = "<|start_header_id|>";
+pub(crate) const END_HEADER: &str = "<|end_header_id|>";
+pub(crate) const END_OF_TURN: &str = "<|eot_id|>";
+pub(crate) const IM_START: &str = "<|im_start|>";
+pub(crate) const IM_END: &str = "<|im_end|>";
 pub(crate) const END_OF_TEXT: &str = "<|endoftext|>";
-pub const SMOLLM2_DEFAULT_SYSTEM_PROMPT: &str =
+pub(crate) const SMOLLM2_DEFAULT_SYSTEM_PROMPT: &str =
     "You are a helpful AI assistant named SmolLM, trained by Hugging Face";
 
 /// Explicit conversation and generated-output protocol selected from validated artifacts.

--- a/crates/rig-core/src/client/mod.rs
+++ b/crates/rig-core/src/client/mod.rs
@@ -1263,7 +1263,6 @@ mod wasm_model_listing_compile_checks {
             .map(assert_model_listing_client);
     }
 
-    #[allow(dead_code)]
     fn compile_assertions() {
         assert_simple_model_listers_accept_wasm_only_http_clients();
     }

--- a/crates/rig-core/src/client/mod.rs
+++ b/crates/rig-core/src/client/mod.rs
@@ -1263,6 +1263,9 @@ mod wasm_model_listing_compile_checks {
             .map(assert_model_listing_client);
     }
 
+    // Only referenced on the wasm target's compile pass; native builds see it
+    // as dead code.
+    #[allow(dead_code)]
     fn compile_assertions() {
         assert_simple_model_listers_accept_wasm_only_http_clients();
     }

--- a/crates/rig-core/src/http_client/retry.rs
+++ b/crates/rig-core/src/http_client/retry.rs
@@ -50,11 +50,7 @@ impl RetryPolicy for ExponentialBackoff {
                 .is_none_or(|max_retries| retry_num < max_retries)
             {
                 let duration = last_duration.mul_f64(self.factor);
-                if let Some(max_duration) = self.max_duration {
-                    Some(duration.min(max_duration))
-                } else {
-                    Some(duration)
-                }
+                Some(self.max_duration.map_or(duration, |max| duration.min(max)))
             } else {
                 None
             }

--- a/crates/rig-core/src/loaders/epub/loader.rs
+++ b/crates/rig-core/src/loaders/epub/loader.rs
@@ -64,9 +64,9 @@ impl Loadable for PathBuf {
 ///     for (path, chapters) in contents {
 ///         println!("{}", path.display());
 ///         for (idx, chapter) in chapters {
-///             println!("Chapter {} begins", idx);
-///             println!("{}", chapter);
-///             println!("Chapter {} ends", idx);
+///             println!("Chapter {idx} begins");
+///             println!("{chapter}");
+///             println!("Chapter {idx} ends");
 ///         }
 ///     }
 ///
@@ -83,9 +83,9 @@ impl Loadable for PathBuf {
 ///     for (path, chapters) in contents {
 ///         println!("{}", path.display());
 ///         for (idx, chapter) in chapters {
-///             println!("Chapter {} begins", idx);
-///             println!("{}", chapter);
-///             println!("Chapter {} ends", idx);
+///             println!("Chapter {idx} begins");
+///             println!("{chapter}");
+///             println!("Chapter {idx} ends");
 ///         }
 ///     }
 ///
@@ -118,8 +118,8 @@ impl<'a, P> EpubFileLoader<'a, Result<PathBuf, EpubLoaderError>, P> {
     /// let content = EpubFileLoader::<_, RawTextProcessor>::with_glob("tests/data/*.epub")?.load().into_iter();
     /// for result in content {
     ///     match result {
-    ///         Ok(doc) => println!("{:?}", doc),
-    ///         Err(e) => eprintln!("Error reading epub: {}", e),
+    ///         Ok(doc) => println!("{doc:?}"),
+    ///         Err(e) => eprintln!("Error reading epub: {e}"),
     ///     }
     /// }
     /// # Ok(())
@@ -146,8 +146,8 @@ impl<'a, P> EpubFileLoader<'a, Result<PathBuf, EpubLoaderError>, P> {
     /// let content = EpubFileLoader::<_, RawTextProcessor>::with_glob("tests/data/*.epub")?.load_with_path().into_iter();
     /// for result in content {
     ///     match result {
-    ///         Ok((path, doc)) => println!("{:?} {:?}", path, doc),
-    ///         Err(e) => eprintln!("Error reading epub: {}", e),
+    ///         Ok((path, doc)) => println!("{path:?} {doc:?}"),
+    ///         Err(e) => eprintln!("Error reading epub: {e}"),
     ///     }
     /// }
     /// # Ok(())
@@ -177,8 +177,8 @@ where
     /// let content = EpubFileLoader::<_, RawTextProcessor>::with_glob("tests/data/*.epub")?.read().into_iter();
     /// for result in content {
     ///     match result {
-    ///         Ok(content) => println!("{}", content),
-    ///         Err(e) => eprintln!("Error reading epub: {}", e),
+    ///         Ok(content) => println!("{content}"),
+    ///         Err(e) => eprintln!("Error reading epub: {e}"),
     ///     }
     /// }
     /// # Ok(())
@@ -212,8 +212,8 @@ where
     /// let content = EpubFileLoader::<_, RawTextProcessor>::with_glob("tests/data/*.epub")?.read_with_path().into_iter();
     /// for result in content {
     ///     match result {
-    ///         Ok((path, content)) => println!("{:?} {}", path, content),
-    ///         Err(e) => eprintln!("Error reading epub: {}", e),
+    ///         Ok((path, content)) => println!("{path:?} {content}"),
+    ///         Err(e) => eprintln!("Error reading epub: {e}"),
     ///     }
     /// }
     /// # Ok(())
@@ -256,8 +256,8 @@ where
     ///     .into_iter();
     /// for result in content {
     ///     match result {
-    ///         Ok(chapter) => println!("{}", chapter),
-    ///         Err(e) => eprintln!("Error reading chapter: {}", e),
+    ///         Ok(chapter) => println!("{chapter}"),
+    ///         Err(e) => eprintln!("Error reading chapter: {e}"),
     ///     }
     /// }
     /// # Ok(())
@@ -290,7 +290,7 @@ impl<'a, P: TextProcessor> EpubFileLoader<'a, (PathBuf, EpubDoc<BufReader<File>>
     ///     .into_iter();
     ///
     /// for result in content {
-    ///     println!("{:?}", result);
+    ///     println!("{result:?}");
     /// }
     /// # Ok(())
     /// # }

--- a/crates/rig-core/src/loaders/file.rs
+++ b/crates/rig-core/src/loaders/file.rs
@@ -77,7 +77,7 @@ impl Readable for Vec<u8> {
 ///         .collect();
 ///
 ///     for content in contents {
-///         println!("{}", content);
+///         println!("{content}");
 ///     }
 ///
 ///     Ok(())
@@ -104,8 +104,8 @@ impl<'a, T: Readable + 'a> FileLoader<'a, T> {
     /// let content = FileLoader::with_glob("files/*.txt")?.read();
     /// for result in content {
     ///     match result {
-    ///         Ok(content) => println!("{}", content),
-    ///         Err(e) => eprintln!("Error reading file: {}", e),
+    ///         Ok(content) => println!("{content}"),
+    ///         Err(e) => eprintln!("Error reading file: {e}"),
     ///     }
     /// }
     /// # Ok(())
@@ -129,8 +129,8 @@ impl<'a, T: Readable + 'a> FileLoader<'a, T> {
     /// let content = FileLoader::with_glob("files/*.txt")?.read_with_path();
     /// for result in content {
     ///     match result {
-    ///         Ok((path, content)) => println!("{:?} {}", path, content),
-    ///         Err(e) => eprintln!("Error reading file: {}", e),
+    ///         Ok((path, content)) => println!("{path:?} {content}"),
+    ///         Err(e) => eprintln!("Error reading file: {e}"),
     ///     }
     /// }
     /// # Ok(())

--- a/crates/rig-core/src/loaders/pdf.rs
+++ b/crates/rig-core/src/loaders/pdf.rs
@@ -76,7 +76,7 @@ impl Loadable for Vec<u8> {
 ///         .collect();
 ///
 ///     for content in contents {
-///         println!("{}", content);
+///         println!("{content}");
 ///     }
 ///
 ///     Ok(())
@@ -105,8 +105,8 @@ impl<'a, T: Loadable + 'a> PdfFileLoader<'a, T> {
     /// let content = PdfFileLoader::with_glob("tests/data/*.pdf")?.load().into_iter();
     /// for result in content {
     ///     match result {
-    ///         Ok(doc) => println!("{:?}", doc),
-    ///         Err(e) => eprintln!("Error reading pdf: {}", e),
+    ///         Ok(doc) => println!("{doc:?}"),
+    ///         Err(e) => eprintln!("Error reading pdf: {e}"),
     ///     }
     /// }
     /// # Ok(())
@@ -131,8 +131,8 @@ impl<'a, T: Loadable + 'a> PdfFileLoader<'a, T> {
     /// let content = PdfFileLoader::with_glob("tests/data/*.pdf")?.load_with_path().into_iter();
     /// for result in content {
     ///     match result {
-    ///         Ok((path, doc)) => println!("{:?} {:?}", path, doc),
-    ///         Err(e) => eprintln!("Error reading pdf: {}", e),
+    ///         Ok((path, doc)) => println!("{path:?} {doc:?}"),
+    ///         Err(e) => eprintln!("Error reading pdf: {e}"),
     ///     }
     /// }
     /// # Ok(())
@@ -178,8 +178,8 @@ impl<'a, T: Loadable + 'a> PdfFileLoader<'a, T> {
     /// let content = PdfFileLoader::with_glob("tests/data/*.pdf")?.read().into_iter();
     /// for result in content {
     ///     match result {
-    ///         Ok(content) => println!("{}", content),
-    ///         Err(e) => eprintln!("Error reading pdf: {}", e),
+    ///         Ok(content) => println!("{content}"),
+    ///         Err(e) => eprintln!("Error reading pdf: {e}"),
     ///     }
     /// }
     /// # Ok(())
@@ -204,8 +204,8 @@ impl<'a, T: Loadable + 'a> PdfFileLoader<'a, T> {
     /// let content = PdfFileLoader::with_glob("tests/data/*.pdf")?.read_with_path().into_iter();
     /// for result in content {
     ///     match result {
-    ///         Ok((path, content)) => println!("{:?} {}", path, content),
-    ///         Err(e) => eprintln!("Error reading pdf: {}", e),
+    ///         Ok((path, content)) => println!("{path:?} {content}"),
+    ///         Err(e) => eprintln!("Error reading pdf: {e}"),
     ///     }
     /// }
     /// # Ok(())
@@ -238,8 +238,8 @@ impl<'a> PdfFileLoader<'a, Document> {
     ///     .into_iter();
     /// for result in content {
     ///     match result {
-    ///         Ok(page) => println!("{}", page),
-    ///         Err(e) => eprintln!("Error reading pdf: {}", e),
+    ///         Ok(page) => println!("{page}"),
+    ///         Err(e) => eprintln!("Error reading pdf: {e}"),
     ///     }
     /// }
     /// # Ok(())
@@ -276,8 +276,8 @@ impl<'a> PdfFileLoader<'a, (PathBuf, Document)> {
     ///     println!("{}", path.display());
     ///     for (pageno, result) in pages {
     ///         match result {
-    ///             Ok(content) => println!("Page {}: {}", pageno, content),
-    ///             Err(e) => eprintln!("Error reading page: {}", e),
+    ///             Ok(content) => println!("Page {pageno}: {content}"),
+    ///             Err(e) => eprintln!("Error reading page: {e}"),
     ///         }
     ///     }
     /// }

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -192,14 +192,10 @@ impl std::fmt::Display for Usage {
             f,
             "Input tokens: {}\nCache read input tokens: {}\nCache creation input tokens: {}\nOutput tokens: {}",
             self.input_tokens,
-            match self.cache_read_input_tokens {
-                Some(token) => token.to_string(),
-                None => "n/a".to_string(),
-            },
-            match self.cache_creation_input_tokens {
-                Some(token) => token.to_string(),
-                None => "n/a".to_string(),
-            },
+            self.cache_read_input_tokens
+                .map_or_else(|| "n/a".to_string(), |token| token.to_string()),
+            self.cache_creation_input_tokens
+                .map_or_else(|| "n/a".to_string(), |token| token.to_string()),
             self.output_tokens
         )
     }
@@ -2704,12 +2700,12 @@ pub(super) fn extract_top_level_cache_control(
 
 pub(super) fn resolve_top_level_cache_control(
     automatic_caching: bool,
-    automatic_caching_ttl: &Option<CacheTtl>,
+    automatic_caching_ttl: Option<&CacheTtl>,
     additional_params: &mut serde_json::Value,
 ) -> Result<Option<CacheControl>, CompletionError> {
     let raw_cache_control = extract_top_level_cache_control(additional_params)?;
     let typed_cache_control = automatic_caching.then_some(CacheControl::Ephemeral {
-        ttl: automatic_caching_ttl.clone(),
+        ttl: automatic_caching_ttl.cloned(),
     });
 
     match (typed_cache_control, raw_cache_control) {
@@ -2855,7 +2851,7 @@ impl AnthropicCompletionRequest {
             .unwrap_or(serde_json::Value::Null);
         let top_level_cache_control = resolve_top_level_cache_control(
             automatic_caching,
-            &automatic_caching_ttl,
+            automatic_caching_ttl.as_ref(),
             &mut additional_params_payload,
         )?;
         let mut tools =

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -1172,7 +1172,7 @@ mod tests {
             "cache_control": {"type": "ephemeral", "ttl": "1h"}
         });
         let top_level_cache_control =
-            resolve_top_level_cache_control(false, &None, &mut additional_params).unwrap();
+            resolve_top_level_cache_control(false, None, &mut additional_params).unwrap();
         let mut tools =
             build_tool_definitions::<crate::providers::anthropic::client::AnthropicExt>(
                 vec![crate::completion::ToolDefinition {

--- a/crates/rig-core/src/providers/copilot/auth/native.rs
+++ b/crates/rig-core/src/providers/copilot/auth/native.rs
@@ -343,10 +343,7 @@ impl ApiKeyRecord {
             return false;
         }
 
-        match bootstrap_token {
-            Some(bootstrap_token) => self.matches_bootstrap_token(bootstrap_token),
-            None => true,
-        }
+        bootstrap_token.is_none_or(|bootstrap_token| self.matches_bootstrap_token(bootstrap_token))
     }
 
     fn can_reuse_for_bootstrap_token(&self, bootstrap_token: &str) -> bool {

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -1642,14 +1642,10 @@ pub mod gemini_api_types {
                 f,
                 "Prompt token count: {}\nCached content token count: {}\nCandidates token count: {}\nTotal token count: {}",
                 self.prompt_token_count,
-                match self.cached_content_token_count {
-                    Some(count) => count.to_string(),
-                    None => "n/a".to_string(),
-                },
-                match self.candidates_token_count {
-                    Some(count) => count.to_string(),
-                    None => "n/a".to_string(),
-                },
+                self.cached_content_token_count
+                    .map_or_else(|| "n/a".to_string(), |count| count.to_string()),
+                self.candidates_token_count
+                    .map_or_else(|| "n/a".to_string(), |count| count.to_string()),
                 self.total_token_count
             )
         }
@@ -2068,11 +2064,10 @@ pub mod gemini_api_types {
     /// schema references.
     pub fn flatten_schema(mut schema: Value) -> Result<Value, CompletionError> {
         // extracting $defs if they exist
-        let defs = if let Some(obj) = schema.as_object() {
-            obj.get("$defs").or_else(|| obj.get("definitions")).cloned()
-        } else {
-            None
-        };
+        let defs = schema
+            .as_object()
+            .and_then(|obj| obj.get("$defs").or_else(|| obj.get("definitions")))
+            .cloned();
 
         let Some(defs_value) = defs else {
             return Ok(schema);

--- a/crates/rig-core/src/providers/gemini/transcription.rs
+++ b/crates/rig-core/src/providers/gemini/transcription.rs
@@ -55,12 +55,9 @@ where
             role: Some(Role::Model),
         });
 
-        let mime_type =
-            if let Some(mime) = mime_guess::from_path(Path::new(&request.filename)).first() {
-                mime.to_string()
-            } else {
-                "audio/mpeg".to_string()
-            };
+        let mime_type = mime_guess::from_path(Path::new(&request.filename))
+            .first()
+            .map_or_else(|| "audio/mpeg".to_string(), |mime| mime.to_string());
 
         let request = GenerateContentRequest {
             contents: vec![Content {

--- a/crates/rig-core/src/providers/internal/device_auth.rs
+++ b/crates/rig-core/src/providers/internal/device_auth.rs
@@ -37,10 +37,7 @@ pub(crate) fn token_expired(expires_at: Option<i64>, skew_seconds: i64) -> bool 
         .map(|duration| duration.as_secs() as i64)
         .unwrap_or_default();
 
-    match expires_at {
-        Some(exp) => now >= exp - skew_seconds,
-        None => true,
-    }
+    expires_at.is_none_or(|exp| now >= exp - skew_seconds)
 }
 
 /// Reads a JSON record from `path`, returning `T::default()` when no path is

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -34,7 +34,7 @@
 //!     "Why is the sky blue?".to_owned(),
 //!     "Why is the grass green?".to_owned()
 //! ]).await?;
-//! println!("Embedding response: {:?}", embeddings);
+//! println!("Embedding response: {embeddings:?}");
 //! # Ok(())
 //! # }
 //! ```

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -555,10 +555,10 @@ impl TryFrom<(&str, CompletionRequest)> for OllamaCompletionRequest {
         crate::providers::internal::resolve_empty_tool_result_names(&mut partial_history);
 
         // Add preamble to chat history (if available)
-        let mut full_history: Vec<Message> = match &req.preamble {
-            Some(preamble) => vec![Message::system(preamble)],
-            None => vec![],
-        };
+        let mut full_history: Vec<Message> = req
+            .preamble
+            .as_deref()
+            .map_or_else(Vec::new, |preamble| vec![Message::system(preamble)]);
 
         // Convert and extend the rest of the history
         full_history.extend(

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -887,10 +887,7 @@ impl TryFrom<message::UserContent> for UserContent {
                 DocumentSourceKind::Base64(data) => Ok(UserContent::Audio {
                     input_audio: InputAudio {
                         data,
-                        format: match media_type {
-                            Some(media_type) => media_type,
-                            None => AudioMediaType::MP3,
-                        },
+                        format: media_type.unwrap_or(AudioMediaType::MP3),
                     },
                 }),
                 DocumentSourceKind::Url(_) => Err(message::MessageError::ConversionError(

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -532,11 +532,9 @@ impl TryFrom<crate::completion::Message> for Vec<InputItem> {
                         }) => {
                             let url = match data {
                                 DocumentSourceKind::Base64(data) => {
-                                    let media_type = if let Some(media_type) = media_type {
-                                        media_type.to_mime_type().to_string()
-                                    } else {
-                                        String::new()
-                                    };
+                                    let media_type = media_type
+                                        .map(|media_type| media_type.to_mime_type().to_string())
+                                        .unwrap_or_default();
                                     format!("data:{media_type};base64,{data}")
                                 }
                                 DocumentSourceKind::Url(url) => url,

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -457,17 +457,13 @@ impl RawChoiceAccumulator {
 
     /// Open the text block for the message item a text/refusal delta belongs
     /// to, when the wire identifies it and it differs from the open one.
-    fn start_text_item(
-        &mut self,
-        item_id: &Option<String>,
-        immediate: &mut Vec<StreamingRawChoice>,
-    ) {
+    fn start_text_item(&mut self, item_id: Option<&str>, immediate: &mut Vec<StreamingRawChoice>) {
         if let Some(item_id) = item_id
             && self.current_text_item.as_deref() != Some(item_id)
         {
-            self.current_text_item = Some(item_id.clone());
+            self.current_text_item = Some(item_id.to_string());
             immediate.push(streaming::RawStreamingChoice::TextStart {
-                id: crate::streaming::StreamPartId::wire(item_id.clone()),
+                id: crate::streaming::StreamPartId::wire(item_id.to_string()),
                 additional_params: None,
             });
         }
@@ -561,7 +557,7 @@ impl RawChoiceAccumulator {
             // (re)open the item's text block before their fragment.
             ItemChunkKind::OutputTextDelta(DeltaTextChunk { delta, .. })
             | ItemChunkKind::RefusalDelta(DeltaTextChunk { delta, .. }) => {
-                self.start_text_item(&outer_item_id, &mut immediate);
+                self.start_text_item(outer_item_id.as_deref(), &mut immediate);
                 immediate.push(streaming::RawStreamingChoice::Message(delta));
             }
             // Summary and raw-reasoning deltas differ only in which wire

--- a/crates/rig-core/src/streaming/mod.rs
+++ b/crates/rig-core/src/streaming/mod.rs
@@ -406,9 +406,7 @@ impl UnknownPayload {
 impl std::fmt::Debug for UnknownPayload {
     /// Structural metadata only — never the payload.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let bytes = serde_json::to_vec(&self.0)
-            .map(|json| json.len())
-            .unwrap_or(0);
+        let bytes = serde_json::to_vec(&self.0).map_or(0, |json| json.len());
         write!(f, "UnknownPayload({bytes} bytes redacted)")
     }
 }

--- a/crates/rig-core/src/tool/catalog.rs
+++ b/crates/rig-core/src/tool/catalog.rs
@@ -145,7 +145,7 @@ mod tests {
         assert_eq!(catalog.definitions().len(), 2);
         assert_eq!(
             catalog.definitions(),
-            &set.get_tool_definitions()[..2],
+            &set.tool_definitions()[..2],
             "always-exposed definitions are the set's, in order"
         );
         assert!(set.contains("gamma") && !catalog.contains("gamma"));

--- a/crates/rig-core/src/tool/contextual.rs
+++ b/crates/rig-core/src/tool/contextual.rs
@@ -778,7 +778,7 @@ impl ToolSet {
     }
 
     /// Provider-facing definitions in registration order.
-    pub fn get_tool_definitions(&self) -> Vec<ToolDefinition> {
+    pub fn tool_definitions(&self) -> Vec<ToolDefinition> {
         self.tools
             .iter()
             .map(|(name, registration)| registration.tool.definition_with_name(name.clone()))
@@ -924,7 +924,7 @@ mod tests {
     async fn toolset_dispatch_snapshot_is_canonical_and_returns_result_metadata() {
         let mut set = ToolSet::default();
         set.add_tool(Echo);
-        let definitions = set.get_tool_definitions();
+        let definitions = set.tool_definitions();
         assert_eq!(definitions[0].name, "echo");
 
         let mut context = ToolContext::new();

--- a/crates/rig-derive/src/tool/args.rs
+++ b/crates/rig-derive/src/tool/args.rs
@@ -31,11 +31,10 @@ impl MacroArgs {
 }
 
 fn unsupported_argument(path: &syn::Path) -> syn::Error {
-    let message = if let Some(ident) = path.get_ident() {
-        format!("unsupported top-level #[rig_tool] argument `{ident}`")
-    } else {
-        "unsupported top-level #[rig_tool] argument".to_string()
-    };
+    let message = path.get_ident().map_or_else(
+        || "unsupported top-level #[rig_tool] argument".to_string(),
+        |ident| format!("unsupported top-level #[rig_tool] argument `{ident}`"),
+    );
 
     syn::Error::new_spanned(path, message)
 }
@@ -83,7 +82,7 @@ fn validate_explicit_tool_name(name: &str, expr: &Expr) -> syn::Result<()> {
 }
 
 fn reject_duplicate<T>(
-    slot: &Option<T>,
+    slot: Option<&T>,
     spanned: impl quote::ToTokens,
     what: &str,
 ) -> syn::Result<()> {
@@ -124,13 +123,13 @@ impl Parse for MacroArgs {
 
                     match ident.to_string().as_str() {
                         "name" => {
-                            reject_duplicate(&name, &nv.path, "name")?;
+                            reject_duplicate(name.as_ref(), &nv.path, "name")?;
                             let parsed_name = parse_string_literal(&nv.value, "name")?;
                             validate_explicit_tool_name(&parsed_name, &nv.value)?;
                             name = Some(parsed_name);
                         }
                         "description" => {
-                            reject_duplicate(&description, &nv.path, "description")?;
+                            reject_duplicate(description.as_ref(), &nv.path, "description")?;
                             description = Some(parse_string_literal(&nv.value, "description")?);
                         }
                         _ => {
@@ -146,7 +145,11 @@ impl Parse for MacroArgs {
 
                     match ident.to_string().as_str() {
                         "params" => {
-                            reject_duplicate(&param_descriptions, &list.path, "params(...)")?;
+                            reject_duplicate(
+                                param_descriptions.as_ref(),
+                                &list.path,
+                                "params(...)",
+                            )?;
                             let nested: Punctuated<Meta, Token![,]> =
                                 list.parse_args_with(Punctuated::parse_terminated)?;
 
@@ -182,7 +185,7 @@ impl Parse for MacroArgs {
                             param_descriptions = Some(descriptions);
                         }
                         "required" => {
-                            reject_duplicate(&required, &list.path, "required(...)")?;
+                            reject_duplicate(required.as_ref(), &list.path, "required(...)")?;
                             let required_variables: Punctuated<Ident, Token![,]> =
                                 list.parse_args_with(Punctuated::parse_terminated)?;
 

--- a/crates/rig-derive/src/tool/expand.rs
+++ b/crates/rig-derive/src/tool/expand.rs
@@ -143,10 +143,10 @@ pub(crate) fn expand_rig_tool(
     let fn_doc = extract_doc_comment(&input_fn.attrs);
     let tool_description = match &args.description {
         Some(desc) => quote! { #desc.to_string() },
-        None => match fn_doc {
-            Some(doc) => quote! { #doc.to_string() },
-            None => quote! { format!("Function to {}", #tool_name) },
-        },
+        None => fn_doc.map_or_else(
+            || quote! { format!("Function to {}", #tool_name) },
+            |doc| quote! { #doc.to_string() },
+        ),
     };
 
     // Classify parameters: model-facing fields are built independently from

--- a/crates/rig-memory/src/lib.rs
+++ b/crates/rig-memory/src/lib.rs
@@ -661,7 +661,7 @@ macro_rules! stateful_wrapper_common {
             /// Useful for telemetry and leak detection. Returns `0` if the
             /// internal state lock is poisoned.
             pub fn tracked_conversations(&self) -> usize {
-                self.state.lock().map(|g| g.len()).unwrap_or(0)
+                self.state.lock().map_or(0, |g| g.len())
             }
         }
 
@@ -1336,10 +1336,10 @@ fn truncate_summary(buf: &str, cap: usize) -> String {
     const MARKER: &str = "[\u{2026}truncated\u{2026}]\n";
     // Body starts right after the first newline in `buf`. If `buf` has
     // no newline at all there is no body to drop, so return as-is.
-    let header_prefix_len = match buf.find('\n') {
-        Some(i) => i + 1,
-        None => return buf.to_string(),
+    let Some(newline) = buf.find('\n') else {
+        return buf.to_string();
     };
+    let header_prefix_len = newline + 1;
     if buf.len() <= header_prefix_len {
         return buf.to_string();
     }

--- a/crates/rig-milvus/src/lib.rs
+++ b/crates/rig-milvus/src/lib.rs
@@ -8,6 +8,8 @@
 
 mod filter;
 
+pub use filter::{Filter, MilvusValue};
+
 use reqwest::StatusCode;
 use rig_core::{
     Embed,
@@ -18,8 +20,6 @@ use rig_core::{
     },
 };
 use serde::{Deserialize, Serialize};
-
-use crate::filter::Filter;
 
 /// Represents a vector store implementation using Milvus - <https://milvus.io/> as the backend.
 ///

--- a/crates/rig-milvus/src/lib.rs
+++ b/crates/rig-milvus/src/lib.rs
@@ -40,10 +40,10 @@ pub struct MilvusVectorStore {
 /// [`rig_core::http_client::Error`]: a status-carrying failure keeps its status
 /// as `InvalidStatusCode`, a response-less one becomes `Instance`.
 fn from_reqwest(err: reqwest::Error) -> rig_core::http_client::Error {
-    match err.status() {
-        Some(status) => rig_core::http_client::Error::InvalidStatusCode(status),
-        None => rig_core::http_client::Error::instance(err),
-    }
+    err.status().map_or_else(
+        || rig_core::http_client::Error::instance(err),
+        rig_core::http_client::Error::InvalidStatusCode,
+    )
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/rig-neo4j/src/lib.rs
+++ b/crates/rig-neo4j/src/lib.rs
@@ -82,7 +82,7 @@
 //!         plot: String,
 //!     }
 //!     let results = index.top_n::<Movie>("Batman", 3).await.unwrap();
-//!     println!("{:#?}", results);
+//!     println!("{results:#?}");
 //! }
 //! ```
 pub mod vector_index;

--- a/crates/rig-postgres/src/lib.rs
+++ b/crates/rig-postgres/src/lib.rs
@@ -8,7 +8,7 @@
 //! The root `rig` facade re-exports this crate as `rig::postgres` when the
 //! `postgres` feature is enabled.
 
-use std::{fmt::Display, ops::RangeInclusive};
+use std::{fmt::Display, fmt::Write as _, ops::RangeInclusive};
 
 use rig_core::{
     Embed,
@@ -310,7 +310,7 @@ impl PostgresVectorStore {
             buf.push(c);
 
             if c == '$' {
-                buf.push_str(counter.to_string().as_str());
+                let _ = write!(buf, "{counter}");
                 counter += 1;
             }
         }

--- a/crates/rig-reqwest/src/lib.rs
+++ b/crates/rig-reqwest/src/lib.rs
@@ -126,10 +126,8 @@ use std::pin::Pin;
 /// paths can still read the code; a response-less failure (connect, decode,
 /// timeout) becomes [`Error::Instance`].
 pub fn from_reqwest(err: reqwest::Error) -> Error {
-    match err.status() {
-        Some(status) => Error::InvalidStatusCode(status),
-        None => Error::instance(err),
-    }
+    err.status()
+        .map_or_else(|| Error::instance(err), Error::InvalidStatusCode)
 }
 
 /// Read the status, headers and body off a failed `reqwest::Response` and

--- a/crates/rig-reqwest/src/openai_websocket.rs
+++ b/crates/rig-reqwest/src/openai_websocket.rs
@@ -388,10 +388,7 @@ where
         }
 
         loop {
-            let message = match self.read_next_message().await {
-                Ok(message) => message,
-                Err(error) => return Err(error),
-            };
+            let message = self.read_next_message().await?;
 
             let Some(message) = message else {
                 self.mark_closed();

--- a/crates/rig-rmcp/src/tests.rs
+++ b/crates/rig-rmcp/src/tests.rs
@@ -742,7 +742,7 @@ mod migrated_tests {
         ]);
         let handle = ToolServer::new().run();
         let (client, task) = connect(server, handle.clone()).await;
-        let defs = handle.get_tool_defs(None).await.unwrap();
+        let defs = handle.tool_defs(None).await.unwrap();
         assert_eq!(
             defs.iter().map(|d| d.name.as_str()).collect::<Vec<_>>(),
             vec!["tool_a", "tool_b"]
@@ -756,11 +756,11 @@ mod migrated_tests {
         let server = DynamicToolServer::new(vec![make_tool("tool_a", "First")]);
         let handle = ToolServer::new().run();
         let (client, task) = connect(server, handle.clone()).await;
-        assert_eq!(handle.get_tool_defs(None).await.unwrap().len(), 1);
+        assert_eq!(handle.tool_defs(None).await.unwrap().len(), 1);
 
         client.cancel().await.unwrap();
 
-        let defs = handle.get_tool_defs(None).await.unwrap();
+        let defs = handle.tool_defs(None).await.unwrap();
         assert!(
             defs.is_empty(),
             "a disconnected sole owner must not remain provider-visible"
@@ -773,7 +773,7 @@ mod migrated_tests {
         let server = DynamicToolServer::new(vec![make_tool("tool_a", "First")]);
         let handle = ToolServer::new().run();
         let (client, task) = connect(server, handle.clone()).await;
-        assert_eq!(handle.get_tool_defs(None).await.unwrap().len(), 1);
+        assert_eq!(handle.tool_defs(None).await.unwrap().len(), 1);
 
         client.cancel().await.unwrap();
 
@@ -843,7 +843,7 @@ mod migrated_tests {
             .connect((cfs, c2s))
             .await
             .unwrap();
-        assert_eq!(handle.get_tool_defs(None).await.unwrap()[0].name, "alpha");
+        assert_eq!(handle.tool_defs(None).await.unwrap()[0].name, "alpha");
         server
             .set_tools(vec![make_tool("beta", "Beta"), make_tool("gamma", "Gamma")])
             .await;
@@ -851,7 +851,7 @@ mod migrated_tests {
         running.peer().notify_tool_list_changed().await.unwrap();
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
-                let defs = handle.get_tool_defs(None).await.unwrap();
+                let defs = handle.tool_defs(None).await.unwrap();
                 if defs.len() == 2 {
                     break;
                 }
@@ -861,7 +861,7 @@ mod migrated_tests {
         .await
         .expect("refresh");
         let names = handle
-            .get_tool_defs(None)
+            .tool_defs(None)
             .await
             .unwrap()
             .into_iter()
@@ -907,7 +907,7 @@ mod migrated_tests {
 
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
-                let defs = handle.get_tool_defs(None).await.unwrap();
+                let defs = handle.tool_defs(None).await.unwrap();
                 if defs.len() == 1 && defs[0].name == "newest" {
                     break;
                 }
@@ -929,7 +929,7 @@ mod migrated_tests {
         for _ in 0..10 {
             tokio::task::yield_now().await;
         }
-        let defs = handle.get_tool_defs(None).await.unwrap();
+        let defs = handle.tool_defs(None).await.unwrap();
         assert_eq!(defs.len(), 1);
         assert_eq!(defs[0].name, "newest");
 
@@ -960,7 +960,7 @@ mod migrated_tests {
 
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
-                let defs = handle.get_tool_defs(None).await.unwrap();
+                let defs = handle.tool_defs(None).await.unwrap();
                 let names = defs
                     .iter()
                     .map(|definition| definition.name.as_str())
@@ -989,7 +989,7 @@ mod migrated_tests {
         let (second_client, second_server_task) = connect(second_server, handle.clone()).await;
         let second_running_server = second_server_task.await.unwrap();
         assert_eq!(
-            handle.get_tool_defs(None).await.unwrap()[0].description,
+            handle.tool_defs(None).await.unwrap()[0].description,
             "Second owner"
         );
 
@@ -1001,7 +1001,7 @@ mod migrated_tests {
             .unwrap();
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
-                if handle.get_tool_defs(None).await.unwrap().is_empty() {
+                if handle.tool_defs(None).await.unwrap().is_empty() {
                     break;
                 }
                 tokio::task::yield_now().await;
@@ -1023,7 +1023,7 @@ mod migrated_tests {
             .unwrap();
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
-                let defs = handle.get_tool_defs(None).await.unwrap();
+                let defs = handle.tool_defs(None).await.unwrap();
                 if defs.len() == 1 && defs[0].description == "First owner refreshed" {
                     break;
                 }
@@ -1057,7 +1057,7 @@ mod migrated_tests {
 
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
-                let defs = handle.get_tool_defs(None).await.unwrap();
+                let defs = handle.tool_defs(None).await.unwrap();
                 if defs
                     .iter()
                     .any(|definition| definition.name == "refresh_complete")
@@ -1070,7 +1070,7 @@ mod migrated_tests {
         .await
         .expect("MCP refresh completed");
 
-        let defs = handle.get_tool_defs(None).await.unwrap();
+        let defs = handle.tool_defs(None).await.unwrap();
         let alpha = defs
             .iter()
             .find(|definition| definition.name == "alpha")
@@ -1110,7 +1110,7 @@ mod migrated_tests {
 
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
-                let defs = handle.get_tool_defs(None).await.unwrap();
+                let defs = handle.tool_defs(None).await.unwrap();
                 if defs
                     .iter()
                     .any(|definition| definition.name == "a_refresh_complete")
@@ -1123,7 +1123,7 @@ mod migrated_tests {
         .await
         .expect("handler A refresh completed");
 
-        let defs = handle.get_tool_defs(None).await.unwrap();
+        let defs = handle.tool_defs(None).await.unwrap();
         let alpha = defs
             .iter()
             .find(|definition| definition.name == "alpha")
@@ -1145,7 +1145,7 @@ mod migrated_tests {
 
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
-                let defs = handle.get_tool_defs(None).await.unwrap();
+                let defs = handle.tool_defs(None).await.unwrap();
                 if defs
                     .iter()
                     .any(|definition| definition.description == "Reclaimed handler A")
@@ -1195,13 +1195,13 @@ mod migrated_tests {
         let handle = ToolServer::new()
             .portable_dynamic_tool(McpTool::from_mcp_server(tool, client.peer().clone()).into())
             .run();
-        let defs = handle.get_tool_defs(None).await.unwrap();
+        let defs = handle.tool_defs(None).await.unwrap();
         assert_eq!(defs.len(), 1);
         assert_eq!(defs[0].name, "search_docs");
         assert_eq!(defs[0].description, "Search the docs");
         client.cancel().await.unwrap();
 
-        let defs = handle.get_tool_defs(None).await.unwrap();
+        let defs = handle.tool_defs(None).await.unwrap();
         assert!(
             defs.is_empty(),
             "a disconnected directly registered MCP tool must not remain provider-visible"
@@ -1309,11 +1309,7 @@ mod migrated_tests {
                     .collect(),
             )
             .build();
-        let definitions = agent
-            .tool_server_handle()
-            .get_tool_defs(None)
-            .await
-            .unwrap();
+        let definitions = agent.tool_server_handle().tool_defs(None).await.unwrap();
         assert_eq!(
             definitions
                 .iter()

--- a/crates/rig-vectorize/src/client/types.rs
+++ b/crates/rig-vectorize/src/client/types.rs
@@ -81,7 +81,6 @@ pub struct ApiMessage {
 #[derive(Debug, Clone, Deserialize)]
 pub struct QueryResult {
     /// Number of matches returned.
-    #[allow(dead_code)]
     pub count: u64,
 
     /// The matching vectors.
@@ -99,7 +98,6 @@ pub struct VectorMatch {
 
     /// The vector values (only present if `returnValues: true`).
     #[serde(default)]
-    #[allow(dead_code)]
     pub values: Option<Vec<f64>>,
 
     /// Metadata associated with the vector.
@@ -108,7 +106,6 @@ pub struct VectorMatch {
 
     /// The namespace this vector belongs to.
     #[serde(default)]
-    #[allow(dead_code)]
     pub namespace: Option<String>,
 }
 
@@ -140,7 +137,6 @@ pub struct UpsertRequest {
 /// Result payload from an upsert request.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 pub struct UpsertResult {
     /// Mutation identifier for tracking async processing.
     pub mutation_id: String,
@@ -156,7 +152,6 @@ pub struct DeleteByIdsRequest {
 /// Result payload from a delete_by_ids request.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 pub struct DeleteResult {
     /// Mutation identifier for tracking async processing.
     pub mutation_id: String,

--- a/crates/rig-vertexai/src/client.rs
+++ b/crates/rig-vertexai/src/client.rs
@@ -105,7 +105,7 @@ impl ClientBuilder {
 
     /// Build the client with the configured values, falling back to environment variables where not set.
     ///
-    /// The Vertex AI client is built lazily on first use via `get_inner()`.
+    /// The Vertex AI client is built lazily on first use via `inner()`.
     pub fn build(self) -> Result<Client, VertexAiClientError> {
         let project = self
             .project
@@ -203,9 +203,7 @@ impl Client {
         &self.location
     }
 
-    pub async fn get_inner(
-        &self,
-    ) -> Result<&vertexai::client::PredictionService, VertexAiClientError> {
+    pub async fn inner(&self) -> Result<&vertexai::client::PredictionService, VertexAiClientError> {
         let credentials = self.credentials.clone();
         self.vertex_client
             .get_or_init(|| async {

--- a/crates/rig-vertexai/src/completion.rs
+++ b/crates/rig-vertexai/src/completion.rs
@@ -83,7 +83,7 @@ impl CompletionModel {
 
         let mut request_builder = self
             .client
-            .get_inner()
+            .inner()
             .await
             .map_err(|error| CompletionError::ProviderError(error.to_string()))?
             .generate_content()
@@ -162,7 +162,7 @@ impl CompletionModelTrait for CompletionModel {
 /// [`http::StatusCode`] to attach; the error body is preserved via
 /// [`CompletionError::from_provider_body`] (`status: None`) rather than a
 /// Rig-prefixed [`CompletionError::ProviderError`] diagnostic. (The
-/// `get_inner()` client-init failure stays a `ProviderError` because it is a
+/// `inner()` client-init failure stays a `ProviderError` because it is a
 /// Rig-side setup failure, not a provider response.)
 ///
 /// Note: the SDK does not distinguish a server-returned gRPC error from a

--- a/examples/agent_run_stepping/src/main.rs
+++ b/examples/agent_run_stepping/src/main.rs
@@ -98,7 +98,7 @@ async fn main() -> Result<()> {
         .build();
     let mut local_tools = ToolSet::default();
     local_tools.add_tool(Add);
-    let tool_definitions = local_tools.get_tool_definitions();
+    let tool_definitions = local_tools.tool_definitions();
 
     let mut run = AgentRun::new("What is 2 + 5?").max_turns(2);
 

--- a/examples/agent_with_durable_approval/src/main.rs
+++ b/examples/agent_with_durable_approval/src/main.rs
@@ -154,7 +154,7 @@ async fn main() -> Result<()> {
     let mut tools = ToolSet::default();
     tools.add_tool(GetBalance);
     tools.add_tool(TransferFunds);
-    let tool_definitions = tools.get_tool_definitions();
+    let tool_definitions = tools.tool_definitions();
 
     let prompt = "Check the balance of account A-1, then transfer $500 to account B-2.";
     println!("User: {prompt}");

--- a/examples/manual_tool_calls/src/main.rs
+++ b/examples/manual_tool_calls/src/main.rs
@@ -154,7 +154,7 @@ async fn main() -> Result<()> {
             .completion_request(current_prompt.clone())
             .preamble(preamble.to_string())
             .messages(history.clone())
-            .tools(local_tools.get_tool_definitions());
+            .tools(local_tools.tool_definitions());
         if round == 1 {
             // Force the first turn through the tool path so the example always demonstrates it.
             request = request.tool_choice(ToolChoice::Required);

--- a/tests/tool_facade_traits.rs
+++ b/tests/tool_facade_traits.rs
@@ -91,7 +91,7 @@ fn portable_tool_registers_with_classic_toolset() {
     let mut set = ToolSet::default();
     set.add_tool(PortableAdder);
     let names: Vec<String> = set
-        .get_tool_definitions()
+        .tool_definitions()
         .into_iter()
         .map(|definition| definition.name)
         .collect();


### PR DESCRIPTION
Second workspace-wide idiomatic-Rust pass, following up #2409. Baseline was fully clean (clippy 0 warnings), so this round targets what the first sweep missed.

## Commits

- **Combinator cleanups** (workspace): ~20 manual `match`/`if let` ladders on `Option`/`Result` replaced with `map_or`/`map_or_else`/`is_none_or`/`and_then`/`transpose`/`let-else`/`?` across rig-core (anthropic, gemini, openai, ollama, copilot, device_auth, retry, streaming), rig-agent, rig-reqwest, rig-bedrock, rig-memory, rig-derive, rig-postgres (per-char `to_string` → `write!`), rig-milvus. Includes two `&Option<T>` params → `Option<&T>` (`resolve_top_level_cache_control`, responses-API `start_text_item`) and deleting rig-candle's hand-rolled `override_or` (= `Option::unwrap_or`).
- **rig-milvus: re-export `Filter` and `MilvusValue`**: `VectorStoreIndex::Filter` named them in public signatures but the `filter` module was private, so their constructors were unreachable downstream (rig-qdrant already re-exports its filter).
- **rig-candle: `pub(crate)` chat-template constants** — seven `pub const`s in a private module, invisible externally either way.
- **Getter renames** [**breaking**]: `get_tool_definitions` → `tool_definitions` (rig-core contextual tools), `get_tool_defs` → `tool_defs` (rig-agent tool server; siblings already dropped the prefix in #2400), `Client::get_inner` → `inner` (rig-bedrock, rig-vertexai). CHANGELOG updated. Left alone: `multipart::Part::get_filename`/`get_content_type` and `ClientBuilder::get_base_url`, whose unprefixed names collide with same-type builder setters, and verb-like `get_index`/`get_by_id`/`get_interaction` remote fetches.
- **Docs: inline format args in rustdoc examples** — 37 sites in loaders (epub/pdf/file), ollama, rig-neo4j; clippy doesn't lint doctest bodies so #2409 missed them.
- **Drop `#[allow(dead_code)]` that no longer fire** — verified by removal + clippy: 5 stale in rig-vectorize, 1 in rig-core `client/mod.rs`. Ones that still fire were kept.

## Deliberately not touched (surveyed, deferred)

- 402/84/32 undocumented public items in rig-core/rig-bedrock/rig-agent (mostly provider wire DTOs) — needs a `missing_docs` lint decision, not a drive-by.
- ~273 unmarked `#[must_use]` builder methods — better served by gating `clippy::must_use_candidate` than hand-annotation.
- Bool params (`record_content_telemetry(bool)`, `from_string(_, bool)`) — API redesign, not a mechanical refactor.
- `internal::envelope::into_payload -> Result<_, String>` — documented as deliberate.
- Per-test-module clippy allows vs crate-level `cfg_attr(test, ...)` — per-module *is* the dominant idiom here; only rig-s3vectors differs.
- No `rust-version` key anywhere in the workspace (crates publish with no declared MSRV) — flagging, not deciding.

## Verification

- `cargo clippy --workspace --all-features --all-targets`: 0 warnings (matches CI's clippy gate)
- `cargo nextest run --locked -p rig-core -p rig-reqwest -p rig-agent -p rig-rmcp --all-features`: 2214 passed
- nextest on the other 9 touched crates (`--all-features`): 365 passed
- `cargo test --locked --doc --workspace --all-features`: all pass
- `cargo fmt --check`, `cargo doc --locked --no-deps --all-features`: clean