### PR TITLE
refactor: ownership sweep round 4 — avoidable clones, dead public items, is_false dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(agent, core, neo4j, vertexai)* builder setters that stored an owned `String` now take `impl Into<String>` instead of `&str` (`AgentBuilder::{name, description, preamble, context}`, Azure `api_version`/`audio_api_version`, Anthropic `anthropic_version`/`anthropic_beta`, neo4j `SearchParams` setters, Vertex AI `with_project`/`with_location`) — every existing `&str` call site still compiles, and an owned `String` is no longer copied
 - *(core, agent, bedrock, vertexai)* [**breaking**] accessors drop their `get_` prefix per Rust naming convention: `ToolCatalog`-side `get_tool_definitions` → `tool_definitions` (rig-core contextual tools), `ToolServerHandle::get_tool_defs` → `tool_defs` (rig-agent), and `Client::get_inner` → `inner` (rig-bedrock, rig-vertexai)
 
+### Removed
+
+- *(core)* [**breaking**] `embeddings::NormalizeImageEmbeddingResponse` is deleted: nothing in the workspace or any provider implemented or consumed it (the image-embedding path erases through `ImageEmbeddingModel` directly). An out-of-tree implementor can define the same one-method trait locally; the text-side `NormalizeEmbeddingResponse` is unchanged
+- *(sqlite)* [**breaking**] `SqliteError` is deleted: the public enum was constructed and matched nowhere — the crate reports through `VectorStoreError` (internally via `SqliteInternalError`). Code naming `rig_sqlite::SqliteError` should switch to `rig_core::vector_store::VectorStoreError`
+
 ### Fixed
 
 - *(milvus)* `Filter` and `MilvusValue` are now re-exported from the crate root — `VectorStoreIndex::Filter` named them in public signatures, but their constructors were unreachable outside the crate

