### PR TITLE
refactor!: remove backwards-compat shims (aliases, legacy preamble, extractor usage API, persisted-format tolerance, dead model ids)

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -806,6 +806,76 @@ handed back a silently short list.
 
 ## 0.41 → next
 
+### Backwards-compat shims removed
+
+A sweep removed every remaining backwards-compatibility shim. Each item below
+is a hard break with no deprecation window.
+
+**Rename aliases deleted** — use the canonical name:
+
+| Removed | Use instead |
+| --- | --- |
+| `rig_candle::ModelFamily` | `rig_candle::ConversationProtocol` |
+| `rig_candle::LlamaModel` | `rig_candle::CandleModel` |
+| `rig::tool_macro` / `rig_agent::tool_macro` | `rig_tool` |
+| `rig_agent::tool::server::ToolRegistrySnapshot` | `rig_agent::tool::ToolCatalog` |
+| `rig_bedrock::embedding::AMAZON_TITAN_EMBED_TEXT_V1` (and `_IMAGE_V1`, `_TEXT_V2_0`, `COHERE_EMBED_ENGLISH_V3`, `COHERE_EMBED_MULTILINGUAL_V3`) | the canonical constants in `rig_bedrock::completion` (`AMAZON_TITAN_EMBEDDINGS_G1_TEXT`, `AMAZON_TITAN_MULTIMODAL_EMBEDDINGS_G1`, `AMAZON_TITAN_TEXT_EMBEDDINGS_V2`, `COHERE_EMBED_ENGLISH`, `COHERE_EMBED_MULTILINGUAL`) |
+
+The hook event struct `rig_agent::agent::hook::CompletionCall` is renamed to
+`CompletionCallEvent` — the name the `rig_agent::agent::CompletionCallEvent`
+re-export always used, and no longer colliding with the run-record
+`rig_agent::agent::CompletionCall`. Code importing the event from the `hook`
+module must rename; code using `agent::CompletionCallEvent` compiles unchanged.
+
+**`CompletionRequest::preamble` is gone.** System instructions are carried
+solely by leading `Message::System` entries in `chat_history` — the shape the
+builder has emitted since 0.33. `CompletionRequestBuilder::preamble(..)` is
+unchanged (it funnels into a leading system message at build time). Only code
+that constructed `CompletionRequest` literals or read `.preamble` breaks:
+put the system prompt in `chat_history` instead. Serialized requests no
+longer carry the field; a persisted request with `"preamble"` set loses it on
+load (unknown fields are ignored) — re-nest it as a leading system message.
+Telemetry `system_instructions`, which only the dead field fed, is no longer
+reported by provider spans.
+
+**Extractor API collapsed.** `extract_with_usage` and
+`extract_with_chat_history_with_usage` are gone; `extract` and
+`extract_with_chat_history` now return
+`ExtractionResponse<T>` (`{ data, usage }`) instead of bare `T`.
+Migrate `let x = extractor.extract(text).await?` to
+`let x = extractor.extract(text).await?.data`, and calls to the `_with_usage`
+variants to the short names.
+
+**Extractors no longer silently ignore invalid tool calls.** The internal
+policy that discarded unhandled non-`submit` tool calls in extractor runs (the
+legacy extractor transport's semantics) is removed. An invalid call that no
+hook resolves now fails the attempt like any other agent run, and the
+extractor's retry loop retries it. `AgentRun::ignore_invalid_tool_call`, the
+driver primitive that existed for that policy, is removed —
+`InvalidToolCallAction` covers deliberate recovery.
+
+**Retired provider model-id constants deleted** (the providers no longer serve
+them): Cohere `COMMAND_R_PLUS`, `COMMAND_R`, `COMMAND`, `COMMAND_NIGHTLY`,
+`COMMAND_LIGHT`, `COMMAND_LIGHT_NIGHTLY`; Mistral `PIXTRAL_LARGE`,
+`MISTRAL_SABA`, `PIXTRAL_SMALL`, `MISTRAL_NEMO`, `CODESTRAL_MAMBA`; DeepSeek
+`DEEPSEEK_CHAT`, `DEEPSEEK_REASONER`; Moonshot `MOONSHOT_CHAT`
+(`moonshot-v1-128k`). Pass the model-id string directly if you must keep
+calling a retired model.
+
+**Persisted-format tolerances removed (silent behavior changes):**
+
+- `CompletionCall.usage` is a required object. The pre-monoid `Option`
+  encoding — `"usage": null` in run records, stream items, or suspended
+  `AgentRun` state — no longer deserializes. Re-persist old records with a
+  zero-valued usage object in place of `null`.
+- `json_utils::string_or_vec` no longer accepts `null` (it decodes a string,
+  a sequence, or a single bare object). Fields where `null` is a real wire
+  shape — OpenAI's `"content": null` on tool-calls-only assistant messages —
+  use the new `string_null_or_vec`, so provider decoding is unchanged;
+  hand-written payloads that passed `null` for Anthropic message content or
+  OpenAI system/user content now get a loud decode error.
+
+
 ### Typed ids: `InternalCallId` is a counter, `ConversationId` is a newtype
 
 Two identifiers that were bare `String`s are now dedicated types in

--- a/crates/rig-agent/src/agent/builder.rs
+++ b/crates/rig-agent/src/agent/builder.rs
@@ -9,7 +9,9 @@ use rig_core::{
 };
 
 use crate::{
-    agent::hook::{AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch},
+    agent::hook::{
+        AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch,
+    },
     completion::{CompletionModel, Document},
     tool::{
         DynamicTool, PortableDynamicTool, Tool, ToolSet,

--- a/crates/rig-agent/src/agent/builder.rs
+++ b/crates/rig-agent/src/agent/builder.rs
@@ -9,7 +9,7 @@ use rig_core::{
 };
 
 use crate::{
-    agent::hook::{AgentHook, CompletionCall, CompletionCallAction, HookContext, RequestPatch},
+    agent::hook::{AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch},
     completion::{CompletionModel, Document},
     tool::{
         DynamicTool, PortableDynamicTool, Tool, ToolSet,
@@ -31,7 +31,7 @@ where
     async fn on_completion_call(
         &self,
         _ctx: &HookContext,
-        event: CompletionCall<'_>,
+        event: CompletionCallEvent<'_>,
     ) -> CompletionCallAction {
         let query = event.prompt.rag_text().or_else(|| {
             event

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -650,7 +650,6 @@ mod request_identity_tests {
     "max_tokens": 512,
     "model": null,
     "output_schema": null,
-    "preamble": null,
     "temperature": 0.25,
     "tool_choice": "required",
     "tools": [
@@ -767,7 +766,6 @@ mod request_identity_tests {
     "max_tokens": 512,
     "model": null,
     "output_schema": null,
-    "preamble": null,
     "temperature": 0.25,
     "tool_choice": "required",
     "tools": [
@@ -903,7 +901,6 @@ mod request_identity_tests {
     "max_tokens": 512,
     "model": null,
     "output_schema": null,
-    "preamble": null,
     "temperature": 0.25,
     "tool_choice": "required",
     "tools": [

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -9,7 +9,8 @@ use crate::{
         Prompt, PromptError, ToolDefinition, TypedPrompt,
     },
     streaming::{StreamingChat, StreamingPrompt},
-    tool::server::{ToolRegistrySnapshot, ToolServerError, ToolServerHandle},
+    tool::ToolCatalog,
+    tool::server::{ToolServerError, ToolServerHandle},
 };
 use rig_core::completion::ModelHandle;
 use rig_core::id::ConversationId;
@@ -26,7 +27,7 @@ pub(crate) struct PreparedCompletionRequest {
     /// executes the prepared request.
     pub(crate) builder: CompletionRequestBuilder<ModelHandle>,
     /// Exact implementations behind this turn's provider definitions.
-    pub(crate) tool_snapshot: Arc<ToolRegistrySnapshot>,
+    pub(crate) tool_snapshot: Arc<ToolCatalog>,
     /// The definitions the request carries (executable tools plus, in Tool
     /// output mode, the synthetic output tool), for the run's `TurnTools`.
     pub(crate) advertised_tools: Vec<ToolDefinition>,

--- a/crates/rig-agent/src/agent/hook.rs
+++ b/crates/rig-agent/src/agent/hook.rs
@@ -560,7 +560,7 @@ pub use rig_run::policy::{InvalidToolCallAction, InvalidToolCallContext, RetryRe
 /// selection entirely and does not advance
 /// [`ModelSelection::previous_model`].
 #[derive(Clone, Copy)]
-pub struct CompletionCall<'a> {
+pub struct CompletionCallEvent<'a> {
     /// Prompt for this turn.
     pub prompt: &'a Message,
     /// History preceding the prompt.
@@ -1181,7 +1181,7 @@ pub trait AgentHook: WasmCompatSend + WasmCompatSync {
     fn on_completion_call(
         &self,
         _ctx: &HookContext,
-        _event: CompletionCall<'_>,
+        _event: CompletionCallEvent<'_>,
     ) -> impl Future<Output = CompletionCallAction> + WasmCompatSend {
         async { CompletionCallAction::Continue }
     }
@@ -1317,7 +1317,7 @@ macro_rules! for_each_boxed_hook_event {
         $m!(
             completion_call,
             on_completion_call,
-            CompletionCall,
+            CompletionCallEvent,
             CompletionCallAction
         );
         $m!(
@@ -1642,7 +1642,7 @@ impl AgentHook for HookStack {
     async fn on_completion_call(
         &self,
         ctx: &HookContext,
-        event: CompletionCall<'_>,
+        event: CompletionCallEvent<'_>,
     ) -> CompletionCallAction {
         let mut merged: Option<RequestPatch> = None;
         for hook in &self.hooks {
@@ -1839,7 +1839,7 @@ mod tests {
         async fn on_completion_call(
             &self,
             _ctx: &HookContext,
-            _event: CompletionCall<'_>,
+            _event: CompletionCallEvent<'_>,
         ) -> CompletionCallAction {
             CompletionCallAction::patch(RequestPatch::new().temperature(self.0))
         }
@@ -1854,7 +1854,7 @@ mod tests {
         let action = outer
             .on_completion_call(
                 &HookContext::new(false, None),
-                CompletionCall {
+                CompletionCallEvent {
                     prompt: &prompt,
                     history: &[],
                     turn: 1,
@@ -2365,7 +2365,7 @@ mod migrated_tests {
         async fn on_completion_call(
             &self,
             _ctx: &HookContext,
-            _event: CompletionCall<'_>,
+            _event: CompletionCallEvent<'_>,
         ) -> CompletionCallAction {
             self.log.lock().expect("log").push(self.label);
             if self.stop {
@@ -2384,9 +2384,9 @@ mod migrated_tests {
             args: "{}",
         }
     }
-    fn completion_call_event() -> CompletionCall<'static> {
+    fn completion_call_event() -> CompletionCallEvent<'static> {
         static PROMPT: std::sync::OnceLock<rig_core::message::Message> = std::sync::OnceLock::new();
-        CompletionCall {
+        CompletionCallEvent {
             prompt: PROMPT.get_or_init(|| rig_core::message::Message::user("hi")),
             history: &[],
             turn: 1,

--- a/crates/rig-agent/src/agent/mod.rs
+++ b/crates/rig-agent/src/agent/mod.rs
@@ -115,7 +115,7 @@ pub(crate) const UNKNOWN_AGENT_NAME: &str = "Unnamed Agent";
 
 pub use builder::{AgentBuilder, NoToolConfig, WithBuilderTools, WithToolServerHandle};
 pub use completion::Agent;
-pub use hook::CompletionCall as CompletionCallEvent;
+pub use hook::CompletionCallEvent;
 pub use hook::{
     AgentHook, CompletionCallAction, CompletionResponse as CompletionResponseEvent, HookContext,
     HookStack, InvalidToolCallAction, InvalidToolCallContext, ModelSelection, ModelSelectionAction,

--- a/crates/rig-agent/src/agent/prompt_request/mod.rs
+++ b/crates/rig-agent/src/agent/prompt_request/mod.rs
@@ -1202,21 +1202,19 @@ mod tests {
     }
 
     #[test]
-    fn prompt_response_deserializes_pre_monoid_null_usage_format() {
-        // Pins `CompletionCall.usage`'s null tolerance: `"usage": null` (the
-        // pre-monoid Option encoding) must map to zero-valued usage. The
-        // fixture otherwise uses the current shape — `content` is a required
-        // field since the missing-`content` reconstruction was dropped.
-        let fixture = r#"{"output":"ok","usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7,"cached_input_tokens":0,"cache_creation_input_tokens":0,"tool_use_prompt_tokens":0,"reasoning_tokens":0},"completion_calls":[{"call_index":0,"usage":null},{"call_index":1,"usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7,"cached_input_tokens":0,"cache_creation_input_tokens":0,"tool_use_prompt_tokens":0,"reasoning_tokens":0}}],"messages":[{"role":"user","content":[{"type":"text","text":"add things"}]}],"content":[{"type":"text","text":"ok"}]}"#;
+    fn prompt_response_rejects_pre_monoid_null_usage_format() {
+        // `CompletionCall.usage` is a required object: `"usage": null` (the
+        // pre-monoid Option encoding) no longer deserializes.
+        let fixture = r#"{"output":"ok","usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7,"cached_input_tokens":0,"cache_creation_input_tokens":0,"tool_use_prompt_tokens":0,"reasoning_tokens":0},"completion_calls":[{"call_index":0,"usage":null}],"messages":[{"role":"user","content":[{"type":"text","text":"add things"}]}],"content":[{"type":"text","text":"ok"}]}"#;
+        serde_json::from_str::<PromptResponse>(fixture)
+            .expect_err("null usage must not deserialize");
 
+        let fixture = r#"{"output":"ok","usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7,"cached_input_tokens":0,"cache_creation_input_tokens":0,"tool_use_prompt_tokens":0,"reasoning_tokens":0},"completion_calls":[{"call_index":1,"usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7,"cached_input_tokens":0,"cache_creation_input_tokens":0,"tool_use_prompt_tokens":0,"reasoning_tokens":0}}],"messages":[{"role":"user","content":[{"type":"text","text":"add things"}]}],"content":[{"type":"text","text":"ok"}]}"#;
         let response: PromptResponse =
-            serde_json::from_str(fixture).expect("old-format response should deserialize");
+            serde_json::from_str(fixture).expect("current-shape response should deserialize");
         assert_eq!(
             response.completion_calls(),
-            &[
-                CompletionCall::new(0, Usage::new()),
-                CompletionCall::new(1, usage(3, 4))
-            ]
+            &[CompletionCall::new(1, usage(3, 4))]
         );
         // `content` uses the tagged shape — assistant content is tagged like
         // user content (see `the_type_key_is_the_tag_and_the_untagged_shape_does_not_load`).
@@ -1560,7 +1558,7 @@ mod tests {
     }
 
     /// Without a context, the same tool runs with an empty one (no panic, no
-    /// stale value) — the backward-compatible default path.
+    /// stale value) — the default path when no context is supplied.
     #[tokio::test]
     async fn tool_runs_with_empty_context_when_none_supplied() {
         let model = MockCompletionModel::new([

--- a/crates/rig-agent/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-agent/src/agent/prompt_request/streaming.rs
@@ -3416,20 +3416,14 @@ mod migrated_tests {
             })
         );
 
-        // Stream items serialized before the Option encoding was dropped used
-        // `"usage": null`; they must still deserialize.
-        let legacy: MultiTurnStreamItem = serde_json::from_value(serde_json::json!({
+        // The pre-monoid `Option` encoding (`"usage": null`) is no longer
+        // tolerated — usage is a required object.
+        serde_json::from_value::<MultiTurnStreamItem>(serde_json::json!({
             "type": "completionCall",
             "call_index": 3,
             "usage": null
         }))
-        .expect("legacy null-usage event should deserialize");
-        match legacy {
-            MultiTurnStreamItem::CompletionCall(call) => {
-                assert_eq!(call, CompletionCall::new(3, Usage::new()));
-            }
-            other => panic!("expected completion call event, got {other:?}"),
-        }
+        .expect_err("null usage must not deserialize");
     }
 
     #[test]

--- a/crates/rig-agent/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-agent/src/agent/prompt_request/streaming.rs
@@ -24,7 +24,7 @@ use crate::{
         resolve_model_turn_action, run_single_tool,
     },
     streaming::{StreamedAssistantContent, StreamedUserContent, ToolCallDeltaContent},
-    tool::{ToolContext, server::ToolRegistrySnapshot},
+    tool::{ToolCatalog, ToolContext},
 };
 use futures::{SinkExt, Stream, StreamExt, channel::mpsc, stream, stream::FusedStream};
 use serde::{Deserialize, Serialize};
@@ -412,7 +412,7 @@ pub(crate) trait TurnSource: WasmCompatSend {
         hook_ctx: &'a HookContext,
         run: &'a mut AgentRun,
         calls: Vec<PendingToolCall>,
-        tool_snapshot: Arc<ToolRegistrySnapshot>,
+        tool_snapshot: Arc<ToolCatalog>,
     ) -> DriveStream<'a>;
 
     /// Record run-level telemetry onto the agent span at `Done`. Gated on
@@ -495,7 +495,7 @@ where
         // Set only after a model turn commits successfully and consumed by its
         // immediately following CallTools step. This keeps the sans-IO run state
         // serializable while pinning execution to the definitions sent that turn.
-        let mut pending_tool_snapshot: Option<Arc<ToolRegistrySnapshot>> = None;
+        let mut pending_tool_snapshot: Option<Arc<ToolCatalog>> = None;
         // Live routing state stays in the driver, not the serde `AgentRun`. It
         // records the model behind the preceding *issued* attempt: it advances
         // immediately before the selected model's unary or streaming operation
@@ -816,7 +816,7 @@ pub(crate) fn drive_tool_calls<'a, F>(
     hook_ctx: &'a HookContext,
     run: &'a mut AgentRun,
     calls: Vec<PendingToolCall>,
-    tool_snapshot: Arc<ToolRegistrySnapshot>,
+    tool_snapshot: Arc<ToolCatalog>,
     chain_tool_span: F,
     forward_items: bool,
 ) -> DriveStream<'a>
@@ -1623,7 +1623,7 @@ impl TurnSource for StreamingTurnSource {
         hook_ctx: &'a HookContext,
         run: &'a mut AgentRun,
         calls: Vec<PendingToolCall>,
-        tool_snapshot: Arc<ToolRegistrySnapshot>,
+        tool_snapshot: Arc<ToolCatalog>,
     ) -> DriveStream<'a> {
         // The streaming surface chains nothing onto its tool spans, and forwards
         // the ToolCall/ToolResult items to the consumer.

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -36,7 +36,7 @@ use super::{
     ModelHandle,
     completion::{Agent, AgentConfig, PreparedCompletionRequest},
     hook::{
-        AgentHook, CompletionCall, CompletionCallAction,
+        AgentHook, CompletionCallAction, CompletionCallEvent,
         CompletionResponse as CompletionResponseEvent, HookContext, HookStack,
         InvalidToolCallAction, ModelTurnAction, ModelTurnFinished, ObservationAction, RequestPatch,
         ToolCall as ToolCallEvent, ToolCallAction, ToolResultAction, ToolResultEvent,
@@ -62,7 +62,8 @@ use crate::{
     json_utils,
     tool::{
         ToolContext, ToolDispatch, ToolResult,
-        server::{ToolRegistrySnapshot, ToolServerHandle},
+        server::ToolServerHandle,
+        ToolCatalog,
     },
 };
 
@@ -535,7 +536,7 @@ pub(crate) async fn resolve_completion_call(
     match hooks
         .on_completion_call(
             ctx,
-            CompletionCall {
+            CompletionCallEvent {
                 prompt,
                 history,
                 turn,
@@ -605,7 +606,7 @@ pub(crate) struct ToolCallOutcome {
 pub(crate) async fn run_single_tool(
     runner: &AgentRunner,
     ctx: &HookContext,
-    tool_snapshot: &ToolRegistrySnapshot,
+    tool_snapshot: &ToolCatalog,
     tool_call: &ToolCall,
     internal_call_id: rig_core::id::InternalCallId,
     error_history: &[Message],
@@ -1008,7 +1009,7 @@ impl TurnSource for UnaryTurnSource {
         hook_ctx: &'a HookContext,
         run: &'a mut AgentRun,
         calls: Vec<PendingToolCall>,
-        tool_snapshot: Arc<ToolRegistrySnapshot>,
+        tool_snapshot: Arc<ToolCatalog>,
     ) -> DriveStream<'a> {
         // The blocking surface chains tool spans into its linear `follows_from`
         // sequence (chat -> tool -> chat), and discards the yielded items, so it

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -60,21 +60,10 @@ use rig_core::{
 use crate::{
     completion::{CompletionError, CompletionModel, Document, Message, PromptError, Usage},
     json_utils,
-    tool::{
-        ToolContext, ToolDispatch, ToolResult,
-        server::ToolServerHandle,
-        ToolCatalog,
-    },
+    tool::{ToolCatalog, ToolContext, ToolDispatch, ToolResult, server::ToolServerHandle},
 };
 
 use super::UNKNOWN_AGENT_NAME;
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) enum UnhandledInvalidToolCallPolicy {
-    #[default]
-    Fail,
-    IgnoreForExtractor,
-}
 
 /// Build the per-turn `chat` span shared by both turn sources.
 ///
@@ -165,7 +154,6 @@ pub struct AgentRunner {
     pub(crate) output_tool_name: Option<String>,
     pub(crate) output_tool_description: Option<String>,
     pub(crate) augment_output_preamble: bool,
-    pub(crate) unhandled_invalid_tool_call_policy: UnhandledInvalidToolCallPolicy,
     pub(crate) concurrency: usize,
     pub(crate) error_usage: Option<Arc<Mutex<Usage>>>,
 }
@@ -191,7 +179,6 @@ impl AgentRunner {
             output_tool_name: None,
             output_tool_description: None,
             augment_output_preamble: true,
-            unhandled_invalid_tool_call_policy: UnhandledInvalidToolCallPolicy::Fail,
             concurrency: 1,
             error_usage: None,
         }
@@ -361,18 +348,6 @@ impl AgentRunner {
         self.output_tool_name = Some(name.into());
         self.output_tool_description = Some(description.into());
         self.augment_output_preamble = augment_preamble;
-        self
-    }
-
-    /// Ignore invalid tool calls when every registered hook declines to act.
-    ///
-    /// This is an internal compatibility policy for extractors, whose legacy
-    /// transport treated every non-`submit` call as irrelevant response
-    /// content. Hooks still receive the invalid-call event first and retain
-    /// full control over recovery or termination.
-    pub(crate) fn ignore_unhandled_invalid_tool_calls(mut self) -> Self {
-        self.unhandled_invalid_tool_call_policy =
-            UnhandledInvalidToolCallPolicy::IgnoreForExtractor;
         self
     }
 
@@ -910,12 +885,6 @@ impl TurnSource for UnaryTurnSource {
                             .await;
                         let resolution = match action {
                             Some(action) => run.resolve_invalid_tool_call(action),
-                            None
-                                if runner.unhandled_invalid_tool_call_policy
-                                    == UnhandledInvalidToolCallPolicy::IgnoreForExtractor =>
-                            {
-                                run.ignore_invalid_tool_call()
-                            }
                             None => run.resolve_invalid_tool_call(InvalidToolCallAction::fail()),
                         };
                         outcome = match resolution {

--- a/crates/rig-agent/src/extractor.rs
+++ b/crates/rig-agent/src/extractor.rs
@@ -166,20 +166,14 @@ where
     }
 
     forward_default_run! {
-        /// Attempts to extract data from the given text with a number of retries.
-        extract() -> T;
-
-        /// Attempts to extract data from the given text with a number of retries.
-        extract_with_chat_history(chat_history: Vec<Message>) -> T;
+        /// Attempts to extract data from the given text with a number of retries,
+        /// returning the extracted data and accumulated token usage.
+        extract() -> ExtractionResponse<T> => usage;
 
         /// Attempts to extract data from the given text with a number of retries,
-        /// returning both the extracted data and accumulated token usage.
-        extract_with_usage() -> ExtractionResponse<T> => usage;
-
-        /// Attempts to extract data from the given text with a number of retries,
-        /// providing chat history context, and returning both the extracted data
-        /// and accumulated token usage.
-        extract_with_chat_history_with_usage(chat_history: Vec<Message>) -> ExtractionResponse<T>
+        /// providing chat history context, and returning the extracted data and
+        /// accumulated token usage.
+        extract_with_chat_history(chat_history: Vec<Message>) -> ExtractionResponse<T>
             => usage;
     }
 
@@ -248,7 +242,6 @@ where
                 "Submit the structured data you extracted from the provided text.",
                 false,
             )
-            .ignore_unhandled_invalid_tool_calls()
             .run_with_error_usage()
             .await;
         let response = match result {
@@ -284,37 +277,17 @@ impl<T> ExtractorRun<'_, T>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend + WasmCompatSync,
 {
-    /// Extract structured data with the run-local model.
+    /// Extract structured data and accumulated usage with the run-local model.
     pub async fn extract(
         &self,
         text: impl Into<Message> + WasmCompatSend,
-    ) -> Result<T, ExtractionError> {
-        Ok(self.extract_with_usage(text).await?.data)
-    }
-
-    /// Extract structured data with chat history and the run-local model.
-    pub async fn extract_with_chat_history(
-        &self,
-        text: impl Into<Message> + WasmCompatSend,
-        chat_history: Vec<Message>,
-    ) -> Result<T, ExtractionError> {
-        Ok(self
-            .extract_with_chat_history_with_usage(text, chat_history)
-            .await?
-            .data)
-    }
-
-    /// Extract structured data and usage with the run-local model.
-    pub async fn extract_with_usage(
-        &self,
-        text: impl Into<Message> + WasmCompatSend,
     ) -> Result<ExtractionResponse<T>, ExtractionError> {
-        self.extract_with_chat_history_with_usage(text, vec![])
-            .await
+        self.extract_with_chat_history(text, vec![]).await
     }
 
-    /// Extract structured data with chat history and usage using the run-local model.
-    pub async fn extract_with_chat_history_with_usage(
+    /// Extract structured data, with chat history context, and accumulated
+    /// usage using the run-local model.
+    pub async fn extract_with_chat_history(
         &self,
         text: impl Into<Message> + WasmCompatSend,
         chat_history: Vec<Message>,
@@ -680,7 +653,7 @@ mod tests {
             .await
             .expect("extraction should succeed");
 
-        assert_eq!(response.name, "John");
+        assert_eq!(response.data.name, "John");
         assert_eq!(model.request_count(), 1);
         assert_eq!(counts.completion_calls.load(Ordering::SeqCst), 1);
         assert_eq!(counts.completion_responses.load(Ordering::SeqCst), 1);
@@ -700,7 +673,7 @@ mod tests {
             .extract("John")
             .await
             .expect("extraction should succeed");
-        assert_eq!(response.name, "John");
+        assert_eq!(response.data.name, "John");
 
         let (prompt, content, observed_usage, message_id) = capture
             .snapshot
@@ -736,7 +709,7 @@ mod tests {
             .await
             .expect("extraction should succeed");
 
-        assert_eq!(response.name, "John");
+        assert_eq!(response.data.name, "John");
         assert_eq!(
             *queries.lock().expect("extractor queries"),
             vec![("John".to_string(), 2)]
@@ -778,7 +751,7 @@ mod tests {
         ]);
 
         let response = extractor(model, 1)
-            .extract_with_usage("John")
+            .extract("John")
             .await
             .expect("second attempt should succeed");
 
@@ -803,7 +776,7 @@ mod tests {
                 calls: Arc::new(AtomicUsize::new(0)),
             })
             .build()
-            .extract_with_usage("John")
+            .extract("John")
             .await
             .expect("second attempt should succeed");
 
@@ -829,7 +802,7 @@ mod tests {
         ]);
 
         let response = extractor(model, 1)
-            .extract_with_usage("John")
+            .extract("John")
             .await
             .expect("second attempt should succeed");
 
@@ -838,7 +811,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unexpected_tool_call_runs_hooks_before_extractor_fallback() {
+    async fn unexpected_tool_call_runs_hooks_then_fails_and_retries() {
         let model = MockCompletionModel::new([
             MockTurn::tool_call("unknown", "unexpected", json!({})).with_usage(usage(10)),
             submit_turn("John").with_usage(usage(5)),
@@ -849,15 +822,17 @@ mod tests {
             .retries(1)
             .add_hook(counts.clone())
             .build()
-            .extract_with_usage("John")
+            .extract("John")
             .await
-            .expect("deferred invalid call should use extractor fallback");
+            .expect("the retry should recover from the failed attempt");
 
         assert_eq!(response.data.name, "John");
         assert_eq!(response.usage.total_tokens, 15);
         assert_eq!(counts.invalid_tool_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(counts.completion_responses.load(Ordering::SeqCst), 2);
-        assert_eq!(counts.model_turns.load(Ordering::SeqCst), 2);
+        // The failed attempt terminates at the invalid call, so only the
+        // successful retry produces response-finish and model-turn events.
+        assert_eq!(counts.completion_responses.load(Ordering::SeqCst), 1);
+        assert_eq!(counts.model_turns.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
@@ -894,7 +869,7 @@ mod tests {
             .await
             .expect("repaired output-tool call should finalize extraction");
 
-        assert_eq!(response.name, "John");
+        assert_eq!(response.data.name, "John");
     }
 
     #[tokio::test]
@@ -912,56 +887,45 @@ mod tests {
             .await
             .expect("skipping an invalid sibling should preserve submit");
 
-        assert_eq!(response.name, "John");
+        assert_eq!(response.data.name, "John");
     }
 
     #[tokio::test]
-    async fn submit_call_wins_over_unexpected_sibling_call() {
+    async fn unresolved_sibling_call_fails_the_attempt() {
+        // An invalid sibling no hook resolves fails the attempt even when a
+        // valid submit is present — extractors follow the same fail-closed
+        // invalid-tool-call semantics as every other agent run. A hook that
+        // wants the old discard behavior skips the call
+        // (`skip_hook_preserves_valid_submit_sibling` pins that path).
         let turn = MockTurn::from_contents([
             tool_call("unknown", "unexpected", json!({})),
             tool_call("submit", SUBMIT_TOOL_NAME, json!({ "name": "John" })),
         ])
         .with_usage(usage(7));
-        let model = MockCompletionModel::new([turn]);
 
-        let response = extractor(model, 0)
-            .extract_with_usage("John")
+        let error = extractor(MockCompletionModel::new([turn]), 0)
+            .extract("John")
             .await
-            .expect("submit should remain authoritative");
+            .expect_err("an unresolved invalid sibling must fail the attempt");
 
-        assert_eq!(response.data.name, "John");
-        assert_eq!(response.usage.total_tokens, 7);
+        assert!(matches!(
+            error,
+            ExtractionError::PromptError(PromptError::UnknownToolCall { ref tool_name, .. })
+                if tool_name == "unexpected"
+        ));
     }
 
     #[tokio::test]
-    async fn submit_call_wins_before_unexpected_sibling_call() {
+    async fn unresolved_sibling_call_fails_the_attempt_even_after_submit() {
         let turn = MockTurn::from_contents([
             tool_call("submit", SUBMIT_TOOL_NAME, json!({ "name": "John" })),
             tool_call("unknown", "unexpected", json!({})),
         ]);
 
-        let response = extractor(MockCompletionModel::new([turn]), 0)
+        extractor(MockCompletionModel::new([turn]), 0)
             .extract("John")
             .await
-            .expect("an earlier submit should remain authoritative");
-
-        assert_eq!(response.name, "John");
-    }
-
-    #[tokio::test]
-    async fn multiple_unexpected_calls_surrounding_submit_are_ignored() {
-        let turn = MockTurn::from_contents([
-            tool_call("unknown-before", "unexpected_before", json!({})),
-            tool_call("submit", SUBMIT_TOOL_NAME, json!({ "name": "John" })),
-            tool_call("unknown-after", "unexpected_after", json!({})),
-        ]);
-
-        let response = extractor(MockCompletionModel::new([turn]), 0)
-            .extract("John")
-            .await
-            .expect("unexpected siblings should not displace submit");
-
-        assert_eq!(response.name, "John");
+            .expect_err("an unresolved invalid sibling must fail the attempt");
     }
 
     #[tokio::test]
@@ -972,7 +936,7 @@ mod tests {
         ]);
 
         let response = extractor(model, 1)
-            .extract_with_usage("John")
+            .extract("John")
             .await
             .expect("second attempt should succeed");
 
@@ -984,7 +948,7 @@ mod tests {
         let model = MockCompletionModel::new([submit_turn("John").with_usage(usage(7))]);
 
         let response = extractor(model, 0)
-            .extract_with_usage("John")
+            .extract("John")
             .await
             .expect("extraction should succeed");
 

--- a/crates/rig-agent/src/lib.rs
+++ b/crates/rig-agent/src/lib.rs
@@ -86,7 +86,6 @@ pub use extractor::ExtractionResponse;
 pub use rig_derive::rig_tool;
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
-pub use rig_derive::rig_tool as tool_macro;
 
 // Compile-time thread-safety contract: the agent surface must be safe to hold
 // in shared host state (worker pools, ECS resources) on native targets.

--- a/crates/rig-agent/src/lib.rs
+++ b/crates/rig-agent/src/lib.rs
@@ -84,8 +84,6 @@ pub use extractor::ExtractionResponse;
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 pub use rig_derive::rig_tool;
-#[cfg(feature = "derive")]
-#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 
 // Compile-time thread-safety contract: the agent surface must be safe to hold
 // in shared host state (worker pools, ECS resources) on native targets.

--- a/crates/rig-agent/src/test_utils/model_conformance.rs
+++ b/crates/rig-agent/src/test_utils/model_conformance.rs
@@ -1326,7 +1326,7 @@ where
         .max_tokens(384)
         .retries(0)
         .build()
-        .extract_with_usage(INPUT)
+        .extract(INPUT)
         .await?;
     validate_extraction_fields(
         SCENARIO,

--- a/crates/rig-agent/src/tool/server.rs
+++ b/crates/rig-agent/src/tool/server.rs
@@ -18,17 +18,6 @@ use rig_core::vector_store::{
     VectorSearchRequest, VectorStoreError, VectorStoreIndexDyn, request::Filter,
 };
 
-/// A pinned view of the tool registry: provider definitions plus the exact
-/// implementations behind them — [`rig_core::tool::ToolCatalog`] under the
-/// name the agent runtime has always used.
-///
-/// The agent loop takes one per turn ([`ToolServerHandle::snapshot`] for the
-/// registry as it stands, the retrieval-aware `snapshot_tool_defs` for a
-/// prompt), so registration changes after a snapshot is built take effect on
-/// the next turn and calls from the current turn dispatch through these
-/// pinned handles.
-pub type ToolRegistrySnapshot = ToolCatalog;
-
 /// Shared state behind a `ToolServerHandle`.
 struct ToolServerState {
     /// Vector indexes used to select retrieval-only tools for each prompt.
@@ -369,7 +358,7 @@ impl ToolServerHandle {
     ///
     /// For the retrieval-aware view that also selects dynamic tools for a
     /// prompt, use the async [`tool_defs`](Self::tool_defs).
-    pub fn snapshot(&self) -> ToolRegistrySnapshot {
+    pub fn snapshot(&self) -> ToolCatalog {
         let tools = self.with_registry(|state| snapshot_registered_tools(state, &[]));
         ToolCatalog::from_registered(tools)
     }
@@ -415,7 +404,7 @@ impl ToolServerHandle {
     pub(crate) async fn snapshot_tool_defs(
         &self,
         prompt: Option<String>,
-    ) -> Result<ToolRegistrySnapshot, ToolServerError> {
+    ) -> Result<ToolCatalog, ToolServerError> {
         let retrieval_indexes = {
             let state = self.state();
             state.retrieval_indexes.clone()
@@ -508,7 +497,7 @@ fn snapshot_registered_tools(
 const _: fn() = || {
     fn assert_send_sync_static<T: Send + Sync + 'static>() {}
     assert_send_sync_static::<ToolSet>();
-    assert_send_sync_static::<ToolRegistrySnapshot>();
+    assert_send_sync_static::<ToolCatalog>();
 };
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/rig-agent/tests/runtime_model_swapping.rs
+++ b/crates/rig-agent/tests/runtime_model_swapping.rs
@@ -377,7 +377,6 @@ fn beta_static(text: &str) -> BetaModel {
 fn request(prompt: &str) -> CompletionRequest {
     CompletionRequest {
         model: None,
-        preamble: None,
         chat_history: vec![Message::user(prompt)],
         documents: Vec::new(),
         tools: Vec::new(),

--- a/crates/rig-agent/tests/runtime_model_swapping.rs
+++ b/crates/rig-agent/tests/runtime_model_swapping.rs
@@ -454,7 +454,7 @@ async fn downstream_models_keep_typed_low_level_apis_and_share_a_concrete_agent_
     .extract("extract a value")
     .await
     .expect("custom model extraction");
-    assert_eq!(extracted.value, "external model extraction");
+    assert_eq!(extracted.data.value, "external model extraction");
 
     let handle = ModelHandle::named("diagnostic-alpha", alpha);
     let debug = format!("{handle:?}");
@@ -681,13 +681,13 @@ async fn extraction_override_is_run_local_and_sets_each_retry_default() {
         .extract("use the specialist")
         .await
         .expect("run-local extraction override");
-    assert_eq!(specialist.value, "specialist");
+    assert_eq!(specialist.data.value, "specialist");
     assert_eq!(specialist_script.requests().len(), 2);
     assert!(default_script.requests().is_empty());
 
     let typed = extractor
         .using_model_value(BetaModel(Script::new("typed", [], typed_turn)))
-        .extract_with_usage("use a typed model value")
+        .extract("use a typed model value")
         .await
         .expect("typed extraction override");
     assert_eq!(typed.data.value, "typed specialist");
@@ -697,7 +697,7 @@ async fn extraction_override_is_run_local_and_sets_each_retry_default() {
         .extract("use the default again")
         .await
         .expect("default extraction remains unchanged");
-    assert_eq!(default.value, "default");
+    assert_eq!(default.data.value, "default");
     assert_eq!(default_script.requests().len(), 1);
 }
 
@@ -748,7 +748,7 @@ async fn extraction_retries_reenter_model_selection_hooks() {
         .await
         .expect("hook-routed extraction retry");
 
-    assert_eq!(extracted.value, "hook selected");
+    assert_eq!(extracted.data.value, "hook selected");
     assert_eq!(attempts.load(Ordering::SeqCst), 2);
     assert_eq!(first_script.requests().len(), 1);
     assert_eq!(second_script.requests().len(), 1);

--- a/crates/rig-bedrock/examples/embedding_with_bedrock.rs
+++ b/crates/rig-bedrock/examples/embedding_with_bedrock.rs
@@ -1,5 +1,5 @@
 use rig_bedrock::client::Client;
-use rig_bedrock::embedding::AMAZON_TITAN_EMBED_TEXT_V2_0;
+use rig_bedrock::completion::AMAZON_TITAN_TEXT_EMBEDDINGS_V2;
 use rig_core::client::{EmbeddingsClient, ProviderClient};
 use tracing::info;
 
@@ -18,7 +18,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let client = Client::from_env()?;
     let embeddings = client
-        .embeddings_with_ndims(AMAZON_TITAN_EMBED_TEXT_V2_0, 256)
+        .embeddings_with_ndims(AMAZON_TITAN_TEXT_EMBEDDINGS_V2, 256)
         .document(Greetings {
             message: "aa".to_string(),
         })?

--- a/crates/rig-bedrock/examples/extractor_with_bedrock.rs
+++ b/crates/rig-bedrock/examples/extractor_with_bedrock.rs
@@ -24,7 +24,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let data_extractor = client.extractor::<Person>(AMAZON_NOVA_LITE).build();
     let person = data_extractor
         .extract("Hello my name is John Doe! I am a software engineer.")
-        .await?;
+        .await?
+        .data;
 
     info!("AWS Bedrock: {}", serde_json::to_string_pretty(&person)?);
     Ok(())

--- a/crates/rig-bedrock/examples/rag_with_bedrock.rs
+++ b/crates/rig-bedrock/examples/rag_with_bedrock.rs
@@ -3,7 +3,7 @@ use std::vec;
 use rig_agent::prelude::*;
 use rig_bedrock::client::Client;
 use rig_bedrock::completion::AMAZON_NOVA_LITE;
-use rig_bedrock::embedding::AMAZON_TITAN_EMBED_TEXT_V2_0;
+use rig_bedrock::completion::AMAZON_TITAN_TEXT_EMBEDDINGS_V2;
 use rig_core::client::{EmbeddingsClient, ProviderClient};
 use rig_core::{embeddings::EmbeddingsBuilder, vector_store::in_memory_store::InMemoryVectorStore};
 use serde::Serialize;
@@ -28,7 +28,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .init();
 
     let client = Client::from_env()?;
-    let embedding_model = client.embedding_model_with_ndims(AMAZON_TITAN_EMBED_TEXT_V2_0, 256);
+    let embedding_model = client.embedding_model_with_ndims(AMAZON_TITAN_TEXT_EMBEDDINGS_V2, 256);
 
     // Generate embeddings for the definitions of all the documents using the specified embedding model.
     let embeddings = EmbeddingsBuilder::new(embedding_model.clone())

--- a/crates/rig-bedrock/src/completion.rs
+++ b/crates/rig-bedrock/src/completion.rs
@@ -215,10 +215,7 @@ impl CompletionModel {
 
         let span =
             CompletionSpanBuilder::new("aws_bedrock", &request_model, CompletionOperation::Chat)
-                .system_instructions(
-                    completion_request.preamble.as_deref(),
-                    completion_request.record_telemetry_content,
-                )
+                .system_instructions(None, completion_request.record_telemetry_content)
                 .build();
 
         let request = AwsCompletionRequest {

--- a/crates/rig-bedrock/src/embedding.rs
+++ b/crates/rig-bedrock/src/embedding.rs
@@ -20,16 +20,6 @@ pub struct EmbeddingResponse {
     pub input_text_token_count: usize,
 }
 
-// The model-id string values are canonically defined in `crate::completion`;
-// these aliases keep this module's historical public names.
-pub use crate::completion::{
-    AMAZON_TITAN_EMBEDDINGS_G1_TEXT as AMAZON_TITAN_EMBED_TEXT_V1,
-    AMAZON_TITAN_MULTIMODAL_EMBEDDINGS_G1 as AMAZON_TITAN_EMBED_IMAGE_V1,
-    AMAZON_TITAN_TEXT_EMBEDDINGS_V2 as AMAZON_TITAN_EMBED_TEXT_V2_0,
-    COHERE_EMBED_ENGLISH as COHERE_EMBED_ENGLISH_V3,
-    COHERE_EMBED_MULTILINGUAL as COHERE_EMBED_MULTILINGUAL_V3,
-};
-
 #[derive(Clone)]
 pub struct EmbeddingModel {
     client: Client,

--- a/crates/rig-bedrock/src/streaming.rs
+++ b/crates/rig-bedrock/src/streaming.rs
@@ -408,7 +408,6 @@ impl CompletionModel {
     ) -> Result<rig_core::streaming::RawStreamingResult<BedrockStreamingResponse>, CompletionError>
     {
         let request_model = resolve_request_model(&self.model, &completion_request);
-        let system_instructions = completion_request.preamble.clone();
         let record_telemetry_content = completion_request.record_telemetry_content;
         let request = AwsCompletionRequest {
             inner: completion_request,
@@ -419,7 +418,7 @@ impl CompletionModel {
             &request_model,
             CompletionOperation::ChatStreaming,
         )
-        .system_instructions(system_instructions.as_deref(), record_telemetry_content)
+        .system_instructions(None, record_telemetry_content)
         .build();
 
         let mut converse_builder = self

--- a/crates/rig-bedrock/src/types/completion_request.rs
+++ b/crates/rig-bedrock/src/types/completion_request.rs
@@ -147,12 +147,6 @@ impl AwsCompletionRequest {
     pub fn system_prompt(&self) -> Result<Option<Vec<SystemContentBlock>>, CompletionError> {
         let mut system_blocks = Vec::new();
 
-        if let Some(system_prompt) = self.inner.preamble.clone()
-            && !system_prompt.is_empty()
-        {
-            system_blocks.push(SystemContentBlock::Text(system_prompt));
-        }
-
         for message in self.inner.chat_history.iter() {
             if let Message::System { content } = message
                 && !content.is_empty()
@@ -248,7 +242,6 @@ mod tests {
     fn minimal_request() -> CompletionRequest {
         CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![Message::User {
                 content: vec![UserContent::Text(Text::new("test".to_string()))],
             }],
@@ -507,7 +500,6 @@ mod tests {
     fn test_system_prompt_includes_system_history() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 Message::system("History system instruction"),
                 Message::User {
@@ -535,7 +527,12 @@ mod tests {
     #[test]
     fn test_system_prompt_appends_cache_point_when_prompt_caching_enabled() {
         let request = CompletionRequest {
-            preamble: Some("System prompt".to_string()),
+            chat_history: vec![
+                Message::system("System prompt"),
+                Message::User {
+                    content: vec![UserContent::Text(Text::new("test".to_string()))],
+                },
+            ],
             ..minimal_request()
         };
 
@@ -562,7 +559,6 @@ mod tests {
     fn test_messages_exclude_system_history() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 Message::system("History system instruction"),
                 Message::User {

--- a/crates/rig-candle/src/generation.rs
+++ b/crates/rig-candle/src/generation.rs
@@ -235,7 +235,7 @@ use tokenizers::{
 use web_time::{Duration, Instant};
 
 use crate::loader::{LoadedModel, LoadedWeights};
-use crate::profile::ModelFamily;
+use crate::profile::ConversationProtocol;
 use crate::runtime::{CancellationSignal, check_cancellation};
 use crate::types::{CandleCompletionResponse, FinishReason};
 
@@ -601,7 +601,7 @@ pub(crate) fn stream_generate(
     cancellation: &CancellationSignal,
     mut emit: impl FnMut(RawStreamingChoice<CandleCompletionResponse>) -> Result<(), CandleError>,
 ) -> Result<CandleCompletionResponse, CandleError> {
-    if loaded.profile.definition.protocol != ModelFamily::Qwen3 {
+    if loaded.profile.definition.protocol != ConversationProtocol::Qwen3 {
         return generate(loaded, request, cancellation, |fragment| {
             emit(RawStreamingChoice::Message(fragment))
         });

--- a/crates/rig-candle/src/lib.rs
+++ b/crates/rig-candle/src/lib.rs
@@ -12,8 +12,8 @@ mod validation;
 
 pub use artifacts::{GgufModelData, ModelArtifacts, ModelData};
 pub use generation::GenerationConfig;
-pub use model::{CandleModel, CandleModelBuilder, LlamaModel, stream_from_events};
-pub use profile::{ConversationProtocol, ModelArchitecture, ModelFamily, Quantization};
+pub use model::{CandleModel, CandleModelBuilder, stream_from_events};
+pub use profile::{ConversationProtocol, ModelArchitecture, Quantization};
 pub use types::{CandleCompletionResponse, CandleError, FinishReason};
 
 pub(crate) use profile::{

--- a/crates/rig-candle/src/loader.rs
+++ b/crates/rig-candle/src/loader.rs
@@ -20,7 +20,7 @@ use crate::generation::GenerationConfig;
 #[cfg(target_family = "wasm")]
 use crate::profile::ModelArchitecture;
 use crate::profile::{
-    ArtifactFormat, LoaderBackend, ModelFamily, ValidatedProfile, definition_for,
+    ArtifactFormat, LoaderBackend, ConversationProtocol, ValidatedProfile, definition_for,
     validate_identity, validate_tokenizer_requirements,
 };
 use crate::runtime::RuntimeDevice;
@@ -60,7 +60,7 @@ struct PreparedModel {
 
 pub(crate) fn load_model_with_family(
     artifacts: ModelArtifacts,
-    selected_family: Option<ModelFamily>,
+    selected_family: Option<ConversationProtocol>,
     generation: GenerationConfig,
     _max_concurrent_requests: usize,
 ) -> Result<LoadedModel, CandleError> {
@@ -124,7 +124,7 @@ pub(crate) fn load_model_with_family(
 
 pub(crate) fn load_gguf_model(
     data: GgufModelData<'_>,
-    selected_family: Option<ModelFamily>,
+    selected_family: Option<ConversationProtocol>,
     generation: GenerationConfig,
     _max_concurrent_requests: usize,
 ) -> Result<LoadedModel, CandleError> {
@@ -166,7 +166,7 @@ pub(crate) fn load_gguf_model(
 fn prepare_model(
     config_bytes: &[u8],
     tokenizer_bytes: &[u8],
-    selected_family: Option<ModelFamily>,
+    selected_family: Option<ConversationProtocol>,
     artifact_format: ArtifactFormat,
 ) -> Result<PreparedModel, CandleError> {
     let identity: ModelIdentity = serde_json::from_slice(config_bytes)
@@ -181,7 +181,7 @@ fn prepare_model(
     if is_qwen3 {
         let config: Qwen3Config = serde_json::from_slice(config_bytes)
             .map_err(|error| CandleError::Configuration(error.to_string()))?;
-        let detected_family = ModelFamily::Qwen3;
+        let detected_family = ConversationProtocol::Qwen3;
         if let Some(selected) = selected_family
             && selected != detected_family
         {

--- a/crates/rig-candle/src/loader.rs
+++ b/crates/rig-candle/src/loader.rs
@@ -20,7 +20,7 @@ use crate::generation::GenerationConfig;
 #[cfg(target_family = "wasm")]
 use crate::profile::ModelArchitecture;
 use crate::profile::{
-    ArtifactFormat, LoaderBackend, ConversationProtocol, ValidatedProfile, definition_for,
+    ArtifactFormat, ConversationProtocol, LoaderBackend, ValidatedProfile, definition_for,
     validate_identity, validate_tokenizer_requirements,
 };
 use crate::runtime::RuntimeDevice;

--- a/crates/rig-candle/src/model.rs
+++ b/crates/rig-candle/src/model.rs
@@ -90,7 +90,7 @@ use crate::loader::{LoadedModel, load_gguf_model, load_model_with_family};
 use crate::profile::{ArtifactFormat, LoaderBackend, definition_for};
 #[cfg(test)]
 use crate::profile::{BEGIN_OF_TEXT, END_HEADER, END_OF_TURN, IM_END, IM_START, START_HEADER};
-use crate::profile::{ConversationProtocol, ModelArchitecture, ModelFamily, Quantization};
+use crate::profile::{ConversationProtocol, ModelArchitecture, Quantization};
 use crate::runtime::CancellationSignal;
 #[cfg(all(test, not(target_family = "wasm")))]
 use crate::runtime::TestControl;
@@ -116,7 +116,7 @@ pub struct CandleModel {
 /// Builder for loading a [`CandleModel`] and customizing generation defaults.
 pub struct CandleModelBuilder<'a> {
     source: ModelSource<'a>,
-    family: Option<ModelFamily>,
+    family: Option<ConversationProtocol>,
     generation: GenerationConfig,
     max_concurrent_requests: usize,
 }
@@ -125,12 +125,6 @@ enum ModelSource<'a> {
     Owned(ModelArtifacts),
     BorrowedGguf(GgufModelData<'a>),
 }
-
-/// Backwards-compatible alias for [`CandleModel`].
-///
-/// New code should use `CandleModel`, which accurately reflects that the
-/// backend also supports validated Qwen3 checkpoints.
-pub type LlamaModel = CandleModel;
 
 impl CandleModel {
     /// Loads a model from config, tokenizer, and one unsharded safetensors buffer.
@@ -307,13 +301,13 @@ async fn join_model_load(
 
 #[cfg(test)]
 fn render_prompt(request: &CompletionRequest) -> Result<String, CandleError> {
-    render_prompt_for(request, ModelFamily::Llama3)
+    render_prompt_for(request, ConversationProtocol::Llama3)
 }
 
 #[cfg(test)]
 fn render_prompt_for(
     request: &CompletionRequest,
-    family: ModelFamily,
+    family: ConversationProtocol,
 ) -> Result<String, CandleError> {
     crate::protocol::render_prompt(request, family)
 }

--- a/crates/rig-candle/src/model/tests.rs
+++ b/crates/rig-candle/src/model/tests.rs
@@ -229,7 +229,6 @@ fn config_with(
 fn request(messages: Vec<Message>) -> CompletionRequest {
     CompletionRequest {
         model: None,
-        preamble: None,
         chat_history: if messages.is_empty() {
             vec![Message::user("hello")]
         } else {

--- a/crates/rig-candle/src/model/tests.rs
+++ b/crates/rig-candle/src/model/tests.rs
@@ -19,7 +19,7 @@ use tokenizers::{AddedToken, TokenizerBuilder};
 use super::*;
 
 #[cfg(not(target_family = "wasm"))]
-type ControlledModel = (LlamaModel, Arc<TestControl>, Arc<tokio::sync::Semaphore>);
+type ControlledModel = (CandleModel, Arc<TestControl>, Arc<tokio::sync::Semaphore>);
 
 struct TestTensor {
     dtype: Dtype,
@@ -248,7 +248,7 @@ fn request(messages: Vec<Message>) -> CompletionRequest {
 
 #[cfg(not(target_family = "wasm"))]
 async fn collect_stream(
-    model: &LlamaModel,
+    model: &CandleModel,
     request: CompletionRequest,
 ) -> Result<(String, CandleCompletionResponse), Box<dyn std::error::Error + Send + Sync>> {
     let mut response = model.raw_stream(request).await?;
@@ -281,7 +281,7 @@ fn controlled_model(
     let concurrency = Arc::clone(&loaded.concurrency);
     loaded.test_control = Some(Arc::clone(&control));
     Ok((
-        LlamaModel {
+        CandleModel {
             state: Arc::new(loaded),
         },
         control,
@@ -317,7 +317,7 @@ fn rejects_empty_and_malformed_artifacts() -> Result<(), Box<dyn std::error::Err
             },
         ),
     ] {
-        let error = LlamaModel::from_safetensors(data)
+        let error = CandleModel::from_safetensors(data)
             .err()
             .ok_or("expected empty-buffer error")?;
         assert!(
@@ -328,19 +328,19 @@ fn rejects_empty_and_malformed_artifacts() -> Result<(), Box<dyn std::error::Err
     let mut data = model_data()?;
     data.config = b"not json".to_vec();
     assert!(matches!(
-        LlamaModel::from_safetensors(data),
+        CandleModel::from_safetensors(data),
         Err(CandleError::Configuration(_))
     ));
     let mut data = model_data()?;
     data.tokenizer = b"not json".to_vec();
     assert!(matches!(
-        LlamaModel::from_safetensors(data),
+        CandleModel::from_safetensors(data),
         Err(CandleError::TokenizerLoading(_))
     ));
     let mut data = model_data()?;
     data.weights = b"not safetensors".to_vec();
     assert!(matches!(
-        LlamaModel::from_safetensors(data),
+        CandleModel::from_safetensors(data),
         Err(CandleError::InvalidCheckpoint(_))
     ));
     Ok(())
@@ -413,7 +413,7 @@ fn validates_tensor_shapes_dtypes_and_tied_embeddings()
         &checkpoint_custom(true, tensor(&[8, 4]), false)?,
         &tied_config,
     )?;
-    let model = LlamaModel::from_safetensors(ModelData {
+    let model = CandleModel::from_safetensors(ModelData {
         config: config_with("tie_word_embeddings", true.into())?,
         tokenizer: tiny_tokenizer()?,
         weights: checkpoint_custom(true, tensor(&[8, 4]), false)?,
@@ -433,7 +433,7 @@ fn validates_tokenizer_vocabulary_special_tokens_and_configured_ids()
         weights: checkpoint(true)?,
     };
     assert!(matches!(
-        LlamaModel::from_safetensors(data),
+        CandleModel::from_safetensors(data),
         Err(CandleError::TokenizerVocabularyMismatch {
             expected: 9,
             actual: 8
@@ -442,8 +442,8 @@ fn validates_tokenizer_vocabulary_special_tokens_and_configured_ids()
 
     let config: LlamaConfig = serde_json::from_slice(&tiny_config())?;
     let config = config.into_config(false);
-    let llama = definition_for(ModelFamily::Llama3, ArtifactFormat::Safetensors)?;
-    let smollm2 = definition_for(ModelFamily::SmolLm2, ArtifactFormat::Gguf)?;
+    let llama = definition_for(ConversationProtocol::Llama3, ArtifactFormat::Safetensors)?;
+    let smollm2 = definition_for(ConversationProtocol::SmolLm2, ArtifactFormat::Gguf)?;
     let tokenizer = Tokenizer::from_bytes(tiny_tokenizer_with_end_header("<other>", true)?)?;
     assert!(matches!(
         validate_tokenizer(&config, &tokenizer, llama),
@@ -472,7 +472,7 @@ fn validates_tokenizer_vocabulary_special_tokens_and_configured_ids()
         weights: checkpoint(true)?,
     };
     assert!(matches!(
-        LlamaModel::from_safetensors(data),
+        CandleModel::from_safetensors(data),
         Err(CandleError::TokenIdOutOfRange { token, id: 8, .. }) if token == "bos_token_id"
     ));
     let data = ModelData {
@@ -481,7 +481,7 @@ fn validates_tokenizer_vocabulary_special_tokens_and_configured_ids()
         weights: checkpoint(true)?,
     };
     assert!(matches!(
-        LlamaModel::from_safetensors(data),
+        CandleModel::from_safetensors(data),
         Err(CandleError::TokenIdOutOfRange { token, id: 9, .. }) if token == "eos_token_id"
     ));
     for (field, value) in [("bos_token_id", 7.into()), ("eos_token_id", 3.into())] {
@@ -491,7 +491,7 @@ fn validates_tokenizer_vocabulary_special_tokens_and_configured_ids()
             weights: checkpoint(true)?,
         };
         assert!(matches!(
-            LlamaModel::from_safetensors(data),
+            CandleModel::from_safetensors(data),
             Err(CandleError::ArtifactMismatch { artifact, .. }) if artifact == field
         ));
     }
@@ -501,7 +501,7 @@ fn validates_tokenizer_vocabulary_special_tokens_and_configured_ids()
         weights: checkpoint(true)?,
     };
     assert!(matches!(
-        LlamaModel::from_safetensors(data),
+        CandleModel::from_safetensors(data),
         Err(CandleError::InvalidConfigurationValue {
             field: "eos_token_id",
             ..
@@ -642,7 +642,7 @@ fn context_limit_boundaries_clamp_and_detect_conversion_overflow() {
 
 #[test]
 fn loads_entirely_from_owned_bytes() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let model = LlamaModel::from_safetensors(model_data()?)?;
+    let model = CandleModel::from_safetensors(model_data()?)?;
     let loaded = &model.state;
     assert!(loaded.runtime.is_consistent_cpu());
     assert_eq!(
@@ -653,7 +653,7 @@ fn loads_entirely_from_owned_bytes() -> Result<(), Box<dyn std::error::Error + S
         loaded.profile.definition.artifact_format,
         ArtifactFormat::Safetensors
     );
-    assert_eq!(model.conversation_protocol(), Some(ModelFamily::Llama3));
+    assert_eq!(model.conversation_protocol(), Some(ConversationProtocol::Llama3));
     assert_eq!(model.quantization(), None);
     Ok(())
 }
@@ -666,7 +666,7 @@ fn borrowed_gguf_builder_keeps_borrowed_artifacts_and_all_settings() {
         weights: b"weights",
     };
     let builder = CandleModel::builder_from_gguf_bytes(data)
-        .conversation_protocol(ModelFamily::SmolLm2)
+        .conversation_protocol(ConversationProtocol::SmolLm2)
         .max_tokens(17)
         .temperature(0.25)
         .top_k(Some(4))
@@ -679,7 +679,7 @@ fn borrowed_gguf_builder_keeps_borrowed_artifacts_and_all_settings() {
     assert!(
         matches!(builder.source, ModelSource::BorrowedGguf(actual) if actual.weights.as_ptr() == data.weights.as_ptr())
     );
-    assert_eq!(builder.family, Some(ModelFamily::SmolLm2));
+    assert_eq!(builder.family, Some(ConversationProtocol::SmolLm2));
     assert_eq!(builder.generation.max_tokens, 17);
     assert_eq!(builder.generation.temperature, 0.25);
     assert_eq!(builder.generation.top_k, Some(4));
@@ -695,7 +695,7 @@ fn borrowed_gguf_builder_keeps_borrowed_artifacts_and_all_settings() {
 async fn async_loading_succeeds_and_preserves_builder_settings()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let direct = CandleModel::from_safetensors_async(model_data()?).await?;
-    assert_eq!(direct.conversation_protocol(), Some(ModelFamily::Llama3));
+    assert_eq!(direct.conversation_protocol(), Some(ConversationProtocol::Llama3));
 
     let configured = CandleModel::builder(model_data()?)
         .max_tokens(17)
@@ -749,17 +749,17 @@ fn typed_gguf_and_family_errors_preserve_the_failure_kind()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let data = model_data()?;
     assert!(matches!(
-        LlamaModel::builder(data)
-            .conversation_protocol(ModelFamily::SmolLm2)
+        CandleModel::builder(data)
+            .conversation_protocol(ConversationProtocol::SmolLm2)
             .build(),
         Err(CandleError::ModelFamilyMismatch {
-            selected: ModelFamily::SmolLm2,
-            detected: ModelFamily::Llama3,
+            selected: ConversationProtocol::SmolLm2,
+            detected: ConversationProtocol::Llama3,
         })
     ));
 
     assert!(matches!(
-        LlamaModel::from_gguf(model_data()?),
+        CandleModel::from_gguf(model_data()?),
         Err(CandleError::UnsupportedModelFamily(_))
     ));
     Ok(())
@@ -777,7 +777,7 @@ fn gguf_metadata_shapes_and_tensor_encodings_are_validated_before_loading()
         tensor_data_offset: 0,
     };
     let tokenizer = Tokenizer::from_bytes(tiny_tokenizer()?)?;
-    let definition = definition_for(ModelFamily::SmolLm2, ArtifactFormat::Gguf)?;
+    let definition = definition_for(ConversationProtocol::SmolLm2, ArtifactFormat::Gguf)?;
     assert!(matches!(
         validate_gguf_metadata(&content, &config, &tokenizer, definition),
         Err(CandleError::ArtifactMismatch {
@@ -820,7 +820,7 @@ fn loaded_model_works_with_agent_builder() -> Result<(), Box<dyn std::error::Err
 
     let runtime = tokio::runtime::Builder::new_current_thread().build()?;
     runtime.block_on(async {
-        let model = LlamaModel::builder(model_data()?)
+        let model = CandleModel::builder(model_data()?)
             .temperature(0.0)
             .max_tokens(1)
             .build()?;
@@ -835,7 +835,7 @@ fn loaded_model_works_with_agent_builder() -> Result<(), Box<dyn std::error::Err
 #[tokio::test(flavor = "current_thread")]
 async fn buffered_and_streaming_generation_are_equivalent()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let model = LlamaModel::builder(model_data()?)
+    let model = CandleModel::builder(model_data()?)
         .temperature(0.0)
         .max_tokens(3)
         .build()?;
@@ -866,7 +866,7 @@ async fn streaming_reports_eos_and_excludes_the_stop_token()
     let mut loaded = load_model(model_data()?, GenerationConfig::default(), 1)?;
     loaded.generation.temperature = 0.0;
     loaded.profile.stop_tokens.insert(0);
-    let model = LlamaModel {
+    let model = CandleModel {
         state: Arc::new(loaded),
     };
     let (text, raw) = collect_stream(&model, request(vec![Message::user("hello")])).await?;
@@ -889,7 +889,7 @@ async fn streaming_clamps_context_and_rejects_bad_request_options()
     let prompt = render_prompt(&completion_request)?;
     let prompt_tokens = loaded.tokenizer.encode(prompt, false)?.len();
     loaded.profile.context_limit = prompt_tokens + 2;
-    let model = LlamaModel {
+    let model = CandleModel {
         state: Arc::new(loaded),
     };
     let (_, raw) = collect_stream(&model, completion_request).await?;
@@ -1070,7 +1070,7 @@ fn qwen3_4b_configuration_is_exactly_scoped() -> Result<(), CandleError> {
         }"#,
     )
     .map_err(|error| CandleError::Configuration(error.to_string()))?;
-    let definition = definition_for(ModelFamily::Qwen3, ArtifactFormat::Gguf)?;
+    let definition = definition_for(ConversationProtocol::Qwen3, ArtifactFormat::Gguf)?;
     validate_qwen3_config(&config, definition)?;
 
     config.model_type = "qwen2".to_string();
@@ -1095,7 +1095,7 @@ fn qwen3_4b_configuration_is_exactly_scoped() -> Result<(), CandleError> {
 fn concurrency_limit_and_cancellation_are_deterministic()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     assert!(matches!(
-        LlamaModel::builder(model_data()?)
+        CandleModel::builder(model_data()?)
             .max_concurrent_requests(0)
             .build(),
         Err(CandleError::InvalidConcurrencyLimit)
@@ -1126,7 +1126,7 @@ fn concurrency_limit_and_cancellation_are_deterministic()
 #[tokio::test(flavor = "current_thread")]
 async fn concurrent_completions_have_independent_caches_and_samplers()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let model = LlamaModel::builder(model_data()?)
+    let model = CandleModel::builder(model_data()?)
         .temperature(0.0)
         .max_tokens(2)
         .max_concurrent_requests(2)
@@ -1163,7 +1163,7 @@ async fn concurrent_completions_have_independent_caches_and_samplers()
 #[tokio::test(flavor = "current_thread")]
 async fn closed_admission_controller_fails_public_operations()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let model = LlamaModel::builder(model_data()?).build()?;
+    let model = CandleModel::builder(model_data()?).build()?;
     let loaded = &model.state;
     loaded.concurrency.close();
     let completion_error = model
@@ -1313,7 +1313,7 @@ async fn blocking_task_panic_maps_to_typed_completion_error()
 #[test]
 fn builder_rejects_invalid_generation_defaults() {
     assert!(matches!(
-        LlamaModel::builder(ModelData {
+        CandleModel::builder(ModelData {
             config: Vec::new(),
             tokenizer: Vec::new(),
             weights: Vec::new(),
@@ -1323,7 +1323,7 @@ fn builder_rejects_invalid_generation_defaults() {
         Err(CandleError::InvalidGeneration(_))
     ));
     assert!(matches!(
-        LlamaModel::builder(ModelData {
+        CandleModel::builder(ModelData {
             config: Vec::new(),
             tokenizer: Vec::new(),
             weights: Vec::new(),
@@ -1333,7 +1333,7 @@ fn builder_rejects_invalid_generation_defaults() {
         Err(CandleError::InvalidGeneration(_))
     ));
     assert!(matches!(
-        LlamaModel::builder(ModelData {
+        CandleModel::builder(ModelData {
             config: Vec::new(),
             tokenizer: Vec::new(),
             weights: Vec::new(),
@@ -1343,7 +1343,7 @@ fn builder_rejects_invalid_generation_defaults() {
         Err(CandleError::InvalidGeneration(_))
     ));
     assert!(matches!(
-        LlamaModel::builder(ModelData {
+        CandleModel::builder(ModelData {
             config: Vec::new(),
             tokenizer: Vec::new(),
             weights: Vec::new(),
@@ -1389,13 +1389,13 @@ fn renders_smollm2_history_default_system_and_generation_suffix()
         Message::user("follow-up"),
     ]);
     assert_eq!(
-        render_prompt_for(&with_system, ModelFamily::SmolLm2)?,
+        render_prompt_for(&with_system, ConversationProtocol::SmolLm2)?,
         "<|im_start|>system\nrules<|im_end|>\n<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\nanswer<|im_end|>\n<|im_start|>user\nfollow-up<|im_end|>\n<|im_start|>assistant\n"
     );
 
     let without_system = request(vec![Message::user("hello")]);
     assert_eq!(
-        render_prompt_for(&without_system, ModelFamily::SmolLm2)?,
+        render_prompt_for(&without_system, ConversationProtocol::SmolLm2)?,
         "<|im_start|>system\nYou are a helpful AI assistant named SmolLM, trained by Hugging Face<|im_end|>\n<|im_start|>user\nhello<|im_end|>\n<|im_start|>assistant\n"
     );
     Ok(())
@@ -1619,7 +1619,7 @@ async fn stream_from_events_terminal_carries_raw()
 #[tokio::test(flavor = "current_thread")]
 async fn completion_raw_round_trips_into_the_local_record()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let model = LlamaModel::builder(model_data()?)
+    let model = CandleModel::builder(model_data()?)
         .temperature(0.0)
         .max_tokens(2)
         .build()?;
@@ -1663,7 +1663,7 @@ async fn completion_raw_round_trips_into_the_local_record()
 #[tokio::test(flavor = "current_thread")]
 async fn stream_terminal_raw_round_trips_into_the_local_record()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let model = LlamaModel::builder(model_data()?)
+    let model = CandleModel::builder(model_data()?)
         .temperature(0.0)
         .max_tokens(2)
         .build()?;

--- a/crates/rig-candle/src/model/tests.rs
+++ b/crates/rig-candle/src/model/tests.rs
@@ -652,7 +652,10 @@ fn loads_entirely_from_owned_bytes() -> Result<(), Box<dyn std::error::Error + S
         loaded.profile.definition.artifact_format,
         ArtifactFormat::Safetensors
     );
-    assert_eq!(model.conversation_protocol(), Some(ConversationProtocol::Llama3));
+    assert_eq!(
+        model.conversation_protocol(),
+        Some(ConversationProtocol::Llama3)
+    );
     assert_eq!(model.quantization(), None);
     Ok(())
 }
@@ -694,7 +697,10 @@ fn borrowed_gguf_builder_keeps_borrowed_artifacts_and_all_settings() {
 async fn async_loading_succeeds_and_preserves_builder_settings()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let direct = CandleModel::from_safetensors_async(model_data()?).await?;
-    assert_eq!(direct.conversation_protocol(), Some(ConversationProtocol::Llama3));
+    assert_eq!(
+        direct.conversation_protocol(),
+        Some(ConversationProtocol::Llama3)
+    );
 
     let configured = CandleModel::builder(model_data()?)
         .max_tokens(17)

--- a/crates/rig-candle/src/profile.rs
+++ b/crates/rig-candle/src/profile.rs
@@ -29,9 +29,6 @@ pub enum ConversationProtocol {
     Qwen3,
 }
 
-/// Backwards-compatible name for [`ConversationProtocol`].
-pub type ModelFamily = ConversationProtocol;
-
 /// Transformer architecture used to execute a loaded checkpoint.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/rig-candle/src/protocol.rs
+++ b/crates/rig-candle/src/protocol.rs
@@ -96,9 +96,6 @@ fn validate_protocol_inputs(
     request: &CompletionRequest,
     protocol: ConversationProtocol,
 ) -> Result<(), CandleError> {
-    if let Some(preamble) = request.preamble.as_deref() {
-        validate_protocol_text(preamble, "preamble", protocol)?;
-    }
     for document in &request.documents {
         validate_protocol_text(&document.to_string(), "document", protocol)?;
     }
@@ -328,11 +325,7 @@ fn validate_tool_definition(tool: &ToolDefinition) -> Result<(), CandleError> {
 }
 
 fn messages_with_documents(request: &CompletionRequest) -> Vec<Message> {
-    let mut messages = Vec::new();
-    if let Some(preamble) = &request.preamble {
-        messages.push(Message::system(preamble.clone()));
-    }
-    messages.extend(request.chat_history.iter().cloned());
+    let mut messages: Vec<Message> = request.chat_history.clone();
     if !request.documents.is_empty() {
         let context = request
             .documents
@@ -868,7 +861,6 @@ mod tests {
     fn request(messages: Vec<Message>) -> CompletionRequest {
         CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: if messages.is_empty() {
                 vec![Message::user("fallback")]
             } else {

--- a/crates/rig-candle/src/protocol.rs
+++ b/crates/rig-candle/src/protocol.rs
@@ -9,7 +9,7 @@ use rig_core::message::{
 use serde::Deserialize;
 
 use crate::{
-    BEGIN_OF_TEXT, CandleError, END_HEADER, END_OF_TURN, IM_END, IM_START, ConversationProtocol,
+    BEGIN_OF_TEXT, CandleError, ConversationProtocol, END_HEADER, END_OF_TURN, IM_END, IM_START,
     SMOLLM2_DEFAULT_SYSTEM_PROMPT, START_HEADER,
 };
 
@@ -916,7 +916,8 @@ mod tests {
             text: "document-marker".to_string(),
             additional_props: HashMap::new(),
         });
-        let prompt = render_prompt(&request, ConversationProtocol::Qwen3).expect("render documents");
+        let prompt =
+            render_prompt(&request, ConversationProtocol::Qwen3).expect("render documents");
         let system = prompt.find("system-marker").expect("system marker");
         let tools = prompt.find("# Tools").expect("tools marker");
         let document = prompt.find("document-marker").expect("document marker");

--- a/crates/rig-candle/src/protocol.rs
+++ b/crates/rig-candle/src/protocol.rs
@@ -9,7 +9,7 @@ use rig_core::message::{
 use serde::Deserialize;
 
 use crate::{
-    BEGIN_OF_TEXT, CandleError, END_HEADER, END_OF_TURN, IM_END, IM_START, ModelFamily,
+    BEGIN_OF_TEXT, CandleError, END_HEADER, END_OF_TURN, IM_END, IM_START, ConversationProtocol,
     SMOLLM2_DEFAULT_SYSTEM_PROMPT, START_HEADER,
 };
 
@@ -48,22 +48,22 @@ enum RenderedMessage {
 
 pub(crate) fn render_prompt(
     request: &CompletionRequest,
-    protocol: ModelFamily,
+    protocol: ConversationProtocol,
 ) -> Result<String, CandleError> {
     validate_common_request(request)?;
     validate_protocol_inputs(request, protocol)?;
     match protocol {
-        ModelFamily::Llama3 => render_plain_chat(request, ModelFamily::Llama3),
-        ModelFamily::SmolLm2 => render_plain_chat(request, ModelFamily::SmolLm2),
-        ModelFamily::Qwen3 => render_qwen3(request),
+        ConversationProtocol::Llama3 => render_plain_chat(request, ConversationProtocol::Llama3),
+        ConversationProtocol::SmolLm2 => render_plain_chat(request, ConversationProtocol::SmolLm2),
+        ConversationProtocol::Qwen3 => render_qwen3(request),
     }
 }
 
-fn reserved_markers(protocol: ModelFamily) -> &'static [&'static str] {
+fn reserved_markers(protocol: ConversationProtocol) -> &'static [&'static str] {
     match protocol {
-        ModelFamily::Llama3 => &[BEGIN_OF_TEXT, START_HEADER, END_HEADER, END_OF_TURN],
-        ModelFamily::SmolLm2 => &[IM_START, IM_END],
-        ModelFamily::Qwen3 => &[
+        ConversationProtocol::Llama3 => &[BEGIN_OF_TEXT, START_HEADER, END_HEADER, END_OF_TURN],
+        ConversationProtocol::SmolLm2 => &[IM_START, IM_END],
+        ConversationProtocol::Qwen3 => &[
             IM_START,
             IM_END,
             "<tools>",
@@ -81,7 +81,7 @@ fn reserved_markers(protocol: ModelFamily) -> &'static [&'static str] {
 fn validate_protocol_text(
     value: &str,
     field: &'static str,
-    protocol: ModelFamily,
+    protocol: ConversationProtocol,
 ) -> Result<(), CandleError> {
     if let Some(marker) = reserved_markers(protocol)
         .iter()
@@ -94,7 +94,7 @@ fn validate_protocol_text(
 
 fn validate_protocol_inputs(
     request: &CompletionRequest,
-    protocol: ModelFamily,
+    protocol: ConversationProtocol,
 ) -> Result<(), CandleError> {
     if let Some(preamble) = request.preamble.as_deref() {
         validate_protocol_text(preamble, "preamble", protocol)?;
@@ -197,14 +197,14 @@ fn validate_protocol_inputs(
 pub(crate) fn parse_assistant(
     raw: &str,
     request: &CompletionRequest,
-    protocol: ModelFamily,
+    protocol: ConversationProtocol,
 ) -> Result<ParsedAssistant, CandleError> {
     match protocol {
-        ModelFamily::Llama3 | ModelFamily::SmolLm2 => Ok(ParsedAssistant {
+        ConversationProtocol::Llama3 | ConversationProtocol::SmolLm2 => Ok(ParsedAssistant {
             items: vec![AssistantContent::text(raw)],
             visible_text: raw.to_string(),
         }),
-        ModelFamily::Qwen3 => parse_qwen3_assistant(raw, request),
+        ConversationProtocol::Qwen3 => parse_qwen3_assistant(raw, request),
     }
 }
 
@@ -351,7 +351,7 @@ fn messages_with_documents(request: &CompletionRequest) -> Vec<Message> {
 
 fn render_plain_chat(
     request: &CompletionRequest,
-    family: ModelFamily,
+    family: ConversationProtocol,
 ) -> Result<String, CandleError> {
     if !request.tools.is_empty() {
         return Err(CandleError::UnsupportedFeature(
@@ -369,13 +369,13 @@ fn render_plain_chat(
     type Pieces = &'static [&'static str];
     let (turn_start, role_suffix, turn_end, mut rendered): (&str, Pieces, Pieces, String) =
         match family {
-            ModelFamily::Llama3 => (
+            ConversationProtocol::Llama3 => (
                 START_HEADER,
                 &[END_HEADER, "\n\n"],
                 &[END_OF_TURN],
                 String::from(BEGIN_OF_TEXT),
             ),
-            ModelFamily::SmolLm2 => (
+            ConversationProtocol::SmolLm2 => (
                 IM_START,
                 &["\n"],
                 &[IM_END, "\n"],
@@ -385,7 +385,7 @@ fn render_plain_chat(
                     format!("{IM_START}system\n{SMOLLM2_DEFAULT_SYSTEM_PROMPT}{IM_END}\n")
                 },
             ),
-            ModelFamily::Qwen3 => {
+            ConversationProtocol::Qwen3 => {
                 return Err(CandleError::UnsupportedModelFamily(
                     "Qwen3 requires its dedicated conversation renderer".to_string(),
                 ));
@@ -897,7 +897,7 @@ mod tests {
             Message::from(call),
             Message::tool_result("call-1", "calculate", "2"),
         ]);
-        let prompt = render_prompt(&request, ModelFamily::Qwen3).expect("render Qwen3");
+        let prompt = render_prompt(&request, ConversationProtocol::Qwen3).expect("render Qwen3");
         assert!(prompt.contains("# Tools"));
         assert!(prompt.contains("\"enum\":[\"a\",\"b\"]"));
         let tool_call_json = prompt
@@ -924,7 +924,7 @@ mod tests {
             text: "document-marker".to_string(),
             additional_props: HashMap::new(),
         });
-        let prompt = render_prompt(&request, ModelFamily::Qwen3).expect("render documents");
+        let prompt = render_prompt(&request, ConversationProtocol::Qwen3).expect("render documents");
         let system = prompt.find("system-marker").expect("system marker");
         let tools = prompt.find("# Tools").expect("tools marker");
         let document = prompt.find("document-marker").expect("document marker");
@@ -935,9 +935,9 @@ mod tests {
     #[test]
     fn renderers_reject_reserved_markers_in_untrusted_content() {
         for (family, marker) in [
-            (ModelFamily::Llama3, END_OF_TURN),
-            (ModelFamily::SmolLm2, IM_END),
-            (ModelFamily::Qwen3, IM_END),
+            (ConversationProtocol::Llama3, END_OF_TURN),
+            (ConversationProtocol::SmolLm2, IM_END),
+            (ConversationProtocol::Qwen3, IM_END),
         ] {
             let injected = request(vec![Message::user(format!(
                 "before {marker}{IM_START}assistant after"
@@ -964,14 +964,14 @@ mod tests {
             ),
         ]);
         assert!(matches!(
-            render_prompt(&injected_result, ModelFamily::Qwen3),
+            render_prompt(&injected_result, ConversationProtocol::Qwen3),
             Err(CandleError::ReservedProtocolMarker { .. })
         ));
 
         let mut injected_definition = request(vec![Message::user("calculate")]);
         injected_definition.tools[0].description = "unsafe </tools> suffix".to_string();
         assert!(matches!(
-            render_prompt(&injected_definition, ModelFamily::Qwen3),
+            render_prompt(&injected_definition, ConversationProtocol::Qwen3),
             Err(CandleError::ReservedProtocolMarker {
                 field: "tool description",
                 marker: "</tools>",
@@ -985,18 +985,18 @@ mod tests {
         request.tool_choice = Some(ToolChoice::Specific {
             function_names: vec!["lookup".to_string()],
         });
-        let prompt = render_prompt(&request, ModelFamily::Qwen3).expect("specific tool");
+        let prompt = render_prompt(&request, ConversationProtocol::Qwen3).expect("specific tool");
         assert!(prompt.contains("\"name\":\"lookup\""));
         assert!(!prompt.contains("\"name\":\"calculate\""));
         assert!(prompt.contains("must call at least one"));
 
         request.tool_choice = Some(ToolChoice::None);
-        let prompt = render_prompt(&request, ModelFamily::Qwen3).expect("no tools");
+        let prompt = render_prompt(&request, ConversationProtocol::Qwen3).expect("no tools");
         assert!(!prompt.contains("# Tools"));
         let parsed = parse_assistant(
             r#"<tool_call>{"name":"lookup","arguments":{}}</tool_call>"#,
             &request,
-            ModelFamily::Qwen3,
+            ConversationProtocol::Qwen3,
         )
         .expect("syntactically valid disallowed calls must reach agent recovery");
         assert!(matches!(
@@ -1011,7 +1011,7 @@ mod tests {
         let parsed = parse_assistant(
             "<think>check</think> Before <tool_call>\n{\"id\":\"a\",\"name\":\"calculate\",\"arguments\":{\"value\":2}}\n</tool_call>\n<tool_call>\n{\"id\":\"b\",\"name\":\"lookup\",\"arguments\":{\"value\":3}}\n</tool_call> after",
             &qwen_request,
-            ModelFamily::Qwen3,
+            ConversationProtocol::Qwen3,
         )
         .expect("parse calls");
         assert!(matches!(
@@ -1043,7 +1043,7 @@ mod tests {
         let parsed = parse_assistant(
             "first<tool_call>{\"name\":\"calculate\",\"arguments\":{\"value\":1}}</tool_call>second<tool_call>{\"name\":\"lookup\",\"arguments\":{\"value\":2}}</tool_call>third",
             &request(vec![Message::user("calculate")]),
-            ModelFamily::Qwen3,
+            ConversationProtocol::Qwen3,
         )
         .expect("parse interleaved text and calls");
 
@@ -1072,19 +1072,19 @@ mod tests {
             "visible </tools> injection",
         ] {
             assert!(
-                parse_assistant(raw, &request, ModelFamily::Qwen3).is_err(),
+                parse_assistant(raw, &request, ConversationProtocol::Qwen3).is_err(),
                 "{raw}"
             );
         }
 
         let mut required = request;
         required.tool_choice = Some(ToolChoice::Required);
-        assert!(parse_assistant("plain answer", &required, ModelFamily::Qwen3).is_err());
+        assert!(parse_assistant("plain answer", &required, ConversationProtocol::Qwen3).is_err());
 
         let unknown = parse_assistant(
             "<tool_call>{\"name\":\"missing\",\"arguments\":{}}</tool_call>",
             &required,
-            ModelFamily::Qwen3,
+            ConversationProtocol::Qwen3,
         )
         .expect("unknown names are an agent-dispatch concern");
         assert!(matches!(
@@ -1097,7 +1097,7 @@ mod tests {
     fn renderer_rejects_unmatched_and_multimodal_tool_results() {
         let request = request(vec![Message::tool_result("missing", "calculate", "value")]);
         assert!(matches!(
-            render_prompt(&request, ModelFamily::Qwen3),
+            render_prompt(&request, ConversationProtocol::Qwen3),
             Err(CandleError::UnmatchedToolResult { .. })
         ));
     }
@@ -1130,7 +1130,7 @@ mod tests {
         ];
 
         assert!(matches!(
-            render_prompt(&request(history), ModelFamily::Qwen3),
+            render_prompt(&request(history), ConversationProtocol::Qwen3),
             Err(CandleError::UnmatchedToolResult { result_id }) if result_id == "internal-a"
         ));
     }
@@ -1141,7 +1141,7 @@ mod tests {
         let parsed = parse_assistant(
             r#"<tool_call>{"name":"calculate","arguments":{"value":2,"options":{"label":"a","items":[1,2]},"optional":null}}</tool_call>"#,
             &qwen_request,
-            ModelFamily::Qwen3,
+            ConversationProtocol::Qwen3,
         )
         .expect("nested arguments");
         let Some(AssistantContent::ToolCall(call)) = parsed.items.first() else {
@@ -1161,7 +1161,7 @@ mod tests {
         let parsed = parse_assistant(
             r#"<think>private planning</think><tool_call>{"name":"calculate","arguments":{}}</tool_call><tool_call>{"name":"lookup","arguments":{"value":3,"text":"Grüße 東京 \"quoted\" C:\\tmp"}}</tool_call>done"#,
             &qwen_request,
-            ModelFamily::Qwen3,
+            ConversationProtocol::Qwen3,
         )
         .expect("zero-argument and escaped calls should parse");
         let calls = parsed
@@ -1194,7 +1194,7 @@ mod tests {
             "answer <think>hidden</think>",
         ] {
             assert!(
-                parse_assistant(raw, &qwen_request, ModelFamily::Qwen3).is_err(),
+                parse_assistant(raw, &qwen_request, ConversationProtocol::Qwen3).is_err(),
                 "{raw}"
             );
         }
@@ -1202,14 +1202,14 @@ mod tests {
         let mut invalid_name = qwen_request.clone();
         invalid_name.tools[0].name = "bad name".to_string();
         assert!(matches!(
-            render_prompt(&invalid_name, ModelFamily::Qwen3),
+            render_prompt(&invalid_name, ConversationProtocol::Qwen3),
             Err(CandleError::InvalidToolDefinition { .. })
         ));
 
         let mut invalid_schema = qwen_request.clone();
         invalid_schema.tools[0].parameters = serde_json::json!({"type": "array"});
         assert!(matches!(
-            render_prompt(&invalid_schema, ModelFamily::Qwen3),
+            render_prompt(&invalid_schema, ConversationProtocol::Qwen3),
             Err(CandleError::InvalidToolDefinition { .. })
         ));
 
@@ -1219,7 +1219,7 @@ mod tests {
                 .expect("valid test schema"),
         );
         assert!(matches!(
-            render_prompt(&native_schema, ModelFamily::Qwen3),
+            render_prompt(&native_schema, ConversationProtocol::Qwen3),
             Err(CandleError::UnsupportedFeature(feature)) if feature.contains("constrained decoding")
         ));
 
@@ -1228,7 +1228,7 @@ mod tests {
             ToolFunction::new("calculate".to_string(), serde_json::json!({"value": 1})),
         ))]);
         assert!(matches!(
-            render_prompt(&dangling_call, ModelFamily::Qwen3),
+            render_prompt(&dangling_call, ConversationProtocol::Qwen3),
             Err(CandleError::MalformedToolCall(reason)) if reason.contains("no correlated")
         ));
     }

--- a/crates/rig-candle/src/types.rs
+++ b/crates/rig-candle/src/types.rs
@@ -4,7 +4,7 @@ use rig_core::completion::{CompletionError, Usage};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::profile::ModelFamily;
+use crate::profile::ConversationProtocol;
 
 /// Why a local Candle completion failed.
 #[derive(Debug, Error, Clone)]
@@ -33,9 +33,9 @@ pub enum CandleError {
     #[error("selected model family {selected:?} does not match detected family {detected:?}")]
     ModelFamilyMismatch {
         /// Family requested by the caller.
-        selected: ModelFamily,
+        selected: ConversationProtocol,
         /// Family detected from the tokenizer.
-        detected: ModelFamily,
+        detected: ConversationProtocol,
     },
     /// Independently supplied model artifacts disagree with one another.
     #[error("{artifact} does not match the selected model artifacts: {reason}")]

--- a/crates/rig-candle/src/validation.rs
+++ b/crates/rig-candle/src/validation.rs
@@ -10,7 +10,7 @@ use tokenizers::Tokenizer;
 
 use crate::CandleError;
 use crate::profile::{
-    BEGIN_OF_TEXT, ConfigValues, END_HEADER, END_OF_TURN, IM_END, IM_START, ConversationProtocol,
+    BEGIN_OF_TEXT, ConfigValues, ConversationProtocol, END_HEADER, END_OF_TURN, IM_END, IM_START,
     ProfileDefinition, START_HEADER, validate_config_requirements, validate_dimensions,
     validate_tokenizer_requirements,
 };
@@ -252,7 +252,9 @@ pub(crate) fn validate_positive_finite(field: &'static str, value: f32) -> Resul
     Ok(())
 }
 
-pub(crate) fn detect_model_family(tokenizer: &Tokenizer) -> Result<ConversationProtocol, CandleError> {
+pub(crate) fn detect_model_family(
+    tokenizer: &Tokenizer,
+) -> Result<ConversationProtocol, CandleError> {
     let llama3 = [BEGIN_OF_TEXT, START_HEADER, END_HEADER, END_OF_TURN]
         .iter()
         .all(|token| tokenizer.token_to_id(token).is_some());

--- a/crates/rig-candle/src/validation.rs
+++ b/crates/rig-candle/src/validation.rs
@@ -10,7 +10,7 @@ use tokenizers::Tokenizer;
 
 use crate::CandleError;
 use crate::profile::{
-    BEGIN_OF_TEXT, ConfigValues, END_HEADER, END_OF_TURN, IM_END, IM_START, ModelFamily,
+    BEGIN_OF_TEXT, ConfigValues, END_HEADER, END_OF_TURN, IM_END, IM_START, ConversationProtocol,
     ProfileDefinition, START_HEADER, validate_config_requirements, validate_dimensions,
     validate_tokenizer_requirements,
 };
@@ -252,7 +252,7 @@ pub(crate) fn validate_positive_finite(field: &'static str, value: f32) -> Resul
     Ok(())
 }
 
-pub(crate) fn detect_model_family(tokenizer: &Tokenizer) -> Result<ModelFamily, CandleError> {
+pub(crate) fn detect_model_family(tokenizer: &Tokenizer) -> Result<ConversationProtocol, CandleError> {
     let llama3 = [BEGIN_OF_TEXT, START_HEADER, END_HEADER, END_OF_TURN]
         .iter()
         .all(|token| tokenizer.token_to_id(token).is_some());
@@ -260,8 +260,8 @@ pub(crate) fn detect_model_family(tokenizer: &Tokenizer) -> Result<ModelFamily, 
         .iter()
         .all(|token| tokenizer.token_to_id(token).is_some());
     match (llama3, smollm2) {
-        (true, false) => Ok(ModelFamily::Llama3),
-        (false, true) => Ok(ModelFamily::SmolLm2),
+        (true, false) => Ok(ConversationProtocol::Llama3),
+        (false, true) => Ok(ConversationProtocol::SmolLm2),
         (true, true) => Err(CandleError::UnsupportedModelFamily(
             "tokenizer ambiguously contains both Llama 3 and SmolLM2 control tokens".to_string(),
         )),

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -1849,7 +1849,6 @@ mod tests {
                 .message(Message::user("History"))
                 .build();
 
-
         let history = request.chat_history.into_iter().collect::<Vec<_>>();
         assert_eq!(history.len(), 3);
         assert!(matches!(

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -719,11 +719,6 @@ impl<M: CompletionModel + ?Sized> CompletionModel for std::sync::Arc<M> {
 pub struct CompletionRequest {
     /// Optional model override for this request.
     pub model: Option<String>,
-    /// Legacy preamble field preserved for backwards compatibility.
-    ///
-    /// New code should prefer a leading [`Message::System`]
-    /// in `chat_history` as the canonical representation of system instructions.
-    pub preamble: Option<String>,
     /// The chat history to be sent to the completion model provider.
     /// The very last message is the prompt.
     ///
@@ -1278,7 +1273,6 @@ impl<M: CompletionModel> CompletionRequestBuilder<M> {
 
         let request = CompletionRequest {
             model: self.request_model,
-            preamble: None,
             chat_history,
             documents: self.documents,
             tools: self.tools,
@@ -1319,7 +1313,6 @@ mod tests {
         fn request(chat_history: Vec<Message>) -> CompletionRequest {
             CompletionRequest {
                 model: None,
-                preamble: None,
                 chat_history,
                 documents: Vec::new(),
                 tools: Vec::new(),
@@ -1803,7 +1796,6 @@ mod tests {
 
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["What is the capital of France?".into()],
             documents: vec![doc1, doc2],
             tools: Vec::new(),
@@ -1835,7 +1827,6 @@ mod tests {
     fn test_normalize_documents_without_documents() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["What is the capital of France?".into()],
             documents: Vec::new(),
             tools: Vec::new(),
@@ -1858,7 +1849,6 @@ mod tests {
                 .message(Message::user("History"))
                 .build();
 
-        assert_eq!(request.preamble, None);
 
         let history = request.chat_history.into_iter().collect::<Vec<_>>();
         assert_eq!(history.len(), 3);
@@ -1878,7 +1868,6 @@ mod tests {
                 .without_preamble()
                 .build();
 
-        assert_eq!(request.preamble, None);
         let history = request.chat_history.into_iter().collect::<Vec<_>>();
         assert_eq!(history.len(), 1);
         assert!(matches!(&history[0], Message::User { .. }));
@@ -1955,7 +1944,6 @@ mod tests {
     fn chat_history_with_documents_places_documents_after_leading_system_messages() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 Message::system("System prompt"),
                 Message::assistant("Earlier assistant turn"),
@@ -1988,7 +1976,6 @@ mod tests {
     fn chat_history_with_documents_places_documents_before_mid_conversation_system_messages() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 Message::system("Leading system prompt"),
                 Message::assistant("Earlier assistant turn"),
@@ -2025,7 +2012,6 @@ mod tests {
     fn chat_history_with_documents_does_not_duplicate_documents() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 Message::system("System prompt"),
                 Message::user("Earlier user turn"),

--- a/crates/rig-core/src/json_utils.rs
+++ b/crates/rig-core/src/json_utils.rs
@@ -188,6 +188,9 @@ pub mod stringified_json {
     }
 }
 
+/// Decode a string, a sequence, or a bare object into a `Vec` — `null` is a
+/// loud decode error. A bare object where a list is expected is one block,
+/// not a defect: several wires spell single-block content that way.
 pub fn string_or_vec<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
 where
     T: Deserialize<'de> + FromStr<Err = Infallible>,
@@ -202,7 +205,7 @@ where
         type Value = Vec<T>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-            formatter.write_str("a string, sequence, or null")
+            formatter.write_str("a string, sequence, or object")
         }
 
         fn visit_str<E>(self, value: &str) -> Result<Vec<T>, E>
@@ -220,19 +223,55 @@ where
             Deserialize::deserialize(de::value::SeqAccessDeserializer::new(seq))
         }
 
-        /// A bare object where a list is expected is one block, not a defect —
-        /// several wires spell single-block content that way. This arm comes
-        /// from the removed non-empty container's `string_or_one_or_many`,
-        /// whose callers (Anthropic `Message.content`, OpenAI system and user
-        /// content) now share this helper.
-        ///
-        /// The two were not interchangeable: this one also has
-        /// `visit_none`/`visit_unit`, so the migrated fields now accept `null`
-        /// where they used to raise a parse error. Those arms are load-bearing
-        /// for the OpenAI assistant-content field that already used this
-        /// helper — OpenAI sends `"content": null` for a tool-calls-only
-        /// message — so the widening is the price of sharing one helper, and it
-        /// is documented in MIGRATING rather than hidden.
+        fn visit_map<M>(self, map: M) -> Result<Vec<T>, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            let item = Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))?;
+            Ok(vec![item])
+        }
+    }
+
+    deserializer.deserialize_any(StringOrVec(PhantomData))
+}
+
+/// [`string_or_vec`] widened to also decode `null` as an empty `Vec`.
+///
+/// Reserved for fields where `null` is a real wire shape — OpenAI sends
+/// `"content": null` on a tool-calls-only assistant message. Everywhere else
+/// use [`string_or_vec`], which keeps `null` a loud error.
+pub fn string_null_or_vec<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    T: Deserialize<'de> + FromStr<Err = Infallible>,
+    D: Deserializer<'de>,
+{
+    struct StringNullOrVec<T>(PhantomData<fn() -> T>);
+
+    impl<'de, T> Visitor<'de> for StringNullOrVec<T>
+    where
+        T: Deserialize<'de> + FromStr<Err = Infallible>,
+    {
+        type Value = Vec<T>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a string, sequence, object, or null")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Vec<T>, E>
+        where
+            E: de::Error,
+        {
+            let item = FromStr::from_str(value).map_err(de::Error::custom)?;
+            Ok(vec![item])
+        }
+
+        fn visit_seq<A>(self, seq: A) -> Result<Vec<T>, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            Deserialize::deserialize(de::value::SeqAccessDeserializer::new(seq))
+        }
+
         fn visit_map<M>(self, map: M) -> Result<Vec<T>, M::Error>
         where
             M: MapAccess<'de>,
@@ -256,7 +295,7 @@ where
         }
     }
 
-    deserializer.deserialize_any(StringOrVec(PhantomData))
+    deserializer.deserialize_any(StringNullOrVec(PhantomData))
 }
 
 /// Deserializes `T`, mapping an explicit `null` to `T::default()`.
@@ -530,6 +569,12 @@ mod tests {
             content: Vec<Block>,
         }
 
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct NullTolerantHolder {
+            #[serde(deserialize_with = "super::super::string_null_or_vec")]
+            content: Vec<Block>,
+        }
+
         fn decode(json: serde_json::Value) -> Vec<Block> {
             serde_json::from_value::<Holder>(json)
                 .expect("shape should decode")
@@ -577,11 +622,22 @@ mod tests {
         }
 
         #[test]
-        fn null_is_an_empty_list() {
-            // Load-bearing: OpenAI sends `"content": null` for a message that
-            // carries only tool calls, so dropping this arm would turn a normal
-            // response into a decode error.
-            assert!(decode(serde_json::json!({"content": null})).is_empty());
+        fn null_is_a_loud_error() {
+            // `string_or_vec` is the strict default: `null` where a list is
+            // expected is malformed data, not canonical absence.
+            serde_json::from_value::<Holder>(serde_json::json!({"content": null}))
+                .expect_err("null must not decode");
+        }
+
+        #[test]
+        fn null_is_an_empty_list_only_for_the_null_tolerant_variant() {
+            // Load-bearing for `string_null_or_vec`'s one consumer: OpenAI
+            // sends `"content": null` for a message that carries only tool
+            // calls.
+            let holder: NullTolerantHolder =
+                serde_json::from_value(serde_json::json!({"content": null}))
+                    .expect("null tolerant variant should decode");
+            assert!(holder.content.is_empty());
         }
     }
 }

--- a/crates/rig-core/src/lib.rs
+++ b/crates/rig-core/src/lib.rs
@@ -197,7 +197,7 @@ pub use rig_derive::Embed;
 // pulling in `rig-derive` themselves.
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
-pub use rig_derive::{rig_tool, rig_tool as tool_macro};
+pub use rig_derive::rig_tool;
 
 pub mod telemetry;
 

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -3549,7 +3549,10 @@ mod tests {
     ) -> CompletionRequest {
         CompletionRequest {
             model: None,
-            chat_history: vec![crate::message::Message::system("System prompt".to_string()), message::Message::from("Hello")],
+            chat_history: vec![
+                crate::message::Message::system("System prompt".to_string()),
+                message::Message::from("Hello"),
+            ],
             documents: Vec::new(),
             tools,
             temperature: None,

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -1592,10 +1592,7 @@ where
             .clone()
             .unwrap_or_else(|| self.model.clone());
         let span = CompletionSpanBuilder::new(Ext::PROVIDER_NAME, &request_model, operation)
-            .system_instructions(
-                completion_request.preamble.as_deref(),
-                completion_request.record_telemetry_content,
-            )
+            .system_instructions(None, completion_request.record_telemetry_content)
             .build();
 
         if completion_request.max_tokens.is_none() {
@@ -2850,19 +2847,8 @@ impl AnthropicCompletionRequest {
         let mut tools =
             build_tool_definitions::<Ext>(req.tools, &mut additional_params_payload, strict_tools)?;
 
-        // Convert system prompt to array format for cache_control support
-        let mut system = if let Some(preamble) = req.preamble {
-            if preamble.is_empty() {
-                vec![]
-            } else {
-                vec![SystemContent::Text {
-                    text: preamble,
-                    cache_control: None,
-                }]
-            }
-        } else {
-            vec![]
-        };
+        // System prompt in array format for cache_control support
+        let mut system = vec![];
         system.extend(history_system);
 
         apply_prompt_cache_control(
@@ -3563,8 +3549,7 @@ mod tests {
     ) -> CompletionRequest {
         CompletionRequest {
             model: None,
-            preamble: Some("System prompt".to_string()),
-            chat_history: vec![message::Message::from("Hello")],
+            chat_history: vec![crate::message::Message::system("System prompt".to_string()), message::Message::from("Hello")],
             documents: Vec::new(),
             tools,
             temperature: None,
@@ -3577,12 +3562,14 @@ mod tests {
     }
 
     fn completion_request_with_history(
-        chat_history: Vec<message::Message>,
+        mut chat_history: Vec<message::Message>,
         preamble: Option<String>,
     ) -> CompletionRequest {
+        if let Some(preamble) = preamble {
+            chat_history.insert(0, message::Message::system(preamble));
+        }
         CompletionRequest {
             model: None,
-            preamble,
             chat_history,
             documents: Vec::new(),
             tools: Vec::new(),

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -956,7 +956,6 @@ mod tests {
     fn streaming_request_keeps_documents_after_leading_system_messages() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 RigMessage::system("System prompt"),
                 RigMessage::assistant("Earlier assistant turn"),
@@ -1014,8 +1013,7 @@ mod tests {
 
         let request = CompletionRequest {
             model: None,
-            preamble: Some("You are helpful".to_string()),
-            chat_history: vec![RigMessage::user("What's the weather?")],
+            chat_history: vec![crate::message::Message::system("You are helpful".to_string()), RigMessage::user("What's the weather?")],
             documents: vec![],
             tools: vec![],
             temperature: Some(0.5),
@@ -1069,7 +1067,6 @@ mod tests {
     fn streaming_body_keeps_explicit_tool_choice_auto_when_tools_present_but_unset() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![RigMessage::user("Add 2 and 3")],
             documents: vec![],
             tools: vec![crate::completion::ToolDefinition {
@@ -1102,7 +1099,6 @@ mod tests {
     fn streaming_body_applies_strict_tool_opt_in() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![RigMessage::user("Look this up")],
             documents: vec![],
             tools: vec![crate::completion::ToolDefinition {
@@ -1144,7 +1140,6 @@ mod tests {
         // otherwise). A `tool_choice` set with no tools must not reach the wire.
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![RigMessage::user("Hi")],
             documents: vec![],
             tools: vec![],

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -1013,7 +1013,10 @@ mod tests {
 
         let request = CompletionRequest {
             model: None,
-            chat_history: vec![crate::message::Message::system("You are helpful".to_string()), RigMessage::user("What's the weather?")],
+            chat_history: vec![
+                crate::message::Message::system("You are helpful".to_string()),
+                RigMessage::user("What's the weather?"),
+            ],
             documents: vec![],
             tools: vec![],
             temperature: Some(0.5),

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -887,7 +887,6 @@ mod azure_tests {
         let _ = model
             .completion(CompletionRequest {
                 model: Some("other-deployment".to_string()),
-                preamble: None,
                 chat_history: vec!["Hello!".into()],
                 documents: vec![],
                 max_tokens: None,
@@ -935,8 +934,7 @@ mod azure_tests {
         let Err(error) = model
             .completion(CompletionRequest {
                 model: None,
-                preamble: Some("You are a helpful assistant.".to_string()),
-                chat_history: vec!["Hello!".into()],
+                chat_history: vec![crate::message::Message::system("You are a helpful assistant.".to_string()), "Hello!".into()],
                 documents: vec![],
                 max_tokens: Some(100),
                 temperature: Some(0.0),

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -934,7 +934,10 @@ mod azure_tests {
         let Err(error) = model
             .completion(CompletionRequest {
                 model: None,
-                chat_history: vec![crate::message::Message::system("You are a helpful assistant.".to_string()), "Hello!".into()],
+                chat_history: vec![
+                    crate::message::Message::system("You are a helpful assistant.".to_string()),
+                    "Hello!".into(),
+                ],
                 documents: vec![],
                 max_tokens: Some(100),
                 temperature: Some(0.0),

--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -785,7 +785,6 @@ data: [DONE]"#;
             .openai_model()
             .create_completion_request(completion::CompletionRequest {
                 model: Some("gpt-5.4".to_string()),
-                preamble: Some("System one".to_string()),
                 chat_history,
                 documents: Vec::new(),
                 tools: Vec::new(),
@@ -841,8 +840,7 @@ data: [DONE]"#;
             .create_request(completion::CompletionRequest {
                 record_telemetry_content: false,
                 model: None,
-                preamble: Some("Respond tersely.".to_string()),
-                chat_history: vec![completion::Message::user("hello")],
+                chat_history: vec![completion::Message::system("Respond tersely.".to_string()), completion::Message::user("hello")],
                 documents: Vec::new(),
                 tools: Vec::new(),
                 temperature: None,
@@ -869,7 +867,6 @@ data: [DONE]"#;
         let request = model
             .create_request(completion::CompletionRequest {
                 model: None,
-                preamble: None,
                 chat_history: vec![completion::Message::user("hello")],
                 documents: Vec::new(),
                 tools: Vec::new(),

--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -774,6 +774,9 @@ data: [DONE]"#;
     }
 
     fn chatgpt_conversion_request(chat_history: Vec<completion::Message>) -> ResponsesRequest {
+        let chat_history = std::iter::once(completion::Message::system("System one"))
+            .chain(chat_history)
+            .collect::<Vec<_>>();
         let client = crate::providers::chatgpt::Client::builder()
             .oauth()
             .http_client(crate::test_utils::RecordingHttpClient::new(""))
@@ -840,7 +843,10 @@ data: [DONE]"#;
             .create_request(completion::CompletionRequest {
                 record_telemetry_content: false,
                 model: None,
-                chat_history: vec![completion::Message::system("Respond tersely.".to_string()), completion::Message::user("hello")],
+                chat_history: vec![
+                    completion::Message::system("Respond tersely.".to_string()),
+                    completion::Message::user("hello"),
+                ],
                 documents: Vec::new(),
                 tools: Vec::new(),
                 temperature: None,

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -656,15 +656,10 @@ impl TryFrom<(&str, CompletionRequest)> for CohereCompletionRequest {
         }
 
         let model = req.model.clone().unwrap_or_else(|| model.to_string());
-        let mut partial_history = vec![];
-        partial_history.extend(req.chat_history);
-
-        let mut full_history: Vec<Message> = req.preamble.map_or_else(Vec::new, |preamble| {
-            vec![Message::System { content: preamble }]
-        });
+        let mut full_history: Vec<Message> = Vec::new();
 
         full_history.extend(
-            partial_history
+            req.chat_history
                 .into_iter()
                 .map(message::Message::try_into)
                 .collect::<Result<Vec<Vec<Message>>, _>>()?
@@ -743,13 +738,12 @@ where
         &self,
         completion_request: completion::CompletionRequest,
     ) -> Result<CompletionResponse, CompletionError> {
-        let system_instructions = completion_request.preamble.clone();
         let record_telemetry_content = completion_request.record_telemetry_content;
         let request = CohereCompletionRequest::try_from((self.model.as_ref(), completion_request))?;
 
         let llm_span =
             CompletionSpanBuilder::new(PROVIDER_NAME, &request.model, CompletionOperation::Chat)
-                .system_instructions(system_instructions.as_deref(), record_telemetry_content)
+                .system_instructions(None, record_telemetry_content)
                 .build();
 
         crate::providers::internal::trace_json(

--- a/crates/rig-core/src/providers/cohere/mod.rs
+++ b/crates/rig-core/src/providers/cohere/mod.rs
@@ -42,44 +42,6 @@ pub const COMMAND_R_PLUS_08_2024: &str = "command-r-plus-08-2024";
 /// `command-r-08-2024` completion model
 pub const COMMAND_R_08_2024: &str = "command-r-08-2024";
 
-/// `command-r-plus` completion model
-#[deprecated(
-    note = "Cohere removed `command-r-plus` on 2025-09-15; requests using it fail. \
-    Use `COMMAND_R_PLUS_08_2024`, `COMMAND_A_03_2025`, or `COMMAND_A_PLUS_05_2026` instead."
-)]
-pub const COMMAND_R_PLUS: &str = "command-r-plus";
-/// `command-r` completion model
-#[deprecated(
-    note = "Cohere removed `command-r` on 2025-09-15; requests using it fail. \
-    Use `COMMAND_R_08_2024`, `COMMAND_A_03_2025`, or `COMMAND_A_PLUS_05_2026` instead."
-)]
-pub const COMMAND_R: &str = "command-r";
-/// `command` completion model
-#[deprecated(
-    note = "Cohere removed `command` on 2025-09-15; requests using it fail. \
-    Use `COMMAND_R_08_2024`, `COMMAND_A_03_2025`, or `COMMAND_A_PLUS_05_2026` instead."
-)]
-pub const COMMAND: &str = "command";
-/// `command-nightly` completion model
-#[deprecated(
-    note = "`command-nightly` still resolves but is absent from Cohere's published model \
-    catalogue, so it carries no compatibility or availability guarantee. \
-    Use `COMMAND_A_03_2025` or `COMMAND_A_PLUS_05_2026` instead."
-)]
-pub const COMMAND_NIGHTLY: &str = "command-nightly";
-/// `command-light` completion model
-#[deprecated(
-    note = "Cohere removed `command-light` on 2025-09-15; requests using it fail. \
-    Use `COMMAND_R7B_12_2024` or `COMMAND_A_03_2025` instead."
-)]
-pub const COMMAND_LIGHT: &str = "command-light";
-/// `command-light-nightly` completion model
-#[deprecated(
-    note = "Cohere no longer serves `command-light-nightly`; requests using it return 404. \
-    Use `COMMAND_R7B_12_2024` or `COMMAND_A_03_2025` instead."
-)]
-pub const COMMAND_LIGHT_NIGHTLY: &str = "command-light-nightly";
-
 // ================================================================
 // Cohere Embedding Models
 // ================================================================

--- a/crates/rig-core/src/providers/cohere/streaming.rs
+++ b/crates/rig-core/src/providers/cohere/streaming.rs
@@ -338,7 +338,6 @@ where
         &self,
         request: CompletionRequest,
     ) -> Result<RawStreamingResult<StreamingCompletionResponse>, CompletionError> {
-        let system_instructions = request.preamble.clone();
         let record_telemetry_content = request.record_telemetry_content;
         let mut request = CohereCompletionRequest::try_from((self.model.as_ref(), request))?;
         let span = CompletionSpanBuilder::new(
@@ -346,7 +345,7 @@ where
             &request.model,
             CompletionOperation::ChatStreaming,
         )
-        .system_instructions(system_instructions.as_deref(), record_telemetry_content)
+        .system_instructions(None, record_telemetry_content)
         .build();
 
         let params = json_utils::merge(

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -585,7 +585,7 @@ impl RequestFacts {
         Self {
             initiator: request_initiator(request),
             has_vision: request_has_vision(request),
-            system_instructions: request.preamble.clone(),
+            system_instructions: None,
             record_telemetry_content: request.record_telemetry_content,
         }
     }

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -391,18 +391,6 @@ crate::providers::internal::model_listing::impl_model_lister!(
 // ================================================================
 // DeepSeek Completion API
 // ================================================================
-#[deprecated(
-    note = "The model names `deepseek-chat` and `deepseek-reasoner` will be deprecated on 2026/07/24. \
-    For compatibility, they correspond to the non-thinking mode and thinking mode of `deepseek-v4-flash`, \
-    respectively."
-)]
-pub const DEEPSEEK_CHAT: &str = "deepseek-chat";
-#[deprecated(
-    note = "The model names `deepseek-chat` and `deepseek-reasoner` will be deprecated on 2026/07/24. \
-    For compatibility, they correspond to the non-thinking mode and thinking mode of `deepseek-v4-flash`, \
-    respectively."
-)]
-pub const DEEPSEEK_REASONER: &str = "deepseek-reasoner";
 pub const DEEPSEEK_V4_FLASH: &str = "deepseek-v4-flash";
 pub const DEEPSEEK_V4_PRO: &str = "deepseek-v4-pro";
 

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -4213,7 +4213,11 @@ mod tests {
         .unwrap();
 
         let completion_request = CompletionRequest {
-            chat_history: vec![Message::system("You are a helpful assistant".to_string()), documents_message, Message::user("What are my notes about?")],
+            chat_history: vec![
+                Message::system("You are a helpful assistant".to_string()),
+                documents_message,
+                Message::user("What are my notes about?"),
+            ],
             documents: vec![],
             tools: vec![],
             temperature: None,
@@ -4278,7 +4282,10 @@ mod tests {
         use crate::message::Message;
 
         let completion_request = CompletionRequest {
-            chat_history: vec![Message::system("You are a helpful assistant".to_string()), Message::user("Hello")],
+            chat_history: vec![
+                Message::system("You are a helpful assistant".to_string()),
+                Message::user("Hello"),
+            ],
             documents: vec![], // No documents
             tools: vec![],
             temperature: None,

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -168,10 +168,7 @@ where
             &request_model,
             CompletionOperation::GenerateContent,
         )
-        .system_instructions(
-            completion_request.preamble.as_deref(),
-            completion_request.record_telemetry_content,
-        )
+        .system_instructions(None, completion_request.record_telemetry_content)
         .build();
 
         let mut request = create_request_body(completion_request)?;
@@ -258,7 +255,6 @@ pub(crate) fn create_request_body(
 
     let CompletionRequest {
         model: _,
-        preamble,
         chat_history: _,
         documents: _,
         tools: function_tools,
@@ -369,9 +365,6 @@ pub(crate) fn create_request_body(
     }
 
     let mut system_parts: Vec<Part> = Vec::new();
-    if let Some(preamble) = preamble.filter(|preamble| !preamble.is_empty()) {
-        system_parts.push(preamble.into());
-    }
     for content in history_system {
         if !content.is_empty() {
             system_parts.push(content.into());
@@ -2762,7 +2755,6 @@ mod tests {
     fn test_resolve_request_model_uses_override() {
         let request = CompletionRequest {
             model: Some("gemini-2.5-flash".to_string()),
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -2790,7 +2782,6 @@ mod tests {
     fn test_resolve_request_model_uses_default_when_unset() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -4028,7 +4019,6 @@ mod tests {
         use crate::message::{AssistantContent, ToolCall, ToolFunction, ToolResultContent};
 
         let request = CompletionRequest {
-            preamble: None,
             chat_history: vec![
                 message::Message::user("weather?"),
                 message::Message::Assistant {
@@ -4208,7 +4198,6 @@ mod tests {
         ];
 
         let documents_message = CompletionRequest {
-            preamble: None,
             chat_history: vec![Message::user("placeholder")],
             documents,
             tools: vec![],
@@ -4224,8 +4213,7 @@ mod tests {
         .unwrap();
 
         let completion_request = CompletionRequest {
-            preamble: Some("You are a helpful assistant".to_string()),
-            chat_history: vec![documents_message, Message::user("What are my notes about?")],
+            chat_history: vec![Message::system("You are a helpful assistant".to_string()), documents_message, Message::user("What are my notes about?")],
             documents: vec![],
             tools: vec![],
             temperature: None,
@@ -4290,8 +4278,7 @@ mod tests {
         use crate::message::Message;
 
         let completion_request = CompletionRequest {
-            preamble: Some("You are a helpful assistant".to_string()),
-            chat_history: vec![Message::user("Hello")],
+            chat_history: vec![Message::system("You are a helpful assistant".to_string()), Message::user("Hello")],
             documents: vec![], // No documents
             tools: vec![],
             temperature: None,
@@ -4367,11 +4354,14 @@ mod cached_content_request_tests {
                 parameters: serde_json::json!({"type": "object", "properties": {}}),
             });
         }
+        let mut chat_history = vec![Message::User {
+            content: vec![UserContent::text("hi")],
+        }];
+        if let Some(preamble) = preamble {
+            chat_history.insert(0, Message::system(preamble));
+        }
         super::create_request_body(CompletionRequest {
-            preamble: preamble.map(str::to_owned),
-            chat_history: vec![Message::User {
-                content: vec![UserContent::text("hi")],
-            }],
+            chat_history,
             documents: vec![],
             tools: tool_defs,
             temperature: None,
@@ -4540,11 +4530,14 @@ mod cached_content_request_tests {
         preamble: Option<&str>,
         additional: Option<serde_json::Value>,
     ) -> Result<GenerateContentRequest, CompletionError> {
+        let mut chat_history = vec![Message::User {
+            content: vec![UserContent::text("hi")],
+        }];
+        if let Some(preamble) = preamble {
+            chat_history.insert(0, Message::system(preamble));
+        }
         super::create_request_body(CompletionRequest {
-            preamble: preamble.map(str::to_owned),
-            chat_history: vec![Message::User {
-                content: vec![UserContent::text("hi")],
-            }],
+            chat_history,
             documents: vec![],
             tools: vec![],
             temperature: None,
@@ -4642,7 +4635,6 @@ mod cached_content_request_tests {
     #[test]
     fn unrelated_additional_params_coexist_with_the_typed_field() {
         let mut request = super::create_request_body(CompletionRequest {
-            preamble: None,
             chat_history: vec![Message::User {
                 content: vec![UserContent::text("hi")],
             }],
@@ -4729,7 +4721,6 @@ mod cached_content_request_tests {
         );
 
         let message = super::create_request_body(CompletionRequest {
-            preamble: None,
             chat_history: vec![Message::User {
                 content: vec![UserContent::text("hi")],
             }],
@@ -5011,11 +5002,14 @@ mod cached_content_conflict_matrix {
     const HANDLE: &str = "cachedContents/matrix";
 
     fn build(system: bool, tools: bool, tool_choice: bool) -> GenerateContentRequest {
+        let mut chat_history = vec![Message::User {
+            content: vec![UserContent::text("hi")],
+        }];
+        if system {
+            chat_history.insert(0, Message::system("you are terse"));
+        }
         super::create_request_body(CompletionRequest {
-            preamble: system.then(|| "you are terse".to_owned()),
-            chat_history: vec![Message::User {
-                content: vec![UserContent::text("hi")],
-            }],
+            chat_history,
             documents: vec![],
             tools: if tools {
                 vec![ToolDefinition {

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -133,10 +133,7 @@ where
             &self.model,
             CompletionOperation::Interactions,
         )
-        .system_instructions(
-            completion_request.preamble.as_deref(),
-            completion_request.record_telemetry_content,
-        )
+        .system_instructions(None, completion_request.record_telemetry_content)
         .build();
 
         let request = self.create_completion_request(completion_request, Some(false))?;
@@ -324,15 +321,8 @@ pub(crate) fn create_request_body(
         Some(generation_config)
     };
 
-    let system_instruction = completion_request
-        .preamble
-        .or_else(|| {
-            if history_system.is_empty() {
-                None
-            } else {
-                Some(history_system.join("\n\n"))
-            }
-        })
+    let system_instruction = (!history_system.is_empty())
+        .then(|| history_system.join("\n\n"))
         .or(params.system_instruction.take());
 
     let mut tools = Vec::new();
@@ -2365,8 +2355,7 @@ mod tests {
         let request = CompletionRequest {
             record_telemetry_content: false,
             model: None,
-            preamble: Some("Be precise.".to_string()),
-            chat_history: vec![prompt],
+            chat_history: vec![Message::system("Be precise.".to_string()), prompt],
             documents: vec![],
             tools: vec![],
             temperature: Some(0.7),
@@ -2445,7 +2434,6 @@ mod tests {
         let request = CompletionRequest {
             record_telemetry_content: false,
             model: None,
-            preamble: None,
             chat_history: vec![
                 // A driver-built result carries the executed name (a repair
                 // hook renamed the call: `sum` ran, not `add`).
@@ -2681,7 +2669,6 @@ mod tests {
         let request = CompletionRequest {
             record_telemetry_content: false,
             model: None,
-            preamble: None,
             chat_history: vec![Message::User {
                 content: vec![tool_result],
             }],

--- a/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
@@ -130,10 +130,7 @@ where
             &self.model,
             CompletionOperation::InteractionsStreaming,
         )
-        .system_instructions(
-            completion_request.preamble.as_deref(),
-            completion_request.record_telemetry_content,
-        )
+        .system_instructions(None, completion_request.record_telemetry_content)
         .build();
 
         let request = create_request_body(self.model.clone(), completion_request, Some(true))?;

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -405,10 +405,7 @@ where
             &request_model,
             CompletionOperation::ChatStreaming,
         )
-        .system_instructions(
-            completion_request.preamble.as_deref(),
-            completion_request.record_telemetry_content,
-        )
+        .system_instructions(None, completion_request.record_telemetry_content)
         .build();
         let mut request = create_request_body(completion_request)?;
         if let Some(name) = self.cached_content.as_deref() {

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -11,22 +11,6 @@ use crate::{
 pub const CODESTRAL: &str = "codestral-latest";
 /// The latest version of the `mistral-large` Mistral model
 pub const MISTRAL_LARGE: &str = "mistral-large-latest";
-/// The latest version of the `pixtral-large` Mistral multimodal model
-///
-/// **Retired.** This identifier is no longer in Mistral's `GET /v1/models`
-/// catalog; requests naming it fail with `400 Invalid model`.
-#[deprecated(
-    note = "Mistral no longer serves this model. Pixtral is retired; use `MISTRAL_SMALL` or `MISTRAL_MEDIUM`, which are vision-capable"
-)]
-pub const PIXTRAL_LARGE: &str = "pixtral-large-latest";
-/// The latest version of the `mistral` Mistral multimodal model, trained on datasets from the Middle East & South Asia
-///
-/// **Retired.** This identifier is no longer in Mistral's `GET /v1/models`
-/// catalog; requests naming it fail with `400 Invalid model`.
-#[deprecated(
-    note = "Mistral no longer serves this model. retired; no replacement in the live catalog"
-)]
-pub const MISTRAL_SABA: &str = "mistral-saba-latest";
 /// The latest version of the `mistral-3b` Mistral completions model
 pub const MINISTRAL_3B: &str = "ministral-3b-latest";
 /// The latest version of the `mistral-8b` Mistral completions model
@@ -34,28 +18,6 @@ pub const MINISTRAL_8B: &str = "ministral-8b-latest";
 
 /// The latest version of the `mistral-small` Mistral completions model
 pub const MISTRAL_SMALL: &str = "mistral-small-latest";
-/// The `24-09` version of the `pixtral-small` Mistral multimodal model
-///
-/// **Retired.** This identifier is no longer in Mistral's `GET /v1/models`
-/// catalog; requests naming it fail with `400 Invalid model`.
-#[deprecated(
-    note = "Mistral no longer serves this model. Pixtral is retired; use `MINISTRAL_3B`, which is vision-capable"
-)]
-pub const PIXTRAL_SMALL: &str = "pixtral-12b-2409";
-/// The `open-mistral-nemo` model
-///
-/// **Retired.** This identifier is no longer in Mistral's `GET /v1/models`
-/// catalog; requests naming it fail with `400 Invalid model`.
-#[deprecated(
-    note = "Mistral no longer serves this model. retired; no replacement in the live catalog"
-)]
-pub const MISTRAL_NEMO: &str = "open-mistral-nemo";
-/// The `open-mistral-mamba` model
-///
-/// **Retired.** This identifier is no longer in Mistral's `GET /v1/models`
-/// catalog; requests naming it fail with `400 Invalid model`.
-#[deprecated(note = "Mistral no longer serves this model. retired; use `CODESTRAL`")]
-pub const CODESTRAL_MAMBA: &str = "open-codestral-mamba";
 
 /// Mistral completion model, driven by the shared OpenAI Chat Completions path.
 pub type CompletionModel<H> = openai::completion::GenericCompletionModel<MistralExt, H>;

--- a/crates/rig-core/src/providers/moonshot.rs
+++ b/crates/rig-core/src/providers/moonshot.rs
@@ -101,9 +101,6 @@ const ANTHROPIC_BASE_URLS: AnthropicBaseUrl = AnthropicBaseUrl::new(
 // Moonshot Completion API
 // ================================================================
 
-/// Moonshot v1 128K context model (legacy)
-pub const MOONSHOT_CHAT: &str = "moonshot-v1-128k";
-
 /// Kimi K2 — Mixture-of-Experts model (1T total params, 32B active)
 pub const KIMI_K2: &str = "kimi-k2";
 

--- a/crates/rig-core/src/providers/moonshot.rs
+++ b/crates/rig-core/src/providers/moonshot.rs
@@ -231,7 +231,6 @@ mod tests {
 
         let request = CompletionRequest {
             model: Some("kimi-k2-thinking".to_string()),
-            preamble: None,
             chat_history: vec![assistant],
             documents: vec![],
             tools: vec![],
@@ -265,7 +264,6 @@ mod tests {
 
         let request = CompletionRequest {
             model: Some("kimi-k2-thinking".to_string()),
-            preamble: None,
             chat_history: vec![assistant],
             documents: vec![],
             tools: vec![],
@@ -288,7 +286,6 @@ mod tests {
     fn moonshot_specific_tool_choice_is_rejected() {
         let request = CompletionRequest {
             model: Some("kimi-k2.5".to_string()),
-            preamble: None,
             chat_history: vec![Message::user("Use a tool.")],
             documents: vec![],
             tools: vec![],
@@ -323,7 +320,6 @@ mod tests {
     fn moonshot_required_tool_choice_is_coerced() {
         let request = CompletionRequest {
             model: Some("kimi-k2.5".to_string()),
-            preamble: None,
             chat_history: vec![Message::user("Use a tool.")],
             documents: vec![],
             tools: vec![],

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -554,13 +554,9 @@ impl TryFrom<(&str, CompletionRequest)> for OllamaCompletionRequest {
         // results arrive with an empty name and their call carries it.
         crate::providers::internal::resolve_empty_tool_result_names(&mut partial_history);
 
-        // Add preamble to chat history (if available)
-        let mut full_history: Vec<Message> = req
-            .preamble
-            .as_deref()
-            .map_or_else(Vec::new, |preamble| vec![Message::system(preamble)]);
+        let mut full_history: Vec<Message> = Vec::new();
 
-        // Convert and extend the rest of the history
+        // Convert the history
         full_history.extend(
             partial_history
                 .into_iter()
@@ -778,12 +774,11 @@ where
         &self,
         completion_request: CompletionRequest,
     ) -> Result<CompletionResponse, CompletionError> {
-        let system_instructions = completion_request.preamble.clone();
         let record_telemetry_content = completion_request.record_telemetry_content;
         let request = OllamaCompletionRequest::try_from((self.model.as_ref(), completion_request))?;
         let span =
             CompletionSpanBuilder::new(PROVIDER_NAME, &request.model, CompletionOperation::Chat)
-                .system_instructions(system_instructions.as_deref(), record_telemetry_content)
+                .system_instructions(None, record_telemetry_content)
                 .build();
 
         internal::trace_json(
@@ -833,7 +828,6 @@ where
         &self,
         request: CompletionRequest,
     ) -> Result<RawStreamingResult<StreamingCompletionResponse>, CompletionError> {
-        let system_instructions = request.preamble.clone();
         let record_telemetry_content = request.record_telemetry_content;
         let mut request = OllamaCompletionRequest::try_from((self.model.as_ref(), request))?;
         let span = CompletionSpanBuilder::new(
@@ -841,7 +835,7 @@ where
             &request.model,
             CompletionOperation::ChatStreaming,
         )
-        .system_instructions(system_instructions.as_deref(), record_telemetry_content)
+        .system_instructions(None, record_telemetry_content)
         .build();
         request.stream = true;
 
@@ -2176,8 +2170,7 @@ mod tests {
         // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
         let completion_request = CompletionRequest {
             model: None,
-            preamble: Some("You are a helpful assistant.".to_string()),
-            chat_history: vec![CompletionMessage::User {
+            chat_history: vec![crate::message::Message::system("You are a helpful assistant.".to_string()), CompletionMessage::User {
                 content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
             }],
             documents: vec![],
@@ -2241,8 +2234,7 @@ mod tests {
         // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
         let completion_request = CompletionRequest {
             model: None,
-            preamble: Some("You are a helpful assistant.".to_string()),
-            chat_history: vec![CompletionMessage::User {
+            chat_history: vec![crate::message::Message::system("You are a helpful assistant.".to_string()), CompletionMessage::User {
                 content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
             }],
             documents: vec![],
@@ -2306,8 +2298,7 @@ mod tests {
         // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
         let completion_request = CompletionRequest {
             model: None,
-            preamble: Some("You are a helpful assistant.".to_string()),
-            chat_history: vec![CompletionMessage::User {
+            chat_history: vec![crate::message::Message::system("You are a helpful assistant.".to_string()), CompletionMessage::User {
                 content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
             }],
             documents: vec![],
@@ -2371,8 +2362,7 @@ mod tests {
         // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
         let completion_request = CompletionRequest {
             model: None,
-            preamble: Some("You are a helpful assistant.".to_string()),
-            chat_history: vec![CompletionMessage::User {
+            chat_history: vec![crate::message::Message::system("You are a helpful assistant.".to_string()), CompletionMessage::User {
                 content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
             }],
             documents: vec![],
@@ -2436,8 +2426,7 @@ mod tests {
         // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
         let completion_request = CompletionRequest {
             model: None,
-            preamble: Some("You are a helpful assistant.".to_string()),
-            chat_history: vec![CompletionMessage::User {
+            chat_history: vec![crate::message::Message::system("You are a helpful assistant.".to_string()), CompletionMessage::User {
                 content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
             }],
             documents: vec![],
@@ -2470,8 +2459,7 @@ mod tests {
         // Create a CompletionRequest WITHOUT "think" in additional_params
         let completion_request = CompletionRequest {
             model: None,
-            preamble: Some("You are a helpful assistant.".to_string()),
-            chat_history: vec![CompletionMessage::User {
+            chat_history: vec![crate::message::Message::system("You are a helpful assistant.".to_string()), CompletionMessage::User {
                 content: vec![UserContent::Text(Text::new("Hello!".to_string()))],
             }],
             documents: vec![],
@@ -2525,7 +2513,6 @@ mod tests {
 
         let completion_request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![CompletionMessage::User {
                 content: vec![UserContent::Text(Text::new("Hello!".to_string()))],
             }],
@@ -2559,7 +2546,6 @@ mod tests {
 
         let completion_request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![CompletionMessage::User {
                 content: vec![UserContent::Text(Text::new("Hello!".to_string()))],
             }],
@@ -2597,7 +2583,6 @@ mod tests {
 
         let completion_request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![CompletionMessage::User {
                 content: vec![UserContent::Text(Text::new("Hello!".to_string()))],
             }],
@@ -2636,7 +2621,6 @@ mod tests {
 
         let completion_request = CompletionRequest {
             model: Some("llama3.1".to_string()),
-            preamble: None,
             chat_history: vec![CompletionMessage::User {
                 content: vec![UserContent::Text(Text::new(
                     "How old is Ollama?".to_string(),
@@ -2681,7 +2665,6 @@ mod tests {
 
         let completion_request = CompletionRequest {
             model: Some("llama3.1".to_string()),
-            preamble: None,
             chat_history: vec![CompletionMessage::User {
                 content: vec![UserContent::Text(Text::new("Hello!".to_string()))],
             }],

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -2170,9 +2170,12 @@ mod tests {
         // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
         let completion_request = CompletionRequest {
             model: None,
-            chat_history: vec![crate::message::Message::system("You are a helpful assistant.".to_string()), CompletionMessage::User {
-                content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
-            }],
+            chat_history: vec![
+                crate::message::Message::system("You are a helpful assistant.".to_string()),
+                CompletionMessage::User {
+                    content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
+                },
+            ],
             documents: vec![],
             tools: vec![],
             temperature: Some(0.7),
@@ -2234,9 +2237,12 @@ mod tests {
         // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
         let completion_request = CompletionRequest {
             model: None,
-            chat_history: vec![crate::message::Message::system("You are a helpful assistant.".to_string()), CompletionMessage::User {
-                content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
-            }],
+            chat_history: vec![
+                crate::message::Message::system("You are a helpful assistant.".to_string()),
+                CompletionMessage::User {
+                    content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
+                },
+            ],
             documents: vec![],
             tools: vec![],
             temperature: Some(0.7),
@@ -2298,9 +2304,12 @@ mod tests {
         // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
         let completion_request = CompletionRequest {
             model: None,
-            chat_history: vec![crate::message::Message::system("You are a helpful assistant.".to_string()), CompletionMessage::User {
-                content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
-            }],
+            chat_history: vec![
+                crate::message::Message::system("You are a helpful assistant.".to_string()),
+                CompletionMessage::User {
+                    content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
+                },
+            ],
             documents: vec![],
             tools: vec![],
             temperature: Some(0.7),
@@ -2362,9 +2371,12 @@ mod tests {
         // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
         let completion_request = CompletionRequest {
             model: None,
-            chat_history: vec![crate::message::Message::system("You are a helpful assistant.".to_string()), CompletionMessage::User {
-                content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
-            }],
+            chat_history: vec![
+                crate::message::Message::system("You are a helpful assistant.".to_string()),
+                CompletionMessage::User {
+                    content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
+                },
+            ],
             documents: vec![],
             tools: vec![],
             temperature: Some(0.7),
@@ -2426,9 +2438,12 @@ mod tests {
         // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
         let completion_request = CompletionRequest {
             model: None,
-            chat_history: vec![crate::message::Message::system("You are a helpful assistant.".to_string()), CompletionMessage::User {
-                content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
-            }],
+            chat_history: vec![
+                crate::message::Message::system("You are a helpful assistant.".to_string()),
+                CompletionMessage::User {
+                    content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
+                },
+            ],
             documents: vec![],
             tools: vec![],
             temperature: Some(0.7),
@@ -2459,9 +2474,12 @@ mod tests {
         // Create a CompletionRequest WITHOUT "think" in additional_params
         let completion_request = CompletionRequest {
             model: None,
-            chat_history: vec![crate::message::Message::system("You are a helpful assistant.".to_string()), CompletionMessage::User {
-                content: vec![UserContent::Text(Text::new("Hello!".to_string()))],
-            }],
+            chat_history: vec![
+                crate::message::Message::system("You are a helpful assistant.".to_string()),
+                CompletionMessage::User {
+                    content: vec![UserContent::Text(Text::new("Hello!".to_string()))],
+                },
+            ],
             documents: vec![],
             tools: vec![],
             temperature: Some(0.5),

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -159,7 +159,7 @@ pub enum Message {
     Assistant {
         #[serde(
             default,
-            deserialize_with = "json_utils::string_or_vec",
+            deserialize_with = "json_utils::string_null_or_vec",
             skip_serializing_if = "Vec::is_empty",
             serialize_with = "serialize_assistant_content_vec"
         )]

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -2159,7 +2159,6 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
 
         let CoreCompletionRequest {
             model: request_model,
-            preamble,
             chat_history: _,
             tools,
             temperature,
@@ -2170,14 +2169,10 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
             ..
         } = req;
 
-        let mut partial_history = Vec::new();
-        partial_history.extend(chat_history);
-
-        let mut full_history: Vec<Message> =
-            preamble.map_or_else(Vec::new, |preamble| vec![Message::system(&preamble)]);
+        let mut full_history: Vec<Message> = Vec::new();
 
         full_history.extend(
-            partial_history
+            chat_history
                 .into_iter()
                 .map(message::Message::try_into)
                 .collect::<Result<Vec<Vec<Message>>, _>>()?
@@ -2440,7 +2435,6 @@ where
         &self,
         completion_request: CoreCompletionRequest,
     ) -> Result<(Ext::Response, Option<String>), CompletionError> {
-        let system_instructions = completion_request.preamble.clone();
         let record_telemetry_content = completion_request.record_telemetry_content;
         let options = CompletionModelOptions {
             strict_tools: self.strict_tools,
@@ -2458,7 +2452,7 @@ where
             &request.model,
             CompletionOperation::Chat,
         )
-        .system_instructions(system_instructions.as_deref(), record_telemetry_content)
+        .system_instructions(None, record_telemetry_content)
         .build();
 
         let modern_output_cap = self.sends_modern_output_cap(&request.model);
@@ -2688,7 +2682,6 @@ mod tests {
 
         CoreCompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![message::Message::User {
                 content: vec![message::UserContent::ToolResult(tool_result)],
             }],
@@ -2945,7 +2938,6 @@ mod tests {
     fn test_openai_request_uses_request_model_override() {
         let request = crate::completion::CompletionRequest {
             model: Some("gpt-4.1".to_string()),
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -2977,7 +2969,6 @@ mod tests {
     fn test_openai_request_uses_default_model_when_override_unset() {
         let request = crate::completion::CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -3059,7 +3050,6 @@ mod tests {
     fn openai_chat_direct_request_keeps_documents_after_system_messages() {
         let request = CoreCompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 crate::completion::Message::system("System prompt"),
                 crate::completion::Message::assistant("Earlier assistant turn"),
@@ -3513,7 +3503,6 @@ mod tests {
     fn test_max_tokens_is_forwarded_to_request() {
         let request = crate::completion::CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -3550,7 +3539,6 @@ mod tests {
             model: "gpt-4o-mini".to_string(),
             request: crate::completion::CompletionRequest {
                 model: None,
-                preamble: None,
                 chat_history: vec!["Hello".into()],
                 documents: vec![],
                 tools: vec![],
@@ -3706,7 +3694,6 @@ mod tests {
     fn test_max_tokens_omitted_when_none() {
         let request = crate::completion::CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -3745,7 +3732,6 @@ mod tests {
     fn additional_params_function_tools_merge_and_native_tools_stay() {
         let request = CoreCompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![crate::completion::ToolDefinition {
@@ -3800,7 +3786,6 @@ mod tests {
     fn request_conversion_errors_when_all_messages_are_filtered() {
         let request = CoreCompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![message::Message::Assistant {
                 id: None,
                 content: vec![message::AssistantContent::reasoning("hidden")],
@@ -3832,7 +3817,6 @@ mod tests {
     fn request_conversion_omits_response_format_on_initial_tool_turn() {
         let request = CoreCompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![message::Message::user(
                 "Hello, whats the weather in London?",
             )],
@@ -3891,7 +3875,6 @@ mod tests {
     fn request_conversion_restores_response_format_after_tool_result() {
         let request = CoreCompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 message::Message::user("Hello, whats the weather in London?"),
                 message::Message::Assistant {
@@ -4741,7 +4724,6 @@ mod image_tool_result_gate_tests {
             model: "test-model".to_string(),
             request: crate::completion::CompletionRequest {
                 model: None,
-                preamble: None,
                 chat_history: vec![message::Message::User {
                     content: vec![message::UserContent::ToolResult(message::ToolResult {
                         call: message::ToolCallId::new_or_mint("call_1"),

--- a/crates/rig-core/src/providers/openai/completion/streaming.rs
+++ b/crates/rig-core/src/providers/openai/completion/streaming.rs
@@ -321,7 +321,6 @@ where
         completion_request: CompletionRequest,
     ) -> Result<RawStreamingResult<StreamingCompletionResponse<Ext::StreamingUsage>>, CompletionError>
     {
-        let preamble = completion_request.preamble.clone();
         let record_telemetry_content = completion_request.record_telemetry_content;
         let options = CompletionModelOptions {
             strict_tools: self.strict_tools,
@@ -386,7 +385,7 @@ where
             &resolved_model,
             CompletionOperation::Chat,
         )
-        .system_instructions(preamble.as_deref(), record_telemetry_content)
+        .system_instructions(None, record_telemetry_content)
         .build();
 
         let client = self.client.clone();

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -3708,7 +3708,10 @@ mod tests {
     fn request_with_preamble(preamble: &str) -> completion::CompletionRequest {
         completion::CompletionRequest {
             model: None,
-            chat_history: vec![crate::message::Message::system(preamble.to_string()), message::Message::user("Hello")],
+            chat_history: vec![
+                crate::message::Message::system(preamble.to_string()),
+                message::Message::user("Hello"),
+            ],
             documents: Vec::new(),
             tools: Vec::new(),
             temperature: None,
@@ -5097,7 +5100,8 @@ mod tests {
     fn mocked_second_turn_request_omits_unreplayable_reasoning() {
         let request = crate::completion::CompletionRequest {
             model: None,
-            chat_history: vec![crate::message::Message::system("You are concise.".to_string()),
+            chat_history: vec![
+                crate::message::Message::system("You are concise.".to_string()),
                 completion::Message::User {
                     content: vec![message::UserContent::Text(Text::new(
                         "Think briefly, then answer.",

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -1335,18 +1335,11 @@ impl TryFrom<ResponsesRequestParams> for CompletionRequest {
         } = params;
         let chat_history = req.chat_history_with_documents();
         let model = req.model.clone().unwrap_or(model);
-        let preamble = req.preamble.take();
         let mut instruction_parts = Vec::new();
         let mut input = {
-            let mut partial_history = vec![];
-            partial_history.extend(chat_history);
+            let mut full_history: Vec<InputItem> = Vec::new();
 
-            let mut full_history: Vec<InputItem> = preamble
-                .map(InputItem::system_message)
-                .into_iter()
-                .collect();
-
-            for history_item in partial_history {
+            for history_item in chat_history {
                 full_history.extend(<Vec<InputItem>>::try_from(history_item)?);
             }
 
@@ -2524,7 +2517,6 @@ where
         &self,
         completion_request: crate::completion::CompletionRequest,
     ) -> Result<CompletionResponse, CompletionError> {
-        let system_instructions = completion_request.preamble.clone();
         let record_telemetry_content = completion_request.record_telemetry_content;
         let (request_model, request) = self.create_provider_request(completion_request, false)?;
         let span = CompletionSpanBuilder::new(
@@ -2532,7 +2524,7 @@ where
             &request_model,
             CompletionOperation::Chat,
         )
-        .system_instructions(system_instructions.as_deref(), record_telemetry_content)
+        .system_instructions(None, record_telemetry_content)
         .build();
         let body = serde_json::to_vec(&request)?;
 
@@ -3547,7 +3539,6 @@ mod tests {
     fn weather_tool_request() -> completion::CompletionRequest {
         completion::CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![message::Message::user("what's the weather?")],
             documents: Vec::new(),
             tools: vec![weather_tool_definition()],
@@ -3717,8 +3708,7 @@ mod tests {
     fn request_with_preamble(preamble: &str) -> completion::CompletionRequest {
         completion::CompletionRequest {
             model: None,
-            preamble: Some(preamble.to_string()),
-            chat_history: vec![message::Message::user("Hello")],
+            chat_history: vec![crate::message::Message::system(preamble.to_string()), message::Message::user("Hello")],
             documents: Vec::new(),
             tools: Vec::new(),
             temperature: None,
@@ -3733,7 +3723,6 @@ mod tests {
     fn system_only_request(system_text: &str) -> completion::CompletionRequest {
         completion::CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![completion::Message::system(system_text)],
             documents: Vec::new(),
             tools: Vec::new(),
@@ -4174,7 +4163,6 @@ mod tests {
     fn responses_direct_request_keeps_mid_conversation_system_messages_in_input() {
         let request = crate::completion::CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 completion::Message::system("System prompt"),
                 completion::Message::assistant("Earlier assistant turn"),
@@ -5109,8 +5097,7 @@ mod tests {
     fn mocked_second_turn_request_omits_unreplayable_reasoning() {
         let request = crate::completion::CompletionRequest {
             model: None,
-            preamble: Some("You are concise.".to_string()),
-            chat_history: vec![
+            chat_history: vec![crate::message::Message::system("You are concise.".to_string()),
                 completion::Message::User {
                     content: vec![message::UserContent::Text(Text::new(
                         "Think briefly, then answer.",
@@ -5616,7 +5603,6 @@ mod tests {
     fn url_pdf_in_full_completion_request_omits_filename() {
         let core_request = crate::completion::CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![url_pdf_message()],
             documents: Vec::new(),
             tools: Vec::new(),

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -1484,7 +1484,6 @@ where
         &self,
         completion_request: crate::completion::CompletionRequest,
     ) -> Result<streaming::RawStreamingResult<StreamingCompletionResponse>, CompletionError> {
-        let system_instructions = completion_request.preamble.clone();
         let record_telemetry_content = completion_request.record_telemetry_content;
         let (request_model, request) = self.create_provider_request(completion_request, true)?;
 
@@ -1507,7 +1506,7 @@ where
             &request_model,
             CompletionOperation::ChatStreaming,
         )
-        .system_instructions(system_instructions.as_deref(), record_telemetry_content)
+        .system_instructions(None, record_telemetry_content)
         .build();
         let client = self.client.clone();
         let event_source = GenericEventSource::new(client, req);

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -1461,10 +1461,7 @@ impl TryFrom<OpenRouterRequestParams<'_>> for OpenrouterCompletionRequest {
         let chat_history = req.chat_history_with_documents();
         let model = req.model.clone().unwrap_or_else(|| model.to_string());
 
-        let mut full_history: Vec<Message> = match &req.preamble {
-            Some(preamble) => vec![Message::system(preamble)],
-            None => vec![],
-        };
+        let mut full_history: Vec<Message> = vec![];
 
         let chat_history: Vec<Message> = chat_history
             .into_iter()
@@ -1728,7 +1725,6 @@ mod tests {
     fn test_openrouter_request_uses_request_model_override() {
         let request = CompletionRequest {
             model: Some("google/gemini-2.5-flash".to_string()),
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -1756,7 +1752,6 @@ mod tests {
     fn openrouter_request_carries_caller_max_tokens() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -1784,7 +1779,6 @@ mod tests {
     fn openrouter_params_include_direct_request_documents() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![crate::message::Message::user("What is glarb-glarb?")],
             documents: vec![crate::completion::request::Document {
                 id: "doc_1".to_string(),
@@ -1818,7 +1812,6 @@ mod tests {
     fn test_openrouter_request_uses_default_model_when_override_unset() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -1889,7 +1882,6 @@ mod tests {
 
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -1941,7 +1933,6 @@ mod tests {
 
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -4438,8 +4429,7 @@ mod tests {
     fn prompt_caching_completion_request() -> CompletionRequest {
         CompletionRequest {
             model: None,
-            preamble: Some("You are a helpful assistant.".to_string()),
-            chat_history: vec![crate::message::Message::user("Hello")],
+            chat_history: vec![crate::message::Message::system("You are a helpful assistant.".to_string()), crate::message::Message::user("Hello")],
             documents: vec![],
             tools: vec![],
             temperature: None,

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -4429,7 +4429,10 @@ mod tests {
     fn prompt_caching_completion_request() -> CompletionRequest {
         CompletionRequest {
             model: None,
-            chat_history: vec![crate::message::Message::system("You are a helpful assistant.".to_string()), crate::message::Message::user("Hello")],
+            chat_history: vec![
+                crate::message::Message::system("You are a helpful assistant.".to_string()),
+                crate::message::Message::user("Hello"),
+            ],
             documents: vec![],
             tools: vec![],
             temperature: None,

--- a/crates/rig-core/src/providers/perplexity.rs
+++ b/crates/rig-core/src/providers/perplexity.rs
@@ -166,7 +166,6 @@ mod tests {
         // SUPPORTS_TOOLS = false it must be dropped before that validation.
         let mut request = crate::completion::CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello!".into()],
             documents: vec![],
             max_tokens: None,

--- a/crates/rig-core/src/providers/together/completion.rs
+++ b/crates/rig-core/src/providers/together/completion.rs
@@ -176,7 +176,6 @@ mod tests {
     #[test]
     fn together_request_conversion_errors_when_all_messages_are_filtered() {
         let request = crate::completion::CompletionRequest {
-            preamble: None,
             chat_history: vec![message::Message::Assistant {
                 id: None,
                 content: vec![message::AssistantContent::reasoning("hidden")],

--- a/crates/rig-core/src/providers/xai/api.rs
+++ b/crates/rig-core/src/providers/xai/api.rs
@@ -52,10 +52,7 @@ pub(crate) fn create_completion_request(
         tracing::warn!("Structured outputs currently not supported for xAI");
     }
     let model = req.model.clone().unwrap_or(model);
-    let mut input = req
-        .preamble
-        .as_ref()
-        .map_or_else(Vec::new, |p| vec![Message::system(p)]);
+    let mut input = Vec::new();
     for message in chat_history {
         input.extend(Vec::<Message>::try_from(message)?);
     }
@@ -526,7 +523,6 @@ mod tests {
     fn xai_direct_request_keeps_documents_after_system_messages() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 RigMessage::system("System prompt"),
                 RigMessage::assistant("Earlier assistant turn"),

--- a/crates/rig-core/src/test_utils/completion.rs
+++ b/crates/rig-core/src/test_utils/completion.rs
@@ -384,7 +384,6 @@ mod tests {
     fn request(prompt: &str) -> CompletionRequest {
         CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![Message::user(prompt)],
             documents: Vec::new(),
             tools: Vec::new(),

--- a/crates/rig-gemini-grpc/src/completion.rs
+++ b/crates/rig-gemini-grpc/src/completion.rs
@@ -187,7 +187,6 @@ pub(crate) fn create_grpc_request(
 ) -> Result<GenerateContentRequest, CompletionError> {
     let CompletionRequest {
         model: _,
-        preamble,
         chat_history,
         documents: _,
         tools,
@@ -210,13 +209,8 @@ pub(crate) fn create_grpc_request(
         contents.push(rig_message_to_grpc_content(msg)?);
     }
 
-    // Handle system instruction (preamble)
+    // Handle system instruction
     let mut system_parts = Vec::new();
-    if let Some(preamble) = preamble
-        && !preamble.is_empty()
-    {
-        system_parts.push(text_part(preamble));
-    }
     for content in history_system {
         if !content.is_empty() {
             system_parts.push(text_part(content));
@@ -1062,7 +1056,6 @@ mod tests {
             "gemini-2.5-flash",
             CompletionRequest {
                 model: None,
-                preamble: None,
                 chat_history: vec![
                     // Driver-built: the executed name travels as data (a
                     // repair hook renamed the call: `sum` ran, not `add`).
@@ -1124,7 +1117,6 @@ mod tests {
             "gemini-2.5-flash",
             CompletionRequest {
                 model: None,
-                preamble: None,
                 chat_history: vec![message::Message::user("forecast in Berlin?")],
                 documents: Vec::new(),
                 tools: vec![tool],

--- a/crates/rig-run/src/response.rs
+++ b/crates/rig-run/src/response.rs
@@ -15,7 +15,6 @@ pub struct CompletionCall {
     /// Zero-valued usage is [`Usage`]'s documented sentinel for missing
     /// provider usage metrics; rig does not distinguish "reported all zeros"
     /// from "unreported".
-    #[serde(default, deserialize_with = "usage_null_as_default")]
     pub usage: Usage,
     /// Provider-assigned assistant message ID for this call, when reported.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -106,19 +105,6 @@ impl CompletionCall {
             provider_request_id: self.provider_request_id.clone(),
         }
     }
-}
-
-/// Tolerate `null` usage from data serialized before rig dropped the
-/// `Option<Usage>` encoding of missing provider usage metrics.
-///
-/// This tolerance requires a self-describing format such as JSON; data
-/// serialized with non-self-describing formats (e.g. bincode) from before the
-/// change cannot round-trip.
-fn usage_null_as_default<'de, D>(deserializer: D) -> Result<Usage, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    Ok(Option::<Usage>::deserialize(deserializer)?.unwrap_or_default())
 }
 
 /// The result of an agent run, returned by **both** the blocking

--- a/crates/rig-run/src/run.rs
+++ b/crates/rig-run/src/run.rs
@@ -1449,36 +1449,6 @@ impl AgentRun {
         }
     }
 
-    /// Discard the pending invalid tool call without marking the turn as
-    /// recovered.
-    ///
-    /// This is the extractor driver's fallback after every invalid-tool hook
-    /// has declined to act. Keeping it distinct from [`InvalidToolCallAction::Skip`]
-    /// preserves the extractor's legacy response semantics: unrelated calls
-    /// disappear, a sibling output call can still finalize the turn, and
-    /// response observers still receive the canonical response fields.
-    pub fn ignore_invalid_tool_call(&mut self) -> Result<ModelTurnOutcome, PromptError> {
-        let mut resolving = self.take_resolving(
-            "ignore_invalid_tool_call called without a pending invalid tool call",
-        )?;
-
-        if pending_invalid_call(&resolving).is_none() {
-            self.state = RunState::ResolvingToolCalls(resolving);
-            return Err(self.protocol_violation(
-                "ignore_invalid_tool_call called without a pending invalid tool call",
-            ));
-        }
-
-        resolving.items.remove(resolving.next_index);
-        resolving.has_tool_calls = has_tool_calls(&resolving.items);
-        // Dropping the last item leaves the turn empty, which is now
-        // representable. This used to push a fabricated empty-text part so the
-        // content type stayed satisfied; `is_empty_assistant_turn` keeps such a
-        // turn out of history further along.
-        self.state = RunState::ResolvingToolCalls(resolving);
-        self.advance_resolution()
-    }
-
     /// Feed the tool results for the pending [`AgentRunStep::CallTools`].
     ///
     /// Results may be in any order; they are appended as a single user
@@ -2876,25 +2846,13 @@ mod tests {
     }
 
     #[test]
-    fn agent_run_deserializes_pre_monoid_suspended_state() {
-        // Pins `CompletionCall.usage`'s null tolerance on a suspended run:
-        // `"usage": null` (the pre-monoid Option encoding) must map to
-        // zero-valued usage and the run must resume. The tool calls use the
-        // current schema — the pre-provider-split `call_id` lift is gone
-        // (its ignore-the-key behavior is pinned in rig-core's message
-        // tests).
+    fn agent_run_rejects_pre_monoid_suspended_state() {
+        // `CompletionCall.usage` is a required object: a suspended run
+        // serialized with the pre-monoid Option encoding (`"usage": null`)
+        // no longer loads.
         let fixture = r#"{"max_turns":2,"max_invalid_tool_call_retries":0,"tool_choice":null,"chat_history":null,"new_messages":[{"role":"user","content":[{"type":"text","text":"add things"}]},{"role":"assistant","id":null,"content":[{"type":"toolcall","id":"call_1","function":{"name":"add","arguments":{"x":1}},"signature":null,"additional_params":null}]}],"current_turn":1,"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15,"cached_input_tokens":0,"cache_creation_input_tokens":0,"tool_use_prompt_tokens":0,"reasoning_tokens":0},"completion_calls":[{"call_index":0,"usage":null}],"completion_call_index":1,"invalid_tool_call_retries":0,"rollback_pending":false,"streamed_completion_call_recorded":false,"state":{"ExecutingTools":[{"tool_call":{"id":"call_1","function":{"name":"add","arguments":{"x":1}},"signature":null,"additional_params":null},"preresolved_result":null,"internal_call_id":null}]}}"#;
 
-        let mut restored: AgentRun =
-            serde_json::from_str(fixture).expect("old-format suspended run should deserialize");
-        assert_eq!(restored.completion_calls()[0].usage, Usage::new());
-
-        let calls = expect_call_tools(&mut restored);
-        assert_eq!(calls.len(), 1);
-        restored
-            .tool_results(vec![tool_result("call_1", "2")])
-            .expect("tool_results should succeed");
-        expect_call_model(&mut restored);
+        serde_json::from_str::<AgentRun>(fixture).expect_err("null usage must not deserialize");
     }
 
     #[test]

--- a/crates/rig-vertexai/src/types/completion_request.rs
+++ b/crates/rig-vertexai/src/types/completion_request.rs
@@ -34,12 +34,6 @@ impl VertexCompletionRequest {
 
     pub fn system_instruction(&self) -> Option<vertexai::model::Content> {
         let mut system_texts = Vec::new();
-        if let Some(preamble) = self.0.preamble.as_ref()
-            && !preamble.is_empty()
-        {
-            system_texts.push(preamble.clone());
-        }
-
         for message in self.0.chat_history.iter() {
             if let rig_core::completion::Message::System { content } = message
                 && !content.is_empty()
@@ -315,7 +309,6 @@ mod tests {
     fn minimal_request() -> CompletionRequest {
         CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![Message::User {
                 content: vec![UserContent::Text(Text::new("test".to_string()))],
             }],
@@ -554,7 +547,12 @@ mod tests {
         // Test that preamble converts to system instruction
         let request = CompletionRequest {
             model: None,
-            preamble: Some("You are a helpful assistant.".to_string()),
+            chat_history: vec![
+                Message::system("You are a helpful assistant."),
+                Message::User {
+                    content: vec![UserContent::Text(Text::new("test".to_string()))],
+                },
+            ],
             ..minimal_request()
         };
 
@@ -575,7 +573,6 @@ mod tests {
     fn test_system_instruction_from_system_history_and_contents_skip_system() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 Message::system("System from history"),
                 Message::User {

--- a/examples/agent_autonomous/src/main.rs
+++ b/examples/agent_autonomous/src/main.rs
@@ -39,7 +39,11 @@ async fn main() -> Result<()> {
     let mut interval = tokio::time::interval(STEP_DELAY);
 
     loop {
-        let next_number = extractor.extract(&current_number.to_string()).await?.number;
+        let next_number = extractor
+            .extract(&current_number.to_string())
+            .await?
+            .data
+            .number;
         println!("Step {step}: {current_number} -> {next_number}");
 
         current_number = next_number;

--- a/examples/agent_evaluator_optimizer/src/main.rs
+++ b/examples/agent_evaluator_optimizer/src/main.rs
@@ -72,10 +72,10 @@ async fn main() -> Result<(), anyhow::Error> {
         let eval_result = evaluator_agent
             .extract(&format!("{TASK}\n\n{response}"))
             .await?;
-        if eval_result.evaluation_status == EvalStatus::Pass {
+        if eval_result.data.evaluation_status == EvalStatus::Pass {
             break;
         } else {
-            let context = format!("{TASK}\n\n{}", eval_result.feedback);
+            let context = format!("{TASK}\n\n{}", eval_result.data.feedback);
             response = generator_agent.prompt(context).await?;
             memories.push(response.clone());
         }

--- a/examples/agent_orchestrator/src/main.rs
+++ b/examples/agent_orchestrator/src/main.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .build();
 
     let mut vec: Vec<TaskResults> = Vec::new();
-    for task in specification.tasks {
+    for task in specification.data.tasks {
         let results = content_agent
             .extract(&format!(
                 "
@@ -74,7 +74,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 task.original_task, task.style, task.guidelines
             ))
             .await?;
-        vec.push(results);
+        vec.push(results.data);
     }
 
     let judge_agent = openai_client

--- a/examples/agent_parallelization/src/main.rs
+++ b/examples/agent_parallelization/src/main.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<(), anyhow::Error> {
                     Depression sentiment score: {}
                     Intelligence sentiment score: {}
                     ",
-            manip_score.score, dep_score.score, int_score.score
+            manip_score.data.score, dep_score.data.score, int_score.data.score
         ),
         (manip_score, dep_score, int_score) => format!(
             "

--- a/examples/extractor/src/main.rs
+++ b/examples/extractor/src/main.rs
@@ -26,10 +26,10 @@ async fn main() -> Result<()> {
     let client = openai::Client::from_env()?;
     let extractor = client.extractor::<Person>(openai::GPT_4).build();
 
-    let person = extractor.extract(FIRST_INPUT).await?;
+    let person = extractor.extract(FIRST_INPUT).await?.data;
     println!("{}", serde_json::to_string_pretty(&person)?);
 
-    let response = extractor.extract_with_usage(SECOND_INPUT).await?;
+    let response = extractor.extract(SECOND_INPUT).await?;
     println!("{}", serde_json::to_string_pretty(&response.data)?);
     println!("total tokens: {}", response.usage.total_tokens);
 

--- a/examples/multi_extract/src/main.rs
+++ b/examples/multi_extract/src/main.rs
@@ -69,10 +69,10 @@ async fn main() -> Result<()> {
                 )?;
                 anyhow::Ok(format!(
                     "Extracted names: {}\nExtracted topics: {}\nExtracted sentiment: {} ({})",
-                    names.names.join(", "),
-                    topics.topics.join(", "),
-                    sentiment.sentiment,
-                    sentiment.confidence,
+                    names.data.names.join(", "),
+                    topics.data.topics.join(", "),
+                    sentiment.data.sentiment,
+                    sentiment.data.confidence,
                 ))
             }
         })

--- a/examples/reasoning_loop/src/main.rs
+++ b/examples/reasoning_loop/src/main.rs
@@ -39,11 +39,11 @@ impl Prompt for ReasoningAgent {
                 tracing::error!("Extraction error: {:?}", e);
                 CompletionError::ProviderError("".into())
             })?;
-        if extracted.steps.is_empty() {
+        if extracted.data.steps.is_empty() {
             return Ok("No reasoning steps provided.".into());
         }
         let mut reasoning_prompt = String::new();
-        for (i, step) in extracted.steps.iter().enumerate() {
+        for (i, step) in extracted.data.steps.iter().enumerate() {
             reasoning_prompt.push_str(&format!("Step {}: {}\n", i + 1, step));
         }
         let response = self

--- a/tests/cassette_cache_prefix.rs
+++ b/tests/cassette_cache_prefix.rs
@@ -591,8 +591,9 @@ fn determinism_probe_request() -> CompletionRequest {
         chat_history: vec![
             Message::system("You are a deterministic serialization probe."),
             Message::User {
-            content: vec![UserContent::text("probe")],
-        }],
+                content: vec![UserContent::text("probe")],
+            },
+        ],
         documents: vec![document],
         tools: vec![
             tool("alpha_probe", "alpha_first", "alpha_second"),

--- a/tests/cassette_cache_prefix.rs
+++ b/tests/cassette_cache_prefix.rs
@@ -588,8 +588,9 @@ fn determinism_probe_request() -> CompletionRequest {
     };
 
     CompletionRequest {
-        preamble: Some("You are a deterministic serialization probe.".to_owned()),
-        chat_history: vec![Message::User {
+        chat_history: vec![
+            Message::system("You are a deterministic serialization probe."),
+            Message::User {
             content: vec![UserContent::text("probe")],
         }],
         documents: vec![document],

--- a/tests/common/cache_conformance.rs
+++ b/tests/common/cache_conformance.rs
@@ -267,9 +267,9 @@ impl CacheProbe {
     /// response short and the recording cheap; the tool list is cloned in a fixed
     /// order because a reordered tool set is itself one of the prefix moves this
     /// harness exists to catch.
-    fn request(&self, chat_history: Vec<Message>) -> CompletionRequest {
+    fn request(&self, mut chat_history: Vec<Message>) -> CompletionRequest {
+        chat_history.insert(0, Message::system(self.preamble.clone()));
         CompletionRequest {
-            preamble: Some(self.preamble.clone()),
             chat_history,
             documents: vec![],
             tools: self.tools.clone(),

--- a/tests/common/reasoning.rs
+++ b/tests/common/reasoning.rs
@@ -254,8 +254,7 @@ pub(crate) async fn run_reasoning_roundtrip_streaming_with_final<M, F>(
     };
 
     let request = completion::CompletionRequest {
-        preamble: Some(agent.preamble.clone()),
-        chat_history: vec![turn1_prompt.clone()],
+        chat_history: vec![Message::system(agent.preamble.clone()), turn1_prompt.clone()],
         documents: vec![],
         tools: vec![],
         temperature: None,
@@ -336,8 +335,7 @@ pub(crate) async fn run_reasoning_roundtrip_streaming_with_final<M, F>(
     };
 
     let request2 = completion::CompletionRequest {
-        preamble: Some(agent.preamble.clone()),
-        chat_history: vec![turn1_prompt, turn1_assistant, turn2_prompt],
+        chat_history: vec![Message::system(agent.preamble.clone()), turn1_prompt, turn1_assistant, turn2_prompt],
         documents: vec![],
         tools: vec![],
         temperature: None,
@@ -387,8 +385,7 @@ where
     };
 
     let request = completion::CompletionRequest {
-        preamble: Some(agent.preamble.clone()),
-        chat_history: vec![turn1_prompt.clone()],
+        chat_history: vec![Message::system(agent.preamble.clone()), turn1_prompt.clone()],
         documents: vec![],
         tools: vec![],
         temperature: None,
@@ -433,8 +430,7 @@ where
     };
 
     let request2 = completion::CompletionRequest {
-        preamble: Some(agent.preamble.clone()),
-        chat_history: vec![turn1_prompt, turn1_assistant, turn2_prompt],
+        chat_history: vec![Message::system(agent.preamble.clone()), turn1_prompt, turn1_assistant, turn2_prompt],
         documents: vec![],
         tools: vec![],
         temperature: None,

--- a/tests/common/reasoning.rs
+++ b/tests/common/reasoning.rs
@@ -254,7 +254,10 @@ pub(crate) async fn run_reasoning_roundtrip_streaming_with_final<M, F>(
     };
 
     let request = completion::CompletionRequest {
-        chat_history: vec![Message::system(agent.preamble.clone()), turn1_prompt.clone()],
+        chat_history: vec![
+            Message::system(agent.preamble.clone()),
+            turn1_prompt.clone(),
+        ],
         documents: vec![],
         tools: vec![],
         temperature: None,
@@ -335,7 +338,12 @@ pub(crate) async fn run_reasoning_roundtrip_streaming_with_final<M, F>(
     };
 
     let request2 = completion::CompletionRequest {
-        chat_history: vec![Message::system(agent.preamble.clone()), turn1_prompt, turn1_assistant, turn2_prompt],
+        chat_history: vec![
+            Message::system(agent.preamble.clone()),
+            turn1_prompt,
+            turn1_assistant,
+            turn2_prompt,
+        ],
         documents: vec![],
         tools: vec![],
         temperature: None,
@@ -385,7 +393,10 @@ where
     };
 
     let request = completion::CompletionRequest {
-        chat_history: vec![Message::system(agent.preamble.clone()), turn1_prompt.clone()],
+        chat_history: vec![
+            Message::system(agent.preamble.clone()),
+            turn1_prompt.clone(),
+        ],
         documents: vec![],
         tools: vec![],
         temperature: None,
@@ -430,7 +441,12 @@ where
     };
 
     let request2 = completion::CompletionRequest {
-        chat_history: vec![Message::system(agent.preamble.clone()), turn1_prompt, turn1_assistant, turn2_prompt],
+        chat_history: vec![
+            Message::system(agent.preamble.clone()),
+            turn1_prompt,
+            turn1_assistant,
+            turn2_prompt,
+        ],
         documents: vec![],
         tools: vec![],
         temperature: None,

--- a/tests/core/prompt_response_messages.rs
+++ b/tests/core/prompt_response_messages.rs
@@ -63,7 +63,7 @@ fn always_tool_call_turn() -> MockTurn {
 // Tests
 // ---------------------------------------------------------------------------
 
-/// Test 1: Standard path still returns a plain String (backward compat).
+/// Test 1: Standard path returns a plain String.
 #[tokio::test]
 async fn standard_prompt_returns_string() {
     let agent = AgentBuilder::new(simple_text_model(1)).build();
@@ -233,10 +233,10 @@ async fn multi_turn_messages_include_tool_calls() {
     assert_eq!(resp.usage.output_tokens, 12); // 8 + 4
 }
 
-/// Test 6: `PromptResponse::new()` backward compatibility — 2-argument constructor
-/// should still work, and `messages` should be `None`.
+/// Test 6: `PromptResponse::new()` — the 2-argument constructor seeds content
+/// from the output text, and `messages` starts as `None`.
 #[tokio::test]
-async fn prompt_response_new_backward_compat() {
+async fn prompt_response_new_seeds_content_from_output() {
     use rig::agent::PromptResponse;
 
     let resp = PromptResponse::new("output text", Usage::new());

--- a/tests/integrations/bedrock/extractor.rs
+++ b/tests/integrations/bedrock/extractor.rs
@@ -32,7 +32,7 @@ async fn extractor_smoke() {
         .build();
 
     let response = extractor
-        .extract_with_usage(EXTRACTOR_TEXT)
+        .extract(EXTRACTOR_TEXT)
         .await
         .expect("extractor request should succeed");
 
@@ -48,7 +48,7 @@ async fn extractor_with_chat_history_smoke() {
         .build();
 
     let response = extractor
-        .extract_with_chat_history_with_usage(
+        .extract_with_chat_history(
             "The text is about Ada Lovelace, a mathematician.",
             vec![Message::user(
                 "Extract the person's name and job from the next message.",

--- a/tests/integrations/bedrock/mod.rs
+++ b/tests/integrations/bedrock/mod.rs
@@ -1,11 +1,11 @@
 #[path = "../../common/support.rs"]
 mod support;
 
-use rig::bedrock::{client::Client, completion, embedding, image as bedrock_image};
+use rig::bedrock::{client::Client, completion, image as bedrock_image};
 use rig::client::ProviderClient;
 
 pub(crate) const BEDROCK_COMPLETION_MODEL: &str = completion::AMAZON_NOVA_LITE;
-pub(crate) const BEDROCK_EMBEDDING_MODEL: &str = embedding::AMAZON_TITAN_EMBED_TEXT_V2_0;
+pub(crate) const BEDROCK_EMBEDDING_MODEL: &str = completion::AMAZON_TITAN_TEXT_EMBEDDINGS_V2;
 pub(crate) const BEDROCK_IMAGE_MODEL: &str = bedrock_image::AMAZON_NOVA_CANVAS;
 
 pub(crate) fn anthropic_adaptive_model() -> String {

--- a/tests/providers/anthropic/cassette/opus_4_7.rs
+++ b/tests/providers/anthropic/cassette/opus_4_7.rs
@@ -145,7 +145,7 @@ async fn messages_extractor_smoke() {
             let extractor = client.extractor::<SmokePerson>(CLAUDE_OPUS_4_7).build();
 
             let response = extractor
-                .extract_with_usage(EXTRACTOR_TEXT)
+                .extract(EXTRACTOR_TEXT)
                 .await
                 .expect("extractor request should succeed");
 

--- a/tests/providers/bedrock/cassette/embeddings.rs
+++ b/tests/providers/bedrock/cassette/embeddings.rs
@@ -13,7 +13,7 @@ const EMBEDDING_INPUT: &str = "Rust cassette replay keeps Bedrock tests determin
 async fn embeddings_smoke() {
     with_bedrock_cassette("embeddings/embeddings_smoke", |client| async move {
         let model = client
-            .embedding_model_with_ndims(bedrock::embedding::AMAZON_TITAN_EMBED_TEXT_V2_0, 256);
+            .embedding_model_with_ndims(bedrock::completion::AMAZON_TITAN_TEXT_EMBEDDINGS_V2, 256);
 
         let embeddings = model
             .embed_texts([EMBEDDING_INPUT.to_string()])
@@ -35,7 +35,7 @@ async fn embeddings_smoke() {
 async fn embeddings_batch_smoke() {
     with_bedrock_cassette("embeddings/embeddings_batch_smoke", |client| async move {
         let model = client
-            .embedding_model_with_ndims(bedrock::embedding::AMAZON_TITAN_EMBED_TEXT_V2_0, 256);
+            .embedding_model_with_ndims(bedrock::completion::AMAZON_TITAN_TEXT_EMBEDDINGS_V2, 256);
 
         let embeddings = model
             .embed_texts(EMBEDDING_INPUTS.into_iter().map(str::to_string))

--- a/tests/providers/chatgpt/extractor.rs
+++ b/tests/providers/chatgpt/extractor.rs
@@ -11,7 +11,7 @@ async fn extractor_smoke() {
     let extractor = live_client().extractor::<SmokePerson>(LIVE_MODEL).build();
 
     let response = extractor
-        .extract_with_usage(EXTRACTOR_TEXT)
+        .extract(EXTRACTOR_TEXT)
         .await
         .expect("extractor request should succeed");
 

--- a/tests/providers/chatgpt/extractor_usage.rs
+++ b/tests/providers/chatgpt/extractor_usage.rs
@@ -49,9 +49,9 @@ async fn extract_backward_compatibility() -> Result<()> {
         .extract("John Doe is a 30 year old software engineer.")
         .await?;
 
-    anyhow::ensure!(person.name.as_deref() == Some("John Doe"));
-    anyhow::ensure!(person.age == Some(30));
-    anyhow::ensure!(person.profession.as_deref() == Some("software engineer"));
+    anyhow::ensure!(person.data.name.as_deref() == Some("John Doe"));
+    anyhow::ensure!(person.data.age == Some(30));
+    anyhow::ensure!(person.data.profession.as_deref() == Some("software engineer"));
 
     Ok(())
 }
@@ -62,7 +62,7 @@ async fn extract_with_usage_returns_data_and_usage() -> Result<()> {
     let extractor = live_client().extractor::<Person>(LIVE_MODEL).build();
 
     let response: ExtractionResponse<Person> = extractor
-        .extract_with_usage("Jane Smith is a 45 year old data scientist.")
+        .extract("Jane Smith is a 45 year old data scientist.")
         .await?;
 
     anyhow::ensure!(response.data.name.as_deref() == Some("Jane Smith"));
@@ -87,7 +87,7 @@ async fn extract_with_chat_history_with_usage_works() -> Result<()> {
     )];
 
     let response: ExtractionResponse<Address> = extractor
-        .extract_with_chat_history_with_usage(
+        .extract_with_chat_history(
             "The address is 123 Main St in Springfield, IL 62701.",
             chat_history,
         )
@@ -111,14 +111,14 @@ async fn extract_and_extract_with_usage_return_same_data() -> Result<()> {
     let text = "Bob Johnson is a 55 year old retired teacher.";
 
     let person = extractor.extract(text).await?;
-    let response = extractor.extract_with_usage(text).await?;
+    let response = extractor.extract(text).await?;
 
-    anyhow::ensure!(person.name.as_deref() == Some("Bob Johnson"));
+    anyhow::ensure!(person.data.name.as_deref() == Some("Bob Johnson"));
     anyhow::ensure!(response.data.name.as_deref() == Some("Bob Johnson"));
-    anyhow::ensure!(person.age == Some(55));
+    anyhow::ensure!(person.data.age == Some(55));
     anyhow::ensure!(response.data.age == Some(55));
     assert_compatible_professions(
-        person.profession.as_deref(),
+        person.data.profession.as_deref(),
         response.data.profession.as_deref(),
     )?;
     anyhow::ensure!(response.usage.total_tokens > 0, "usage should be populated");
@@ -133,13 +133,13 @@ async fn usage_tracking_works_for_different_schemas() -> Result<()> {
 
     let person_extractor = client.extractor::<Person>(LIVE_MODEL).build();
     let person_response = person_extractor
-        .extract_with_usage("Alice is a 25 year old developer.")
+        .extract("Alice is a 25 year old developer.")
         .await?;
     anyhow::ensure!(person_response.usage.total_tokens > 0);
 
     let address_extractor = client.extractor::<Address>(LIVE_MODEL).build();
     let address_response = address_extractor
-        .extract_with_usage("456 Oak Avenue, Cambridge, MA 02139")
+        .extract("456 Oak Avenue, Cambridge, MA 02139")
         .await?;
     anyhow::ensure!(address_response.usage.total_tokens > 0);
 

--- a/tests/providers/chatgpt/multi_extract.rs
+++ b/tests/providers/chatgpt/multi_extract.rs
@@ -63,10 +63,10 @@ async fn batch_multi_extract_chain() -> Result<()> {
                 )?;
                 anyhow::Ok(format!(
                     "Extracted names: {}\nExtracted topics: {}\nExtracted sentiment: {} ({})",
-                    names.names.join(", "),
-                    topics.topics.join(", "),
-                    sentiment.sentiment,
-                    sentiment.confidence,
+                    names.data.names.join(", "),
+                    topics.data.topics.join(", "),
+                    sentiment.data.sentiment,
+                    sentiment.data.confidence,
                 ))
             }
         })

--- a/tests/providers/copilot/extractor.rs
+++ b/tests/providers/copilot/extractor.rs
@@ -11,7 +11,7 @@ async fn extractor_smoke() {
         let extractor = client.extractor::<SmokePerson>(LIVE_MODEL).build();
 
         let response = extractor
-            .extract_with_usage(EXTRACTOR_TEXT)
+            .extract(EXTRACTOR_TEXT)
             .await
             .expect("extractor request should succeed");
 

--- a/tests/providers/copilot/extractor_usage.rs
+++ b/tests/providers/copilot/extractor_usage.rs
@@ -51,9 +51,9 @@ async fn extract_backward_compatibility() -> Result<()> {
                 .extract("John Doe is a 30 year old software engineer.")
                 .await?;
 
-            anyhow::ensure!(person.name.as_deref() == Some("John Doe"));
-            anyhow::ensure!(person.age == Some(30));
-            anyhow::ensure!(person.profession.as_deref() == Some("software engineer"));
+            anyhow::ensure!(person.data.name.as_deref() == Some("John Doe"));
+            anyhow::ensure!(person.data.age == Some(30));
+            anyhow::ensure!(person.data.profession.as_deref() == Some("software engineer"));
 
             Ok(())
         },
@@ -69,7 +69,7 @@ async fn extract_with_usage_returns_data_and_usage() -> Result<()> {
             let extractor = client.extractor::<Person>(LIVE_LIGHT_MODEL).build();
 
             let response: ExtractionResponse<Person> = extractor
-                .extract_with_usage("Jane Smith is a 45 year old data scientist.")
+                .extract("Jane Smith is a 45 year old data scientist.")
                 .await?;
 
             anyhow::ensure!(response.data.name.as_deref() == Some("Jane Smith"));
@@ -99,7 +99,7 @@ async fn extract_with_chat_history_with_usage_works() -> Result<()> {
             )];
 
             let response: ExtractionResponse<Address> = extractor
-                .extract_with_chat_history_with_usage(
+                .extract_with_chat_history(
                     "The address is 123 Main St in Springfield, IL 62701.",
                     chat_history,
                 )
@@ -128,14 +128,14 @@ async fn extract_and_extract_with_usage_return_same_data() -> Result<()> {
             let text = "Bob Johnson is a 55 year old retired teacher.";
 
             let person = extractor.extract(text).await?;
-            let response = extractor.extract_with_usage(text).await?;
+            let response = extractor.extract(text).await?;
 
-            anyhow::ensure!(person.name.as_deref() == Some("Bob Johnson"));
+            anyhow::ensure!(person.data.name.as_deref() == Some("Bob Johnson"));
             anyhow::ensure!(response.data.name.as_deref() == Some("Bob Johnson"));
-            anyhow::ensure!(person.age == Some(55));
+            anyhow::ensure!(person.data.age == Some(55));
             anyhow::ensure!(response.data.age == Some(55));
             assert_compatible_professions(
-                person.profession.as_deref(),
+                person.data.profession.as_deref(),
                 response.data.profession.as_deref(),
             )?;
             anyhow::ensure!(response.usage.total_tokens > 0, "usage should be populated");
@@ -153,13 +153,13 @@ async fn usage_tracking_works_for_different_schemas() -> Result<()> {
         |client| async move {
             let person_extractor = client.extractor::<Person>(LIVE_LIGHT_MODEL).build();
             let person_response = person_extractor
-                .extract_with_usage("Alice is a 25 year old developer.")
+                .extract("Alice is a 25 year old developer.")
                 .await?;
             anyhow::ensure!(person_response.usage.total_tokens > 0);
 
             let address_extractor = client.extractor::<Address>(LIVE_LIGHT_MODEL).build();
             let address_response = address_extractor
-                .extract_with_usage("456 Oak Avenue, Cambridge, MA 02139")
+                .extract("456 Oak Avenue, Cambridge, MA 02139")
                 .await?;
             anyhow::ensure!(address_response.usage.total_tokens > 0);
 

--- a/tests/providers/copilot/multi_extract.rs
+++ b/tests/providers/copilot/multi_extract.rs
@@ -64,10 +64,10 @@ async fn batch_multi_extract_chain() -> Result<()> {
                         )?;
                         anyhow::Ok(format!(
                             "Extracted names: {}\nExtracted topics: {}\nExtracted sentiment: {} ({})",
-                            names.names.join(", "),
-                            topics.topics.join(", "),
-                            sentiment.sentiment,
-                            sentiment.confidence,
+                            names.data.names.join(", "),
+                            topics.data.topics.join(", "),
+                            sentiment.data.sentiment,
+                            sentiment.data.confidence,
                         ))
                     }
                 })

--- a/tests/providers/deepseek/extractor.rs
+++ b/tests/providers/deepseek/extractor.rs
@@ -19,14 +19,16 @@ async fn extractor_smoke() {
             .expect("extractor request should succeed");
 
         let first_name = person
+            .data
             .first_name
             .as_deref()
             .expect("first_name should be present");
         let last_name = person
+            .data
             .last_name
             .as_deref()
             .expect("last_name should be present");
-        let job = person.job.as_deref().expect("job should be present");
+        let job = person.data.job.as_deref().expect("job should be present");
 
         assert_nonempty_response(first_name);
         assert_nonempty_response(last_name);

--- a/tests/providers/deepseek/extractor_usage.rs
+++ b/tests/providers/deepseek/extractor_usage.rs
@@ -53,16 +53,16 @@ async fn extract_backward_compatibility() -> Result<()> {
                 .await?;
 
             anyhow::ensure!(
-                person.name == Some("John Doe".to_string()),
+                person.data.name == Some("John Doe".to_string()),
                 "expected name John Doe, got {:?}",
-                person.name
+                person.data.name
             );
             anyhow::ensure!(
-                person.age == Some(30),
+                person.data.age == Some(30),
                 "expected age 30, got {:?}",
-                person.age
+                person.data.age
             );
-            assert_compatible_professions(person.profession.as_deref(), "software engineer")?;
+            assert_compatible_professions(person.data.profession.as_deref(), "software engineer")?;
 
             Ok(())
         },
@@ -80,7 +80,7 @@ async fn extract_with_usage_returns_data_and_usage() -> Result<()> {
                 .build();
 
             let response: ExtractionResponse<Person> = extractor
-                .extract_with_usage("Jane Smith is a 45 year old data scientist.")
+                .extract("Jane Smith is a 45 year old data scientist.")
                 .await?;
 
             anyhow::ensure!(
@@ -118,7 +118,7 @@ async fn extract_with_chat_history_with_usage_works() -> Result<()> {
             )];
 
             let response: ExtractionResponse<Address> = extractor
-                .extract_with_chat_history_with_usage(
+                .extract_with_chat_history(
                     "The address is 123 Main St in Springfield, IL 62701.",
                     chat_history,
                 )
@@ -164,12 +164,12 @@ async fn extract_and_extract_with_usage_return_same_data() -> Result<()> {
 
             let text = "Bob Johnson is a 55 year old retired teacher.";
             let person = extractor.extract(text).await?;
-            let response = extractor.extract_with_usage(text).await?;
+            let response = extractor.extract(text).await?;
 
             anyhow::ensure!(
-                person.name == Some("Bob Johnson".to_string()),
+                person.data.name == Some("Bob Johnson".to_string()),
                 "expected extracted name Bob Johnson, got {:?}",
-                person.name
+                person.data.name
             );
             anyhow::ensure!(
                 response.data.name == Some("Bob Johnson".to_string()),
@@ -177,16 +177,16 @@ async fn extract_and_extract_with_usage_return_same_data() -> Result<()> {
                 response.data.name
             );
             anyhow::ensure!(
-                person.age == Some(55),
+                person.data.age == Some(55),
                 "expected extracted age 55, got {:?}",
-                person.age
+                person.data.age
             );
             anyhow::ensure!(
                 response.data.age == Some(55),
                 "expected usage response age 55, got {:?}",
                 response.data.age
             );
-            assert_compatible_professions(person.profession.as_deref(), "retired teacher")?;
+            assert_compatible_professions(person.data.profession.as_deref(), "retired teacher")?;
             assert_compatible_professions(response.data.profession.as_deref(), "retired teacher")?;
             anyhow::ensure!(response.usage.total_tokens > 0, "usage should be populated");
 
@@ -205,7 +205,7 @@ async fn usage_tracking_works_for_different_schemas() -> Result<()> {
                 .extractor::<Person>(deepseek::DEEPSEEK_V4_FLASH)
                 .build();
             let person_response = person_extractor
-                .extract_with_usage("Alice is a 25 year old developer.")
+                .extract("Alice is a 25 year old developer.")
                 .await?;
             anyhow::ensure!(
                 person_response.usage.total_tokens > 0,
@@ -216,7 +216,7 @@ async fn usage_tracking_works_for_different_schemas() -> Result<()> {
                 .extractor::<Address>(deepseek::DEEPSEEK_V4_FLASH)
                 .build();
             let address_response = address_extractor
-                .extract_with_usage("456 Oak Avenue, Cambridge, MA 02139")
+                .extract("456 Oak Avenue, Cambridge, MA 02139")
                 .await?;
             anyhow::ensure!(
                 address_response.usage.total_tokens > 0,

--- a/tests/providers/deepseek/multi_extract.rs
+++ b/tests/providers/deepseek/multi_extract.rs
@@ -66,10 +66,10 @@ async fn batch_multi_extract_chain() -> Result<()> {
                         )?;
                         anyhow::Ok(format!(
                             "Extracted names: {}\nExtracted topics: {}\nExtracted sentiment: {} ({})",
-                            names.names.join(", "),
-                            topics.topics.join(", "),
-                            sentiment.sentiment,
-                            sentiment.confidence,
+                            names.data.names.join(", "),
+                            topics.data.topics.join(", "),
+                            sentiment.data.sentiment,
+                            sentiment.data.confidence,
                         ))
                     }
                 })

--- a/tests/providers/doubleword/cassette/extractor.rs
+++ b/tests/providers/doubleword/cassette/extractor.rs
@@ -12,7 +12,7 @@ async fn extractor_smoke() {
         let response = client
             .extractor::<SmokePerson>(DEFAULT_MODEL)
             .build()
-            .extract_with_usage(EXTRACTOR_TEXT)
+            .extract(EXTRACTOR_TEXT)
             .await
             .expect("extractor request should succeed");
 

--- a/tests/providers/gemini/cassette/cached_content_matrix.rs
+++ b/tests/providers/gemini/cassette/cached_content_matrix.rs
@@ -974,7 +974,6 @@ async fn streaming_against_a_cache_reports_the_cache_read() {
                     .with_cached_content(cache.name.clone());
 
                 let request = rig::completion::CompletionRequest {
-                    preamble: None,
                     chat_history: vec![rig::message::Message::User {
                         content: vec![rig::message::UserContent::text(
                             "Reply with exactly: streamed",

--- a/tests/providers/gemini/cassette/extractor.rs
+++ b/tests/providers/gemini/cassette/extractor.rs
@@ -33,7 +33,7 @@ async fn extractor_smoke() {
             .build();
 
         let response = extractor
-            .extract_with_usage(EXTRACTOR_TEXT)
+            .extract(EXTRACTOR_TEXT)
             .await
             .expect("extractor request should succeed");
 
@@ -81,9 +81,9 @@ async fn extractor_with_additional_params() {
                 .await
                 .expect("extract should succeed");
 
-            assert_eq!(person.first_name.as_deref(), Some("John"));
-            assert_eq!(person.last_name.as_deref(), Some("Doe"));
-            assert_nonempty_response(person.job.as_deref().unwrap_or_default());
+            assert_eq!(person.data.first_name.as_deref(), Some("John"));
+            assert_eq!(person.data.last_name.as_deref(), Some("Doe"));
+            assert_nonempty_response(person.data.job.as_deref().unwrap_or_default());
         },
     )
     .await;

--- a/tests/providers/gemini/cassette/prompt_caching.rs
+++ b/tests/providers/gemini/cassette/prompt_caching.rs
@@ -363,7 +363,6 @@ async fn explicit_cache_hits_across_unrelated_conversations() {
                     "Say only the word beta, nothing else",
                 ] {
                     let request = rig::completion::CompletionRequest {
-                        preamble: None,
                         chat_history: vec![rig::message::Message::User {
                             content: vec![rig::message::UserContent::text(prompt)],
                         }],
@@ -470,11 +469,13 @@ fn cache_tokens_details_are_populated_and_agree_with_the_aggregate() {
 fn mutation_request(
     system: Option<&str>,
     tools: Vec<rig::completion::ToolDefinition>,
-    history: Vec<rig::message::Message>,
+    mut history: Vec<rig::message::Message>,
     temperature: f64,
 ) -> rig::completion::CompletionRequest {
+    if let Some(system) = system {
+        history.insert(0, rig::message::Message::system(system));
+    }
     rig::completion::CompletionRequest {
-        preamble: system.map(str::to_owned),
         chat_history: history,
         documents: vec![],
         tools,

--- a/tests/providers/groq/extractor.rs
+++ b/tests/providers/groq/extractor.rs
@@ -14,7 +14,7 @@ async fn extractor_smoke() {
     let extractor = client.extractor::<SmokePerson>(EXTRACTOR_MODEL).build();
 
     let response = extractor
-        .extract_with_usage(EXTRACTOR_TEXT)
+        .extract(EXTRACTOR_TEXT)
         .await
         .expect("extractor request should succeed");
 

--- a/tests/providers/groq/extractor_usage.rs
+++ b/tests/providers/groq/extractor_usage.rs
@@ -55,9 +55,9 @@ async fn extract_backward_compatibility() -> Result<()> {
         .extract("John Doe is a 30 year old software engineer.")
         .await?;
 
-    anyhow::ensure!(person.name.as_deref() == Some("John Doe"));
-    anyhow::ensure!(person.age == Some(30));
-    assert_compatible_professions(person.profession.as_deref(), "software engineer")?;
+    anyhow::ensure!(person.data.name.as_deref() == Some("John Doe"));
+    anyhow::ensure!(person.data.age == Some(30));
+    assert_compatible_professions(person.data.profession.as_deref(), "software engineer")?;
 
     Ok(())
 }
@@ -71,7 +71,7 @@ async fn extract_with_usage_returns_data_and_usage() -> Result<()> {
         .build();
 
     let response: ExtractionResponse<Person> = extractor
-        .extract_with_usage("Jane Smith is a 45 year old data scientist.")
+        .extract("Jane Smith is a 45 year old data scientist.")
         .await?;
 
     anyhow::ensure!(response.data.name.as_deref() == Some("Jane Smith"));
@@ -97,7 +97,7 @@ async fn extract_with_chat_history_with_usage_works() -> Result<()> {
     )];
 
     let response: ExtractionResponse<Address> = extractor
-        .extract_with_chat_history_with_usage(
+        .extract_with_chat_history(
             "The address is 123 Main St in Springfield, IL 62701.",
             chat_history,
         )
@@ -123,13 +123,13 @@ async fn extract_and_extract_with_usage_return_same_data() -> Result<()> {
 
     let text = "Bob Johnson is a 55 year old retired teacher.";
     let person = extractor.extract(text).await?;
-    let response = extractor.extract_with_usage(text).await?;
+    let response = extractor.extract(text).await?;
 
-    anyhow::ensure!(person.name.as_deref() == Some("Bob Johnson"));
+    anyhow::ensure!(person.data.name.as_deref() == Some("Bob Johnson"));
     anyhow::ensure!(response.data.name.as_deref() == Some("Bob Johnson"));
-    anyhow::ensure!(person.age == Some(55));
+    anyhow::ensure!(person.data.age == Some(55));
     anyhow::ensure!(response.data.age == Some(55));
-    assert_compatible_professions(person.profession.as_deref(), "retired teacher")?;
+    assert_compatible_professions(person.data.profession.as_deref(), "retired teacher")?;
     assert_compatible_professions(response.data.profession.as_deref(), "retired teacher")?;
     anyhow::ensure!(response.usage.total_tokens > 0, "usage should be populated");
 
@@ -145,7 +145,7 @@ async fn usage_tracking_works_for_different_schemas() -> Result<()> {
         .extractor::<Person>(EXTRACTOR_USAGE_TRACKING_MODEL)
         .build();
     let person_response = person_extractor
-        .extract_with_usage("Alice is a 25 year old developer.")
+        .extract("Alice is a 25 year old developer.")
         .await?;
     anyhow::ensure!(person_response.usage.total_tokens > 0);
 
@@ -153,7 +153,7 @@ async fn usage_tracking_works_for_different_schemas() -> Result<()> {
         .extractor::<Address>(EXTRACTOR_USAGE_TRACKING_MODEL)
         .build();
     let address_response = address_extractor
-        .extract_with_usage("456 Oak Avenue, Cambridge, MA 02139")
+        .extract("456 Oak Avenue, Cambridge, MA 02139")
         .await?;
     anyhow::ensure!(address_response.usage.total_tokens > 0);
 

--- a/tests/providers/groq/multi_extract.rs
+++ b/tests/providers/groq/multi_extract.rs
@@ -65,10 +65,10 @@ async fn batch_multi_extract_chain() -> Result<()> {
                 )?;
                 anyhow::Ok(format!(
                     "Extracted names: {}\nExtracted topics: {}\nExtracted sentiment: {} ({})",
-                    names.names.join(", "),
-                    topics.topics.join(", "),
-                    sentiment.sentiment,
-                    sentiment.confidence,
+                    names.data.names.join(", "),
+                    topics.data.topics.join(", "),
+                    sentiment.data.sentiment,
+                    sentiment.data.confidence,
                 ))
             }
         })

--- a/tests/providers/llamacpp/cassette/extractor.rs
+++ b/tests/providers/llamacpp/cassette/extractor.rs
@@ -11,7 +11,7 @@ async fn extractor_smoke() {
         let extractor = client.extractor::<SmokePerson>(CASSETTE_MODEL).build();
 
         let response = extractor
-            .extract_with_usage(EXTRACTOR_TEXT)
+            .extract(EXTRACTOR_TEXT)
             .await
             .expect("extractor request should succeed");
 

--- a/tests/providers/llamacpp/cassette/extractor_usage.rs
+++ b/tests/providers/llamacpp/cassette/extractor_usage.rs
@@ -69,9 +69,9 @@ async fn extract_backward_compatibility() -> Result<()> {
                 .extract("John Doe is a 30 year old software engineer.")
                 .await?;
 
-            anyhow::ensure!(person.name.as_deref() == Some("John Doe"));
-            anyhow::ensure!(person.age == Some(30));
-            anyhow::ensure!(person.profession.as_deref() == Some("software engineer"));
+            anyhow::ensure!(person.data.name.as_deref() == Some("John Doe"));
+            anyhow::ensure!(person.data.age == Some(30));
+            anyhow::ensure!(person.data.profession.as_deref() == Some("software engineer"));
 
             Ok(())
         },
@@ -92,7 +92,7 @@ async fn extract_with_usage_returns_data_and_usage() -> Result<()> {
                 .build();
 
             let response: ExtractionResponse<Person> = extractor
-                .extract_with_usage("Jane Smith is a 45 year old data scientist.")
+                .extract("Jane Smith is a 45 year old data scientist.")
                 .await?;
 
             anyhow::ensure!(response.data.name.as_deref() == Some("Jane Smith"));
@@ -127,7 +127,7 @@ async fn extract_with_chat_history_with_usage_works() -> Result<()> {
             )];
 
             let response: ExtractionResponse<Address> = extractor
-                .extract_with_chat_history_with_usage(
+                .extract_with_chat_history(
                     "The address is 123 Main St in Springfield, IL 62701.",
                     chat_history,
                 )
@@ -160,14 +160,14 @@ async fn extract_and_extract_with_usage_return_same_data() -> Result<()> {
 
             let text = "Bob Johnson is a 55 year old retired teacher.";
             let person = extractor.extract(text).await?;
-            let response = extractor.extract_with_usage(text).await?;
+            let response = extractor.extract(text).await?;
 
-            anyhow::ensure!(person.name.as_deref() == Some("Bob Johnson"));
+            anyhow::ensure!(person.data.name.as_deref() == Some("Bob Johnson"));
             anyhow::ensure!(response.data.name.as_deref() == Some("Bob Johnson"));
-            anyhow::ensure!(person.age == Some(55));
+            anyhow::ensure!(person.data.age == Some(55));
             anyhow::ensure!(response.data.age == Some(55));
             assert_compatible_professions(
-                person.profession.as_deref(),
+                person.data.profession.as_deref(),
                 response.data.profession.as_deref(),
             )?;
             anyhow::ensure!(response.usage.total_tokens > 0, "usage should be populated");
@@ -191,7 +191,7 @@ async fn usage_tracking_works_for_different_schemas() -> Result<()> {
                 .additional_params(json!({ "temperature": 0.0 }))
                 .build();
             let person_response = person_extractor
-                .extract_with_usage("Alice is a 25 year old developer.")
+                .extract("Alice is a 25 year old developer.")
                 .await?;
 
             anyhow::ensure!(person_response.usage.total_tokens > 0);
@@ -202,7 +202,7 @@ async fn usage_tracking_works_for_different_schemas() -> Result<()> {
                 .additional_params(json!({ "temperature": 0.0 }))
                 .build();
             let address_response = address_extractor
-                .extract_with_usage("456 Oak Avenue, Cambridge, MA 02139")
+                .extract("456 Oak Avenue, Cambridge, MA 02139")
                 .await?;
 
             anyhow::ensure!(address_response.usage.total_tokens > 0);

--- a/tests/providers/llamacpp/cassette/multi_extract.rs
+++ b/tests/providers/llamacpp/cassette/multi_extract.rs
@@ -73,10 +73,10 @@ async fn batch_multi_extract_chain() -> Result<()> {
                     )?;
                     anyhow::Ok(format!(
                         "Extracted names: {}\nExtracted topics: {}\nExtracted sentiment: {} ({})",
-                        names.names.join(", "),
-                        topics.topics.join(", "),
-                        sentiment.sentiment,
-                        sentiment.confidence,
+                        names.data.names.join(", "),
+                        topics.data.topics.join(", "),
+                        sentiment.data.sentiment,
+                        sentiment.data.confidence,
                     ))
                 }
             })

--- a/tests/providers/llamacpp/cassette/sampling_matrix.rs
+++ b/tests/providers/llamacpp/cassette/sampling_matrix.rs
@@ -443,7 +443,6 @@ fn additional_params_wins_over_the_typed_field_it_collides_with() {
 
     let request = rig::completion::CompletionRequest {
         model: None,
-        preamble: None,
         chat_history: vec![rig::message::Message::User {
             content: vec![rig::message::UserContent::text("hi")],
         }],

--- a/tests/providers/llamacpp/mod.rs
+++ b/tests/providers/llamacpp/mod.rs
@@ -87,7 +87,7 @@
 //! | `context` | 1 | RAG context injection |
 //! | `embeddings` | 2 | `embed_texts` and the `Embed` derive (server 8081) |
 //! | `extractor` | 1 | the extractor facade |
-//! | `extractor_usage` | 5 | `extract_with_usage` and its backward-compatible twin |
+//! | `extractor_usage` | 5 | `extract` usage reporting across call shapes |
 //! | `image_tool_result` | 2 | an image in a tool result, plus its user-message control (server 8082) |
 //! | `loaders` | 1 | the file-loader facade feeding an agent |
 //! | `models` | 1 | `list_models` smoke |

--- a/tests/providers/mistral/extractor.rs
+++ b/tests/providers/mistral/extractor.rs
@@ -14,7 +14,7 @@ async fn extractor_smoke() {
     let extractor = client.extractor::<SmokePerson>(DEFAULT_MODEL).build();
 
     let response = extractor
-        .extract_with_usage(EXTRACTOR_TEXT)
+        .extract(EXTRACTOR_TEXT)
         .await
         .expect("extractor request should succeed");
 

--- a/tests/providers/mistral/extractor_usage.rs
+++ b/tests/providers/mistral/extractor_usage.rs
@@ -49,9 +49,9 @@ async fn extract_backward_compatibility() -> Result<()> {
         .extract("John Doe is a 30 year old software engineer.")
         .await?;
 
-    anyhow::ensure!(person.name.as_deref() == Some("John Doe"));
-    anyhow::ensure!(person.age == Some(30));
-    assert_compatible_professions(person.profession.as_deref(), "software engineer")?;
+    anyhow::ensure!(person.data.name.as_deref() == Some("John Doe"));
+    anyhow::ensure!(person.data.age == Some(30));
+    assert_compatible_professions(person.data.profession.as_deref(), "software engineer")?;
 
     Ok(())
 }
@@ -63,7 +63,7 @@ async fn extract_with_usage_returns_data_and_usage() -> Result<()> {
     let extractor = client.extractor::<Person>(DEFAULT_MODEL).build();
 
     let response: ExtractionResponse<Person> = extractor
-        .extract_with_usage("Jane Smith is a 45 year old data scientist.")
+        .extract("Jane Smith is a 45 year old data scientist.")
         .await?;
 
     anyhow::ensure!(response.data.name.as_deref() == Some("Jane Smith"));
@@ -87,7 +87,7 @@ async fn extract_with_chat_history_with_usage_works() -> Result<()> {
     )];
 
     let response: ExtractionResponse<Address> = extractor
-        .extract_with_chat_history_with_usage(
+        .extract_with_chat_history(
             "The address is 123 Main St in Springfield, IL 62701.",
             chat_history,
         )
@@ -111,13 +111,13 @@ async fn extract_and_extract_with_usage_return_same_data() -> Result<()> {
 
     let text = "Bob Johnson is a 55 year old retired teacher.";
     let person = extractor.extract(text).await?;
-    let response = extractor.extract_with_usage(text).await?;
+    let response = extractor.extract(text).await?;
 
-    anyhow::ensure!(person.name.as_deref() == Some("Bob Johnson"));
+    anyhow::ensure!(person.data.name.as_deref() == Some("Bob Johnson"));
     anyhow::ensure!(response.data.name.as_deref() == Some("Bob Johnson"));
-    anyhow::ensure!(person.age == Some(55));
+    anyhow::ensure!(person.data.age == Some(55));
     anyhow::ensure!(response.data.age == Some(55));
-    assert_compatible_professions(person.profession.as_deref(), "retired teacher")?;
+    assert_compatible_professions(person.data.profession.as_deref(), "retired teacher")?;
     assert_compatible_professions(response.data.profession.as_deref(), "retired teacher")?;
     anyhow::ensure!(response.usage.total_tokens > 0, "usage should be populated");
 
@@ -131,13 +131,13 @@ async fn usage_tracking_works_for_different_schemas() -> Result<()> {
 
     let person_extractor = client.extractor::<Person>(DEFAULT_MODEL).build();
     let person_response = person_extractor
-        .extract_with_usage("Alice is a 25 year old developer.")
+        .extract("Alice is a 25 year old developer.")
         .await?;
     anyhow::ensure!(person_response.usage.total_tokens > 0);
 
     let address_extractor = client.extractor::<Address>(DEFAULT_MODEL).build();
     let address_response = address_extractor
-        .extract_with_usage("456 Oak Avenue, Cambridge, MA 02139")
+        .extract("456 Oak Avenue, Cambridge, MA 02139")
         .await?;
     anyhow::ensure!(address_response.usage.total_tokens > 0);
 

--- a/tests/providers/mistral/multi_extract.rs
+++ b/tests/providers/mistral/multi_extract.rs
@@ -110,10 +110,10 @@ async fn batch_multi_extract_chain() -> Result<()> {
                     sentiment_extractor.extract(text),
                 )?;
                 anyhow::Ok(CombinedExtract {
-                    names: names.names,
-                    topics: topics.topics,
-                    sentiment: sentiment.sentiment,
-                    confidence: sentiment.confidence,
+                    names: names.data.names,
+                    topics: topics.data.topics,
+                    sentiment: sentiment.data.sentiment,
+                    confidence: sentiment.data.confidence,
                 })
             }
         })

--- a/tests/providers/moonshot/agent.rs
+++ b/tests/providers/moonshot/agent.rs
@@ -11,7 +11,7 @@ use crate::support::{BASIC_PREAMBLE, BASIC_PROMPT, assert_nonempty_response};
 async fn completion_smoke() {
     let client = moonshot::Client::from_env().expect("moonshot client should build");
     let agent = client
-        .agent(moonshot::MOONSHOT_CHAT)
+        .agent("moonshot-v1-128k")
         .preamble(BASIC_PREAMBLE)
         .temperature(0.5)
         .max_tokens(1024)

--- a/tests/providers/moonshot/context.rs
+++ b/tests/providers/moonshot/context.rs
@@ -13,7 +13,7 @@ async fn context_smoke() {
     let agent = CONTEXT_DOCS
         .iter()
         .copied()
-        .fold(client.agent(moonshot::MOONSHOT_CHAT), |builder, doc| {
+        .fold(client.agent("moonshot-v1-128k"), |builder, doc| {
             builder.context(doc)
         })
         .build();

--- a/tests/providers/openai/cassette/extractor.rs
+++ b/tests/providers/openai/cassette/extractor.rs
@@ -13,7 +13,7 @@ async fn extractor_smoke() {
         let extractor = client.extractor::<SmokePerson>(openai::GPT_4O).build();
 
         let response = extractor
-            .extract_with_usage(EXTRACTOR_TEXT)
+            .extract(EXTRACTOR_TEXT)
             .await
             .expect("extractor request should succeed");
 

--- a/tests/providers/openai/cassette/extractor_usage.rs
+++ b/tests/providers/openai/cassette/extractor_usage.rs
@@ -1,8 +1,7 @@
 //! Integration tests for extractor usage tracking.
 //!
 //! These tests verify that:
-//! - The original `extract()` API still works (backward compatibility)
-//! - The new `extract_with_usage()` API correctly returns usage data
+//! - `extract()` returns the extracted data alongside usage data
 //! - Usage accumulates across retry attempts
 //! - Both `extract` and `extract_with_chat_history` variants work
 
@@ -47,8 +46,8 @@ fn assert_compatible_professions(left: Option<&str>, right: Option<&str>) -> Res
     Ok(())
 }
 
-/// Test backward compatibility: the original `extract()` method should still work
-/// and return just the extracted data (not wrapped in a response type).
+/// Test that `extract()` returns the extracted data (via the `data` field of the
+/// response).
 #[tokio::test]
 async fn extract_backward_compatibility() -> Result<()> {
     with_openai_cassette_result(
@@ -62,9 +61,9 @@ async fn extract_backward_compatibility() -> Result<()> {
                 .extract("John Doe is a 30 year old software engineer.")
                 .await?;
 
-            anyhow::ensure!(person.name.as_deref() == Some("John Doe"));
-            anyhow::ensure!(person.age == Some(30));
-            anyhow::ensure!(person.profession.as_deref() == Some("software engineer"));
+            anyhow::ensure!(person.data.name.as_deref() == Some("John Doe"));
+            anyhow::ensure!(person.data.age == Some(30));
+            anyhow::ensure!(person.data.profession.as_deref() == Some("software engineer"));
 
             Ok(())
         },
@@ -72,7 +71,7 @@ async fn extract_backward_compatibility() -> Result<()> {
     .await
 }
 
-/// Test `extract_with_usage()` returns the extracted data with usage information.
+/// Test `extract()` returns the extracted data with usage information.
 #[tokio::test]
 async fn extract_with_usage_returns_data_and_usage() -> Result<()> {
     with_openai_cassette_result(
@@ -83,7 +82,7 @@ async fn extract_with_usage_returns_data_and_usage() -> Result<()> {
                 .build();
 
             let response: ExtractionResponse<Person> = extractor
-                .extract_with_usage("Jane Smith is a 45 year old data scientist.")
+                .extract("Jane Smith is a 45 year old data scientist.")
                 .await?;
 
             anyhow::ensure!(response.data.name.as_deref() == Some("Jane Smith"));
@@ -100,7 +99,7 @@ async fn extract_with_usage_returns_data_and_usage() -> Result<()> {
     .await
 }
 
-/// Test `extract_with_chat_history_with_usage()` returns the extracted data with usage information.
+/// Test `extract_with_chat_history()` returns the extracted data with usage information.
 #[tokio::test]
 async fn extract_with_chat_history_with_usage_works() -> Result<()> {
     use rig::message::Message;
@@ -117,7 +116,7 @@ async fn extract_with_chat_history_with_usage_works() -> Result<()> {
             )];
 
             let response: ExtractionResponse<Address> = extractor
-                .extract_with_chat_history_with_usage(
+                .extract_with_chat_history(
                     "The address is 123 Main St in Springfield, IL 62701.",
                     chat_history,
                 )
@@ -137,7 +136,7 @@ async fn extract_with_chat_history_with_usage_works() -> Result<()> {
     .await
 }
 
-/// Test that `extract_with_usage()` and `extract()` agree on the stable extracted fields.
+/// Test that two `extract()` calls agree on the stable extracted fields.
 /// These are separate model calls, so exact wording can vary across runs.
 #[tokio::test]
 async fn extract_and_extract_with_usage_return_same_data() -> Result<()> {
@@ -152,14 +151,14 @@ async fn extract_and_extract_with_usage_return_same_data() -> Result<()> {
 
             let person = extractor.extract(text).await?;
 
-            let response = extractor.extract_with_usage(text).await?;
+            let response = extractor.extract(text).await?;
 
-            anyhow::ensure!(person.name.as_deref() == Some("Bob Johnson"));
+            anyhow::ensure!(person.data.name.as_deref() == Some("Bob Johnson"));
             anyhow::ensure!(response.data.name.as_deref() == Some("Bob Johnson"));
-            anyhow::ensure!(person.age == Some(55));
+            anyhow::ensure!(person.data.age == Some(55));
             anyhow::ensure!(response.data.age == Some(55));
             assert_compatible_professions(
-                person.profession.as_deref(),
+                person.data.profession.as_deref(),
                 response.data.profession.as_deref(),
             )?;
             anyhow::ensure!(response.usage.total_tokens > 0, "usage should be populated");
@@ -181,7 +180,7 @@ async fn usage_tracking_works_for_different_schemas() -> Result<()> {
                 .build();
 
             let person_response = person_extractor
-                .extract_with_usage("Alice is a 25 year old developer.")
+                .extract("Alice is a 25 year old developer.")
                 .await?;
 
             anyhow::ensure!(person_response.usage.total_tokens > 0);
@@ -191,7 +190,7 @@ async fn usage_tracking_works_for_different_schemas() -> Result<()> {
                 .build();
 
             let address_response = address_extractor
-                .extract_with_usage("456 Oak Avenue, Cambridge, MA 02139")
+                .extract("456 Oak Avenue, Cambridge, MA 02139")
                 .await?;
 
             anyhow::ensure!(address_response.usage.total_tokens > 0);

--- a/tests/providers/openai/cassette/max_completion_tokens_matrix.rs
+++ b/tests/providers/openai/cassette/max_completion_tokens_matrix.rs
@@ -567,7 +567,7 @@ async fn capped_extractor_turn_on_reasoning_model() {
                 .await
                 .expect("a capped extraction must be accepted");
 
-            assert_eq!(person.first_name.as_deref(), Some("Ada"));
+            assert_eq!(person.data.first_name.as_deref(), Some("Ada"));
         },
     )
     .await;

--- a/tests/providers/openai/cassette/multi_extract.rs
+++ b/tests/providers/openai/cassette/multi_extract.rs
@@ -70,10 +70,10 @@ async fn batch_multi_extract_chain() -> Result<()> {
                         )?;
                         anyhow::Ok(format!(
                             "Extracted names: {}\nExtracted topics: {}\nExtracted sentiment: {} ({})",
-                            names.names.join(", "),
-                            topics.topics.join(", "),
-                            sentiment.sentiment,
-                            sentiment.confidence,
+                            names.data.names.join(", "),
+                            topics.data.topics.join(", "),
+                            sentiment.data.sentiment,
+                            sentiment.data.confidence,
                         ))
                     }
                 })

--- a/tests/providers/openai/cassette/responses_input_item.rs
+++ b/tests/providers/openai/cassette/responses_input_item.rs
@@ -130,7 +130,6 @@ fn assistant_reasoning_mixed_content_serializes_text_content_and_summaries() {
 #[test]
 fn openai_responses_request_auto_adds_reasoning_encrypted_include() {
     let core_request = rig::completion::CompletionRequest {
-        preamble: None,
         chat_history: vec![CompletionMessage::user("hello")],
         documents: vec![],
         tools: vec![],
@@ -304,7 +303,6 @@ fn assistant_reasoning_redacted_only_serializes_as_encrypted_content() {
 fn openai_responses_request_reasoning_without_id_is_omitted_without_panicking() {
     let panic_result = catch_unwind(AssertUnwindSafe(|| {
         let request = rig::completion::CompletionRequest {
-            preamble: None,
             chat_history: vec![CompletionMessage::Assistant {
                 id: Some("assistant_message_id".to_string()),
                 content: vec![AssistantContent::Reasoning(Reasoning::new("thought"))],
@@ -471,7 +469,6 @@ fn user_tool_result_without_provider_id_serializes_the_minted_call_id() {
 fn openai_responses_invalid_additional_params_returns_error_without_panicking() {
     let panic_result = catch_unwind(AssertUnwindSafe(|| {
         let request = rig::completion::CompletionRequest {
-            preamble: None,
             chat_history: vec![CompletionMessage::user("hello")],
             documents: vec![],
             tools: vec![],
@@ -499,7 +496,6 @@ fn openai_responses_invalid_additional_params_returns_error_without_panicking() 
 #[test]
 fn openai_responses_request_preserves_prompt_cache_parameters() {
     let request = rig::completion::CompletionRequest {
-        preamble: None,
         chat_history: vec![CompletionMessage::user("hello")],
         documents: vec![],
         tools: vec![],

--- a/tests/providers/openai/live/gpt_5_5.rs
+++ b/tests/providers/openai/live/gpt_5_5.rs
@@ -148,7 +148,7 @@ async fn responses_extractor_smoke() {
     let extractor = client.extractor::<SmokePerson>(openai::GPT_5_5).build();
 
     let response = extractor
-        .extract_with_usage(EXTRACTOR_TEXT)
+        .extract(EXTRACTOR_TEXT)
         .await
         .expect("extractor request should succeed");
 
@@ -369,7 +369,7 @@ async fn chat_completions_extractor_smoke() {
     let extractor = client.extractor::<SmokePerson>(openai::GPT_5_5).build();
 
     let response = extractor
-        .extract_with_usage(EXTRACTOR_TEXT)
+        .extract(EXTRACTOR_TEXT)
         .await
         .expect("chat completions extractor request should succeed");
 

--- a/tests/providers/openai/regressions.rs
+++ b/tests/providers/openai/regressions.rs
@@ -72,7 +72,7 @@ async fn extractor_accepts_nullable_strict_in_echoed_tool_definition() {
         .expect("nullable strict should not prevent extraction");
 
     assert_eq!(
-        extracted,
+        extracted.data,
         KeywordPayload {
             keywords: vec!["fruit".to_string(), "produce".to_string()]
         }

--- a/tests/providers/openrouter/cassette/extractor.rs
+++ b/tests/providers/openrouter/cassette/extractor.rs
@@ -12,7 +12,7 @@ async fn extractor_smoke() {
         let extractor = client.extractor::<SmokePerson>(DEFAULT_MODEL).build();
 
         let response = extractor
-            .extract_with_usage(EXTRACTOR_TEXT)
+            .extract(EXTRACTOR_TEXT)
             .await
             .expect("extractor request should succeed");
 

--- a/tests/providers/openrouter/cassette/extractor_usage.rs
+++ b/tests/providers/openrouter/cassette/extractor_usage.rs
@@ -49,9 +49,9 @@ async fn extract_backward_compatibility() -> Result<()> {
                 .extract("John Doe is a 30 year old software engineer.")
                 .await?;
 
-            anyhow::ensure!(person.name.as_deref() == Some("John Doe"));
-            anyhow::ensure!(person.age == Some(30));
-            assert_compatible_professions(person.profession.as_deref(), "software engineer")?;
+            anyhow::ensure!(person.data.name.as_deref() == Some("John Doe"));
+            anyhow::ensure!(person.data.age == Some(30));
+            assert_compatible_professions(person.data.profession.as_deref(), "software engineer")?;
 
             Ok(())
         },
@@ -67,7 +67,7 @@ async fn extract_with_usage_returns_data_and_usage() -> Result<()> {
             let extractor = client.extractor::<Person>(DEFAULT_MODEL).build();
 
             let response: ExtractionResponse<Person> = extractor
-                .extract_with_usage("Jane Smith is a 45 year old data scientist.")
+                .extract("Jane Smith is a 45 year old data scientist.")
                 .await?;
 
             anyhow::ensure!(response.data.name.as_deref() == Some("Jane Smith"));
@@ -95,7 +95,7 @@ async fn extract_with_chat_history_with_usage_works() -> Result<()> {
             )];
 
             let response: ExtractionResponse<Address> = extractor
-                .extract_with_chat_history_with_usage(
+                .extract_with_chat_history(
                     "The address is 123 Main St in Springfield, IL 62701.",
                     chat_history,
                 )
@@ -123,13 +123,13 @@ async fn extract_and_extract_with_usage_return_same_data() -> Result<()> {
 
             let text = "Bob Johnson is a 55 year old retired teacher.";
             let person = extractor.extract(text).await?;
-            let response = extractor.extract_with_usage(text).await?;
+            let response = extractor.extract(text).await?;
 
-            anyhow::ensure!(person.name.as_deref() == Some("Bob Johnson"));
+            anyhow::ensure!(person.data.name.as_deref() == Some("Bob Johnson"));
             anyhow::ensure!(response.data.name.as_deref() == Some("Bob Johnson"));
-            anyhow::ensure!(person.age == Some(55));
+            anyhow::ensure!(person.data.age == Some(55));
             anyhow::ensure!(response.data.age == Some(55));
-            assert_compatible_professions(person.profession.as_deref(), "retired teacher")?;
+            assert_compatible_professions(person.data.profession.as_deref(), "retired teacher")?;
             assert_compatible_professions(response.data.profession.as_deref(), "retired teacher")?;
             anyhow::ensure!(response.usage.total_tokens > 0, "usage should be populated");
 
@@ -146,13 +146,13 @@ async fn usage_tracking_works_for_different_schemas() -> Result<()> {
         |client| async move {
             let person_extractor = client.extractor::<Person>(DEFAULT_MODEL).build();
             let person_response = person_extractor
-                .extract_with_usage("Alice is a 25 year old developer.")
+                .extract("Alice is a 25 year old developer.")
                 .await?;
             anyhow::ensure!(person_response.usage.total_tokens > 0);
 
             let address_extractor = client.extractor::<Address>(DEFAULT_MODEL).build();
             let address_response = address_extractor
-                .extract_with_usage("456 Oak Avenue, Cambridge, MA 02139")
+                .extract("456 Oak Avenue, Cambridge, MA 02139")
                 .await?;
             anyhow::ensure!(address_response.usage.total_tokens > 0);
 

--- a/tests/providers/openrouter/cassette/multi_extract.rs
+++ b/tests/providers/openrouter/cassette/multi_extract.rs
@@ -66,10 +66,10 @@ async fn batch_multi_extract_chain() -> Result<()> {
                         )?;
                         anyhow::Ok(format!(
                             "Extracted names: {}\nExtracted topics: {}\nExtracted sentiment: {} ({})",
-                            names.names.join(", "),
-                            topics.topics.join(", "),
-                            sentiment.sentiment,
-                            sentiment.confidence,
+                            names.data.names.join(", "),
+                            topics.data.topics.join(", "),
+                            sentiment.data.sentiment,
+                            sentiment.data.confidence,
                         ))
                     }
                 })

--- a/tests/providers/venice/cassette/extractor.rs
+++ b/tests/providers/venice/cassette/extractor.rs
@@ -12,7 +12,7 @@ async fn extractor_smoke() {
         let response = client
             .extractor::<SmokePerson>(DEFAULT_MODEL)
             .build()
-            .extract_with_usage(EXTRACTOR_TEXT)
+            .extract(EXTRACTOR_TEXT)
             .await
             .expect("extractor request should succeed");
 

--- a/tests/providers/xai/extractor.rs
+++ b/tests/providers/xai/extractor.rs
@@ -12,7 +12,7 @@ async fn extractor_smoke() {
         let extractor = client.extractor::<SmokePerson>(xai::GROK_3_MINI).build();
 
         let response = extractor
-            .extract_with_usage(EXTRACTOR_TEXT)
+            .extract(EXTRACTOR_TEXT)
             .await
             .expect("extractor request should succeed");
 

--- a/tests/providers/xai/extractor_usage.rs
+++ b/tests/providers/xai/extractor_usage.rs
@@ -50,9 +50,9 @@ async fn extract_backward_compatibility() -> Result<()> {
                 .extract("John Doe is a 30 year old software engineer.")
                 .await?;
 
-            anyhow::ensure!(person.name.as_deref() == Some("John Doe"));
-            anyhow::ensure!(person.age == Some(30));
-            assert_compatible_professions(person.profession.as_deref(), "software engineer")?;
+            anyhow::ensure!(person.data.name.as_deref() == Some("John Doe"));
+            anyhow::ensure!(person.data.age == Some(30));
+            assert_compatible_professions(person.data.profession.as_deref(), "software engineer")?;
 
             Ok(())
         },
@@ -68,7 +68,7 @@ async fn extract_with_usage_returns_data_and_usage() -> Result<()> {
             let extractor = client.extractor::<Person>(xai::GROK_3_MINI).build();
 
             let response: ExtractionResponse<Person> = extractor
-                .extract_with_usage("Jane Smith is a 45 year old data scientist.")
+                .extract("Jane Smith is a 45 year old data scientist.")
                 .await?;
 
             anyhow::ensure!(response.data.name.as_deref() == Some("Jane Smith"));
@@ -96,7 +96,7 @@ async fn extract_with_chat_history_with_usage_works() -> Result<()> {
             )];
 
             let response: ExtractionResponse<Address> = extractor
-                .extract_with_chat_history_with_usage(
+                .extract_with_chat_history(
                     "The address is 123 Main St in Springfield, IL 62701.",
                     chat_history,
                 )
@@ -124,13 +124,13 @@ async fn extract_and_extract_with_usage_return_same_data() -> Result<()> {
 
             let text = "Bob Johnson is a 55 year old retired teacher.";
             let person = extractor.extract(text).await?;
-            let response = extractor.extract_with_usage(text).await?;
+            let response = extractor.extract(text).await?;
 
-            anyhow::ensure!(person.name.as_deref() == Some("Bob Johnson"));
+            anyhow::ensure!(person.data.name.as_deref() == Some("Bob Johnson"));
             anyhow::ensure!(response.data.name.as_deref() == Some("Bob Johnson"));
-            anyhow::ensure!(person.age == Some(55));
+            anyhow::ensure!(person.data.age == Some(55));
             anyhow::ensure!(response.data.age == Some(55));
-            assert_compatible_professions(person.profession.as_deref(), "retired teacher")?;
+            assert_compatible_professions(person.data.profession.as_deref(), "retired teacher")?;
             assert_compatible_professions(response.data.profession.as_deref(), "retired teacher")?;
             anyhow::ensure!(response.usage.total_tokens > 0, "usage should be populated");
 
@@ -147,13 +147,13 @@ async fn usage_tracking_works_for_different_schemas() -> Result<()> {
         |client| async move {
             let person_extractor = client.extractor::<Person>(xai::GROK_3_MINI).build();
             let person_response = person_extractor
-                .extract_with_usage("Alice is a 25 year old developer.")
+                .extract("Alice is a 25 year old developer.")
                 .await?;
             anyhow::ensure!(person_response.usage.total_tokens > 0);
 
             let address_extractor = client.extractor::<Address>(xai::GROK_3_MINI).build();
             let address_response = address_extractor
-                .extract_with_usage("456 Oak Avenue, Cambridge, MA 02139")
+                .extract("456 Oak Avenue, Cambridge, MA 02139")
                 .await?;
             anyhow::ensure!(address_response.usage.total_tokens > 0);
 

--- a/tests/providers/xai/multi_extract.rs
+++ b/tests/providers/xai/multi_extract.rs
@@ -112,10 +112,10 @@ async fn batch_multi_extract_chain() -> Result<()> {
                             sentiment_extractor.extract(text),
                         )?;
                         anyhow::Ok(CombinedExtract {
-                            names: names.names,
-                            topics: topics.topics,
-                            sentiment: sentiment.sentiment,
-                            confidence: sentiment.confidence,
+                            names: names.data.names,
+                            topics: topics.data.topics,
+                            sentiment: sentiment.data.sentiment,
+                            confidence: sentiment.data.confidence,
                         })
                     }
                 })


### PR DESCRIPTION
A sweep removing every remaining backwards-compatibility shim, per the project's no-backcompat policy. Every break is documented in MIGRATING.md ("Backwards-compat shims removed" under 0.41 → next).

## Removed

**Rename aliases** (pure old-name shims):
- `rig_candle::ModelFamily` → use `ConversationProtocol`; `rig_candle::LlamaModel` → use `CandleModel` (internal code mass-renamed to the canonical names)
- `rig::tool_macro` / `rig_agent::tool_macro` re-exports of `rig_tool`
- `rig_agent::tool::server::ToolRegistrySnapshot` alias of `ToolCatalog`
- `rig_bedrock::embedding`'s historical constant names (`AMAZON_TITAN_EMBED_TEXT_V1` etc.) aliasing the canonical `completion` constants
- the hook event struct is now named `CompletionCallEvent` itself (was `hook::CompletionCall` + a renaming re-export), ending the collision with the run-record `CompletionCall`

**`CompletionRequest::preamble`** — the legacy field "preserved for backwards compatibility". The builder has funneled the preamble into a leading `Message::System` since 0.33 and always emitted `preamble: None`; every provider read of the field was a dead parallel channel for hand-built requests. Providers now derive system instructions solely from leading system messages (they already did). `CompletionRequestBuilder::preamble(..)` survives as pure build-time sugar. Provider telemetry `system_instructions`, fed only by the dead field, now reports none.

**Extractor API** — `extract_with_usage`/`extract_with_chat_history_with_usage` deleted; `extract`/`extract_with_chat_history` now return `ExtractionResponse<T>` (`{ data, usage }`). ~120 call sites migrated.

**Extractor legacy-transport policy** — `ignore_unhandled_invalid_tool_calls` (invalid tool calls silently discarded in extractor runs) removed; unresolved invalid calls now fail the attempt and the extractor's retry loop retries. `AgentRun::ignore_invalid_tool_call`, which existed only for that policy, is removed.

**Retired provider model constants** — all 13 `#[deprecated]` model ids (Cohere ×6, Mistral ×5, DeepSeek ×2) plus the undead `MOONSHOT_CHAT` (`moonshot-v1-128k`, doc-marked "(legacy)") are deleted rather than left warning; the providers no longer serve these models.

**Persisted-format tolerances**:
- `CompletionCall.usage` is a required object — the pre-monoid `"usage": null` encoding no longer loads (run records, stream items, suspended `AgentRun` state). Pinning tests flipped to assert rejection.
- `json_utils::string_or_vec` re-tightened: `null` is a loud error again. The one field where `null` is a real wire shape (OpenAI assistant content on tool-calls-only messages) uses the new `string_null_or_vec`, so provider decoding is unchanged.

## Considered and deliberately kept

- **`AdditionalParams` `{}`/`null` → absent canonicalization** — this is the type's core absence doctrine (non-empty-map invariant), not a bolt-on compat path; removing it would break the design, including serialization-skip symmetry.
- **`PromptResponse::new(output, usage)` / `TypedPromptResponse::new`** — flagged by a test comment as "backward compatibility", but `new` + `with_*` is the intended builder shape; only the stale test labels were rewritten.
- **The rig-agent → rig-run/rig-core re-export layer** — not a compat alias set but the facade's live API: rig-agent's own signatures return rig-run types (`PromptResponse`, `CompletionCall`, `AgentRun`), so the re-exports are load-bearing.
- **Copilot `bootstrap_token_fingerprint: Option<String>`** — user on-disk auth state, fail-safe (`None` forces refresh), cheap.
- **All `#[serde(alias)]` sites** — verified to handle currently-live provider wire dialects (OpenAI `developer` role, gateway `role: "model"`, Mistral dual spelling, Jina/TEI rerank keys, …), not rig compat.
- **`keys_lost_in_round_trip`** — opt-in migration tooling, correctly outside the load path.

## Verification

- `cargo check`/`clippy --workspace --all-features --all-targets`: clean
- `cargo check --target wasm32-unknown-unknown` for rig-core/rig-agent/rig-run: clean
- full test suite (`cargo nextest run --workspace --all-features`): **6239/6239 passed** (213 skipped)
- cassette scenario literals untouched (replays remain valid; the preamble → leading-system-message change is wire-identical for recorded requests)
