### PR TITLE
refactor!: rig-reqwest API and hygiene cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,6 +2260,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
+name = "cohere_image_embeddings"
+version = "0.42.0"
+dependencies = [
+ "anyhow",
+ "rig",
+ "tokio",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -806,6 +806,56 @@ handed back a silently short list.
 
 ## 0.41 → next
 
+### The bundled transport newtypes expose their inner client once, not three ways
+
+`ReqwestClient` and `ReqwestMiddlewareClient` each handed out the client they
+wrap through a public tuple field, a `Deref`, *and* `From`. `Deref` on a type
+that is not a smart pointer makes reqwest's whole inherent API look like the
+newtype's own, which it is not, and the public field made it redundant besides.
+Both now have a private field and two explicit accessors:
+
+```rust
+// Before
+let inner: &reqwest::Client = &client.0;
+let response = client.get(url).send().await?;   // via Deref
+
+// After
+let inner: &reqwest::Client = client.as_ref();
+let response = client.as_ref().get(url).send().await?;
+let owned: reqwest::Client = client.into_inner();
+```
+
+Construction is unchanged (`From`, `Default`, and now an explicit
+`ReqwestClient::new(..)`), so `ReqwestClient::default()`,
+`reqwest_client.into()` and `ClientBuilder::new(..).build().into()` all keep
+working.
+
+`ReqwestMiddlewareClient` gained the erasure `ReqwestClient` already had —
+`boxed()` and `impl From<ReqwestMiddlewareClient> for BoxedHttpClient` — so a
+host that erases its transport does not lose the option by having chosen
+middleware. It deliberately still has no `Default`: a middleware client with no
+middleware is a `reqwest::Client` with extra indirection.
+
+### `multipart_form` reports an unusable content type instead of dropping it
+
+`rig_reqwest::multipart_form` now returns
+`http_client::Result<reqwest::multipart::Form>`. It used to rebuild the part
+without its content type when reqwest rejected the MIME string and send the
+request anyway, so the provider saw a part with *no* content type and answered
+with something unrelated to the actual mistake.
+
+```rust
+// Before
+let form = rig_reqwest::multipart_form(parts);
+
+// After
+let form = rig_reqwest::multipart_form(parts)?;
+```
+
+Rig's own multipart parts carry a parsed `mime::Mime`, so in practice this
+fires only on a `mime`/`reqwest` version skew — the point is that it now fires
+at all rather than silently changing the request.
+
 ### Websockets are transport-agnostic: the protocol moved to `rig-core`, the socket to `rig-tungstenite`
 
 The OpenAI Responses websocket mode used to live in `rig-reqwest`, because

--- a/crates/rig-milvus/Cargo.toml
+++ b/crates/rig-milvus/Cargo.toml
@@ -11,12 +11,16 @@ workspace = true
 [dependencies]
 reqwest = { workspace = true, features = ["json"] }
 rig-core = { path = "../rig-core", version = "0.42.0", default-features = false }
+# The bundled reqwest transport, for `from_reqwest`. This crate holds a
+# `reqwest::Client` directly rather than an `H: HttpClientExt`, so it is already
+# reqwest-coupled; `default-features = false` keeps the TLS choice this crate's
+# own `rustls`/`native-tls` features make.
+rig-reqwest = { path = "../rig-reqwest", version = "0.42.0", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
-rig-reqwest = { path = "../rig-reqwest", version = "0.42.0" }
 anyhow = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/crates/rig-milvus/src/lib.rs
+++ b/crates/rig-milvus/src/lib.rs
@@ -11,6 +11,7 @@ mod filter;
 pub use filter::{Filter, MilvusValue};
 
 use reqwest::StatusCode;
+// The same mapping this crate used to define for itself; see rig#2426's review.
 use rig_core::{
     Embed,
     embeddings::{Embedding, EmbeddingModel, EmbeddingModelHandle},
@@ -19,6 +20,7 @@ use rig_core::{
         request::{SearchFilter, VectorSearchRequest},
     },
 };
+use rig_reqwest::from_reqwest;
 use serde::{Deserialize, Serialize};
 
 /// Represents a vector store implementation using Milvus - <https://milvus.io/> as the backend.
@@ -34,16 +36,6 @@ pub struct MilvusVectorStore {
     database_name: String,
     collection_name: String,
     token: Option<String>,
-}
-
-/// Map a transport-level `reqwest::Error` onto rig's transport-agnostic
-/// [`rig_core::http_client::Error`]: a status-carrying failure keeps its status
-/// as `InvalidStatusCode`, a response-less one becomes `Instance`.
-fn from_reqwest(err: reqwest::Error) -> rig_core::http_client::Error {
-    err.status().map_or_else(
-        || rig_core::http_client::Error::instance(err),
-        rig_core::http_client::Error::InvalidStatusCode,
-    )
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/rig-reqwest/Cargo.toml
+++ b/crates/rig-reqwest/Cargo.toml
@@ -47,6 +47,22 @@ futures = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [features]
+# TLS: enable exactly one of `rustls` (the default) and `native-tls`. They are
+# additive, so enabling both compiles both stacks and reqwest — not rig — picks
+# which one a client uses. There is deliberately no `compile_error!` for the
+# pair: `--all-features` enables it, and that is the lane CI's clippy, test and
+# doc jobs run in, so the guard would break the build it is meant to protect.
+# The websocket axis in `rig-tungstenite` is documented the same way, for the
+# related reason that additive features cannot express "replace stack A with B".
+#
+# Unlike that axis, a single-stack build here is reachable for every selector:
+# `--no-default-features --features native-tls` and
+# `--no-default-features --features reqwest-middleware-native-tls` both resolve
+# to native-tls with no rustls in the tree.
+#
+# `reqwest-middleware` shares its name with the optional dependency it enables
+# (`dep:reqwest-middleware`). That is legal, and it is the name the `rig` facade
+# forwards, so it stays.
 default = ["rustls"]
 socks = ["reqwest/socks"]
 # Provider-aware conveniences need the same feature surface as rig-core's

--- a/crates/rig-reqwest/src/lib.rs
+++ b/crates/rig-reqwest/src/lib.rs
@@ -39,22 +39,42 @@ pub use reqwest;
 ///
 /// A newtype rather than `reqwest::Client` itself because the orphan rule
 /// forbids implementing rig-core's trait for reqwest's type from this crate.
-/// It derefs to the inner client, converts `From<reqwest::Client>`, and
-/// `Default` builds `reqwest::Client::default()`.
+/// That is the whole of its job, so its surface is deliberately small: convert
+/// in with [`From`] or [`Default`], borrow the inner client with [`AsRef`],
+/// take it back with [`into_inner`](Self::into_inner).
+///
+/// It used to expose the inner client three ways at once — a public field,
+/// `Deref`, and `From`. `Deref` on a type that is not a smart pointer makes
+/// reqwest's whole inherent API look like this type's own, which it is not;
+/// the two explicit accessors say the same thing without the illusion.
 #[derive(Clone, Debug, Default)]
-pub struct ReqwestClient(pub reqwest::Client);
+pub struct ReqwestClient(reqwest::Client);
+
+impl ReqwestClient {
+    /// Wrap an already-configured `reqwest::Client` — timeouts, proxies, a
+    /// connection pool shared with the rest of the host.
+    #[must_use]
+    pub fn new(client: reqwest::Client) -> Self {
+        Self(client)
+    }
+
+    /// Take the inner client back.
+    #[must_use]
+    pub fn into_inner(self) -> reqwest::Client {
+        self.0
+    }
+
+    /// Erase this transport behind [`BoxedHttpClient`], for hosts that hold
+    /// one transport for many providers without naming it in their types.
+    #[must_use]
+    pub fn boxed(self) -> BoxedHttpClient {
+        BoxedHttpClient::new(self)
+    }
+}
 
 impl From<reqwest::Client> for ReqwestClient {
     fn from(client: reqwest::Client) -> Self {
         Self(client)
-    }
-}
-
-impl ReqwestClient {
-    /// Erase this transport behind [`BoxedHttpClient`], for hosts that hold
-    /// one transport for many providers without naming it in their types.
-    pub fn boxed(self) -> BoxedHttpClient {
-        BoxedHttpClient::new(self)
     }
 }
 
@@ -64,18 +84,45 @@ impl From<ReqwestClient> for BoxedHttpClient {
     }
 }
 
-impl std::ops::Deref for ReqwestClient {
-    type Target = reqwest::Client;
-    fn deref(&self) -> &reqwest::Client {
+impl AsRef<reqwest::Client> for ReqwestClient {
+    fn as_ref(&self) -> &reqwest::Client {
         &self.0
     }
 }
 
 /// [`HttpClientExt`] for a `reqwest_middleware::ClientWithMiddleware`.
+///
+/// The same shape as [`ReqwestClient`], minus `Default`: a middleware client
+/// with no middleware is just a `reqwest::Client` with extra indirection, so
+/// there is no default worth having — build one with
+/// `reqwest_middleware::ClientBuilder` and convert it in.
 #[cfg(feature = "reqwest-middleware")]
 #[cfg_attr(docsrs, doc(cfg(feature = "reqwest-middleware")))]
 #[derive(Clone, Debug)]
-pub struct ReqwestMiddlewareClient(pub reqwest_middleware::ClientWithMiddleware);
+pub struct ReqwestMiddlewareClient(reqwest_middleware::ClientWithMiddleware);
+
+#[cfg(feature = "reqwest-middleware")]
+impl ReqwestMiddlewareClient {
+    /// Wrap a built `ClientWithMiddleware`.
+    #[must_use]
+    pub fn new(client: reqwest_middleware::ClientWithMiddleware) -> Self {
+        Self(client)
+    }
+
+    /// Take the inner client back.
+    #[must_use]
+    pub fn into_inner(self) -> reqwest_middleware::ClientWithMiddleware {
+        self.0
+    }
+
+    /// Erase this transport behind [`BoxedHttpClient`], as
+    /// [`ReqwestClient::boxed`] does — a host that erases its transport should
+    /// not lose the option by having chosen middleware.
+    #[must_use]
+    pub fn boxed(self) -> BoxedHttpClient {
+        BoxedHttpClient::new(self)
+    }
+}
 
 #[cfg(feature = "reqwest-middleware")]
 impl From<reqwest_middleware::ClientWithMiddleware> for ReqwestMiddlewareClient {
@@ -85,9 +132,15 @@ impl From<reqwest_middleware::ClientWithMiddleware> for ReqwestMiddlewareClient 
 }
 
 #[cfg(feature = "reqwest-middleware")]
-impl std::ops::Deref for ReqwestMiddlewareClient {
-    type Target = reqwest_middleware::ClientWithMiddleware;
-    fn deref(&self) -> &reqwest_middleware::ClientWithMiddleware {
+impl From<ReqwestMiddlewareClient> for BoxedHttpClient {
+    fn from(client: ReqwestMiddlewareClient) -> Self {
+        client.boxed()
+    }
+}
+
+#[cfg(feature = "reqwest-middleware")]
+impl AsRef<reqwest_middleware::ClientWithMiddleware> for ReqwestMiddlewareClient {
+    fn as_ref(&self) -> &reqwest_middleware::ClientWithMiddleware {
         &self.0
     }
 }
@@ -134,10 +187,26 @@ async fn non_success_status_error(response: reqwest::Response) -> Error {
     Error::non_success_with_details(status, headers, body)
 }
 
-/// Build the transport-agnostic response whose body is read lazily (the
-/// caller awaits it later). Only valid when the caller can poll reqwest
-/// futures — i.e. inside a tokio runtime (or on wasm).
-async fn into_lazy_response<U>(response: reqwest::Response) -> Result<Response<LazyBody<U>>>
+/// When the body is read.
+///
+/// The two moments look alike and are not interchangeable: the caller decides
+/// which by whether it can still poll reqwest when it awaits the body.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum BodyTiming {
+    /// Hand back a body future the caller awaits later. Only valid where the
+    /// caller can poll reqwest futures — inside a tokio runtime, or on wasm.
+    Lazy,
+    /// Read the body now and hand back a ready future. This is the off-runtime
+    /// path: the future it returns may be polled by an executor that cannot
+    /// drive reqwest, so nothing reqwest-shaped may survive into it.
+    Eager,
+}
+
+/// Build the transport-agnostic response, reading the body at `timing`.
+async fn into_response<U>(
+    response: reqwest::Response,
+    timing: BodyTiming,
+) -> Result<Response<LazyBody<U>>>
 where
     U: From<Bytes>,
     U: WasmCompatSend + 'static,
@@ -151,36 +220,30 @@ where
         *headers = response.headers().clone();
     }
 
-    let body: LazyBody<U> = Box::pin(async {
-        let bytes = response.bytes().await.map_err(Error::instance)?;
-        Ok(U::from(bytes))
-    });
+    let body: LazyBody<U> = match timing {
+        BodyTiming::Lazy => Box::pin(async {
+            let bytes = response.bytes().await.map_err(Error::instance)?;
+            Ok(U::from(bytes))
+        }),
+        BodyTiming::Eager => {
+            let bytes = response.bytes().await.map_err(Error::instance)?;
+            Box::pin(std::future::ready(Ok(U::from(bytes))))
+        }
+    };
 
     res.body(body).map_err(Error::Protocol)
 }
 
-/// Like [`into_lazy_response`], but reads the body eagerly — for the
-/// off-runtime path, where the returned future may be polled by an executor
-/// that cannot drive reqwest.
-#[cfg(not(target_family = "wasm"))]
-async fn into_eager_response<U>(response: reqwest::Response) -> Result<Response<LazyBody<U>>>
-where
-    U: From<Bytes>,
-    U: WasmCompatSend + 'static,
-{
-    if !response.status().is_success() {
-        return Err(non_success_status_error(response).await);
-    }
-
-    let mut res = Response::builder().status(response.status());
-    if let Some(headers) = res.headers_mut() {
-        *headers = response.headers().clone();
-    }
-
-    let bytes = response.bytes().await.map_err(Error::instance)?;
-    let body: LazyBody<U> = Box::pin(std::future::ready(Ok(U::from(bytes))));
-    res.body(body).map_err(Error::Protocol)
-}
+/// The timing the off-runtime side of [`drive`] needs.
+///
+/// On wasm there is no fallback runtime and no off-runtime path, so the body
+/// stays lazy; natively the off-runtime side must not hand reqwest futures to
+/// an executor that cannot poll them.
+const OFF_RUNTIME_TIMING: BodyTiming = if cfg!(target_family = "wasm") {
+    BodyTiming::Lazy
+} else {
+    BodyTiming::Eager
+};
 
 fn streaming_head(response: &reqwest::Response) -> http::response::Builder {
     #[cfg(not(target_family = "wasm"))]
@@ -244,8 +307,24 @@ async fn into_forwarded_streaming_response(
     res.body(stream).map_err(Error::Protocol)
 }
 
+/// A part's content type was not a MIME type reqwest would accept.
+#[derive(Debug, thiserror::Error)]
+#[error("multipart part {part:?} has an unusable content type {content_type:?}: {source}")]
+struct InvalidPartContentType {
+    part: String,
+    content_type: String,
+    source: reqwest::Error,
+}
+
 /// Render a [`MultipartForm`] as a `reqwest::multipart::Form`.
-pub fn multipart_form(value: MultipartForm) -> reqwest::multipart::Form {
+///
+/// Fails when a part names a content type reqwest rejects. That used to be
+/// swallowed — the part was rebuilt without its content type and the request
+/// went out anyway — so a typo'd MIME reached the provider as a *missing* one
+/// and came back as an opaque provider error about the payload. A content type
+/// the caller asked for and did not get is a caller bug worth reporting at the
+/// call site.
+pub fn multipart_form(value: MultipartForm) -> Result<reqwest::multipart::Form> {
     let mut form = reqwest::multipart::Form::new();
 
     for part in value.into_parts() {
@@ -255,13 +334,16 @@ pub fn multipart_form(value: MultipartForm) -> reqwest::multipart::Form {
                 form = form.text(name, text);
             }
             PartContent::Binary(bytes) => {
-                let mut req_part = if let Some(content_type) = content_type.as_ref() {
-                    reqwest::multipart::Part::bytes(bytes.to_vec())
-                        .mime_str(content_type.as_ref())
-                        .unwrap_or_else(|_| reqwest::multipart::Part::bytes(bytes.to_vec()))
-                } else {
-                    reqwest::multipart::Part::bytes(bytes.to_vec())
-                };
+                let mut req_part = reqwest::multipart::Part::bytes(bytes.to_vec());
+                if let Some(content_type) = content_type.as_ref() {
+                    req_part = req_part.mime_str(content_type.as_ref()).map_err(|source| {
+                        Error::instance(InvalidPartContentType {
+                            part: name.clone(),
+                            content_type: content_type.as_ref().to_string(),
+                            source,
+                        })
+                    })?;
+                }
 
                 if let Some(filename) = filename {
                     req_part = req_part.file_name(filename);
@@ -272,7 +354,7 @@ pub fn multipart_form(value: MultipartForm) -> reqwest::multipart::Form {
         }
     }
 
-    form
+    Ok(form)
 }
 
 /// The one request-driving routine both reqwest-flavoured clients share:
@@ -383,11 +465,11 @@ where
         .with_headers(parts.headers)
         .with_body(body.into().into());
 
-    #[cfg(not(target_family = "wasm"))]
-    let off = into_eager_response::<U>;
-    #[cfg(target_family = "wasm")]
-    let off = into_lazy_response::<U>;
-    drive(req, into_lazy_response::<U>, off)
+    drive(
+        req,
+        |response| into_response::<U>(response, BodyTiming::Lazy),
+        |response| into_response::<U>(response, OFF_RUNTIME_TIMING),
+    )
 }
 
 fn send_multipart_via<C, U>(
@@ -399,16 +481,25 @@ where
     U: From<Bytes> + WasmCompatSend + 'static,
 {
     let (parts, body) = req.into_parts();
-    let req = client
-        .request_builder(parts.method, parts.uri.to_string())
-        .with_headers(parts.headers)
-        .with_multipart(multipart_form(body));
+    // The form is rendered before the request is driven, so an unusable
+    // content type fails here rather than reaching the provider as a silently
+    // missing one.
+    let form = multipart_form(body);
+    let req = form.map(|form| {
+        client
+            .request_builder(parts.method, parts.uri.to_string())
+            .with_headers(parts.headers)
+            .with_multipart(form)
+    });
 
-    #[cfg(not(target_family = "wasm"))]
-    let off = into_eager_response::<U>;
-    #[cfg(target_family = "wasm")]
-    let off = into_lazy_response::<U>;
-    drive(req, into_lazy_response::<U>, off)
+    async move {
+        drive(
+            req?,
+            |response| into_response::<U>(response, BodyTiming::Lazy),
+            |response| into_response::<U>(response, OFF_RUNTIME_TIMING),
+        )
+        .await
+    }
 }
 
 fn send_streaming_via<C, T>(

--- a/crates/rig-reqwest/src/runtime.rs
+++ b/crates/rig-reqwest/src/runtime.rs
@@ -29,15 +29,27 @@ static RUNTIME: LazyLock<Result<Runtime, RuntimeUnavailable>> = LazyLock::new(||
 });
 
 /// The fallback tokio runtime could not be started.
+///
+/// Private: this module is private, so a `pub` here was unnameable by callers
+/// anyway. The failure reaches them as the `Error::Instance` this is boxed
+/// into, whose `Display` carries the message. `rig-tungstenite` keeps the same
+/// type private for the same reason.
 #[derive(Debug, Clone, thiserror::Error)]
 #[error("rig-reqwest: failed to start the fallback tokio runtime: {0}")]
-pub struct RuntimeUnavailable(String);
+struct RuntimeUnavailable(String);
 
 fn runtime() -> Result<&'static Runtime, Error> {
     RUNTIME.as_ref().map_err(|err| Error::instance(err.clone()))
 }
 
 /// Whether the current task already runs inside a tokio runtime.
+///
+/// A caveat: a `current_thread` runtime built without
+/// `enable_io()`/`enable_time()` answers `true` here, and reqwest then panics
+/// with "there is no reactor running". `Handle::try_current()` cannot
+/// distinguish a runtime with the I/O driver from one without it, so a host
+/// that builds its own runtime must enable I/O. `rig-tungstenite`'s backend
+/// shares the caveat and documents it in the same place.
 pub(crate) fn in_tokio() -> bool {
     Handle::try_current().is_ok()
 }

--- a/crates/rig-reqwest/tests/multipart.rs
+++ b/crates/rig-reqwest/tests/multipart.rs
@@ -1,0 +1,104 @@
+//! What a multipart request actually puts on the wire.
+//!
+//! A part's content type is the piece most easily lost in translation: rig
+//! carries it as a typed `mime::Mime`, reqwest wants a string, and until this
+//! was fixed a content type reqwest would not take was dropped and the request
+//! was sent anyway — so a provider saw a part with *no* content type and
+//! answered with something unrelated to the real mistake.
+//!
+//! The provider-facing property is simply that the content type survives, so
+//! that is what this asserts, against a socket rather than through reqwest's
+//! `Form` (which exposes no way to read a part back).
+
+#![cfg(not(target_family = "wasm"))]
+#![allow(clippy::expect_used, clippy::indexing_slicing)]
+
+use rig_core::http_client::multipart::{MultipartForm, Part};
+use rig_core::http_client::{HttpClientExt, Request};
+use rig_reqwest::ReqwestClient;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::mpsc;
+
+/// Accept one request, hand its full text back to the test, and answer 200.
+fn capture_one_request() -> (String, mpsc::Receiver<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let address = listener.local_addr().expect("addr");
+    let (tx, rx) = mpsc::channel();
+
+    std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept");
+        // One read is enough: these bodies are far below the socket buffer, and
+        // the assertions only need the headers and part preamble.
+        let mut buffer = vec![0u8; 8192];
+        let read = stream.read(&mut buffer).unwrap_or(0);
+        let _ = tx.send(String::from_utf8_lossy(&buffer[..read]).into_owned());
+        let _ = stream
+            .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\nconnection: close\r\n\r\n{}");
+        let _ = stream.flush();
+    });
+
+    (format!("http://{address}/"), rx)
+}
+
+#[tokio::test]
+async fn a_parts_content_type_reaches_the_wire() {
+    let (url, requests) = capture_one_request();
+
+    let form = MultipartForm::new().text("model", "whisper-1").part(
+        Part::bytes("file", vec![0x89, 0x50, 0x4e, 0x47])
+            .filename("audio.png")
+            .content_type("image/png".parse().expect("a valid mime")),
+    );
+
+    let request = Request::builder()
+        .method(http::Method::POST)
+        .uri(&url)
+        .body(form)
+        .expect("request should build");
+
+    let response = ReqwestClient::default()
+        .send_multipart::<Vec<u8>>(request)
+        .await
+        .expect("the request should be sent");
+    assert!(response.status().is_success());
+
+    let sent = requests.recv().expect("the server should see the request");
+    assert!(
+        sent.contains("content-type: image/png") || sent.contains("Content-Type: image/png"),
+        "the part's content type must reach the wire, got:\n{sent}"
+    );
+    assert!(
+        sent.contains("audio.png"),
+        "the part's filename must reach the wire, got:\n{sent}"
+    );
+    assert!(
+        sent.contains("whisper-1"),
+        "the text part must reach the wire, got:\n{sent}"
+    );
+}
+
+/// A form with no content type on its binary part is still valid — the field
+/// is optional, and rendering must not invent one.
+#[tokio::test]
+async fn a_part_without_a_content_type_is_still_rendered() {
+    let (url, requests) = capture_one_request();
+
+    let form = MultipartForm::new().part(Part::bytes("file", vec![1, 2, 3]));
+    let request = Request::builder()
+        .method(http::Method::POST)
+        .uri(&url)
+        .body(form)
+        .expect("request should build");
+
+    ReqwestClient::default()
+        .send_multipart::<Vec<u8>>(request)
+        .await
+        .expect("the request should be sent");
+
+    let sent = requests.recv().expect("the server should see the request");
+    assert!(
+        sent.contains("name=\"file\""),
+        "the part must reach the wire, got:\n{sent}"
+    );
+}

--- a/examples/cohere_image_embeddings/Cargo.toml
+++ b/examples/cohere_image_embeddings/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cohere_image_embeddings"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+rig = { workspace = true }
+anyhow = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/examples/cohere_image_embeddings/src/main.rs
+++ b/examples/cohere_image_embeddings/src/main.rs
@@ -3,13 +3,13 @@
 //! Set `COHERE_API_KEY`, then run:
 //!
 //! ```text
-//! cargo run -p rig-reqwest --example cohere_image_embeddings -- path/to/image.png
+//! cargo run -p cohere_image_embeddings -- path/to/image.png
 //! ```
 
 use anyhow::{Context, Result};
-use rig_core::embeddings::ImageEmbeddingModel;
-use rig_reqwest::prelude::*;
-use rig_reqwest::providers::cohere::Client;
+use rig::embeddings::ImageEmbeddingModel;
+use rig::prelude::*;
+use rig::providers::cohere::Client;
 
 #[tokio::main]
 async fn main() -> Result<()> {


### PR DESCRIPTION
Phase 3 — the last of the `rig-reqwest` review, after #2426 (websockets) and #2427 (the generated alias tree). Eight independent items; each is separately reviewable.

## The two breaks

**1. The transport newtypes exposed their inner client three ways** — a public tuple field, a `Deref`, and a `From`. `Deref` on a type that is not a smart pointer makes reqwest's whole inherent API look like the newtype's own, and the public field made it redundant besides. Both now have a private field plus `new` / `into_inner` / `AsRef`.

`ReqwestMiddlewareClient` gains the erasure `ReqwestClient` already had (`boxed()`, `From<…> for BoxedHttpClient`): a host that erases its transport should not lose the option by having chosen middleware. It deliberately still has **no `Default`** — a middleware client with no middleware is a `reqwest::Client` with extra indirection, so mechanical symmetry would have been wrong here.

**2. `multipart_form` dropped an unusable content type silently** and sent the request anyway, so the provider saw a part with *no* content type and answered about the wrong problem. It returns `Result` now.

Worth stating plainly: rig's parts carry a parsed `mime::Mime`, so this can realistically only fire on a `mime`/`reqwest` version skew. This is not a live data-loss fix — the value is that the failure is no longer silent. The new `tests/multipart.rs` covers what does matter and had no coverage at all: that the content type, filename and text parts reach the wire. It asserts against a socket because reqwest's `Form` exposes no way to read a part back.

`MIGRATING.md` has before/after for both; `cargo public-api --all-features` was used to enumerate exactly what changed.

## The rest

**3. rig-milvus no longer duplicates `from_reqwest`** (it had a byte-identical copy). The prompt assumed rig-reqwest was already a dependency; it was a *dev*-dependency, so this needed a judgment call. rig-milvus holds a `reqwest::Client` directly rather than an `H: HttpClientExt`, so it is already reqwest-coupled and depending on the bundled transport crate is not a layering violation — and MIGRATING.md already points callers in this position at `from_reqwest`. With `default-features = false` the dependency count went **down**, 207 → 167, because the crate was carrying rig-reqwest as a dev-dependency with default features on.

**4. `into_lazy_response` / `into_eager_response` were one line apart** — now one function taking a `BodyTiming`, with the three cfg-selected bindings collapsed into one `OFF_RUNTIME_TIMING` constant.

**5. `RuntimeUnavailable` was `pub` inside a private module**, so unnameable by callers. Private now, matching rig-tungstenite.

**6. `in_tokio()`'s hazard is documented** — a `current_thread` runtime built without `enable_io()` answers `true` and reqwest then panics with "there is no reactor running". rig-tungstenite's copy already said *"a caveat this shares with rig-reqwest"*, which was a promise this side did not keep.

**7. TLS features: documented, not guarded.** I checked the trees rather than reasoning from the feature list, and the axis is in better shape than the websocket one was — every single-stack selector is reachable:

```
rustls                          rustls-crate=7 native-tls-crate=0
native-tls                      rustls-crate=0 native-tls-crate=5
reqwest-middleware              rustls-crate=7 native-tls-crate=0
reqwest-middleware-native-tls   rustls-crate=0 native-tls-crate=5
rustls,native-tls               rustls-crate=7 native-tls-crate=5
```

The only rough edge is the last row, and **a `compile_error!` is not available**: `--all-features` enables the pair, and that is the lane CI's clippy, test and doc jobs run in — the guard would break the build it exists to protect. That is a different reason from the websocket axis's (where additive features could not express replacement at all), and both are now recorded next to the features they describe.

The `reqwest-middleware` feature keeps its name despite colliding with the dependency it enables: it is legal, it is the name the facade forwards, and renaming a working public feature for tidiness is churn. Flagging it as deliberately not done rather than silently skipped.

**8. The stray example moved** to `examples/cohere_image_embeddings` — the only example that was not a workspace example package.

## Verification

- `cargo nextest run --locked`: 5858 passed, 0 failed.
- `cargo clippy --workspace --all-targets --all-features` clean; `cargo fmt --check` clean.
- `cargo xtask generate-provider-aliases --check` still clean — item 1 did not move the generated tree.
- Feature matrix, trees inspected and not just built: `-p rig-reqwest --no-default-features` with none / `audio` / `image` / `native-tls` / `reqwest-middleware` / `reqwest-middleware-native-tls`.
- `cargo check -p rig-reqwest --target wasm32-unknown-unknown` (the crate is in CI's wasm matrix).
- `cargo check --workspace --all-features --all-targets`, since item 1 changes a dependency edge.