### PR TITLE
refactor: idiomatic Rust sweep, round 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- *(core, agent, bedrock, gemini-grpc)* [**breaking**] `telemetry::ProviderResponseExt` methods drop their `get_` prefix: `get_response_id` → `response_id`, `get_response_model_name` → `response_model_name`, `get_text_response` → `text_response`, `get_usage` → `usage` — continuing the `get_`-prefix sweep across all provider impls
+- *(agent, core, neo4j, vertexai)* builder setters that stored an owned `String` now take `impl Into<String>` instead of `&str` (`AgentBuilder::{name, description, preamble, context}`, Azure `api_version`/`audio_api_version`, Anthropic `anthropic_version`/`anthropic_beta`, neo4j `SearchParams` setters, Vertex AI `with_project`/`with_location`) — every existing `&str` call site still compiles, and an owned `String` is no longer copied
 - *(core, agent, bedrock, vertexai)* [**breaking**] accessors drop their `get_` prefix per Rust naming convention: `ToolCatalog`-side `get_tool_definitions` → `tool_definitions` (rig-core contextual tools), `ToolServerHandle::get_tool_defs` → `tool_defs` (rig-agent), and `Client::get_inner` → `inner` (rig-bedrock, rig-vertexai)
 
 ### Fixed

--- a/crates/rig-agent/src/agent/builder.rs
+++ b/crates/rig-agent/src/agent/builder.rs
@@ -127,19 +127,19 @@ pub struct AgentBuilder<ToolState = NoToolConfig> {
 
 impl<ToolState> AgentBuilder<ToolState> {
     /// Set the name of the agent
-    pub fn name(mut self, name: &str) -> Self {
+    pub fn name(mut self, name: impl Into<String>) -> Self {
         self.config.name = Some(name.into());
         self
     }
 
     /// Set the description of the agent
-    pub fn description(mut self, description: &str) -> Self {
+    pub fn description(mut self, description: impl Into<String>) -> Self {
         self.config.description = Some(description.into());
         self
     }
 
     /// Set the system prompt
-    pub fn preamble(mut self, preamble: &str) -> Self {
+    pub fn preamble(mut self, preamble: impl Into<String>) -> Self {
         self.config.preamble = Some(preamble.into());
         self
     }
@@ -161,7 +161,7 @@ impl<ToolState> AgentBuilder<ToolState> {
     }
 
     /// Add a static context document to the agent
-    pub fn context(mut self, doc: &str) -> Self {
+    pub fn context(mut self, doc: impl Into<String>) -> Self {
         self.config.static_context.push(Document {
             id: format!("static_doc_{}", self.config.static_context.len()),
             text: doc.into(),

--- a/crates/rig-bedrock/src/completion.rs
+++ b/crates/rig-bedrock/src/completion.rs
@@ -261,7 +261,7 @@ impl CompletionModel {
 
             let span = tracing::Span::current();
             span.record_response_metadata(&aws_output);
-            span.record_token_usage(&aws_output.get_usage().unwrap_or_default());
+            span.record_token_usage(&aws_output.usage().unwrap_or_default());
 
             Ok(aws_output)
         }

--- a/crates/rig-bedrock/src/types/assistant_content.rs
+++ b/crates/rig-bedrock/src/types/assistant_content.rs
@@ -38,15 +38,15 @@ pub(crate) fn normalize_usage(usage: &TokenUsage) -> completion::Usage {
 impl ProviderResponseExt for AwsConverseOutput {
     type Usage = completion::Usage;
 
-    fn get_response_id(&self) -> Option<&str> {
+    fn response_id(&self) -> Option<&str> {
         None // Bedrock Converse API doesn't return a response ID
     }
 
-    fn get_response_model_name(&self) -> Option<&str> {
+    fn response_model_name(&self) -> Option<&str> {
         None // Bedrock doesn't echo model name in response
     }
 
-    fn get_text_response(&self) -> Option<String> {
+    fn text_response(&self) -> Option<String> {
         let output = self.0.output.as_ref()?;
         let message = output.as_message().ok()?;
         let response = message
@@ -66,7 +66,7 @@ impl ProviderResponseExt for AwsConverseOutput {
         }
     }
 
-    fn get_usage(&self) -> Option<Self::Usage> {
+    fn usage(&self) -> Option<Self::Usage> {
         self.0.usage().map(normalize_usage)
     }
 }
@@ -434,38 +434,38 @@ mod tests {
     }
 
     #[test]
-    fn provider_response_ext_get_text_response() {
+    fn provider_response_ext_text_response() {
         let out = make_output("hello world", None);
-        assert_eq!(out.get_text_response(), Some("hello world".to_string()));
+        assert_eq!(out.text_response(), Some("hello world".to_string()));
     }
 
     #[test]
     fn provider_response_ext_response_id_is_none() {
         let out = make_output("x", None);
-        assert!(out.get_response_id().is_none());
-        assert!(out.get_response_model_name().is_none());
+        assert!(out.response_id().is_none());
+        assert!(out.response_model_name().is_none());
     }
 
     #[test]
-    fn provider_response_ext_get_usage_with_tokens() {
+    fn provider_response_ext_usage_with_tokens() {
         let out = make_output("x", Some(make_usage(100, 50, 150)));
-        let usage = out.get_usage().unwrap();
+        let usage = out.usage().unwrap();
         assert_eq!(usage.input_tokens, 100);
         assert_eq!(usage.output_tokens, 50);
         assert_eq!(usage.total_tokens, 150);
     }
 
     #[test]
-    fn provider_response_ext_get_usage_none_when_missing() {
+    fn provider_response_ext_usage_none_when_missing() {
         let out = make_output("x", None);
-        assert!(out.get_usage().is_none());
+        assert!(out.usage().is_none());
     }
 
     #[test]
-    fn get_token_usage_delegates_to_provider_response_ext() {
+    fn token_usage_delegates_to_provider_response_ext() {
         let out = make_output("x", Some(make_usage(10, 20, 30)));
         assert_eq!(
-            out.get_usage().unwrap_or_default(),
+            out.usage().unwrap_or_default(),
             completion::Usage {
                 input_tokens: 10,
                 output_tokens: 20,
@@ -476,15 +476,12 @@ mod tests {
     }
 
     #[test]
-    fn get_token_usage_zero_when_no_usage() {
+    fn token_usage_zero_when_no_usage() {
         let out = make_output("x", None);
         // Zero-valued usage is rig's documented sentinel for "the provider
         // reported no usage metrics".
-        assert_eq!(
-            out.get_usage().unwrap_or_default(),
-            completion::Usage::new()
-        );
-        assert!(!out.get_usage().unwrap_or_default().has_values());
+        assert_eq!(out.usage().unwrap_or_default(), completion::Usage::new());
+        assert!(!out.usage().unwrap_or_default().has_values());
     }
 
     #[test]

--- a/crates/rig-core/src/providers/anthropic/client.rs
+++ b/crates/rig-core/src/providers/anthropic/client.rs
@@ -119,7 +119,7 @@ client::impl_provider_from_env!(
 /// # }
 /// ```
 impl<H> ClientBuilder<H> {
-    pub fn anthropic_version(self, anthropic_version: &str) -> Self {
+    pub fn anthropic_version(self, anthropic_version: impl Into<String>) -> Self {
         self.over_ext(|ext| AnthropicBuilder {
             anthropic_version: anthropic_version.into(),
             ..ext
@@ -135,7 +135,7 @@ impl<H> ClientBuilder<H> {
         })
     }
 
-    pub fn anthropic_beta(self, anthropic_beta: &str) -> Self {
+    pub fn anthropic_beta(self, anthropic_beta: impl Into<String>) -> Self {
         self.over_ext(|mut ext| {
             ext.anthropic_betas.push(anthropic_beta.into());
 
@@ -204,7 +204,7 @@ macro_rules! impl_anthropic_compatible_builder {
                 H,
             >
         {
-            pub fn anthropic_version(self, anthropic_version: &str) -> Self {
+            pub fn anthropic_version(self, anthropic_version: impl Into<String>) -> Self {
                 self.over_ext(|mut ext| {
                     ext.anthropic.anthropic_version = anthropic_version.into();
                     ext
@@ -220,7 +220,7 @@ macro_rules! impl_anthropic_compatible_builder {
                 })
             }
 
-            pub fn anthropic_beta(self, anthropic_beta: &str) -> Self {
+            pub fn anthropic_beta(self, anthropic_beta: impl Into<String>) -> Self {
                 self.over_ext(|mut ext| {
                     ext.anthropic.anthropic_betas.push(anthropic_beta.into());
                     ext

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -111,15 +111,15 @@ pub(crate) fn map_finish_reason(stop_reason: &str) -> completion::FinishReason {
 impl ProviderResponseExt for CompletionResponse {
     type Usage = Usage;
 
-    fn get_response_id(&self) -> Option<&str> {
+    fn response_id(&self) -> Option<&str> {
         Some(self.id.as_str())
     }
 
-    fn get_response_model_name(&self) -> Option<&str> {
+    fn response_model_name(&self) -> Option<&str> {
         Some(self.model.as_str())
     }
 
-    fn get_text_response(&self) -> Option<String> {
+    fn text_response(&self) -> Option<String> {
         let res = self
             .content
             .iter()
@@ -135,7 +135,7 @@ impl ProviderResponseExt for CompletionResponse {
         if res.is_empty() { None } else { Some(res) }
     }
 
-    fn get_usage(&self) -> Option<Self::Usage> {
+    fn usage(&self) -> Option<Self::Usage> {
         Some(self.usage)
     }
 }
@@ -6358,7 +6358,7 @@ mod tests {
         let response: CompletionResponse = serde_json::from_value(value).unwrap();
         // The wire response is consumed by the conversion, so read the
         // provider-native text off it first.
-        let raw_text_response = response.get_text_response();
+        let raw_text_response = response.text_response();
         let converted = response.normalize("anthropic").unwrap();
         assert_eq!(converted.choice.len(), 3);
         assert_eq!(
@@ -6715,7 +6715,7 @@ mod tests {
         };
 
         assert_eq!(
-            response.get_text_response().as_deref(),
+            response.text_response().as_deref(),
             Some("According to the document, the grass is green and the sky is blue.")
         );
     }

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -152,7 +152,7 @@ impl ProviderBuilder for AzureExtBuilder {
 
 impl<H> ClientBuilder<H> {
     /// API version to use (e.g., "2024-10-21" for GA, "2024-10-01-preview" for preview)
-    pub fn api_version(mut self, api_version: &str) -> Self {
+    pub fn api_version(mut self, api_version: impl Into<String>) -> Self {
         self.ext_mut().api_version = api_version.into();
 
         self
@@ -162,7 +162,7 @@ impl<H> ClientBuilder<H> {
     ///
     /// This defaults to `2025-04-01-preview`, the first deployment-scoped
     /// Azure API release that exposes text-to-speech.
-    pub fn audio_api_version(mut self, api_version: &str) -> Self {
+    pub fn audio_api_version(mut self, api_version: impl Into<String>) -> Self {
         self.ext_mut().audio_api_version = api_version.into();
 
         self

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -50,15 +50,15 @@ impl CompletionResponse {
 impl crate::telemetry::ProviderResponseExt for CompletionResponse {
     type Usage = Usage;
 
-    fn get_response_id(&self) -> Option<&str> {
+    fn response_id(&self) -> Option<&str> {
         Some(self.id.as_str())
     }
 
-    fn get_response_model_name(&self) -> Option<&str> {
+    fn response_model_name(&self) -> Option<&str> {
         None
     }
 
-    fn get_text_response(&self) -> Option<String> {
+    fn text_response(&self) -> Option<String> {
         let Message::Assistant { ref content, .. } = self.message else {
             return None;
         };
@@ -78,7 +78,7 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
         if res.is_empty() { None } else { Some(res) }
     }
 
-    fn get_usage(&self) -> Option<Self::Usage> {
+    fn usage(&self) -> Option<Self::Usage> {
         self.usage
     }
 }

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -196,15 +196,15 @@ pub struct CompletionResponse {
 impl ProviderResponseExt for CompletionResponse {
     type Usage = Usage;
 
-    fn get_response_id(&self) -> Option<&str> {
+    fn response_id(&self) -> Option<&str> {
         self.id.as_deref()
     }
 
-    fn get_response_model_name(&self) -> Option<&str> {
+    fn response_model_name(&self) -> Option<&str> {
         self.model.as_deref()
     }
 
-    fn get_text_response(&self) -> Option<String> {
+    fn text_response(&self) -> Option<String> {
         self.choices
             .iter()
             .find_map(|choice| match &choice.message {
@@ -213,7 +213,7 @@ impl ProviderResponseExt for CompletionResponse {
             })
     }
 
-    fn get_usage(&self) -> Option<Self::Usage> {
+    fn usage(&self) -> Option<Self::Usage> {
         Some(self.usage)
     }
 }

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -887,15 +887,15 @@ pub mod gemini_api_types {
     impl ProviderResponseExt for GenerateContentResponse {
         type Usage = UsageMetadata;
 
-        fn get_response_id(&self) -> Option<&str> {
+        fn response_id(&self) -> Option<&str> {
             Some(self.response_id.as_str())
         }
 
-        fn get_response_model_name(&self) -> Option<&str> {
+        fn response_model_name(&self) -> Option<&str> {
             self.model_version.as_deref()
         }
 
-        fn get_text_response(&self) -> Option<String> {
+        fn text_response(&self) -> Option<String> {
             let str = self
                 .candidates
                 .iter()
@@ -913,7 +913,7 @@ pub mod gemini_api_types {
             if str.is_empty() { None } else { Some(str) }
         }
 
-        fn get_usage(&self) -> Option<Self::Usage> {
+        fn usage(&self) -> Option<Self::Usage> {
             self.usage_metadata.clone()
         }
     }
@@ -930,7 +930,7 @@ pub mod gemini_api_types {
     /// The *skip* rule lives here; the *join* rule stays with each caller,
     /// because they differ legitimately: a transcript is one continuous text
     /// whose part boundaries are not sentence boundaries, so transcription
-    /// concatenates, while `get_text_response` keeps the newline separator it
+    /// concatenates, while `text_response` keeps the newline separator it
     /// has always used between a candidate's blocks.
     pub(crate) fn visible_text_parts(content: &Content) -> impl Iterator<Item = &str> {
         content.parts.iter().filter_map(|part| match &part.part {

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -755,7 +755,7 @@ pub mod interactions_api_types {
     impl ProviderResponseExt for Interaction {
         type Usage = InteractionUsage;
 
-        fn get_response_id(&self) -> Option<&str> {
+        fn response_id(&self) -> Option<&str> {
             if self.id.is_empty() {
                 None
             } else {
@@ -763,11 +763,11 @@ pub mod interactions_api_types {
             }
         }
 
-        fn get_response_model_name(&self) -> Option<&str> {
+        fn response_model_name(&self) -> Option<&str> {
             self.model.as_deref()
         }
 
-        fn get_text_response(&self) -> Option<String> {
+        fn text_response(&self) -> Option<String> {
             let text = self
                 .output_contents()
                 .iter()
@@ -781,7 +781,7 @@ pub mod interactions_api_types {
             if text.is_empty() { None } else { Some(text) }
         }
 
-        fn get_usage(&self) -> Option<Self::Usage> {
+        fn usage(&self) -> Option<Self::Usage> {
             self.usage
         }
     }

--- a/crates/rig-core/src/providers/llamacpp/completion.rs
+++ b/crates/rig-core/src/providers/llamacpp/completion.rs
@@ -125,20 +125,20 @@ impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
 impl crate::telemetry::ProviderResponseExt for CompletionResponse {
     type Usage = openai::Usage;
 
-    fn get_response_id(&self) -> Option<&str> {
-        self.openai.get_response_id()
+    fn response_id(&self) -> Option<&str> {
+        self.openai.response_id()
     }
 
-    fn get_response_model_name(&self) -> Option<&str> {
-        self.openai.get_response_model_name()
+    fn response_model_name(&self) -> Option<&str> {
+        self.openai.response_model_name()
     }
 
-    fn get_text_response(&self) -> Option<String> {
-        self.openai.get_text_response()
+    fn text_response(&self) -> Option<String> {
+        self.openai.text_response()
     }
 
-    fn get_usage(&self) -> Option<Self::Usage> {
-        self.openai.get_usage()
+    fn usage(&self) -> Option<Self::Usage> {
+        self.openai.usage()
     }
 }
 
@@ -181,7 +181,7 @@ mod tests {
         assert_eq!(response.predicted_tokens_per_second(), Some(118.3));
 
         // The OpenAI half is intact and normalizes exactly as before.
-        assert_eq!(response.get_response_id(), Some("chatcmpl-abc"));
+        assert_eq!(response.response_id(), Some("chatcmpl-abc"));
         assert_eq!(
             response.openai.system_fingerprint.as_deref(),
             Some("b10499-6d05498")
@@ -211,7 +211,7 @@ mod tests {
             .unwrap_or_else(|error| panic!("should decode without timings: {error}"));
         assert!(response.timings.is_none());
         assert!(response.predicted_tokens_per_second().is_none());
-        assert_eq!(response.get_text_response().as_deref(), Some("ok"));
+        assert_eq!(response.text_response().as_deref(), Some("ok"));
     }
 
     /// Round-tripping must not invent or lose the extra field.

--- a/crates/rig-core/src/providers/mira.rs
+++ b/crates/rig-core/src/providers/mira.rs
@@ -152,21 +152,21 @@ pub type CompletionModel<H> =
 impl crate::telemetry::ProviderResponseExt for CompletionResponse {
     type Usage = Usage;
 
-    fn get_response_id(&self) -> Option<&str> {
+    fn response_id(&self) -> Option<&str> {
         match self {
             Self::Structured { id, .. } => Some(id.as_str()),
             Self::Simple(_) => None,
         }
     }
 
-    fn get_response_model_name(&self) -> Option<&str> {
+    fn response_model_name(&self) -> Option<&str> {
         match self {
             Self::Structured { model, .. } => Some(model.as_str()),
             Self::Simple(_) => None,
         }
     }
 
-    fn get_text_response(&self) -> Option<String> {
+    fn text_response(&self) -> Option<String> {
         match self {
             Self::Structured { choices, .. } => choices
                 .iter()
@@ -176,7 +176,7 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
         }
     }
 
-    fn get_usage(&self) -> Option<Self::Usage> {
+    fn usage(&self) -> Option<Self::Usage> {
         match self {
             Self::Structured { usage, .. } => usage.clone(),
             Self::Simple(_) => None,

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -394,15 +394,15 @@ pub struct CompletionResponse {
 impl crate::telemetry::ProviderResponseExt for CompletionResponse {
     type Usage = Usage;
 
-    fn get_response_id(&self) -> Option<&str> {
+    fn response_id(&self) -> Option<&str> {
         Some(self.id.as_str())
     }
 
-    fn get_response_model_name(&self) -> Option<&str> {
+    fn response_model_name(&self) -> Option<&str> {
         Some(self.model.as_str())
     }
 
-    fn get_text_response(&self) -> Option<String> {
+    fn text_response(&self) -> Option<String> {
         let res = self
             .choices
             .iter()
@@ -422,7 +422,7 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
         if res.is_empty() { None } else { Some(res) }
     }
 
-    fn get_usage(&self) -> Option<Self::Usage> {
+    fn usage(&self) -> Option<Self::Usage> {
         self.usage.clone()
     }
 }

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -407,22 +407,22 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
     type Usage = Usage;
 
     /// Ollama's chat API carries no response ID.
-    fn get_response_id(&self) -> Option<&str> {
+    fn response_id(&self) -> Option<&str> {
         None
     }
 
-    fn get_response_model_name(&self) -> Option<&str> {
+    fn response_model_name(&self) -> Option<&str> {
         Some(self.model.as_str())
     }
 
-    fn get_text_response(&self) -> Option<String> {
+    fn text_response(&self) -> Option<String> {
         match &self.message {
             Message::Assistant { content, .. } if !content.is_empty() => Some(content.clone()),
             _ => None,
         }
     }
 
-    fn get_usage(&self) -> Option<Self::Usage> {
+    fn usage(&self) -> Option<Self::Usage> {
         Some(Usage::from(self))
     }
 }

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -1390,15 +1390,15 @@ impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
 impl ProviderResponseExt for CompletionResponse {
     type Usage = Usage;
 
-    fn get_response_id(&self) -> Option<&str> {
+    fn response_id(&self) -> Option<&str> {
         Some(self.id.as_str())
     }
 
-    fn get_response_model_name(&self) -> Option<&str> {
+    fn response_model_name(&self) -> Option<&str> {
         Some(self.model.as_str())
     }
 
-    fn get_text_response(&self) -> Option<String> {
+    fn text_response(&self) -> Option<String> {
         let response = self
             .choices
             .iter()
@@ -1413,7 +1413,7 @@ impl ProviderResponseExt for CompletionResponse {
         }
     }
 
-    fn get_usage(&self) -> Option<Self::Usage> {
+    fn usage(&self) -> Option<Self::Usage> {
         self.usage
     }
 }
@@ -2491,7 +2491,7 @@ where
             |response| {
                 let span = tracing::Span::current();
                 span.record_response_metadata(response);
-                let usage = response.get_usage().map(Into::into).unwrap_or_default();
+                let usage = response.usage().map(Into::into).unwrap_or_default();
                 span.record_token_usage(&usage);
             },
         )
@@ -3235,7 +3235,7 @@ mod tests {
         };
 
         assert_eq!(
-            response.get_text_response(),
+            response.text_response(),
             Some("first\nsecond\nthird".to_owned())
         );
     }
@@ -3287,7 +3287,7 @@ mod tests {
             usage: None,
         };
 
-        assert_eq!(response.get_text_response(), Some("blocked".to_owned()));
+        assert_eq!(response.text_response(), Some("blocked".to_owned()));
     }
 
     /// One chat-completions turn, built from the wire shape a structured-output
@@ -3338,7 +3338,7 @@ mod tests {
             "refusal": "I'm sorry, I can't help with that."
         });
         let raw_text = refusal_response(message.clone())
-            .get_text_response()
+            .text_response()
             .expect("raw text view");
 
         assert_eq!(

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -2464,19 +2464,19 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
 
     /// The response ID (`resp_...`), which is deliberately *not* the assistant
     /// message ID (`msg_...`) that the normalized response carries.
-    fn get_response_id(&self) -> Option<&str> {
+    fn response_id(&self) -> Option<&str> {
         Some(self.id.as_str())
     }
 
-    fn get_response_model_name(&self) -> Option<&str> {
+    fn response_model_name(&self) -> Option<&str> {
         Some(self.model.as_str())
     }
 
-    fn get_text_response(&self) -> Option<String> {
+    fn text_response(&self) -> Option<String> {
         output_text_response(&self.output)
     }
 
-    fn get_usage(&self) -> Option<Self::Usage> {
+    fn usage(&self) -> Option<Self::Usage> {
         self.usage
     }
 }

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -711,7 +711,7 @@ impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
                 // `refusal` content part below — that spelling belongs to the
                 // Responses API, which this wire never sends. Reading only
                 // `content` dropped the refusal outright and normalized the
-                // turn to nothing, while `get_text_response` already fell back
+                // turn to nothing, while `text_response` already fell back
                 // to the field and the streaming path already delivered it.
                 // The rule is shared with the OpenAI chat path so no two
                 // readers of this wire can disagree about it (#2332).
@@ -860,15 +860,15 @@ impl crate::completion::NormalizeCompletionResponse for CompletionResponse {
 impl ProviderResponseExt for CompletionResponse {
     type Usage = Usage;
 
-    fn get_response_id(&self) -> Option<&str> {
+    fn response_id(&self) -> Option<&str> {
         Some(self.id.as_str())
     }
 
-    fn get_response_model_name(&self) -> Option<&str> {
+    fn response_model_name(&self) -> Option<&str> {
         Some(self.model.as_str())
     }
 
-    fn get_text_response(&self) -> Option<String> {
+    fn text_response(&self) -> Option<String> {
         let response = self
             .choices
             .iter()
@@ -881,7 +881,7 @@ impl ProviderResponseExt for CompletionResponse {
         (!response.is_empty()).then_some(response)
     }
 
-    fn get_usage(&self) -> Option<Self::Usage> {
+    fn usage(&self) -> Option<Self::Usage> {
         self.usage
     }
 }
@@ -5032,7 +5032,7 @@ mod tests {
             "refusal": "I'm sorry, but I can't help with that.",
         }));
 
-        let raw_text = response.get_text_response().unwrap();
+        let raw_text = response.text_response().unwrap();
         let normalized = response.normalize(PROVIDER_NAME).unwrap();
 
         assert_eq!(text_parts(&normalized), vec![raw_text]);

--- a/crates/rig-core/src/providers/venice/completion.rs
+++ b/crates/rig-core/src/providers/venice/completion.rs
@@ -305,20 +305,20 @@ impl NormalizeCompletionResponse for CompletionResponse {
 impl ProviderResponseExt for CompletionResponse {
     type Usage = <openai::CompletionResponse as ProviderResponseExt>::Usage;
 
-    fn get_response_id(&self) -> Option<&str> {
-        self.openai.get_response_id()
+    fn response_id(&self) -> Option<&str> {
+        self.openai.response_id()
     }
 
-    fn get_response_model_name(&self) -> Option<&str> {
-        self.openai.get_response_model_name()
+    fn response_model_name(&self) -> Option<&str> {
+        self.openai.response_model_name()
     }
 
-    fn get_text_response(&self) -> Option<String> {
-        self.openai.get_text_response()
+    fn text_response(&self) -> Option<String> {
+        self.openai.text_response()
     }
 
-    fn get_usage(&self) -> Option<Self::Usage> {
-        self.openai.get_usage()
+    fn usage(&self) -> Option<Self::Usage> {
+        self.openai.usage()
     }
 }
 
@@ -391,7 +391,7 @@ mod tests {
             serde_json::from_value(body).expect("response should decode");
 
         assert_eq!(response.openai.id, "chatcmpl-1");
-        assert_eq!(response.get_text_response().as_deref(), Some("hi"));
+        assert_eq!(response.text_response().as_deref(), Some("hi"));
         assert_eq!(response.cost.expect("cost").diem, 0.0);
         assert_eq!(response.web_search_citations().len(), 1);
         assert_eq!(response.web_search_citations()[0].title, "Rust");

--- a/crates/rig-core/src/telemetry/mod.rs
+++ b/crates/rig-core/src/telemetry/mod.rs
@@ -925,16 +925,16 @@ pub trait ProviderResponseExt {
     type Usage: Serialize;
 
     /// Returns the provider response ID, if supplied.
-    fn get_response_id(&self) -> Option<&str>;
+    fn response_id(&self) -> Option<&str>;
 
     /// Returns the provider response model name, if supplied.
-    fn get_response_model_name(&self) -> Option<&str>;
+    fn response_model_name(&self) -> Option<&str>;
 
     /// Returns the primary text response, when available.
-    fn get_text_response(&self) -> Option<String>;
+    fn text_response(&self) -> Option<String>;
 
     /// Returns provider-native usage metrics, if supplied.
-    fn get_usage(&self) -> Option<Self::Usage>;
+    fn usage(&self) -> Option<Self::Usage>;
 }
 
 /// A trait designed specifically to be used with Spans for the purpose of recording telemetry.
@@ -984,11 +984,11 @@ impl SpanCombinator for tracing::Span {
             return;
         }
 
-        if let Some(id) = response.get_response_id() {
+        if let Some(id) = response.response_id() {
             self.record("gen_ai.response.id", id);
         }
 
-        if let Some(model_name) = response.get_response_model_name() {
+        if let Some(model_name) = response.response_model_name() {
             self.record("gen_ai.response.model", model_name);
         }
     }

--- a/crates/rig-gemini-grpc/src/completion.rs
+++ b/crates/rig-gemini-grpc/src/completion.rs
@@ -564,7 +564,7 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse {
 impl ProviderResponseExt for GenerateContentResponse {
     type Usage = proto::UsageMetadata;
 
-    fn get_response_id(&self) -> Option<&str> {
+    fn response_id(&self) -> Option<&str> {
         if self.response_id.is_empty() {
             None
         } else {
@@ -572,7 +572,7 @@ impl ProviderResponseExt for GenerateContentResponse {
         }
     }
 
-    fn get_response_model_name(&self) -> Option<&str> {
+    fn response_model_name(&self) -> Option<&str> {
         if self.model_version.is_empty() {
             None
         } else {
@@ -580,7 +580,7 @@ impl ProviderResponseExt for GenerateContentResponse {
         }
     }
 
-    fn get_text_response(&self) -> Option<String> {
+    fn text_response(&self) -> Option<String> {
         self.candidates.first().and_then(|c| {
             c.content.as_ref().and_then(|content| {
                 let text: Vec<String> = content
@@ -610,7 +610,7 @@ impl ProviderResponseExt for GenerateContentResponse {
         })
     }
 
-    fn get_usage(&self) -> Option<Self::Usage> {
+    fn usage(&self) -> Option<Self::Usage> {
         self.usage_metadata
     }
 }
@@ -1159,7 +1159,7 @@ mod tests {
     /// There is no cassette harness for this transport (it is protobuf over
     /// gRPC, not HTTP), so the wire shape is stated directly.
     #[test]
-    fn get_text_response_skips_thought_parts() {
+    fn text_response_skips_thought_parts() {
         let response = proto::GenerateContentResponse {
             candidates: vec![proto::Candidate {
                 content: Some(proto::Content {
@@ -1185,7 +1185,7 @@ mod tests {
         };
 
         assert_eq!(
-            response.get_text_response().as_deref(),
+            response.text_response().as_deref(),
             Some("The answer is 42."),
             "reasoning must not be reported as the response text"
         );

--- a/crates/rig-neo4j/src/vector_index.rs
+++ b/crates/rig-neo4j/src/vector_index.rs
@@ -66,8 +66,8 @@ impl IndexConfig {
         }
     }
 
-    pub fn index_name(mut self, index_name: &str) -> Self {
-        self.index_name = index_name.to_string();
+    pub fn index_name(mut self, index_name: impl Into<String>) -> Self {
+        self.index_name = index_name.into();
         self
     }
 
@@ -76,14 +76,14 @@ impl IndexConfig {
         self
     }
 
-    pub fn embedding_property(mut self, embedding_property: &str) -> Self {
-        self.embedding_property = embedding_property.to_string();
+    pub fn embedding_property(mut self, embedding_property: impl Into<String>) -> Self {
+        self.embedding_property = embedding_property.into();
         self
     }
 
     /// Sets the node label that [`InsertDocuments`] writes to.
-    pub fn node_label(mut self, node_label: &str) -> Self {
-        self.node_label = Some(node_label.to_string());
+    pub fn node_label(mut self, node_label: impl Into<String>) -> Self {
+        self.node_label = Some(node_label.into());
         self
     }
 }

--- a/crates/rig-vertexai/src/client.rs
+++ b/crates/rig-vertexai/src/client.rs
@@ -80,8 +80,8 @@ impl ClientBuilder {
     /// Set the Google Cloud project ID explicitly.
     ///
     /// If not set, will fall back to `GOOGLE_CLOUD_PROJECT` environment variable.
-    pub fn with_project(mut self, project: &str) -> Self {
-        self.project = Some(project.to_string());
+    pub fn with_project(mut self, project: impl Into<String>) -> Self {
+        self.project = Some(project.into());
         self
     }
 
@@ -89,8 +89,8 @@ impl ClientBuilder {
     ///
     /// If not set, will fall back to `GOOGLE_CLOUD_LOCATION` environment variable,
     /// or default to "global" if the env var is also not set.
-    pub fn with_location(mut self, location: &str) -> Self {
-        self.location = Some(location.to_string());
+    pub fn with_location(mut self, location: impl Into<String>) -> Self {
+        self.location = Some(location.into());
         self
     }
 

--- a/examples/multi_agent/src/main.rs
+++ b/examples/multi_agent/src/main.rs
@@ -86,7 +86,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let translator_tool = TranslatorTool(translator_agent);
 
     let multi_agent_system = AgentBuilder::new(model)
-        .preamble(&format!(
+        .preamble(format!(
             "You are a helpful assistant that can work with text in any language. \
             When you receive input that is not in English, or contains grammatical errors \
             use the {TRANSLATOR_TOOL_NAME} tool first to ensure proper English, then provide your response. \

--- a/tests/providers/anthropic/cassette/opus_4_8.rs
+++ b/tests/providers/anthropic/cassette/opus_4_8.rs
@@ -47,7 +47,7 @@ async fn web_search_with_dynamic_filtering_succeeds() {
                 .raw_completion(request)
                 .await
                 .expect("Opus 4.8 dynamic web-search request should succeed");
-            let raw_text = raw.get_text_response();
+            let raw_text = raw.text_response();
             let response: RigCompletionResponse = raw.normalize(ANTHROPIC_PROVIDER)
                 .expect("Opus 4.8 dynamic web-search response should normalize");
 
@@ -89,7 +89,7 @@ async fn messages_preserve_mid_conversation_system_role() {
                 .raw_completion(request)
                 .await
                 .expect("Opus 4.8 system-role request should succeed");
-            let raw_text = raw.get_text_response();
+            let raw_text = raw.text_response();
             let response: RigCompletionResponse = raw
                 .normalize(ANTHROPIC_PROVIDER)
                 .expect("Opus 4.8 system-role response should normalize");
@@ -143,7 +143,7 @@ async fn messages_preserve_system_role_after_server_tool_result() {
             let raw = model.raw_completion(request).await.expect(
                 "Opus 4.8 request with system role after server tool result should succeed",
             );
-            let raw_text = raw.get_text_response();
+            let raw_text = raw.text_response();
             let response: RigCompletionResponse = raw.normalize(ANTHROPIC_PROVIDER).expect(
                 "Opus 4.8 response with system role after server tool result should normalize",
             );
@@ -186,7 +186,7 @@ async fn documents_keep_leading_system_message_top_level() {
             let raw = model.raw_completion(request).await.expect(
                 "Opus 4.8 request with documents and a leading system message should succeed",
             );
-            let raw_text = raw.get_text_response();
+            let raw_text = raw.text_response();
             let response: RigCompletionResponse = raw.normalize(ANTHROPIC_PROVIDER).expect(
                 "Opus 4.8 response with documents and a leading system message should normalize",
             );

--- a/tests/providers/anthropic/cassette/plaintext_document.rs
+++ b/tests/providers/anthropic/cassette/plaintext_document.rs
@@ -184,7 +184,7 @@ async fn document_citations_followup_preserves_assistant_citation_history() {
                 .raw_completion(first_request)
                 .await
                 .expect("first document citation turn should succeed");
-            let first_turn_raw_text = first_turn_raw.get_text_response();
+            let first_turn_raw_text = first_turn_raw.text_response();
             let first_turn: rig::completion::CompletionResponse = first_turn_raw
                 .normalize(ANTHROPIC_PROVIDER)
                 .expect("first document citation turn should normalize");

--- a/tests/providers/anthropic/cassette/prompt_caching.rs
+++ b/tests/providers/anthropic/cassette/prompt_caching.rs
@@ -313,7 +313,7 @@ fn assert_matrix_raw_response(
     prefix_ttl: Option<&CacheTtl>,
     context: &str,
 ) {
-    let text = response.get_text_response().unwrap_or_default();
+    let text = response.text_response().unwrap_or_default();
     assert_text_contains_cache_probe(&text, CACHE_PROBE_RESPONSE);
     assert_cache_creation_split(&response.usage, mode, prefix_ttl, context);
 }

--- a/tests/providers/bedrock/cassette/raw_completion.rs
+++ b/tests/providers/bedrock/cassette/raw_completion.rs
@@ -31,7 +31,7 @@ async fn raw_response_text_matches_normalized_choice_text() {
                 .await
                 .expect("raw Bedrock request should succeed");
             let raw_text = raw
-                .get_text_response()
+                .text_response()
                 .expect("raw Bedrock response should contain assistant text");
             let response: rig::completion::CompletionResponse = raw
                 .try_into()

--- a/tests/providers/gemini/cassette/thought_text_matrix.rs
+++ b/tests/providers/gemini/cassette/thought_text_matrix.rs
@@ -13,7 +13,7 @@
 //!   `response.text` was **the model's private reasoning** and the actual
 //!   transcript, sitting in parts[1], was dropped. A transcript split across
 //!   several text parts lost everything after the first, too.
-//! * `ProviderResponseExt::get_text_response` collected *every* text part,
+//! * `ProviderResponseExt::text_response` collected *every* text part,
 //!   gluing the chain-of-thought onto the answer. Rig's other Gemini
 //!   transport (the Interactions API) and Anthropic both exclude reasoning
 //!   from that method, so the REST wire was the odd one out.
@@ -35,24 +35,24 @@
 //! | 4 | `transcription_with_thoughts_on_gemini_3_flash` | transcription | `thinkingLevel` dialect |
 //! | 5 | `transcription_with_thoughts_and_temperature` | transcription | temperature alongside thoughts |
 //! | 6 | `transcription_with_a_large_thinking_budget` | transcription | long reasoning before the transcript |
-//! | 7 | `text_response_skips_thoughts_on_gemini_2_5_flash` | `get_text_response` | the bug's second reader |
-//! | 8 | `text_response_skips_thoughts_on_gemini_3_flash` | `get_text_response` | `thinkingLevel` dialect |
-//! | 9 | `text_response_with_thinking_disabled_is_unchanged` | `get_text_response` | no-thoughts regression guard |
-//! | 10 | `text_response_on_gemini_2_5_flash_lite` | `get_text_response` | third model |
-//! | 11 | `text_response_on_gemini_3_1_flash_lite` | `get_text_response` | pre-thinking model family |
-//! | 12 | `text_response_with_a_large_thinking_budget` | `get_text_response` | long reasoning |
-//! | 13 | `text_response_with_a_preamble` | `get_text_response` | `systemInstruction` present |
-//! | 14 | `text_response_on_a_tool_call_turn` | `get_text_response` | thought part beside a `functionCall` |
-//! | 15 | `text_response_with_structured_output` | `get_text_response` | `responseJsonSchema` turn |
-//! | 16 | `text_response_across_two_candidates` | `get_text_response` | `candidateCount: 2` |
-//! | 17 | `text_response_is_none_when_the_turn_is_all_thought` | `get_text_response` | budget spent entirely on thinking |
+//! | 7 | `text_response_skips_thoughts_on_gemini_2_5_flash` | `text_response` | the bug's second reader |
+//! | 8 | `text_response_skips_thoughts_on_gemini_3_flash` | `text_response` | `thinkingLevel` dialect |
+//! | 9 | `text_response_with_thinking_disabled_is_unchanged` | `text_response` | no-thoughts regression guard |
+//! | 10 | `text_response_on_gemini_2_5_flash_lite` | `text_response` | third model |
+//! | 11 | `text_response_on_gemini_3_1_flash_lite` | `text_response` | pre-thinking model family |
+//! | 12 | `text_response_with_a_large_thinking_budget` | `text_response` | long reasoning |
+//! | 13 | `text_response_with_a_preamble` | `text_response` | `systemInstruction` present |
+//! | 14 | `text_response_on_a_tool_call_turn` | `text_response` | thought part beside a `functionCall` |
+//! | 15 | `text_response_with_structured_output` | `text_response` | `responseJsonSchema` turn |
+//! | 16 | `text_response_across_two_candidates` | `text_response` | `candidateCount: 2` |
+//! | 17 | `text_response_is_none_when_the_turn_is_all_thought` | `text_response` | budget spent entirely on thinking |
 //! | 18 | `streaming_twin_keeps_reasoning_out_of_the_text` | stream | streaming parity for the same request |
 //! | 19 | `text_response_matches_the_choice_text` (unit) | both | see below |
 //! | 20 | `transcription_joins_every_visible_text_part` (unit) | transcription | see below |
 //! | 21 | `transcription_rejects_a_thought_only_candidate` (unit) | transcription | see below |
 //! | 22 | `transcription_rejects_a_candidate_with_no_text_part` (unit) | transcription | see below |
-//! | 23 | `text_response_is_none_for_a_thought_only_candidate` (unit) | `get_text_response` | see below |
-//! | 24 | `text_response_still_ignores_non_model_roles` (unit) | `get_text_response` | see below |
+//! | 23 | `text_response_is_none_for_a_thought_only_candidate` (unit) | `text_response` | see below |
+//! | 24 | `text_response_still_ignores_non_model_roles` (unit) | `text_response` | see below |
 //! | 25 | `transcription_keeps_an_empty_visible_text_part` (unit) | transcription | see below |
 //! | 26 | `blocking_keeps_a_trailing_thought_signature` | blocking choice | Gemini 3's no-`thought`-flag signature |
 //! | 27 | `streaming_twin_agrees_on_a_trailing_thought_signature` | stream | the same bytes, the same choice |
@@ -412,9 +412,9 @@ async fn transcription_with_a_large_thinking_budget() {
     assert_thought_parts_recorded(SCENARIO, true);
 }
 
-// --- 7-17: the `get_text_response` reader ---------------------------------
+// --- 7-17: the `text_response` reader ---------------------------------
 
-/// One `get_text_response` cell: the provider-native reader and the
+/// One `text_response` cell: the provider-native reader and the
 /// normalized choice must agree about what the *text* of the turn was, and
 /// reasoning must appear in neither's text.
 struct TextResponseCell {
@@ -488,18 +488,18 @@ async fn text_response_body(
         }
     );
 
-    let text_response = raw.get_text_response();
+    let text_response = raw.text_response();
     for thought in &recorded_thoughts {
         if let Some(text) = text_response.as_deref() {
             assert!(
                 !text.contains(thought.as_str()),
-                "{scenario}: get_text_response must not carry the chain-of-thought"
+                "{scenario}: text_response must not carry the chain-of-thought"
             );
         }
     }
 
     // The two readers of one payload must agree. `choice_text` joins the
-    // normalized text blocks the same way `get_text_response` joins parts.
+    // normalized text blocks the same way `text_response` joins parts.
     let normalized: rig::completion::CompletionResponse =
         raw.try_into().expect("payload should normalize");
     assert_eq!(
@@ -761,7 +761,7 @@ async fn text_response_on_a_tool_call_turn() {
 
             // A tool-call turn's *text* is whatever visible text parts it has —
             // never the reasoning that preceded the call.
-            let text_response = raw.get_text_response().unwrap_or_default();
+            let text_response = raw.text_response().unwrap_or_default();
             let normalized: rig::completion::CompletionResponse =
                 raw.try_into().expect("payload should normalize");
             assert_eq!(
@@ -832,7 +832,7 @@ async fn text_response_across_two_candidates() {
     const SCENARIO: &str = "thought_text_matrix/text_response_across_two_candidates";
 
     // `candidateCount: 2` is the one shape where the two readers legitimately
-    // differ: `get_text_response` folds every candidate, while the normalized
+    // differ: `text_response` folds every candidate, while the normalized
     // choice is candidate 0 alone. The thought filter must still apply per
     // candidate rather than only to the first.
     with_gemini_thought_text_cassette(
@@ -867,9 +867,7 @@ async fn text_response_across_two_candidates() {
                 "the recorded turn should carry thought parts"
             );
 
-            let text_response = raw
-                .get_text_response()
-                .expect("a two-candidate turn has text");
+            let text_response = raw.text_response().expect("a two-candidate turn has text");
             for thought in &thoughts {
                 assert!(
                     !text_response.contains(thought.as_str()),
@@ -957,7 +955,7 @@ async fn text_response_is_none_when_the_turn_is_all_thought() {
                 "this cell's premise is a turn whose parts are all thoughts; got {visible:?}"
             );
             assert_eq!(
-                raw.get_text_response(),
+                raw.text_response(),
                 None,
                 "a turn that produced no visible text has no text response — returning the \
              chain-of-thought here is exactly the bug"
@@ -1178,7 +1176,7 @@ mod unit {
 
         for (index, parts) in layouts.into_iter().enumerate() {
             let response = response_with(parts, "model");
-            let text_response = response.get_text_response();
+            let text_response = response.text_response();
             let normalized: rig::completion::CompletionResponse =
                 response.try_into().expect("payload should normalize");
             let choice_text = normalized
@@ -1317,7 +1315,7 @@ mod unit {
     fn text_response_is_none_for_a_thought_only_candidate() {
         let response = response_with(vec![thought_part("Still working it out...")], "model");
         assert_eq!(
-            response.get_text_response(),
+            response.text_response(),
             None,
             "a candidate with no visible text has no text response"
         );
@@ -1430,7 +1428,7 @@ mod unit {
     fn text_response_still_ignores_non_model_roles() {
         let response = response_with(vec![text_part("answer")], "user");
         assert_eq!(
-            response.get_text_response(),
+            response.text_response(),
             None,
             "only model-role candidates contribute text"
         );

--- a/tests/providers/llamacpp/cassette/bare_openai_client.rs
+++ b/tests/providers/llamacpp/cassette/bare_openai_client.rs
@@ -308,7 +308,7 @@ async fn raw_response_text_matches_normalized_choice_text() {
                 .await
                 .expect("raw completions api request should succeed");
             let raw_text = raw
-                .get_text_response()
+                .text_response()
                 .expect("raw completions api response should contain assistant text");
             let response: rig::completion::CompletionResponse = raw
                 .normalize("openai")

--- a/tests/providers/openai/cassette/completions_api.rs
+++ b/tests/providers/openai/cassette/completions_api.rs
@@ -62,7 +62,7 @@ async fn completions_api_raw_response_text_matches_normalized_choice_text() {
                 .await
                 .expect("raw completions api request should succeed");
             let raw_text = raw
-                .get_text_response()
+                .text_response()
                 .expect("raw completions api response should contain assistant text");
 
             let response: rig::completion::CompletionResponse = raw

--- a/tests/providers/openai/cassette/refusal_matrix.rs
+++ b/tests/providers/openai/cassette/refusal_matrix.rs
@@ -19,7 +19,7 @@
 //! * history round-trip (`TryFrom<Message> for message::Message`) → the
 //!   conversion error `Neither `content` nor `tool_calls` was provided`.
 //!
-//! Meanwhile `ProviderResponseExt::get_text_response` *did* fall back to the
+//! Meanwhile `ProviderResponseExt::text_response` *did* fall back to the
 //! field, so the raw text view and the normalized response disagreed about
 //! whether the turn had said anything — and the same rig-level request driven
 //! through the Responses API surfaced the refusal fine.
@@ -218,7 +218,7 @@ async fn chat_blocking_raw_and_normalized_agree() {
                 })
                 .expect("the recorded turn must carry a top-level refusal");
             let raw_text = raw
-                .get_text_response()
+                .text_response()
                 .expect("the raw text view already reported the refusal");
 
             let normalized: rig::completion::CompletionResponse =

--- a/tests/providers/openai/cassette/truncated_turn_matrix.rs
+++ b/tests/providers/openai/cassette/truncated_turn_matrix.rs
@@ -212,7 +212,7 @@ async fn chat_blocking_raw_and_normalized_agree() {
                     .map(|choice| choice.finish_reason.as_str()),
                 Some("length")
             );
-            assert_eq!(raw.get_text_response(), None);
+            assert_eq!(raw.text_response(), None);
 
             let normalized: rig::completion::CompletionResponse =
                 raw.normalize("openai").expect("normalization");

--- a/tests/providers/openrouter/cassette/reasoning_usage_matrix.rs
+++ b/tests/providers/openrouter/cassette/reasoning_usage_matrix.rs
@@ -694,7 +694,7 @@ async fn blocking_raw_usage_and_normalized_usage_agree() {
 
             let raw = model.raw_completion(request).await.expect("raw turn");
             let raw_reasoning = raw
-                .get_usage()
+                .usage()
                 .and_then(|usage| usage.completion_tokens_details)
                 .map(|details| details.reasoning_tokens as u64)
                 .expect("the raw usage must model the breakdown");
@@ -736,7 +736,7 @@ async fn blocking_cost_and_cache_details_still_map() {
                 .build();
 
             let raw = model.raw_completion(request).await.expect("raw turn");
-            let usage = raw.get_usage().expect("usage");
+            let usage = raw.usage().expect("usage");
 
             assert!(usage.cost > 0.0, "{usage:?}");
             assert!(usage.prompt_tokens_details.is_some(), "{usage:?}");

--- a/tests/providers/openrouter/cassette/refusal_matrix.rs
+++ b/tests/providers/openrouter/cassette/refusal_matrix.rs
@@ -18,7 +18,7 @@
 //!
 //! Two things already disagreed with that on `origin/main`:
 //!
-//! * `ProviderResponseExt::get_text_response` routes through
+//! * `ProviderResponseExt::text_response` routes through
 //!   `openai::completion::assistant_message_text_response`, which *does* apply
 //!   the fallback — so the raw text view and the normalized response disagreed
 //!   about whether the turn said anything;
@@ -232,7 +232,7 @@ async fn blocking_raw_and_normalized_agree() {
                 })
                 .expect("the recorded turn must carry a top-level refusal");
             let raw_text = raw
-                .get_text_response()
+                .text_response()
                 .expect("the raw text view already reported the refusal on origin/main");
 
             let normalized = raw.normalize("openrouter").expect("normalization");


### PR DESCRIPTION
Third pass of the idiomatic Rust sweep (after #2409 and #2410). The workspace is largely dry at this point — this round is two focused themes plus a survey confirming the mechanical lint categories are clean.

## Commits

- **`refactor(rig-core): drop get_ prefix from ProviderResponseExt methods`** — continues #2410's `get_`-prefix sweep into the telemetry trait: `get_response_id` → `response_id`, `get_response_model_name` → `response_model_name`, `get_text_response` → `text_response`, `get_usage` → `usage`. 15 impls across rig-core providers, rig-bedrock, and rig-gemini-grpc, plus all call sites (28 files). **Breaking** (pre-1.0, changelog entry included).
- **`refactor: accept impl Into<String> in builder setters that allocate anyway`** — `AgentBuilder::{name, description, preamble, context}`, Azure `api_version`/`audio_api_version`, Anthropic `anthropic_version`/`anthropic_beta`, neo4j `SearchParams` setters, Vertex AI `with_project`/`with_location` took `&str` and immediately called `.into()`/`.to_string()`. Every existing `&str` call site still compiles; owned `String`s are no longer copied. (One example passed `&format!(…)` and now passes the `String` directly.)
- **`docs: changelog entries`**

## Surveyed and clean / deferred

- `uninlined_format_args`, `semicolon_if_nothing_returned`: zero hits — already clean from rounds 1–2.
- `redundant_closure_for_method_calls`: 13 hits, all in test code where the closure reads better than a fully-qualified method path (`|id| id.as_str()` vs `crate::streaming::identity::WireId::as_str`) — deliberately left.
- `needless_pass_by_value`: all remaining hits are test helpers and derive-macro examples taking `serde_json::Value` by value — left.
- `doc_markdown`: ~855 missing-backtick sites — deferred as pure churn; worth a dedicated pass only if the repo decides to gate on the lint.
- `#[must_use]`: the workspace uses it nowhere (0 sites in rig-core), so adding it to builders would introduce a new convention rather than follow one — flagging as a question rather than changing it.
- multipart `get_filename`/`get_content_type`: the `get_` prefix disambiguates from the same-named builder setters — left.

## Verification

- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `cargo nextest run --locked -p rig-core -p rig-reqwest -p rig-agent -p rig-rmcp --all-features --retries 2 -E 'not binary(macro_hygiene)'` — 2213 passed
- `cargo nextest run --locked --features bedrock --retries 2 -E 'not (binary(identity_leak) | binary(macro_hygiene))'` — 5807 passed
- `cargo doc --workspace --no-deps --all-features` — 0 warnings
- `cargo test --doc --workspace --all-features` — all pass
- `cargo check -p rig-core --all-features --target wasm32-unknown-unknown` — clean