--- a/crates/rig-agent/src/agent/hook.rs
+++ b/crates/rig-agent/src/agent/hook.rs
@@ -1644,7 +1644,10 @@ impl AgentHook for HookStack {
             match hook.completion_call(ctx, event).await {
                 CompletionCallAction::Continue => {}
                 CompletionCallAction::Patch(patch) => {
-                    merged = Some(merged.map_or(patch.clone(), |value| value.merge(patch)));
+                    merged = Some(match merged {
+                        None => patch,
+                        Some(value) => value.merge(patch),
+                    });
                 }
                 stop @ CompletionCallAction::Stop(_) => return stop,
             }

--- a/crates/rig-agent/src/agent/tool.rs
+++ b/crates/rig-agent/src/agent/tool.rs
@@ -38,8 +38,8 @@ impl Agent {
             Agent system prompt: {sysprompt}
             ",
             name = name,
-            description = self.config.description.clone().unwrap_or_default(),
-            sysprompt = self.config.preamble.clone().unwrap_or_default()
+            description = self.config.description.as_deref().unwrap_or_default(),
+            sysprompt = self.config.preamble.as_deref().unwrap_or_default()
         );
         let parameters = json!(schema_for!(AgentToolArgs));
         let agent = Arc::new(self);

--- a/crates/rig-candle/src/generation.rs
+++ b/crates/rig-candle/src/generation.rs
@@ -88,7 +88,7 @@ pub(crate) fn effective_generation(
     vocab_size: usize,
 ) -> Result<GenerationConfig, CandleError> {
     let overrides = match &request.additional_params {
-        Some(value) => serde_json::from_value::<RequestGenerationOverrides>(value.clone())
+        Some(value) => RequestGenerationOverrides::deserialize(value)
             .map_err(|error| CandleError::InvalidGeneration(error.to_string()))?,
         None => RequestGenerationOverrides::default(),
     };

--- a/crates/rig-core/src/completion/message.rs
+++ b/crates/rig-core/src/completion/message.rs
@@ -351,7 +351,7 @@ impl ToolResultContent {
         T: serde::de::DeserializeOwned,
     {
         match self {
-            Self::Json { value } => serde_json::from_value(value.clone()),
+            Self::Json { value } => T::deserialize(value),
             Self::Text(text) => serde_json::from_str(&text.text),
             Self::Image(_) => Err(<serde_json::Error as serde::de::Error>::custom(
                 "cannot decode image tool-result content as JSON",

--- a/crates/rig-core/src/embeddings/embedding.rs
+++ b/crates/rig-core/src/embeddings/embedding.rs
@@ -320,23 +320,6 @@ impl ImageEmbeddingResponse {
 
 crate::provider_response::modality_response_metadata_setters!(ImageEmbeddingResponse);
 
-/// Convert a provider's own image embedding payload into the normalized [`ImageEmbeddingResponse`].
-///
-/// The provider descriptor name is an *input*, never something the conversion
-/// knows — several providers share one wire shape, and a hardcoded name would
-/// mislabel every provider but one. A trait rather than `TryFrom<(&str, T)>`
-/// so that out-of-tree provider extensions can implement it on their own
-/// response type without tripping the orphan rule.
-pub trait NormalizeImageEmbeddingResponse {
-    /// Normalize this payload, attributing it to `provider`. `documents` are
-    /// the inputs in request order, for [`Embedding::document`].
-    fn normalize(
-        self,
-        provider: &str,
-        documents: Vec<String>,
-    ) -> Result<ImageEmbeddingResponse, EmbeddingError>;
-}
-
 /// Trait for embedding models that can generate embeddings for images.
 pub trait ImageEmbeddingModel: WasmCompatSend + WasmCompatSync {
     /// The maximum number of images the provider accepts in one request.

--- a/crates/rig-core/src/json_utils.rs
+++ b/crates/rig-core/src/json_utils.rs
@@ -6,6 +6,13 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::str::FromStr;
 
+/// `skip_serializing_if` helper: serde requires a `fn(&bool) -> bool`, so the
+/// trivially-copy lint does not apply here.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(crate) fn is_false(value: &bool) -> bool {
+    !value
+}
+
 /// Serialize a `HashMap` in sorted key order.
 ///
 /// `HashMap` seeds its iteration order per instance, so a map serialized into a

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -258,20 +258,13 @@ pub struct ToolDefinition {
     pub description: Option<String>,
     pub input_schema: serde_json::Value,
     /// Whether Anthropic must constrain tool arguments to `input_schema`.
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(default, skip_serializing_if = "crate::json_utils::is_false")]
     pub strict: bool,
     /// Cache breakpoint marker. Set on the last tool in the array to cache
     /// the tools layer independently of the system prompt. Anthropic accepts
     /// up to 4 `cache_control` markers per request.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<CacheControl>,
-}
-
-// `skip_serializing_if` requires a `fn(&bool) -> bool`, so the trivially-copy
-// lint does not apply here.
-#[allow(clippy::trivially_copy_pass_by_ref)]
-fn is_false(value: &bool) -> bool {
-    !value
 }
 
 /// TTL for a cache control breakpoint.

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -2291,7 +2291,7 @@ pub mod gemini_api_types {
                 // If this object has anyOf/oneOf/allOf, we need to extract properties from the composition.
                 let composition_source = extract_schema_from_composition_obj(obj);
                 let props_source = if obj.get("properties").is_none() {
-                    composition_source.clone().unwrap_or(obj.clone())
+                    composition_source.clone().unwrap_or_else(|| obj.clone())
                 } else {
                     obj.clone()
                 };

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -730,7 +730,7 @@ pub struct ResponsesToolDefinition {
     /// or [`GenericResponsesCompletionModel::with_strict_tools`].
     #[serde(
         default,
-        skip_serializing_if = "is_false",
+        skip_serializing_if = "crate::json_utils::is_false",
         deserialize_with = "json_utils::null_or_default"
     )]
     pub strict: bool,
@@ -744,13 +744,6 @@ pub struct ResponsesToolDefinition {
 
 fn is_json_null(value: &Value) -> bool {
     value.is_null()
-}
-
-// `skip_serializing_if` requires a `fn(&bool) -> bool`, so the trivially-copy
-// lint does not apply here.
-#[allow(clippy::trivially_copy_pass_by_ref)]
-fn is_false(value: &bool) -> bool {
-    !value
 }
 
 impl ResponsesToolDefinition {

--- a/crates/rig-core/src/transcription.rs
+++ b/crates/rig-core/src/transcription.rs
@@ -353,7 +353,7 @@ where
             model,
             TranscriptionRequest {
                 data: data.0,
-                filename: filename.unwrap_or("file".to_string()),
+                filename: filename.unwrap_or_else(|| "file".to_string()),
                 language,
                 prompt,
                 temperature,

--- a/crates/rig-gemini-grpc/src/embedding.rs
+++ b/crates/rig-gemini-grpc/src/embedding.rs
@@ -50,7 +50,7 @@ impl EmbeddingModel {
                 model: format!("models/{}", self.model),
                 content: Some(proto::Content {
                     parts: vec![proto::Part {
-                        data: Some(proto::part::Data::Text(doc.clone())),
+                        data: Some(proto::part::Data::Text(doc)),
                         thought: false,
                         thought_signature: Vec::new(),
                         part_metadata: None,

--- a/crates/rig-lancedb/src/lib.rs
+++ b/crates/rig-lancedb/src/lib.rs
@@ -425,7 +425,7 @@ impl VectorStoreIndex for LanceDbVectorIndex {
                         Some(Value::Number(distance)) => distance.as_f64().unwrap_or_default(),
                         _ => 0.0,
                     },
-                    match value.get(self.id_field.clone()) {
+                    match value.get(self.id_field.as_str()) {
                         Some(Value::String(id)) => id.clone(),
                         _ => format!("unknown{i}"),
                     },
@@ -482,7 +482,7 @@ impl VectorStoreIndex for LanceDbVectorIndex {
                         Some(Value::Number(distance)) => distance.as_f64().unwrap_or_default(),
                         _ => 0.0,
                     },
-                    match value.get(self.id_field.clone()) {
+                    match value.get(self.id_field.as_str()) {
                         Some(Value::String(id)) => id.clone(),
                         _ => "".to_string(),
                     },

--- a/crates/rig-mongodb/src/lib.rs
+++ b/crates/rig-mongodb/src/lib.rs
@@ -49,7 +49,7 @@ impl SearchIndex {
             .await
             .transpose()
             .map_err(VectorStoreError::datastore)?
-            .ok_or(VectorStoreError::DatastoreError("Index not found".into()))
+            .ok_or_else(|| VectorStoreError::DatastoreError("Index not found".into()))
     }
 }
 

--- a/crates/rig-postgres/src/lib.rs
+++ b/crates/rig-postgres/src/lib.rs
@@ -227,7 +227,7 @@ impl PostgresVectorStore {
         Self {
             model: EmbeddingModelHandle::new(model),
             pg_pool,
-            documents_table: documents_table.unwrap_or(String::from("documents")),
+            documents_table: documents_table.unwrap_or_else(|| String::from("documents")),
             distance_function,
         }
     }

--- a/crates/rig-qdrant/src/filter.rs
+++ b/crates/rig-qdrant/src/filter.rs
@@ -165,7 +165,7 @@ impl QdrantFilter {
                     let key = is_empty
                         .get("key")
                         .and_then(|k| k.as_str())
-                        .ok_or(FilterError::MissingField("key".into()))?
+                        .ok_or_else(|| FilterError::MissingField("key".into()))?
                         .to_string();
 
                     Ok(Condition {
@@ -179,19 +179,17 @@ impl QdrantFilter {
                     let is_null_value = is_null
                         .get("value")
                         .and_then(serde_json::Value::as_bool)
-                        .ok_or(FilterError::Must(
-                        "is_null".into(),
-                        "have a 'value' field".into(),
-                    ))?;
+                        .ok_or_else(|| {
+                        FilterError::Must("is_null".into(), "have a 'value' field".into())
+                    })?;
 
                     // Get the key from the parent object
                     let key = value
                         .get("key")
                         .and_then(|k| k.as_str())
-                        .ok_or(FilterError::Must(
-                            "is_null".into(),
-                            "have a 'key' field".into(),
-                        ))?
+                        .ok_or_else(|| {
+                            FilterError::Must("is_null".into(), "have a 'key' field".into())
+                        })?
                         .to_string();
 
                     if is_null_value {

--- a/crates/rig-sqlite/src/lib.rs
+++ b/crates/rig-sqlite/src/lib.rs
@@ -29,13 +29,6 @@ use tracing::{debug, info};
 /// exact result, no `k` cap).
 const SQLITE_VEC_MAX_K: u64 = 4096;
 
-#[derive(Debug)]
-pub enum SqliteError {
-    DatabaseError(Box<dyn std::error::Error + Send + Sync>),
-    SerializationError(Box<dyn std::error::Error + Send + Sync>),
-    InvalidColumnType(String),
-}
-
 /// Value that can be stored in a SQLite vector store document column.
 ///
 /// Use [`serde_json::Value`] for columns declared as `JSON`.

--- a/crates/rig-surrealdb/src/lib.rs
+++ b/crates/rig-surrealdb/src/lib.rs
@@ -119,7 +119,7 @@ where
 
         for record in records {
             self.surreal
-                .create::<Option<CreateRecord>>(self.documents_table.clone())
+                .create::<Option<CreateRecord>>(self.documents_table.as_str())
                 .content(record)
                 .await
                 .map_err(VectorStoreError::datastore)?;
@@ -264,7 +264,7 @@ where
         Self {
             model: EmbeddingModelHandle::new(model),
             surreal,
-            documents_table: documents_table.unwrap_or(String::from("documents")),
+            documents_table: documents_table.unwrap_or_else(|| String::from("documents")),
             distance_function,
         }
     }


### PR DESCRIPTION
Follow-up to the idiomatic sweeps #2409–#2411, focused on the ownership/allocation leg. Net −30 production lines across 9 crates. No behavior change except two declared dead-code removals.

## Changes

**Avoidable clones and eager allocations** (12 sites):
- `rig-agent` hook chain: the `CompletionCallAction::Patch` merge cloned every patch eagerly (`map_or`'s by-value default) even mid-merge — restructured to move.
- `rig-lancedb`: two per-result-row `String` clones used only to index a `serde_json` map → `as_str()`.
- `rig-surrealdb`: loop-invariant `documents_table` clone per inserted record → borrow.
- `rig-gemini-grpc`: per-document `String` clone into the embed request body (the binding is moved-from anyway).
- `rig-agent` agent tool: two clone-to-`format!` allocations → `as_deref()`.
- `rig-core` `ToolResultContent::deserialize_json` and `rig-candle` generation overrides: deserialize from `&Value` instead of `from_value(value.clone())` (these modules are not covered by the serde-policy wall; walled streaming modules were deliberately left untouched — see notes).
- Eager default/error construction → lazy (`unwrap_or_else`/`ok_or_else`) in gemini schema conversion, transcription, postgres, surrealdb, mongodb, qdrant filters.

**Dead public items deleted** (breaking, CHANGELOG'd with recipes):
- `rig_core::embeddings::NormalizeImageEmbeddingResponse` — zero impls or consumers anywhere in workspace/tests/examples.
- `rig_sqlite::SqliteError` — constructed and matched nowhere; the crate reports through `VectorStoreError`.

**Dedup**: the twice-defined private `fn is_false` (anthropic, openai responses) now lives in `json_utils`; `skip_serializing_if` paths updated.

## Notes for reviewers

- Three candidate `from_value(x.clone())` → borrowed-deserialize rewrites in `openai_websocket.rs` / `responses_api/streaming.rs` were attempted and **reverted**: those decodes are enumerated by the `driver_adoption` serde-policy wall, and the borrow form would have silently escaped it. The small clones there are the price of the probe.
- `rig-rmcp`'s `mut params` + field assignment stays: `PaginatedRequestParams` is `#[non_exhaustive]` upstream, so struct-update syntax doesn't compile.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`, `cargo test --workspace --all-features`, doctests, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo check --target wasm32-unknown-unknown -p rig-core -p rig-agent -p rig` — all green; `git diff --stat -- tests/cassettes` empty; no test added, removed, or renamed.