### PR TITLE
refactor!: move the Discord integration out of the workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ dist/
 
 # LanceDB example/test store artifacts (created at the workspace root)
 /data/
+
+# The `discord_bot` example is its own workspace; its lockfile pins the
+# unpatchable `serenity`/`rustls` 0.22 graph that the root workspace excludes.
+examples/discord_bot/Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,9 +475,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "arrow"
@@ -1213,11 +1210,11 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.23.39",
+ "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower 0.5.3",
  "tracing",
 ]
@@ -1739,7 +1736,7 @@ dependencies = [
  "num",
  "pin-project-lite",
  "rand 0.9.4",
- "rustls 0.23.39",
+ "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
@@ -1937,12 +1934,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytecount"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
-
-[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,15 +1994,6 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
-]
-
-[[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-dependencies = [
- "serde_core",
 ]
 
 [[package]]
@@ -2095,28 +2077,6 @@ dependencies = [
  "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2328,17 +2288,6 @@ dependencies = [
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "unicode-width",
-]
-
-[[package]]
-name = "command_attr"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8208103c5e25a091226dfa8d61d08d0561cc14f31b25691811ba37d4ec9b157b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2783,20 +2732,6 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
- "serde",
-]
-
-[[package]]
-name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
@@ -2872,7 +2807,7 @@ checksum = "37cefde60b26a7f4ff61e9d2ff2833322f91df2b568d7238afe67bde5bdffb66"
 dependencies = [
  "arrow",
  "async-trait",
- "dashmap 6.1.0",
+ "dashmap",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-datasource",
@@ -3062,7 +2997,7 @@ dependencies = [
  "arrow-buffer",
  "async-trait",
  "chrono",
- "dashmap 6.1.0",
+ "dashmap",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-physical-expr-common",
@@ -3657,15 +3592,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "discord_bot"
-version = "0.42.0"
-dependencies = [
- "anyhow",
- "rig",
- "tokio",
-]
-
-[[package]]
 name = "diskann"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3983,15 +3909,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "version_check",
 ]
 
 [[package]]
@@ -4923,7 +4840,7 @@ dependencies = [
  "jsonwebtoken",
  "reqwest 0.13.4",
  "rustc_version",
- "rustls 0.23.39",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5571,7 +5488,7 @@ dependencies = [
  "hyper-util",
  "path-tree",
  "regex",
- "rustls 0.23.39",
+ "rustls",
  "serde",
  "serde_json",
  "serde_regex",
@@ -5647,10 +5564,10 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rustls 0.23.39",
+ "rustls",
  "rustls-native-certs 0.8.3",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.7",
 ]
@@ -6335,7 +6252,7 @@ dependencies = [
  "chrono",
  "crossbeam-queue",
  "crossbeam-skiplist",
- "dashmap 6.1.0",
+ "dashmap",
  "datafusion",
  "datafusion-expr",
  "datafusion-functions",
@@ -6901,12 +6818,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
-name = "levenshtein"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
-
-[[package]]
 name = "lexical-core"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7380,21 +7291,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mini-moka"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c325dfab65f261f386debee8b0969da215b3fa0037e74c8a1234db7ba986d803"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-utils",
- "dashmap 5.5.3",
- "skeptic",
- "smallvec",
- "tagptr",
- "triomphe",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7486,7 +7382,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.9.4",
  "rustc_version_runtime",
- "rustls 0.23.39",
+ "rustls",
  "serde",
  "serde_bytes",
  "serde_with",
@@ -7498,7 +7394,7 @@ dependencies = [
  "take_mut",
  "thiserror 2.0.18",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "typed-builder",
  "uuid",
@@ -7717,7 +7613,7 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "url",
  "webpki-roots 0.26.11",
 ]
@@ -8842,7 +8738,7 @@ dependencies = [
  "prettyplease",
  "prost 0.14.4",
  "prost-types 0.14.3",
- "pulldown-cmark 0.13.3",
+ "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.117",
@@ -9005,17 +8901,6 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
-dependencies = [
- "bitflags 2.13.1",
- "memchr",
- "unicase",
-]
-
-[[package]]
-name = "pulldown-cmark"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
@@ -9031,7 +8916,7 @@ version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
 dependencies = [
- "pulldown-cmark 0.13.3",
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -9137,7 +9022,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.39",
+ "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -9159,7 +9044,7 @@ dependencies = [
  "rand_pcg 0.10.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.39",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -9699,7 +9584,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.39",
+ "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
@@ -9708,7 +9593,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
  "tower-http",
@@ -9749,7 +9634,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.39",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -9758,7 +9643,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
  "tower-http",
@@ -9974,7 +9859,6 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "serenity",
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",
@@ -10760,20 +10644,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
@@ -10783,7 +10653,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -10843,10 +10713,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.39",
+ "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -10858,17 +10728,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -11018,7 +10877,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "dashmap 6.1.0",
+ "dashmap",
  "futures",
  "hashbrown 0.15.5",
  "itertools 0.14.0",
@@ -11098,16 +10957,6 @@ dependencies = [
  "generic-array 0.14.7",
  "pkcs8",
  "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "secrecy"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
-dependencies = [
- "serde",
  "zeroize",
 ]
 
@@ -11217,15 +11066,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde_cow"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7bbbec7196bfde255ab54b65e34087c0849629280028238e67ee25d6a4b7da"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -11386,43 +11226,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serenity"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bde37f42765dfdc34e2a039e0c84afbf79a3101c1941763b0beb816c2f17541"
-dependencies = [
- "arrayvec",
- "async-trait",
- "base64 0.22.1",
- "bitflags 2.13.1",
- "bytes",
- "chrono",
- "command_attr",
- "dashmap 5.5.3",
- "flate2",
- "futures",
- "levenshtein",
- "mime_guess",
- "parking_lot",
- "percent-encoding",
- "reqwest 0.12.28",
- "rustc-hash",
- "secrecy",
- "serde",
- "serde_cow",
- "serde_json",
- "static_assertions",
- "time",
- "tokio",
- "tokio-tungstenite 0.21.0",
- "tracing",
- "typemap_rev",
- "typesize",
- "url",
- "uwl",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11567,21 +11370,6 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
-
-[[package]]
-name = "skeptic"
-version = "0.13.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
-dependencies = [
- "bytecount",
- "cargo_metadata",
- "error-chain",
- "glob",
- "pulldown-cmark 0.9.6",
- "tempfile",
- "walkdir",
-]
 
 [[package]]
 name = "slab"
@@ -12135,7 +11923,7 @@ dependencies = [
  "path-clean",
  "reqwest 0.13.4",
  "ring",
- "rustls 0.23.39",
+ "rustls",
  "rustls-pki-types",
  "semver",
  "serde",
@@ -12186,7 +11974,7 @@ dependencies = [
  "bytes",
  "chrono",
  "ciborium",
- "dashmap 6.1.0",
+ "dashmap",
  "deunicode",
  "diskann",
  "diskann-utils",
@@ -12851,22 +12639,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.39",
+ "rustls",
  "tokio",
 ]
 
@@ -12895,32 +12672,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
-dependencies = [
- "futures-util",
- "log",
- "rustls 0.22.4",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.25.0",
- "tungstenite 0.21.0",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.39",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tungstenite 0.28.0",
  "webpki-roots 0.26.11",
 ]
@@ -12934,11 +12695,11 @@ dependencies = [
  "futures-util",
  "log",
  "native-tls",
- "rustls 0.23.39",
+ "rustls",
  "rustls-pki-types",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tungstenite 0.29.0",
  "webpki-roots 0.26.11",
 ]
@@ -13054,7 +12815,7 @@ dependencies = [
  "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -13085,7 +12846,7 @@ dependencies = [
  "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.5.3",
  "tower-layer",
@@ -13331,12 +13092,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "triomphe"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13359,27 +13114,6 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.4.2",
- "httparse",
- "log",
- "rand 0.8.6",
- "rustls 0.22.4",
- "rustls-pki-types",
- "sha1 0.10.6",
- "thiserror 1.0.69",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
@@ -13390,7 +13124,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "rustls 0.23.39",
+ "rustls",
  "rustls-pki-types",
  "sha1 0.10.6",
  "thiserror 2.0.18",
@@ -13411,7 +13145,7 @@ dependencies = [
  "log",
  "native-tls",
  "rand 0.9.4",
- "rustls 0.23.39",
+ "rustls",
  "rustls-pki-types",
  "sha1 0.10.6",
  "thiserror 2.0.18",
@@ -13453,45 +13187,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
-name = "typemap_rev"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b08b0c1257381af16a5c3605254d529d3e7e109f3c62befc5d168968192998"
-
-[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
-
-[[package]]
-name = "typesize"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da66c62c5b7017a2787e77373c03e6a5aafde77a73bff1ff96e91cd2e128179"
-dependencies = [
- "chrono",
- "dashmap 5.5.3",
- "hashbrown 0.14.5",
- "mini-moka",
- "parking_lot",
- "secrecy",
- "serde_json",
- "time",
- "typesize-derive",
- "url",
-]
-
-[[package]]
-name = "typesize-derive"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "536b6812192bda8551cfa0e52524e328c6a951b48e66529ee4522d6c721243d6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "ulid"
@@ -13623,7 +13322,7 @@ dependencies = [
  "log",
  "native-tls",
  "once_cell",
- "rustls 0.23.39",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -13641,7 +13340,7 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "percent-encoding",
- "rustls 0.23.39",
+ "rustls",
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
@@ -13713,12 +13412,6 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "uwl"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4bf03e0ca70d626ecc4ba6b0763b934b6f2976e8c744088bb3c1d646fbb1ad0"
 
 [[package]]
 name = "v_frame"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,10 @@ exclude = [
     # Data/infra dirs under examples/ that are not Cargo packages.
     "examples/documents",
     "examples/otel",
+    # Its own workspace: `serenity` is the only published Discord client and
+    # pins a `rustls` major with four unpatched `rustls-webpki` advisories.
+    # Excluding it keeps that subtree out of the workspace lockfile.
+    "examples/discord_bot",
 ]
 
 [workspace.lints.clippy]
@@ -199,7 +203,6 @@ sqlx = "0.9"
 # 3.2: 3.0/3.1 no longer build against `surrealdb-core ^3` as published.
 surrealdb = "3.2"
 syn = "2"
-serenity = "0.12"
 term_size = "0.3"
 testcontainers = "0.27"
 textwrap = "0.16"
@@ -366,7 +369,6 @@ vertexai = ["dep:rig-vertexai"]
 audio = ["rig-core/audio", "rig-agent?/audio", "rig-reqwest?/audio"]
 image = ["rig-core/image", "rig-agent?/image", "rig-reqwest?/image"]
 derive = ["dep:rig-derive", "rig-core/derive", "rig-agent?/derive"]
-discord-bot = ["agent", "rig-agent/discord-bot"]
 pdf = ["rig-core/pdf"]
 epub = ["rig-core/epub"]
 rayon = ["rig-core/rayon"]

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -806,6 +806,29 @@ handed back a silently short list.
 
 ## 0.41 → next
 
+### The `discord-bot` feature is gone; the integration is an example
+
+`rig`'s `discord-bot` feature, rig-agent's `discord-bot` feature, and
+`rig_agent::integrations::discord_bot` (`DiscordExt`, `DiscordBotError`) are
+removed. `serenity` 0.12.5 is the newest published release and pins `rustls`
+0.22, whose `rustls-webpki` 0.102.8 carries four unpatched advisories — a
+reachable CRL-parsing panic plus three name-constraint/CRL-authority
+weaknesses — with no version to bump to. A demo-grade integration is not worth
+putting that in the dependency graph of everyone who builds the facade with
+`--all-features`.
+
+The code moved verbatim to `examples/discord_bot`, which is now excluded from
+the workspace and carries its own lockfile, so `serenity` is out of the
+workspace `Cargo.lock` entirely. If you were using `DiscordExt`, copy
+`examples/discord_bot/src/discord_bot.rs` into your own crate and depend on
+`serenity` directly — it is ~230 lines over the public `Agent` API and needs
+nothing internal. Two incidental trims came with the move: the unused
+`DiscordExt::into_discord_bot_from_env` default method and the
+`DiscordBotError::MissingToken` variant it fed.
+
+Run the example with `cargo run --manifest-path examples/discord_bot/Cargo.toml`
+(`-p discord_bot` no longer resolves).
+
 ### Run lifecycle hooks and transport middleware
 
 The agent hook surface gained a pre-run and a terminal event, and the erased
@@ -1070,7 +1093,7 @@ unchanged. What changes:
   `ErasedTool` (and `is_live`), `ToolSet::add_erased`, `ToolServer::erased_tool`,
   `AgentBuilder::erased_tool`, `ToolServerHandle::{add_managed_erased_tools,
   reconcile_managed_erased_tools}`, `Agent::tool_server_handle()`. rig-agent's `tokio` is
-  optional, enabled only by `discord-bot` (and `test-utils`).
+  optional, enabled only by `test-utils`.
 
 ### rig-core has no default transport; the bundled reqwest transport is the new `rig-reqwest` crate
 

--- a/crates/rig-agent/Cargo.toml
+++ b/crates/rig-agent/Cargo.toml
@@ -31,7 +31,6 @@ rig-run = { path = "../rig-run", version = "0.42.0" }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-serenity = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync"], optional = true }
 tracing = { workspace = true }
@@ -53,4 +52,3 @@ audio = ["rig-core/audio"]
 image = ["rig-core/image"]
 derive = ["dep:rig-derive", "rig-core/derive"]
 test-utils = ["rig-core/test-utils", "dep:tokio"]
-discord-bot = ["dep:serenity", "dep:tokio"]

--- a/crates/rig-agent/src/integrations/mod.rs
+++ b/crates/rig-agent/src/integrations/mod.rs
@@ -1,5 +1,1 @@
 pub mod cli_chatbot;
-
-#[cfg(feature = "discord-bot")]
-#[cfg_attr(docsrs, doc(cfg(feature = "discord-bot")))]
-pub mod discord_bot;

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,10 @@ Each example is its own package. Run one with:
 cargo run -p <example-name>
 ```
 
+`discord_bot` is the exception: it is excluded from the workspace and carries
+its own lockfile, so run it with
+`cargo run --manifest-path examples/discord_bot/Cargo.toml`.
+
 Most examples expect provider API keys in the environment (e.g. `OPENAI_API_KEY`,
 `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `COHERE_API_KEY`). See each example's source for specifics.
 
@@ -37,7 +41,7 @@ Most examples expect provider API keys in the environment (e.g. `OPENAI_API_KEY`
 | `complex_agentic_loop_claude` | See source. |
 | `custom_vector_store` | Example: Implementing a custom vector store backend |
 | `debate` | See source. |
-| `discord_bot` | See source. |
+| `discord_bot` | Deploys an agent as a Discord bot. Its own workspace — run it with `cargo run --manifest-path examples/discord_bot/Cargo.toml`, not `-p discord_bot`. |
 | `enum_dispatch` | See source. |
 | `extractor` | Demonstrates typed extraction and extraction with usage metadata. |
 | `force_tool_first_turn` | Demonstrates a per-turn `RequestPatch` footgun and its fix: forcing `tool_choice = Required` on *every* turn loops until `max_turns`, so an `AgentHook` gates the patch on `ctx.turn() == 1` to force the tool only up front. |

--- a/examples/discord_bot/Cargo.toml
+++ b/examples/discord_bot/Cargo.toml
@@ -1,13 +1,26 @@
 [package]
 name = "discord_bot"
-version.workspace = true
-edition.workspace = true
+version = "0.42.0"
+edition = "2024"
 publish = false
 
-[lints]
-workspace = true
+# Deliberately its own workspace, and excluded from the root one. `serenity`
+# 0.12.5 is the newest published release and pins `rustls` 0.22, which carries
+# four unpatched `rustls-webpki` 0.102.8 advisories with no version to bump to.
+# Keeping this example out of the workspace keeps those out of the workspace
+# lockfile and off every consumer of the `rig` facade. It is built on demand
+# (`cargo run --manifest-path examples/discord_bot/Cargo.toml`), not by CI.
+[workspace]
+
+[lints.clippy]
+dbg_macro = "forbid"
+todo = "forbid"
+unimplemented = "forbid"
+unwrap_used = "deny"
 
 [dependencies]
-rig = { workspace = true, features = ["discord-bot"] }
-anyhow = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
+rig = { path = "../.." }
+anyhow = "1"
+serenity = "0.12"
+thiserror = "2"
+tokio = { version = "1", features = ["full"] }

--- a/examples/discord_bot/src/discord_bot.rs
+++ b/examples/discord_bot/src/discord_bot.rs
@@ -1,22 +1,24 @@
 //! Integration for deploying your Rig agents (and more) as Discord bots.
-//! This feature is not WASM-compatible (and as such, is incompatible with the `worker` feature).
-use crate::agent::Agent;
-use crate::completion::Chat;
-use rig_core::message::Message as RigMessage;
+//!
+//! This lived behind `rig`'s `discord-bot` feature until it was moved here: the
+//! only published `serenity` release pins a `rustls` major with four
+//! unpatched `rustls-webpki` advisories, and a demo-grade integration is not
+//! worth forcing that on every consumer of the facade. It is a plain module of
+//! this example now, so `serenity` stays out of the workspace lockfile.
+use rig::agent::Agent;
+use rig::completion::Chat;
+use rig::message::Message as RigMessage;
 use serenity::all::{
     Command, CommandInteraction, Context, CreateCommand, CreateThread, EventHandler,
     GatewayIntents, Interaction, Message, Ready, async_trait,
 };
 use std::collections::HashMap;
-use std::env;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::RwLock;
 
 #[derive(Debug, Error)]
 pub enum DiscordBotError {
-    #[error("Discord bot token missing from environment: {0}")]
-    MissingToken(#[from] env::VarError),
     #[error("Failed to build Discord client: {0}")]
     ClientBuild(#[from] serenity::Error),
 }
@@ -213,15 +215,6 @@ where
         self,
         token: &str,
     ) -> impl std::future::Future<Output = Result<serenity::Client, DiscordBotError>> + Send;
-
-    fn into_discord_bot_from_env(
-        self,
-    ) -> impl std::future::Future<Output = Result<serenity::Client, DiscordBotError>> + Send {
-        async move {
-            let token = std::env::var("DISCORD_BOT_TOKEN")?;
-            DiscordExt::into_discord_bot(self, &token).await
-        }
-    }
 }
 
 impl DiscordExt for Agent {

--- a/examples/discord_bot/src/main.rs
+++ b/examples/discord_bot/src/main.rs
@@ -1,4 +1,6 @@
-use rig::integrations::discord_bot::DiscordExt;
+mod discord_bot;
+
+use discord_bot::DiscordExt;
 use rig::prelude::*;
 use rig::providers::openai;
 

--- a/tests/fixtures/tool_facade/Cargo.toml
+++ b/tests/fixtures/tool_facade/Cargo.toml
@@ -43,7 +43,6 @@ all_root = [
     "rig/audio",
     "rig/image",
     "rig/derive",
-    "rig/discord-bot",
     "rig/pdf",
     "rig/epub",
     "rig/rayon",


### PR DESCRIPTION
## Why

The four open `rustls-webpki` 0.102.8 advisories — a reachable CRL-parsing panic plus three name-constraint/CRL-authority weaknesses — are reached only through rig-agent's optional `discord-bot` feature:

```
rustls-webpki 0.102.8 ← rustls 0.22.4 ← tokio-rustls 0.25 ← tokio-tungstenite 0.21
                                          ← serenity 0.12.5 ← rig-agent (feature "discord-bot")
```

`serenity` 0.12.5 is the newest published release and hard-pins `tokio-tungstenite = "0.21.0"`, so no version bump reaches a patched rustls. The alternatives were switching serenity to its native-TLS backend (drops the advisories, but drags openssl into every `--all-features` build and keeps us married to a stale crate) or deleting the integration outright. This does neither: it keeps the demo and gets the graph out of the published crates.

## What changed

- Removed `rig`'s `discord-bot` feature, rig-agent's `discord-bot` feature, and `rig_agent::integrations::discord_bot` (`DiscordExt`, `DiscordBotError`), plus the workspace `serenity` dependency and the fixture entry in `tests/fixtures/tool_facade`.
- Moved the module verbatim into `examples/discord_bot/src/discord_bot.rs`. That crate now depends on `serenity` directly, declares its own `[workspace]`, and is in the root `exclude` list, so its lockfile is separate (and gitignored — no point tracking a lock full of unpatchable pins).
- Incidental trims that came with the move: the unused `DiscordExt::into_discord_bot_from_env` default method and the `DiscordBotError::MissingToken` variant it fed.
- `MIGRATING.md` (0.41 → next) documents the break and the copy-this-file path for anyone who was using `DiscordExt`; `examples/README.md` notes the different run command.

`serenity`, `tokio-tungstenite` 0.21, `rustls` 0.22 and `rustls-webpki` 0.102.8 are gone from the workspace `Cargo.lock` — the only remaining `rustls-webpki` is the patched 0.103.x on the default reqwest path. Most of the lockfile diff is the de-duplication that follows (`rustls 0.23.39` etc. lose their disambiguating version suffixes).

## Breaking

Per rig's no-backcompat policy there is no shim. `rig = { features = ["discord-bot"] }` no longer resolves, and `rig::integrations::discord_bot` is gone. The integration is ~230 lines over the public `Agent` API — copy `examples/discord_bot/src/discord_bot.rs` and depend on `serenity` directly.

## Tradeoff worth flagging

The example leaves CI's workspace build, so it is no longer compile-checked there. Run it with `cargo run --manifest-path examples/discord_bot/Cargo.toml`.

## Verification

- `cargo check --workspace --all-features --all-targets --locked` — clean
- `cargo clippy --workspace --all-features --all-targets` — no warnings
- `cargo test --features facade-build-tests --test tool_facade_features` — passes
- `cargo clippy --manifest-path examples/discord_bot/Cargo.toml --all-targets` — clean
- `cargo fmt --all --check` — clean