### PR TITLE
refactor!: remove every backwards-compatibility shim

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -806,6 +806,42 @@ handed back a silently short list.
 
 ## 0.41 → next
 
+### Compatibility shims are gone: `CompletionRequest::preamble`, retired model constants, `rig-candle` aliases, tolerant decoders
+
+Every remaining backwards-compatibility shim was removed in one sweep. None
+of them had a live producer in the tree; each existed only so that an older
+caller or an older persisted record kept working.
+
+- **`CompletionRequest::preamble` is removed.** `CompletionRequestBuilder::preamble`
+  has always emitted the preamble as the leading `Message::System` of
+  `chat_history` and left the field `None`; the field was read by every
+  provider anyway, so a hand-built request could carry a second system prompt
+  through a path the builder never used. Put the system prompt in
+  `chat_history` — `chat_history: vec![Message::system("…"), …]` — and use the
+  new `CompletionRequest::system_instructions()` (the leading system message's
+  text, `Option<&str>`) where you read it. `CompletionRequestBuilder::without_preamble`
+  is removed with the field; the agent-level `AgentBuilder::without_preamble`
+  and `AgentRunner::without_preamble` are unchanged. Telemetry
+  `gen_ai.system_instructions` is now populated from the leading system
+  message, so spans that previously recorded nothing for the preamble record it.
+- **Retired model-name constants are removed** rather than `#[deprecated]`:
+  `deepseek::{DEEPSEEK_CHAT, DEEPSEEK_REASONER}` (use `DEEPSEEK_V4_FLASH`),
+  `cohere::{COMMAND_R_PLUS, COMMAND_R, COMMAND, COMMAND_NIGHTLY, COMMAND_LIGHT,
+  COMMAND_LIGHT_NIGHTLY}` (use the dated `COMMAND_*_08_2024` / `COMMAND_A_*`
+  constants), and `mistral::{PIXTRAL_LARGE, PIXTRAL_SMALL, MISTRAL_SABA,
+  MISTRAL_NEMO, CODESTRAL_MAMBA}` (use `MISTRAL_SMALL` / `MISTRAL_MEDIUM` /
+  `MINISTRAL_3B` / `CODESTRAL`). Pass the literal string to
+  `completion_model(..)` if you still need to address one of the retired ids.
+- **`rig_candle::{LlamaModel, ModelFamily}` aliases are removed.** Use
+  `CandleModel` and `ConversationProtocol`, which they aliased.
+- **Persisted-record tolerances are removed.** `CompletionCall::usage` no
+  longer accepts `null` (the pre-monoid `Option` encoding) — a record must
+  carry a `Usage` object; OpenAI `UserContent::Audio` no longer accepts the
+  never-on-the-wire `"type": "audio"` tag (only `"input_audio"`); and an OpenAI
+  `ToolResultContent` part must carry its `"type"` tag (`"text"` /
+  `"image_url"`). Records written by any released rig already have these
+  shapes; re-encode anything older before loading it.
+
 ### The bundled transport newtypes expose their inner client once, not three ways
 
 `ReqwestClient` and `ReqwestMiddlewareClient` each handed out the client they

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -649,7 +649,6 @@ mod request_identity_tests {
     "max_tokens": 512,
     "model": null,
     "output_schema": null,
-    "preamble": null,
     "temperature": 0.25,
     "tool_choice": "required",
     "tools": [
@@ -766,7 +765,6 @@ mod request_identity_tests {
     "max_tokens": 512,
     "model": null,
     "output_schema": null,
-    "preamble": null,
     "temperature": 0.25,
     "tool_choice": "required",
     "tools": [
@@ -902,7 +900,6 @@ mod request_identity_tests {
     "max_tokens": 512,
     "model": null,
     "output_schema": null,
-    "preamble": null,
     "temperature": 0.25,
     "tool_choice": "required",
     "tools": [

--- a/crates/rig-agent/src/agent/prompt_request/mod.rs
+++ b/crates/rig-agent/src/agent/prompt_request/mod.rs
@@ -1202,31 +1202,6 @@ mod tests {
     }
 
     #[test]
-    fn prompt_response_deserializes_pre_monoid_null_usage_format() {
-        // Pins `CompletionCall.usage`'s null tolerance: `"usage": null` (the
-        // pre-monoid Option encoding) must map to zero-valued usage. The
-        // fixture otherwise uses the current shape — `content` is a required
-        // field since the missing-`content` reconstruction was dropped.
-        let fixture = r#"{"output":"ok","usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7,"cached_input_tokens":0,"cache_creation_input_tokens":0,"tool_use_prompt_tokens":0,"reasoning_tokens":0},"completion_calls":[{"call_index":0,"usage":null},{"call_index":1,"usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7,"cached_input_tokens":0,"cache_creation_input_tokens":0,"tool_use_prompt_tokens":0,"reasoning_tokens":0}}],"messages":[{"role":"user","content":[{"type":"text","text":"add things"}]}],"content":[{"type":"text","text":"ok"}]}"#;
-
-        let response: PromptResponse =
-            serde_json::from_str(fixture).expect("old-format response should deserialize");
-        assert_eq!(
-            response.completion_calls(),
-            &[
-                CompletionCall::new(0, Usage::new()),
-                CompletionCall::new(1, usage(3, 4))
-            ]
-        );
-        // `content` uses the tagged shape — assistant content is tagged like
-        // user content (see `the_type_key_is_the_tag_and_the_untagged_shape_does_not_load`).
-        let [AssistantContent::Text(text)] = response.content() else {
-            panic!("expected one text block, got {:?}", response.content());
-        };
-        assert_eq!(text.text, "ok");
-    }
-
-    #[test]
     fn the_type_key_is_the_tag_and_the_untagged_shape_does_not_load() {
         // Assistant content is tagged like user content: `"type"` is consumed
         // as the discriminant, never captured into `additional_params`. And

--- a/crates/rig-agent/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-agent/src/agent/prompt_request/streaming.rs
@@ -3415,21 +3415,6 @@ mod migrated_tests {
                 }
             })
         );
-
-        // Stream items serialized before the Option encoding was dropped used
-        // `"usage": null`; they must still deserialize.
-        let legacy: MultiTurnStreamItem = serde_json::from_value(serde_json::json!({
-            "type": "completionCall",
-            "call_index": 3,
-            "usage": null
-        }))
-        .expect("legacy null-usage event should deserialize");
-        match legacy {
-            MultiTurnStreamItem::CompletionCall(call) => {
-                assert_eq!(call, CompletionCall::new(3, Usage::new()));
-            }
-            other => panic!("expected completion call event, got {other:?}"),
-        }
     }
 
     #[test]

--- a/crates/rig-agent/tests/runtime_model_swapping.rs
+++ b/crates/rig-agent/tests/runtime_model_swapping.rs
@@ -377,7 +377,6 @@ fn beta_static(text: &str) -> BetaModel {
 fn request(prompt: &str) -> CompletionRequest {
     CompletionRequest {
         model: None,
-        preamble: None,
         chat_history: vec![Message::user(prompt)],
         documents: Vec::new(),
         tools: Vec::new(),

--- a/crates/rig-bedrock/src/completion.rs
+++ b/crates/rig-bedrock/src/completion.rs
@@ -216,7 +216,7 @@ impl CompletionModel {
         let span =
             CompletionSpanBuilder::new("aws_bedrock", &request_model, CompletionOperation::Chat)
                 .system_instructions(
-                    completion_request.preamble.as_deref(),
+                    completion_request.system_instructions(),
                     completion_request.record_telemetry_content,
                 )
                 .build();

--- a/crates/rig-bedrock/src/streaming.rs
+++ b/crates/rig-bedrock/src/streaming.rs
@@ -408,7 +408,7 @@ impl CompletionModel {
     ) -> Result<rig_core::streaming::RawStreamingResult<BedrockStreamingResponse>, CompletionError>
     {
         let request_model = resolve_request_model(&self.model, &completion_request);
-        let system_instructions = completion_request.preamble.clone();
+        let system_instructions = completion_request.system_instructions().map(str::to_owned);
         let record_telemetry_content = completion_request.record_telemetry_content;
         let request = AwsCompletionRequest {
             inner: completion_request,

--- a/crates/rig-bedrock/src/types/completion_request.rs
+++ b/crates/rig-bedrock/src/types/completion_request.rs
@@ -147,12 +147,6 @@ impl AwsCompletionRequest {
     pub fn system_prompt(&self) -> Result<Option<Vec<SystemContentBlock>>, CompletionError> {
         let mut system_blocks = Vec::new();
 
-        if let Some(system_prompt) = self.inner.preamble.clone()
-            && !system_prompt.is_empty()
-        {
-            system_blocks.push(SystemContentBlock::Text(system_prompt));
-        }
-
         for message in self.inner.chat_history.iter() {
             if let Message::System { content } = message
                 && !content.is_empty()
@@ -248,7 +242,6 @@ mod tests {
     fn minimal_request() -> CompletionRequest {
         CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![Message::User {
                 content: vec![UserContent::Text(Text::new("test".to_string()))],
             }],
@@ -507,7 +500,6 @@ mod tests {
     fn test_system_prompt_includes_system_history() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 Message::system("History system instruction"),
                 Message::User {
@@ -534,10 +526,10 @@ mod tests {
 
     #[test]
     fn test_system_prompt_appends_cache_point_when_prompt_caching_enabled() {
-        let request = CompletionRequest {
-            preamble: Some("System prompt".to_string()),
-            ..minimal_request()
-        };
+        let mut request = minimal_request();
+        request
+            .chat_history
+            .insert(0, Message::system("System prompt"));
 
         let aws_request = aws_request(request, true);
         let system_prompt = aws_request
@@ -562,7 +554,6 @@ mod tests {
     fn test_messages_exclude_system_history() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 Message::system("History system instruction"),
                 Message::User {

--- a/crates/rig-candle/src/generation.rs
+++ b/crates/rig-candle/src/generation.rs
@@ -235,7 +235,7 @@ use tokenizers::{
 use web_time::{Duration, Instant};
 
 use crate::loader::{LoadedModel, LoadedWeights};
-use crate::profile::ModelFamily;
+use crate::profile::ConversationProtocol;
 use crate::runtime::{CancellationSignal, check_cancellation};
 use crate::types::{CandleCompletionResponse, FinishReason};
 
@@ -601,7 +601,7 @@ pub(crate) fn stream_generate(
     cancellation: &CancellationSignal,
     mut emit: impl FnMut(RawStreamingChoice<CandleCompletionResponse>) -> Result<(), CandleError>,
 ) -> Result<CandleCompletionResponse, CandleError> {
-    if loaded.profile.definition.protocol != ModelFamily::Qwen3 {
+    if loaded.profile.definition.protocol != ConversationProtocol::Qwen3 {
         return generate(loaded, request, cancellation, |fragment| {
             emit(RawStreamingChoice::Message(fragment))
         });

--- a/crates/rig-candle/src/lib.rs
+++ b/crates/rig-candle/src/lib.rs
@@ -12,8 +12,8 @@ mod validation;
 
 pub use artifacts::{GgufModelData, ModelArtifacts, ModelData};
 pub use generation::GenerationConfig;
-pub use model::{CandleModel, CandleModelBuilder, LlamaModel, stream_from_events};
-pub use profile::{ConversationProtocol, ModelArchitecture, ModelFamily, Quantization};
+pub use model::{CandleModel, CandleModelBuilder, stream_from_events};
+pub use profile::{ConversationProtocol, ModelArchitecture, Quantization};
 pub use types::{CandleCompletionResponse, CandleError, FinishReason};
 
 pub(crate) use profile::{

--- a/crates/rig-candle/src/loader.rs
+++ b/crates/rig-candle/src/loader.rs
@@ -20,7 +20,7 @@ use crate::generation::GenerationConfig;
 #[cfg(target_family = "wasm")]
 use crate::profile::ModelArchitecture;
 use crate::profile::{
-    ArtifactFormat, LoaderBackend, ModelFamily, ValidatedProfile, definition_for,
+    ArtifactFormat, ConversationProtocol, LoaderBackend, ValidatedProfile, definition_for,
     validate_identity, validate_tokenizer_requirements,
 };
 use crate::runtime::RuntimeDevice;
@@ -60,7 +60,7 @@ struct PreparedModel {
 
 pub(crate) fn load_model_with_family(
     artifacts: ModelArtifacts,
-    selected_family: Option<ModelFamily>,
+    selected_family: Option<ConversationProtocol>,
     generation: GenerationConfig,
     _max_concurrent_requests: usize,
 ) -> Result<LoadedModel, CandleError> {
@@ -124,7 +124,7 @@ pub(crate) fn load_model_with_family(
 
 pub(crate) fn load_gguf_model(
     data: GgufModelData<'_>,
-    selected_family: Option<ModelFamily>,
+    selected_family: Option<ConversationProtocol>,
     generation: GenerationConfig,
     _max_concurrent_requests: usize,
 ) -> Result<LoadedModel, CandleError> {
@@ -166,7 +166,7 @@ pub(crate) fn load_gguf_model(
 fn prepare_model(
     config_bytes: &[u8],
     tokenizer_bytes: &[u8],
-    selected_family: Option<ModelFamily>,
+    selected_family: Option<ConversationProtocol>,
     artifact_format: ArtifactFormat,
 ) -> Result<PreparedModel, CandleError> {
     let identity: ModelIdentity = serde_json::from_slice(config_bytes)
@@ -181,7 +181,7 @@ fn prepare_model(
     if is_qwen3 {
         let config: Qwen3Config = serde_json::from_slice(config_bytes)
             .map_err(|error| CandleError::Configuration(error.to_string()))?;
-        let detected_family = ModelFamily::Qwen3;
+        let detected_family = ConversationProtocol::Qwen3;
         if let Some(selected) = selected_family
             && selected != detected_family
         {

--- a/crates/rig-candle/src/model.rs
+++ b/crates/rig-candle/src/model.rs
@@ -90,7 +90,7 @@ use crate::loader::{LoadedModel, load_gguf_model, load_model_with_family};
 use crate::profile::{ArtifactFormat, LoaderBackend, definition_for};
 #[cfg(test)]
 use crate::profile::{BEGIN_OF_TEXT, END_HEADER, END_OF_TURN, IM_END, IM_START, START_HEADER};
-use crate::profile::{ConversationProtocol, ModelArchitecture, ModelFamily, Quantization};
+use crate::profile::{ConversationProtocol, ModelArchitecture, Quantization};
 use crate::runtime::CancellationSignal;
 #[cfg(all(test, not(target_family = "wasm")))]
 use crate::runtime::TestControl;
@@ -116,7 +116,7 @@ pub struct CandleModel {
 /// Builder for loading a [`CandleModel`] and customizing generation defaults.
 pub struct CandleModelBuilder<'a> {
     source: ModelSource<'a>,
-    family: Option<ModelFamily>,
+    family: Option<ConversationProtocol>,
     generation: GenerationConfig,
     max_concurrent_requests: usize,
 }
@@ -125,12 +125,6 @@ enum ModelSource<'a> {
     Owned(ModelArtifacts),
     BorrowedGguf(GgufModelData<'a>),
 }
-
-/// Backwards-compatible alias for [`CandleModel`].
-///
-/// New code should use `CandleModel`, which accurately reflects that the
-/// backend also supports validated Qwen3 checkpoints.
-pub type LlamaModel = CandleModel;
 
 impl CandleModel {
     /// Loads a model from config, tokenizer, and one unsharded safetensors buffer.
@@ -307,13 +301,13 @@ async fn join_model_load(
 
 #[cfg(test)]
 fn render_prompt(request: &CompletionRequest) -> Result<String, CandleError> {
-    render_prompt_for(request, ModelFamily::Llama3)
+    render_prompt_for(request, ConversationProtocol::Llama3)
 }
 
 #[cfg(test)]
 fn render_prompt_for(
     request: &CompletionRequest,
-    family: ModelFamily,
+    family: ConversationProtocol,
 ) -> Result<String, CandleError> {
     crate::protocol::render_prompt(request, family)
 }

--- a/crates/rig-candle/src/model/tests.rs
+++ b/crates/rig-candle/src/model/tests.rs
@@ -19,7 +19,7 @@ use tokenizers::{AddedToken, TokenizerBuilder};
 use super::*;
 
 #[cfg(not(target_family = "wasm"))]
-type ControlledModel = (LlamaModel, Arc<TestControl>, Arc<tokio::sync::Semaphore>);
+type ControlledModel = (CandleModel, Arc<TestControl>, Arc<tokio::sync::Semaphore>);
 
 struct TestTensor {
     dtype: Dtype,
@@ -229,7 +229,6 @@ fn config_with(
 fn request(messages: Vec<Message>) -> CompletionRequest {
     CompletionRequest {
         model: None,
-        preamble: None,
         chat_history: if messages.is_empty() {
             vec![Message::user("hello")]
         } else {
@@ -248,7 +247,7 @@ fn request(messages: Vec<Message>) -> CompletionRequest {
 
 #[cfg(not(target_family = "wasm"))]
 async fn collect_stream(
-    model: &LlamaModel,
+    model: &CandleModel,
     request: CompletionRequest,
 ) -> Result<(String, CandleCompletionResponse), Box<dyn std::error::Error + Send + Sync>> {
     let mut response = model.raw_stream(request).await?;
@@ -281,7 +280,7 @@ fn controlled_model(
     let concurrency = Arc::clone(&loaded.concurrency);
     loaded.test_control = Some(Arc::clone(&control));
     Ok((
-        LlamaModel {
+        CandleModel {
             state: Arc::new(loaded),
         },
         control,
@@ -317,7 +316,7 @@ fn rejects_empty_and_malformed_artifacts() -> Result<(), Box<dyn std::error::Err
             },
         ),
     ] {
-        let error = LlamaModel::from_safetensors(data)
+        let error = CandleModel::from_safetensors(data)
             .err()
             .ok_or("expected empty-buffer error")?;
         assert!(
@@ -328,19 +327,19 @@ fn rejects_empty_and_malformed_artifacts() -> Result<(), Box<dyn std::error::Err
     let mut data = model_data()?;
     data.config = b"not json".to_vec();
     assert!(matches!(
-        LlamaModel::from_safetensors(data),
+        CandleModel::from_safetensors(data),
         Err(CandleError::Configuration(_))
     ));
     let mut data = model_data()?;
     data.tokenizer = b"not json".to_vec();
     assert!(matches!(
-        LlamaModel::from_safetensors(data),
+        CandleModel::from_safetensors(data),
         Err(CandleError::TokenizerLoading(_))
     ));
     let mut data = model_data()?;
     data.weights = b"not safetensors".to_vec();
     assert!(matches!(
-        LlamaModel::from_safetensors(data),
+        CandleModel::from_safetensors(data),
         Err(CandleError::InvalidCheckpoint(_))
     ));
     Ok(())
@@ -413,7 +412,7 @@ fn validates_tensor_shapes_dtypes_and_tied_embeddings()
         &checkpoint_custom(true, tensor(&[8, 4]), false)?,
         &tied_config,
     )?;
-    let model = LlamaModel::from_safetensors(ModelData {
+    let model = CandleModel::from_safetensors(ModelData {
         config: config_with("tie_word_embeddings", true.into())?,
         tokenizer: tiny_tokenizer()?,
         weights: checkpoint_custom(true, tensor(&[8, 4]), false)?,
@@ -433,7 +432,7 @@ fn validates_tokenizer_vocabulary_special_tokens_and_configured_ids()
         weights: checkpoint(true)?,
     };
     assert!(matches!(
-        LlamaModel::from_safetensors(data),
+        CandleModel::from_safetensors(data),
         Err(CandleError::TokenizerVocabularyMismatch {
             expected: 9,
             actual: 8
@@ -442,8 +441,8 @@ fn validates_tokenizer_vocabulary_special_tokens_and_configured_ids()
 
     let config: LlamaConfig = serde_json::from_slice(&tiny_config())?;
     let config = config.into_config(false);
-    let llama = definition_for(ModelFamily::Llama3, ArtifactFormat::Safetensors)?;
-    let smollm2 = definition_for(ModelFamily::SmolLm2, ArtifactFormat::Gguf)?;
+    let llama = definition_for(ConversationProtocol::Llama3, ArtifactFormat::Safetensors)?;
+    let smollm2 = definition_for(ConversationProtocol::SmolLm2, ArtifactFormat::Gguf)?;
     let tokenizer = Tokenizer::from_bytes(tiny_tokenizer_with_end_header("<other>", true)?)?;
     assert!(matches!(
         validate_tokenizer(&config, &tokenizer, llama),
@@ -472,7 +471,7 @@ fn validates_tokenizer_vocabulary_special_tokens_and_configured_ids()
         weights: checkpoint(true)?,
     };
     assert!(matches!(
-        LlamaModel::from_safetensors(data),
+        CandleModel::from_safetensors(data),
         Err(CandleError::TokenIdOutOfRange { token, id: 8, .. }) if token == "bos_token_id"
     ));
     let data = ModelData {
@@ -481,7 +480,7 @@ fn validates_tokenizer_vocabulary_special_tokens_and_configured_ids()
         weights: checkpoint(true)?,
     };
     assert!(matches!(
-        LlamaModel::from_safetensors(data),
+        CandleModel::from_safetensors(data),
         Err(CandleError::TokenIdOutOfRange { token, id: 9, .. }) if token == "eos_token_id"
     ));
     for (field, value) in [("bos_token_id", 7.into()), ("eos_token_id", 3.into())] {
@@ -491,7 +490,7 @@ fn validates_tokenizer_vocabulary_special_tokens_and_configured_ids()
             weights: checkpoint(true)?,
         };
         assert!(matches!(
-            LlamaModel::from_safetensors(data),
+            CandleModel::from_safetensors(data),
             Err(CandleError::ArtifactMismatch { artifact, .. }) if artifact == field
         ));
     }
@@ -501,7 +500,7 @@ fn validates_tokenizer_vocabulary_special_tokens_and_configured_ids()
         weights: checkpoint(true)?,
     };
     assert!(matches!(
-        LlamaModel::from_safetensors(data),
+        CandleModel::from_safetensors(data),
         Err(CandleError::InvalidConfigurationValue {
             field: "eos_token_id",
             ..
@@ -642,7 +641,7 @@ fn context_limit_boundaries_clamp_and_detect_conversion_overflow() {
 
 #[test]
 fn loads_entirely_from_owned_bytes() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let model = LlamaModel::from_safetensors(model_data()?)?;
+    let model = CandleModel::from_safetensors(model_data()?)?;
     let loaded = &model.state;
     assert!(loaded.runtime.is_consistent_cpu());
     assert_eq!(
@@ -653,7 +652,10 @@ fn loads_entirely_from_owned_bytes() -> Result<(), Box<dyn std::error::Error + S
         loaded.profile.definition.artifact_format,
         ArtifactFormat::Safetensors
     );
-    assert_eq!(model.conversation_protocol(), Some(ModelFamily::Llama3));
+    assert_eq!(
+        model.conversation_protocol(),
+        Some(ConversationProtocol::Llama3)
+    );
     assert_eq!(model.quantization(), None);
     Ok(())
 }
@@ -666,7 +668,7 @@ fn borrowed_gguf_builder_keeps_borrowed_artifacts_and_all_settings() {
         weights: b"weights",
     };
     let builder = CandleModel::builder_from_gguf_bytes(data)
-        .conversation_protocol(ModelFamily::SmolLm2)
+        .conversation_protocol(ConversationProtocol::SmolLm2)
         .max_tokens(17)
         .temperature(0.25)
         .top_k(Some(4))
@@ -679,7 +681,7 @@ fn borrowed_gguf_builder_keeps_borrowed_artifacts_and_all_settings() {
     assert!(
         matches!(builder.source, ModelSource::BorrowedGguf(actual) if actual.weights.as_ptr() == data.weights.as_ptr())
     );
-    assert_eq!(builder.family, Some(ModelFamily::SmolLm2));
+    assert_eq!(builder.family, Some(ConversationProtocol::SmolLm2));
     assert_eq!(builder.generation.max_tokens, 17);
     assert_eq!(builder.generation.temperature, 0.25);
     assert_eq!(builder.generation.top_k, Some(4));
@@ -695,7 +697,10 @@ fn borrowed_gguf_builder_keeps_borrowed_artifacts_and_all_settings() {
 async fn async_loading_succeeds_and_preserves_builder_settings()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let direct = CandleModel::from_safetensors_async(model_data()?).await?;
-    assert_eq!(direct.conversation_protocol(), Some(ModelFamily::Llama3));
+    assert_eq!(
+        direct.conversation_protocol(),
+        Some(ConversationProtocol::Llama3)
+    );
 
     let configured = CandleModel::builder(model_data()?)
         .max_tokens(17)
@@ -749,17 +754,17 @@ fn typed_gguf_and_family_errors_preserve_the_failure_kind()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let data = model_data()?;
     assert!(matches!(
-        LlamaModel::builder(data)
-            .conversation_protocol(ModelFamily::SmolLm2)
+        CandleModel::builder(data)
+            .conversation_protocol(ConversationProtocol::SmolLm2)
             .build(),
         Err(CandleError::ModelFamilyMismatch {
-            selected: ModelFamily::SmolLm2,
-            detected: ModelFamily::Llama3,
+            selected: ConversationProtocol::SmolLm2,
+            detected: ConversationProtocol::Llama3,
         })
     ));
 
     assert!(matches!(
-        LlamaModel::from_gguf(model_data()?),
+        CandleModel::from_gguf(model_data()?),
         Err(CandleError::UnsupportedModelFamily(_))
     ));
     Ok(())
@@ -777,7 +782,7 @@ fn gguf_metadata_shapes_and_tensor_encodings_are_validated_before_loading()
         tensor_data_offset: 0,
     };
     let tokenizer = Tokenizer::from_bytes(tiny_tokenizer()?)?;
-    let definition = definition_for(ModelFamily::SmolLm2, ArtifactFormat::Gguf)?;
+    let definition = definition_for(ConversationProtocol::SmolLm2, ArtifactFormat::Gguf)?;
     assert!(matches!(
         validate_gguf_metadata(&content, &config, &tokenizer, definition),
         Err(CandleError::ArtifactMismatch {
@@ -820,7 +825,7 @@ fn loaded_model_works_with_agent_builder() -> Result<(), Box<dyn std::error::Err
 
     let runtime = tokio::runtime::Builder::new_current_thread().build()?;
     runtime.block_on(async {
-        let model = LlamaModel::builder(model_data()?)
+        let model = CandleModel::builder(model_data()?)
             .temperature(0.0)
             .max_tokens(1)
             .build()?;
@@ -835,7 +840,7 @@ fn loaded_model_works_with_agent_builder() -> Result<(), Box<dyn std::error::Err
 #[tokio::test(flavor = "current_thread")]
 async fn buffered_and_streaming_generation_are_equivalent()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let model = LlamaModel::builder(model_data()?)
+    let model = CandleModel::builder(model_data()?)
         .temperature(0.0)
         .max_tokens(3)
         .build()?;
@@ -866,7 +871,7 @@ async fn streaming_reports_eos_and_excludes_the_stop_token()
     let mut loaded = load_model(model_data()?, GenerationConfig::default(), 1)?;
     loaded.generation.temperature = 0.0;
     loaded.profile.stop_tokens.insert(0);
-    let model = LlamaModel {
+    let model = CandleModel {
         state: Arc::new(loaded),
     };
     let (text, raw) = collect_stream(&model, request(vec![Message::user("hello")])).await?;
@@ -889,7 +894,7 @@ async fn streaming_clamps_context_and_rejects_bad_request_options()
     let prompt = render_prompt(&completion_request)?;
     let prompt_tokens = loaded.tokenizer.encode(prompt, false)?.len();
     loaded.profile.context_limit = prompt_tokens + 2;
-    let model = LlamaModel {
+    let model = CandleModel {
         state: Arc::new(loaded),
     };
     let (_, raw) = collect_stream(&model, completion_request).await?;
@@ -1070,7 +1075,7 @@ fn qwen3_4b_configuration_is_exactly_scoped() -> Result<(), CandleError> {
         }"#,
     )
     .map_err(|error| CandleError::Configuration(error.to_string()))?;
-    let definition = definition_for(ModelFamily::Qwen3, ArtifactFormat::Gguf)?;
+    let definition = definition_for(ConversationProtocol::Qwen3, ArtifactFormat::Gguf)?;
     validate_qwen3_config(&config, definition)?;
 
     config.model_type = "qwen2".to_string();
@@ -1095,7 +1100,7 @@ fn qwen3_4b_configuration_is_exactly_scoped() -> Result<(), CandleError> {
 fn concurrency_limit_and_cancellation_are_deterministic()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     assert!(matches!(
-        LlamaModel::builder(model_data()?)
+        CandleModel::builder(model_data()?)
             .max_concurrent_requests(0)
             .build(),
         Err(CandleError::InvalidConcurrencyLimit)
@@ -1126,7 +1131,7 @@ fn concurrency_limit_and_cancellation_are_deterministic()
 #[tokio::test(flavor = "current_thread")]
 async fn concurrent_completions_have_independent_caches_and_samplers()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let model = LlamaModel::builder(model_data()?)
+    let model = CandleModel::builder(model_data()?)
         .temperature(0.0)
         .max_tokens(2)
         .max_concurrent_requests(2)
@@ -1163,7 +1168,7 @@ async fn concurrent_completions_have_independent_caches_and_samplers()
 #[tokio::test(flavor = "current_thread")]
 async fn closed_admission_controller_fails_public_operations()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let model = LlamaModel::builder(model_data()?).build()?;
+    let model = CandleModel::builder(model_data()?).build()?;
     let loaded = &model.state;
     loaded.concurrency.close();
     let completion_error = model
@@ -1313,7 +1318,7 @@ async fn blocking_task_panic_maps_to_typed_completion_error()
 #[test]
 fn builder_rejects_invalid_generation_defaults() {
     assert!(matches!(
-        LlamaModel::builder(ModelData {
+        CandleModel::builder(ModelData {
             config: Vec::new(),
             tokenizer: Vec::new(),
             weights: Vec::new(),
@@ -1323,7 +1328,7 @@ fn builder_rejects_invalid_generation_defaults() {
         Err(CandleError::InvalidGeneration(_))
     ));
     assert!(matches!(
-        LlamaModel::builder(ModelData {
+        CandleModel::builder(ModelData {
             config: Vec::new(),
             tokenizer: Vec::new(),
             weights: Vec::new(),
@@ -1333,7 +1338,7 @@ fn builder_rejects_invalid_generation_defaults() {
         Err(CandleError::InvalidGeneration(_))
     ));
     assert!(matches!(
-        LlamaModel::builder(ModelData {
+        CandleModel::builder(ModelData {
             config: Vec::new(),
             tokenizer: Vec::new(),
             weights: Vec::new(),
@@ -1343,7 +1348,7 @@ fn builder_rejects_invalid_generation_defaults() {
         Err(CandleError::InvalidGeneration(_))
     ));
     assert!(matches!(
-        LlamaModel::builder(ModelData {
+        CandleModel::builder(ModelData {
             config: Vec::new(),
             tokenizer: Vec::new(),
             weights: Vec::new(),
@@ -1389,13 +1394,13 @@ fn renders_smollm2_history_default_system_and_generation_suffix()
         Message::user("follow-up"),
     ]);
     assert_eq!(
-        render_prompt_for(&with_system, ModelFamily::SmolLm2)?,
+        render_prompt_for(&with_system, ConversationProtocol::SmolLm2)?,
         "<|im_start|>system\nrules<|im_end|>\n<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\nanswer<|im_end|>\n<|im_start|>user\nfollow-up<|im_end|>\n<|im_start|>assistant\n"
     );
 
     let without_system = request(vec![Message::user("hello")]);
     assert_eq!(
-        render_prompt_for(&without_system, ModelFamily::SmolLm2)?,
+        render_prompt_for(&without_system, ConversationProtocol::SmolLm2)?,
         "<|im_start|>system\nYou are a helpful AI assistant named SmolLM, trained by Hugging Face<|im_end|>\n<|im_start|>user\nhello<|im_end|>\n<|im_start|>assistant\n"
     );
     Ok(())
@@ -1619,7 +1624,7 @@ async fn stream_from_events_terminal_carries_raw()
 #[tokio::test(flavor = "current_thread")]
 async fn completion_raw_round_trips_into_the_local_record()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let model = LlamaModel::builder(model_data()?)
+    let model = CandleModel::builder(model_data()?)
         .temperature(0.0)
         .max_tokens(2)
         .build()?;
@@ -1663,7 +1668,7 @@ async fn completion_raw_round_trips_into_the_local_record()
 #[tokio::test(flavor = "current_thread")]
 async fn stream_terminal_raw_round_trips_into_the_local_record()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let model = LlamaModel::builder(model_data()?)
+    let model = CandleModel::builder(model_data()?)
         .temperature(0.0)
         .max_tokens(2)
         .build()?;

--- a/crates/rig-candle/src/profile.rs
+++ b/crates/rig-candle/src/profile.rs
@@ -29,9 +29,6 @@ pub enum ConversationProtocol {
     Qwen3,
 }
 
-/// Backwards-compatible name for [`ConversationProtocol`].
-pub type ModelFamily = ConversationProtocol;
-
 /// Transformer architecture used to execute a loaded checkpoint.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/rig-candle/src/protocol.rs
+++ b/crates/rig-candle/src/protocol.rs
@@ -9,7 +9,7 @@ use rig_core::message::{
 use serde::Deserialize;
 
 use crate::{
-    BEGIN_OF_TEXT, CandleError, END_HEADER, END_OF_TURN, IM_END, IM_START, ModelFamily,
+    BEGIN_OF_TEXT, CandleError, ConversationProtocol, END_HEADER, END_OF_TURN, IM_END, IM_START,
     SMOLLM2_DEFAULT_SYSTEM_PROMPT, START_HEADER,
 };
 
@@ -48,22 +48,22 @@ enum RenderedMessage {
 
 pub(crate) fn render_prompt(
     request: &CompletionRequest,
-    protocol: ModelFamily,
+    protocol: ConversationProtocol,
 ) -> Result<String, CandleError> {
     validate_common_request(request)?;
     validate_protocol_inputs(request, protocol)?;
     match protocol {
-        ModelFamily::Llama3 => render_plain_chat(request, ModelFamily::Llama3),
-        ModelFamily::SmolLm2 => render_plain_chat(request, ModelFamily::SmolLm2),
-        ModelFamily::Qwen3 => render_qwen3(request),
+        ConversationProtocol::Llama3 => render_plain_chat(request, ConversationProtocol::Llama3),
+        ConversationProtocol::SmolLm2 => render_plain_chat(request, ConversationProtocol::SmolLm2),
+        ConversationProtocol::Qwen3 => render_qwen3(request),
     }
 }
 
-fn reserved_markers(protocol: ModelFamily) -> &'static [&'static str] {
+fn reserved_markers(protocol: ConversationProtocol) -> &'static [&'static str] {
     match protocol {
-        ModelFamily::Llama3 => &[BEGIN_OF_TEXT, START_HEADER, END_HEADER, END_OF_TURN],
-        ModelFamily::SmolLm2 => &[IM_START, IM_END],
-        ModelFamily::Qwen3 => &[
+        ConversationProtocol::Llama3 => &[BEGIN_OF_TEXT, START_HEADER, END_HEADER, END_OF_TURN],
+        ConversationProtocol::SmolLm2 => &[IM_START, IM_END],
+        ConversationProtocol::Qwen3 => &[
             IM_START,
             IM_END,
             "<tools>",
@@ -81,7 +81,7 @@ fn reserved_markers(protocol: ModelFamily) -> &'static [&'static str] {
 fn validate_protocol_text(
     value: &str,
     field: &'static str,
-    protocol: ModelFamily,
+    protocol: ConversationProtocol,
 ) -> Result<(), CandleError> {
     if let Some(marker) = reserved_markers(protocol)
         .iter()
@@ -94,11 +94,8 @@ fn validate_protocol_text(
 
 fn validate_protocol_inputs(
     request: &CompletionRequest,
-    protocol: ModelFamily,
+    protocol: ConversationProtocol,
 ) -> Result<(), CandleError> {
-    if let Some(preamble) = request.preamble.as_deref() {
-        validate_protocol_text(preamble, "preamble", protocol)?;
-    }
     for document in &request.documents {
         validate_protocol_text(&document.to_string(), "document", protocol)?;
     }
@@ -197,14 +194,14 @@ fn validate_protocol_inputs(
 pub(crate) fn parse_assistant(
     raw: &str,
     request: &CompletionRequest,
-    protocol: ModelFamily,
+    protocol: ConversationProtocol,
 ) -> Result<ParsedAssistant, CandleError> {
     match protocol {
-        ModelFamily::Llama3 | ModelFamily::SmolLm2 => Ok(ParsedAssistant {
+        ConversationProtocol::Llama3 | ConversationProtocol::SmolLm2 => Ok(ParsedAssistant {
             items: vec![AssistantContent::text(raw)],
             visible_text: raw.to_string(),
         }),
-        ModelFamily::Qwen3 => parse_qwen3_assistant(raw, request),
+        ConversationProtocol::Qwen3 => parse_qwen3_assistant(raw, request),
     }
 }
 
@@ -328,11 +325,7 @@ fn validate_tool_definition(tool: &ToolDefinition) -> Result<(), CandleError> {
 }
 
 fn messages_with_documents(request: &CompletionRequest) -> Vec<Message> {
-    let mut messages = Vec::new();
-    if let Some(preamble) = &request.preamble {
-        messages.push(Message::system(preamble.clone()));
-    }
-    messages.extend(request.chat_history.iter().cloned());
+    let mut messages = request.chat_history.clone();
     if !request.documents.is_empty() {
         let context = request
             .documents
@@ -351,7 +344,7 @@ fn messages_with_documents(request: &CompletionRequest) -> Vec<Message> {
 
 fn render_plain_chat(
     request: &CompletionRequest,
-    family: ModelFamily,
+    family: ConversationProtocol,
 ) -> Result<String, CandleError> {
     if !request.tools.is_empty() {
         return Err(CandleError::UnsupportedFeature(
@@ -369,13 +362,13 @@ fn render_plain_chat(
     type Pieces = &'static [&'static str];
     let (turn_start, role_suffix, turn_end, mut rendered): (&str, Pieces, Pieces, String) =
         match family {
-            ModelFamily::Llama3 => (
+            ConversationProtocol::Llama3 => (
                 START_HEADER,
                 &[END_HEADER, "\n\n"],
                 &[END_OF_TURN],
                 String::from(BEGIN_OF_TEXT),
             ),
-            ModelFamily::SmolLm2 => (
+            ConversationProtocol::SmolLm2 => (
                 IM_START,
                 &["\n"],
                 &[IM_END, "\n"],
@@ -385,7 +378,7 @@ fn render_plain_chat(
                     format!("{IM_START}system\n{SMOLLM2_DEFAULT_SYSTEM_PROMPT}{IM_END}\n")
                 },
             ),
-            ModelFamily::Qwen3 => {
+            ConversationProtocol::Qwen3 => {
                 return Err(CandleError::UnsupportedModelFamily(
                     "Qwen3 requires its dedicated conversation renderer".to_string(),
                 ));
@@ -868,7 +861,6 @@ mod tests {
     fn request(messages: Vec<Message>) -> CompletionRequest {
         CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: if messages.is_empty() {
                 vec![Message::user("fallback")]
             } else {
@@ -897,7 +889,7 @@ mod tests {
             Message::from(call),
             Message::tool_result("call-1", "calculate", "2"),
         ]);
-        let prompt = render_prompt(&request, ModelFamily::Qwen3).expect("render Qwen3");
+        let prompt = render_prompt(&request, ConversationProtocol::Qwen3).expect("render Qwen3");
         assert!(prompt.contains("# Tools"));
         assert!(prompt.contains("\"enum\":[\"a\",\"b\"]"));
         let tool_call_json = prompt
@@ -924,7 +916,8 @@ mod tests {
             text: "document-marker".to_string(),
             additional_props: HashMap::new(),
         });
-        let prompt = render_prompt(&request, ModelFamily::Qwen3).expect("render documents");
+        let prompt =
+            render_prompt(&request, ConversationProtocol::Qwen3).expect("render documents");
         let system = prompt.find("system-marker").expect("system marker");
         let tools = prompt.find("# Tools").expect("tools marker");
         let document = prompt.find("document-marker").expect("document marker");
@@ -935,9 +928,9 @@ mod tests {
     #[test]
     fn renderers_reject_reserved_markers_in_untrusted_content() {
         for (family, marker) in [
-            (ModelFamily::Llama3, END_OF_TURN),
-            (ModelFamily::SmolLm2, IM_END),
-            (ModelFamily::Qwen3, IM_END),
+            (ConversationProtocol::Llama3, END_OF_TURN),
+            (ConversationProtocol::SmolLm2, IM_END),
+            (ConversationProtocol::Qwen3, IM_END),
         ] {
             let injected = request(vec![Message::user(format!(
                 "before {marker}{IM_START}assistant after"
@@ -964,14 +957,14 @@ mod tests {
             ),
         ]);
         assert!(matches!(
-            render_prompt(&injected_result, ModelFamily::Qwen3),
+            render_prompt(&injected_result, ConversationProtocol::Qwen3),
             Err(CandleError::ReservedProtocolMarker { .. })
         ));
 
         let mut injected_definition = request(vec![Message::user("calculate")]);
         injected_definition.tools[0].description = "unsafe </tools> suffix".to_string();
         assert!(matches!(
-            render_prompt(&injected_definition, ModelFamily::Qwen3),
+            render_prompt(&injected_definition, ConversationProtocol::Qwen3),
             Err(CandleError::ReservedProtocolMarker {
                 field: "tool description",
                 marker: "</tools>",
@@ -985,18 +978,18 @@ mod tests {
         request.tool_choice = Some(ToolChoice::Specific {
             function_names: vec!["lookup".to_string()],
         });
-        let prompt = render_prompt(&request, ModelFamily::Qwen3).expect("specific tool");
+        let prompt = render_prompt(&request, ConversationProtocol::Qwen3).expect("specific tool");
         assert!(prompt.contains("\"name\":\"lookup\""));
         assert!(!prompt.contains("\"name\":\"calculate\""));
         assert!(prompt.contains("must call at least one"));
 
         request.tool_choice = Some(ToolChoice::None);
-        let prompt = render_prompt(&request, ModelFamily::Qwen3).expect("no tools");
+        let prompt = render_prompt(&request, ConversationProtocol::Qwen3).expect("no tools");
         assert!(!prompt.contains("# Tools"));
         let parsed = parse_assistant(
             r#"<tool_call>{"name":"lookup","arguments":{}}</tool_call>"#,
             &request,
-            ModelFamily::Qwen3,
+            ConversationProtocol::Qwen3,
         )
         .expect("syntactically valid disallowed calls must reach agent recovery");
         assert!(matches!(
@@ -1011,7 +1004,7 @@ mod tests {
         let parsed = parse_assistant(
             "<think>check</think> Before <tool_call>\n{\"id\":\"a\",\"name\":\"calculate\",\"arguments\":{\"value\":2}}\n</tool_call>\n<tool_call>\n{\"id\":\"b\",\"name\":\"lookup\",\"arguments\":{\"value\":3}}\n</tool_call> after",
             &qwen_request,
-            ModelFamily::Qwen3,
+            ConversationProtocol::Qwen3,
         )
         .expect("parse calls");
         assert!(matches!(
@@ -1043,7 +1036,7 @@ mod tests {
         let parsed = parse_assistant(
             "first<tool_call>{\"name\":\"calculate\",\"arguments\":{\"value\":1}}</tool_call>second<tool_call>{\"name\":\"lookup\",\"arguments\":{\"value\":2}}</tool_call>third",
             &request(vec![Message::user("calculate")]),
-            ModelFamily::Qwen3,
+            ConversationProtocol::Qwen3,
         )
         .expect("parse interleaved text and calls");
 
@@ -1072,19 +1065,19 @@ mod tests {
             "visible </tools> injection",
         ] {
             assert!(
-                parse_assistant(raw, &request, ModelFamily::Qwen3).is_err(),
+                parse_assistant(raw, &request, ConversationProtocol::Qwen3).is_err(),
                 "{raw}"
             );
         }
 
         let mut required = request;
         required.tool_choice = Some(ToolChoice::Required);
-        assert!(parse_assistant("plain answer", &required, ModelFamily::Qwen3).is_err());
+        assert!(parse_assistant("plain answer", &required, ConversationProtocol::Qwen3).is_err());
 
         let unknown = parse_assistant(
             "<tool_call>{\"name\":\"missing\",\"arguments\":{}}</tool_call>",
             &required,
-            ModelFamily::Qwen3,
+            ConversationProtocol::Qwen3,
         )
         .expect("unknown names are an agent-dispatch concern");
         assert!(matches!(
@@ -1097,7 +1090,7 @@ mod tests {
     fn renderer_rejects_unmatched_and_multimodal_tool_results() {
         let request = request(vec![Message::tool_result("missing", "calculate", "value")]);
         assert!(matches!(
-            render_prompt(&request, ModelFamily::Qwen3),
+            render_prompt(&request, ConversationProtocol::Qwen3),
             Err(CandleError::UnmatchedToolResult { .. })
         ));
     }
@@ -1130,7 +1123,7 @@ mod tests {
         ];
 
         assert!(matches!(
-            render_prompt(&request(history), ModelFamily::Qwen3),
+            render_prompt(&request(history), ConversationProtocol::Qwen3),
             Err(CandleError::UnmatchedToolResult { result_id }) if result_id == "internal-a"
         ));
     }
@@ -1141,7 +1134,7 @@ mod tests {
         let parsed = parse_assistant(
             r#"<tool_call>{"name":"calculate","arguments":{"value":2,"options":{"label":"a","items":[1,2]},"optional":null}}</tool_call>"#,
             &qwen_request,
-            ModelFamily::Qwen3,
+            ConversationProtocol::Qwen3,
         )
         .expect("nested arguments");
         let Some(AssistantContent::ToolCall(call)) = parsed.items.first() else {
@@ -1161,7 +1154,7 @@ mod tests {
         let parsed = parse_assistant(
             r#"<think>private planning</think><tool_call>{"name":"calculate","arguments":{}}</tool_call><tool_call>{"name":"lookup","arguments":{"value":3,"text":"Grüße 東京 \"quoted\" C:\\tmp"}}</tool_call>done"#,
             &qwen_request,
-            ModelFamily::Qwen3,
+            ConversationProtocol::Qwen3,
         )
         .expect("zero-argument and escaped calls should parse");
         let calls = parsed
@@ -1194,7 +1187,7 @@ mod tests {
             "answer <think>hidden</think>",
         ] {
             assert!(
-                parse_assistant(raw, &qwen_request, ModelFamily::Qwen3).is_err(),
+                parse_assistant(raw, &qwen_request, ConversationProtocol::Qwen3).is_err(),
                 "{raw}"
             );
         }
@@ -1202,14 +1195,14 @@ mod tests {
         let mut invalid_name = qwen_request.clone();
         invalid_name.tools[0].name = "bad name".to_string();
         assert!(matches!(
-            render_prompt(&invalid_name, ModelFamily::Qwen3),
+            render_prompt(&invalid_name, ConversationProtocol::Qwen3),
             Err(CandleError::InvalidToolDefinition { .. })
         ));
 
         let mut invalid_schema = qwen_request.clone();
         invalid_schema.tools[0].parameters = serde_json::json!({"type": "array"});
         assert!(matches!(
-            render_prompt(&invalid_schema, ModelFamily::Qwen3),
+            render_prompt(&invalid_schema, ConversationProtocol::Qwen3),
             Err(CandleError::InvalidToolDefinition { .. })
         ));
 
@@ -1219,7 +1212,7 @@ mod tests {
                 .expect("valid test schema"),
         );
         assert!(matches!(
-            render_prompt(&native_schema, ModelFamily::Qwen3),
+            render_prompt(&native_schema, ConversationProtocol::Qwen3),
             Err(CandleError::UnsupportedFeature(feature)) if feature.contains("constrained decoding")
         ));
 
@@ -1228,7 +1221,7 @@ mod tests {
             ToolFunction::new("calculate".to_string(), serde_json::json!({"value": 1})),
         ))]);
         assert!(matches!(
-            render_prompt(&dangling_call, ModelFamily::Qwen3),
+            render_prompt(&dangling_call, ConversationProtocol::Qwen3),
             Err(CandleError::MalformedToolCall(reason)) if reason.contains("no correlated")
         ));
     }

--- a/crates/rig-candle/src/types.rs
+++ b/crates/rig-candle/src/types.rs
@@ -4,7 +4,7 @@ use rig_core::completion::{CompletionError, Usage};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::profile::ModelFamily;
+use crate::profile::ConversationProtocol;
 
 /// Why a local Candle completion failed.
 #[derive(Debug, Error, Clone)]
@@ -33,9 +33,9 @@ pub enum CandleError {
     #[error("selected model family {selected:?} does not match detected family {detected:?}")]
     ModelFamilyMismatch {
         /// Family requested by the caller.
-        selected: ModelFamily,
+        selected: ConversationProtocol,
         /// Family detected from the tokenizer.
-        detected: ModelFamily,
+        detected: ConversationProtocol,
     },
     /// Independently supplied model artifacts disagree with one another.
     #[error("{artifact} does not match the selected model artifacts: {reason}")]

--- a/crates/rig-candle/src/validation.rs
+++ b/crates/rig-candle/src/validation.rs
@@ -10,7 +10,7 @@ use tokenizers::Tokenizer;
 
 use crate::CandleError;
 use crate::profile::{
-    BEGIN_OF_TEXT, ConfigValues, END_HEADER, END_OF_TURN, IM_END, IM_START, ModelFamily,
+    BEGIN_OF_TEXT, ConfigValues, ConversationProtocol, END_HEADER, END_OF_TURN, IM_END, IM_START,
     ProfileDefinition, START_HEADER, validate_config_requirements, validate_dimensions,
     validate_tokenizer_requirements,
 };
@@ -252,7 +252,9 @@ pub(crate) fn validate_positive_finite(field: &'static str, value: f32) -> Resul
     Ok(())
 }
 
-pub(crate) fn detect_model_family(tokenizer: &Tokenizer) -> Result<ModelFamily, CandleError> {
+pub(crate) fn detect_model_family(
+    tokenizer: &Tokenizer,
+) -> Result<ConversationProtocol, CandleError> {
     let llama3 = [BEGIN_OF_TEXT, START_HEADER, END_HEADER, END_OF_TURN]
         .iter()
         .all(|token| tokenizer.token_to_id(token).is_some());
@@ -260,8 +262,8 @@ pub(crate) fn detect_model_family(tokenizer: &Tokenizer) -> Result<ModelFamily, 
         .iter()
         .all(|token| tokenizer.token_to_id(token).is_some());
     match (llama3, smollm2) {
-        (true, false) => Ok(ModelFamily::Llama3),
-        (false, true) => Ok(ModelFamily::SmolLm2),
+        (true, false) => Ok(ConversationProtocol::Llama3),
+        (false, true) => Ok(ConversationProtocol::SmolLm2),
         (true, true) => Err(CandleError::UnsupportedModelFamily(
             "tokenizer ambiguously contains both Llama 3 and SmolLM2 control tokens".to_string(),
         )),

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -719,11 +719,6 @@ impl<M: CompletionModel + ?Sized> CompletionModel for std::sync::Arc<M> {
 pub struct CompletionRequest {
     /// Optional model override for this request.
     pub model: Option<String>,
-    /// Legacy preamble field preserved for backwards compatibility.
-    ///
-    /// New code should prefer a leading [`Message::System`]
-    /// in `chat_history` as the canonical representation of system instructions.
-    pub preamble: Option<String>,
     /// The chat history to be sent to the completion model provider.
     /// The very last message is the prompt.
     ///
@@ -769,6 +764,16 @@ pub struct CompletionRequest {
 }
 
 impl CompletionRequest {
+    /// The system instructions of this request: the content of the leading
+    /// [`Message::System`] in `chat_history`, which is where
+    /// [`CompletionRequestBuilder::preamble`] places it.
+    pub fn system_instructions(&self) -> Option<&str> {
+        match self.chat_history.first() {
+            Some(Message::System { content }) => Some(content.as_str()),
+            _ => None,
+        }
+    }
+
     /// Reject a request with no messages, or a message that carries no content.
     ///
     /// Removing the non-empty container removed two guarantees at once, and this
@@ -1059,9 +1064,9 @@ impl<M: CompletionModel> CompletionRequestBuilder<M> {
         }
     }
 
-    /// Sets the preamble for the completion request.
+    /// Sets the preamble for the completion request. It becomes the leading
+    /// [`Message::System`] of `chat_history` at build time.
     pub fn preamble(mut self, preamble: String) -> Self {
-        // Legacy public API: funnel preamble into canonical system messages at build-time.
         self.preamble = Some(preamble);
         self
     }
@@ -1075,11 +1080,6 @@ impl<M: CompletionModel> CompletionRequestBuilder<M> {
     /// Overrides the model used for this request.
     pub fn model_opt(mut self, model: Option<String>) -> Self {
         self.request_model = model;
-        self
-    }
-
-    pub fn without_preamble(mut self) -> Self {
-        self.preamble = None;
         self
     }
 
@@ -1278,7 +1278,6 @@ impl<M: CompletionModel> CompletionRequestBuilder<M> {
 
         let request = CompletionRequest {
             model: self.request_model,
-            preamble: None,
             chat_history,
             documents: self.documents,
             tools: self.tools,
@@ -1319,7 +1318,6 @@ mod tests {
         fn request(chat_history: Vec<Message>) -> CompletionRequest {
             CompletionRequest {
                 model: None,
-                preamble: None,
                 chat_history,
                 documents: Vec::new(),
                 tools: Vec::new(),
@@ -1803,7 +1801,6 @@ mod tests {
 
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["What is the capital of France?".into()],
             documents: vec![doc1, doc2],
             tools: Vec::new(),
@@ -1835,7 +1832,6 @@ mod tests {
     fn test_normalize_documents_without_documents() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["What is the capital of France?".into()],
             documents: Vec::new(),
             tools: Vec::new(),
@@ -1858,8 +1854,6 @@ mod tests {
                 .message(Message::user("History"))
                 .build();
 
-        assert_eq!(request.preamble, None);
-
         let history = request.chat_history.into_iter().collect::<Vec<_>>();
         assert_eq!(history.len(), 3);
         assert!(matches!(
@@ -1868,20 +1862,6 @@ mod tests {
         ));
         assert!(matches!(&history[1], Message::User { .. }));
         assert!(matches!(&history[2], Message::User { .. }));
-    }
-
-    #[test]
-    fn without_preamble_removes_legacy_preamble_injection() {
-        let request =
-            CompletionRequestBuilder::new(MockCompletionModel::default(), Message::user("Prompt"))
-                .preamble("System prompt".to_string())
-                .without_preamble()
-                .build();
-
-        assert_eq!(request.preamble, None);
-        let history = request.chat_history.into_iter().collect::<Vec<_>>();
-        assert_eq!(history.len(), 1);
-        assert!(matches!(&history[0], Message::User { .. }));
     }
 
     #[test]
@@ -1955,7 +1935,6 @@ mod tests {
     fn chat_history_with_documents_places_documents_after_leading_system_messages() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 Message::system("System prompt"),
                 Message::assistant("Earlier assistant turn"),
@@ -1988,7 +1967,6 @@ mod tests {
     fn chat_history_with_documents_places_documents_before_mid_conversation_system_messages() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 Message::system("Leading system prompt"),
                 Message::assistant("Earlier assistant turn"),
@@ -2025,7 +2003,6 @@ mod tests {
     fn chat_history_with_documents_does_not_duplicate_documents() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 Message::system("System prompt"),
                 Message::user("Earlier user turn"),

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -1593,7 +1593,7 @@ where
             .unwrap_or_else(|| self.model.clone());
         let span = CompletionSpanBuilder::new(Ext::PROVIDER_NAME, &request_model, operation)
             .system_instructions(
-                completion_request.preamble.as_deref(),
+                completion_request.system_instructions(),
                 completion_request.record_telemetry_content,
             )
             .build();
@@ -2850,20 +2850,8 @@ impl AnthropicCompletionRequest {
         let mut tools =
             build_tool_definitions::<Ext>(req.tools, &mut additional_params_payload, strict_tools)?;
 
-        // Convert system prompt to array format for cache_control support
-        let mut system = if let Some(preamble) = req.preamble {
-            if preamble.is_empty() {
-                vec![]
-            } else {
-                vec![SystemContent::Text {
-                    text: preamble,
-                    cache_control: None,
-                }]
-            }
-        } else {
-            vec![]
-        };
-        system.extend(history_system);
+        // System prompt in array format for cache_control support
+        let mut system = history_system;
 
         apply_prompt_cache_control(
             &mut system,
@@ -3563,8 +3551,10 @@ mod tests {
     ) -> CompletionRequest {
         CompletionRequest {
             model: None,
-            preamble: Some("System prompt".to_string()),
-            chat_history: vec![message::Message::from("Hello")],
+            chat_history: vec![
+                message::Message::system("System prompt"),
+                message::Message::from("Hello"),
+            ],
             documents: Vec::new(),
             tools,
             temperature: None,
@@ -3582,8 +3572,11 @@ mod tests {
     ) -> CompletionRequest {
         CompletionRequest {
             model: None,
-            preamble,
-            chat_history,
+            chat_history: preamble
+                .map(message::Message::system)
+                .into_iter()
+                .chain(chat_history)
+                .collect(),
             documents: Vec::new(),
             tools: Vec::new(),
             temperature: None,

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -956,7 +956,6 @@ mod tests {
     fn streaming_request_keeps_documents_after_leading_system_messages() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 RigMessage::system("System prompt"),
                 RigMessage::assistant("Earlier assistant turn"),
@@ -1014,8 +1013,10 @@ mod tests {
 
         let request = CompletionRequest {
             model: None,
-            preamble: Some("You are helpful".to_string()),
-            chat_history: vec![RigMessage::user("What's the weather?")],
+            chat_history: vec![
+                RigMessage::system("You are helpful"),
+                RigMessage::user("What's the weather?"),
+            ],
             documents: vec![],
             tools: vec![],
             temperature: Some(0.5),
@@ -1069,7 +1070,6 @@ mod tests {
     fn streaming_body_keeps_explicit_tool_choice_auto_when_tools_present_but_unset() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![RigMessage::user("Add 2 and 3")],
             documents: vec![],
             tools: vec![crate::completion::ToolDefinition {
@@ -1102,7 +1102,6 @@ mod tests {
     fn streaming_body_applies_strict_tool_opt_in() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![RigMessage::user("Look this up")],
             documents: vec![],
             tools: vec![crate::completion::ToolDefinition {
@@ -1144,7 +1143,6 @@ mod tests {
         // otherwise). A `tool_choice` set with no tools must not reach the wire.
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![RigMessage::user("Hi")],
             documents: vec![],
             tools: vec![],

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -887,7 +887,6 @@ mod azure_tests {
         let _ = model
             .completion(CompletionRequest {
                 model: Some("other-deployment".to_string()),
-                preamble: None,
                 chat_history: vec!["Hello!".into()],
                 documents: vec![],
                 max_tokens: None,
@@ -935,8 +934,10 @@ mod azure_tests {
         let Err(error) = model
             .completion(CompletionRequest {
                 model: None,
-                preamble: Some("You are a helpful assistant.".to_string()),
-                chat_history: vec!["Hello!".into()],
+                chat_history: vec![
+                    crate::message::Message::system("You are a helpful assistant."),
+                    "Hello!".into(),
+                ],
                 documents: vec![],
                 max_tokens: Some(100),
                 temperature: Some(0.0),

--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -785,8 +785,9 @@ data: [DONE]"#;
             .openai_model()
             .create_completion_request(completion::CompletionRequest {
                 model: Some("gpt-5.4".to_string()),
-                preamble: Some("System one".to_string()),
-                chat_history,
+                chat_history: std::iter::once(completion::Message::system("System one"))
+                    .chain(chat_history)
+                    .collect(),
                 documents: Vec::new(),
                 tools: Vec::new(),
                 temperature: None,
@@ -841,8 +842,10 @@ data: [DONE]"#;
             .create_request(completion::CompletionRequest {
                 record_telemetry_content: false,
                 model: None,
-                preamble: Some("Respond tersely.".to_string()),
-                chat_history: vec![completion::Message::user("hello")],
+                chat_history: vec![
+                    completion::Message::system("Respond tersely."),
+                    completion::Message::user("hello"),
+                ],
                 documents: Vec::new(),
                 tools: Vec::new(),
                 temperature: None,
@@ -869,7 +872,6 @@ data: [DONE]"#;
         let request = model
             .create_request(completion::CompletionRequest {
                 model: None,
-                preamble: None,
                 chat_history: vec![completion::Message::user("hello")],
                 documents: Vec::new(),
                 tools: Vec::new(),

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -659,9 +659,7 @@ impl TryFrom<(&str, CompletionRequest)> for CohereCompletionRequest {
         let mut partial_history = vec![];
         partial_history.extend(req.chat_history);
 
-        let mut full_history: Vec<Message> = req.preamble.map_or_else(Vec::new, |preamble| {
-            vec![Message::System { content: preamble }]
-        });
+        let mut full_history: Vec<Message> = Vec::new();
 
         full_history.extend(
             partial_history
@@ -743,7 +741,7 @@ where
         &self,
         completion_request: completion::CompletionRequest,
     ) -> Result<CompletionResponse, CompletionError> {
-        let system_instructions = completion_request.preamble.clone();
+        let system_instructions = completion_request.system_instructions().map(str::to_owned);
         let record_telemetry_content = completion_request.record_telemetry_content;
         let request = CohereCompletionRequest::try_from((self.model.as_ref(), completion_request))?;
 

--- a/crates/rig-core/src/providers/cohere/mod.rs
+++ b/crates/rig-core/src/providers/cohere/mod.rs
@@ -42,44 +42,6 @@ pub const COMMAND_R_PLUS_08_2024: &str = "command-r-plus-08-2024";
 /// `command-r-08-2024` completion model
 pub const COMMAND_R_08_2024: &str = "command-r-08-2024";
 
-/// `command-r-plus` completion model
-#[deprecated(
-    note = "Cohere removed `command-r-plus` on 2025-09-15; requests using it fail. \
-    Use `COMMAND_R_PLUS_08_2024`, `COMMAND_A_03_2025`, or `COMMAND_A_PLUS_05_2026` instead."
-)]
-pub const COMMAND_R_PLUS: &str = "command-r-plus";
-/// `command-r` completion model
-#[deprecated(
-    note = "Cohere removed `command-r` on 2025-09-15; requests using it fail. \
-    Use `COMMAND_R_08_2024`, `COMMAND_A_03_2025`, or `COMMAND_A_PLUS_05_2026` instead."
-)]
-pub const COMMAND_R: &str = "command-r";
-/// `command` completion model
-#[deprecated(
-    note = "Cohere removed `command` on 2025-09-15; requests using it fail. \
-    Use `COMMAND_R_08_2024`, `COMMAND_A_03_2025`, or `COMMAND_A_PLUS_05_2026` instead."
-)]
-pub const COMMAND: &str = "command";
-/// `command-nightly` completion model
-#[deprecated(
-    note = "`command-nightly` still resolves but is absent from Cohere's published model \
-    catalogue, so it carries no compatibility or availability guarantee. \
-    Use `COMMAND_A_03_2025` or `COMMAND_A_PLUS_05_2026` instead."
-)]
-pub const COMMAND_NIGHTLY: &str = "command-nightly";
-/// `command-light` completion model
-#[deprecated(
-    note = "Cohere removed `command-light` on 2025-09-15; requests using it fail. \
-    Use `COMMAND_R7B_12_2024` or `COMMAND_A_03_2025` instead."
-)]
-pub const COMMAND_LIGHT: &str = "command-light";
-/// `command-light-nightly` completion model
-#[deprecated(
-    note = "Cohere no longer serves `command-light-nightly`; requests using it return 404. \
-    Use `COMMAND_R7B_12_2024` or `COMMAND_A_03_2025` instead."
-)]
-pub const COMMAND_LIGHT_NIGHTLY: &str = "command-light-nightly";
-
 // ================================================================
 // Cohere Embedding Models
 // ================================================================

--- a/crates/rig-core/src/providers/cohere/streaming.rs
+++ b/crates/rig-core/src/providers/cohere/streaming.rs
@@ -338,7 +338,7 @@ where
         &self,
         request: CompletionRequest,
     ) -> Result<RawStreamingResult<StreamingCompletionResponse>, CompletionError> {
-        let system_instructions = request.preamble.clone();
+        let system_instructions = request.system_instructions().map(str::to_owned);
         let record_telemetry_content = request.record_telemetry_content;
         let mut request = CohereCompletionRequest::try_from((self.model.as_ref(), request))?;
         let span = CompletionSpanBuilder::new(

--- a/crates/rig-core/src/providers/copilot/auth/native.rs
+++ b/crates/rig-core/src/providers/copilot/auth/native.rs
@@ -498,7 +498,7 @@ mod tests {
     }
 
     #[test]
-    fn legacy_api_key_record_without_fingerprint_forces_refresh_when_bootstrap_token_is_known() {
+    fn api_key_record_without_fingerprint_forces_refresh_when_bootstrap_token_is_known() {
         let record = ApiKeyRecord {
             token: Some("copilot-token".into()),
             expires_at: Some(i64::MAX),

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -585,7 +585,7 @@ impl RequestFacts {
         Self {
             initiator: request_initiator(request),
             has_vision: request_has_vision(request),
-            system_instructions: request.preamble.clone(),
+            system_instructions: request.system_instructions().map(str::to_owned),
             record_telemetry_content: request.record_telemetry_content,
         }
     }

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -391,18 +391,6 @@ crate::providers::internal::model_listing::impl_model_lister!(
 // ================================================================
 // DeepSeek Completion API
 // ================================================================
-#[deprecated(
-    note = "The model names `deepseek-chat` and `deepseek-reasoner` will be deprecated on 2026/07/24. \
-    For compatibility, they correspond to the non-thinking mode and thinking mode of `deepseek-v4-flash`, \
-    respectively."
-)]
-pub const DEEPSEEK_CHAT: &str = "deepseek-chat";
-#[deprecated(
-    note = "The model names `deepseek-chat` and `deepseek-reasoner` will be deprecated on 2026/07/24. \
-    For compatibility, they correspond to the non-thinking mode and thinking mode of `deepseek-v4-flash`, \
-    respectively."
-)]
-pub const DEEPSEEK_REASONER: &str = "deepseek-reasoner";
 pub const DEEPSEEK_V4_FLASH: &str = "deepseek-v4-flash";
 pub const DEEPSEEK_V4_PRO: &str = "deepseek-v4-pro";
 

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -169,7 +169,7 @@ where
             CompletionOperation::GenerateContent,
         )
         .system_instructions(
-            completion_request.preamble.as_deref(),
+            completion_request.system_instructions(),
             completion_request.record_telemetry_content,
         )
         .build();
@@ -258,7 +258,6 @@ pub(crate) fn create_request_body(
 
     let CompletionRequest {
         model: _,
-        preamble,
         chat_history: _,
         documents: _,
         tools: function_tools,
@@ -369,9 +368,6 @@ pub(crate) fn create_request_body(
     }
 
     let mut system_parts: Vec<Part> = Vec::new();
-    if let Some(preamble) = preamble.filter(|preamble| !preamble.is_empty()) {
-        system_parts.push(preamble.into());
-    }
     for content in history_system {
         if !content.is_empty() {
             system_parts.push(content.into());
@@ -2762,7 +2758,6 @@ mod tests {
     fn test_resolve_request_model_uses_override() {
         let request = CompletionRequest {
             model: Some("gemini-2.5-flash".to_string()),
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -2790,7 +2785,6 @@ mod tests {
     fn test_resolve_request_model_uses_default_when_unset() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -4028,7 +4022,6 @@ mod tests {
         use crate::message::{AssistantContent, ToolCall, ToolFunction, ToolResultContent};
 
         let request = CompletionRequest {
-            preamble: None,
             chat_history: vec![
                 message::Message::user("weather?"),
                 message::Message::Assistant {
@@ -4208,7 +4201,6 @@ mod tests {
         ];
 
         let documents_message = CompletionRequest {
-            preamble: None,
             chat_history: vec![Message::user("placeholder")],
             documents,
             tools: vec![],
@@ -4224,8 +4216,11 @@ mod tests {
         .unwrap();
 
         let completion_request = CompletionRequest {
-            preamble: Some("You are a helpful assistant".to_string()),
-            chat_history: vec![documents_message, Message::user("What are my notes about?")],
+            chat_history: vec![
+                Message::system("You are a helpful assistant"),
+                documents_message,
+                Message::user("What are my notes about?"),
+            ],
             documents: vec![],
             tools: vec![],
             temperature: None,
@@ -4290,8 +4285,10 @@ mod tests {
         use crate::message::Message;
 
         let completion_request = CompletionRequest {
-            preamble: Some("You are a helpful assistant".to_string()),
-            chat_history: vec![Message::user("Hello")],
+            chat_history: vec![
+                Message::system("You are a helpful assistant"),
+                Message::user("Hello"),
+            ],
             documents: vec![], // No documents
             tools: vec![],
             temperature: None,
@@ -4368,10 +4365,13 @@ mod cached_content_request_tests {
             });
         }
         super::create_request_body(CompletionRequest {
-            preamble: preamble.map(str::to_owned),
-            chat_history: vec![Message::User {
-                content: vec![UserContent::text("hi")],
-            }],
+            chat_history: preamble
+                .map(Message::system)
+                .into_iter()
+                .chain([Message::User {
+                    content: vec![UserContent::text("hi")],
+                }])
+                .collect(),
             documents: vec![],
             tools: tool_defs,
             temperature: None,
@@ -4541,10 +4541,13 @@ mod cached_content_request_tests {
         additional: Option<serde_json::Value>,
     ) -> Result<GenerateContentRequest, CompletionError> {
         super::create_request_body(CompletionRequest {
-            preamble: preamble.map(str::to_owned),
-            chat_history: vec![Message::User {
-                content: vec![UserContent::text("hi")],
-            }],
+            chat_history: preamble
+                .map(Message::system)
+                .into_iter()
+                .chain([Message::User {
+                    content: vec![UserContent::text("hi")],
+                }])
+                .collect(),
             documents: vec![],
             tools: vec![],
             temperature: None,
@@ -4642,7 +4645,6 @@ mod cached_content_request_tests {
     #[test]
     fn unrelated_additional_params_coexist_with_the_typed_field() {
         let mut request = super::create_request_body(CompletionRequest {
-            preamble: None,
             chat_history: vec![Message::User {
                 content: vec![UserContent::text("hi")],
             }],
@@ -4729,7 +4731,6 @@ mod cached_content_request_tests {
         );
 
         let message = super::create_request_body(CompletionRequest {
-            preamble: None,
             chat_history: vec![Message::User {
                 content: vec![UserContent::text("hi")],
             }],
@@ -5012,10 +5013,13 @@ mod cached_content_conflict_matrix {
 
     fn build(system: bool, tools: bool, tool_choice: bool) -> GenerateContentRequest {
         super::create_request_body(CompletionRequest {
-            preamble: system.then(|| "you are terse".to_owned()),
-            chat_history: vec![Message::User {
-                content: vec![UserContent::text("hi")],
-            }],
+            chat_history: system
+                .then(|| Message::system("you are terse"))
+                .into_iter()
+                .chain([Message::User {
+                    content: vec![UserContent::text("hi")],
+                }])
+                .collect(),
             documents: vec![],
             tools: if tools {
                 vec![ToolDefinition {

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -134,7 +134,7 @@ where
             CompletionOperation::Interactions,
         )
         .system_instructions(
-            completion_request.preamble.as_deref(),
+            completion_request.system_instructions(),
             completion_request.record_telemetry_content,
         )
         .build();
@@ -324,15 +324,8 @@ pub(crate) fn create_request_body(
         Some(generation_config)
     };
 
-    let system_instruction = completion_request
-        .preamble
-        .or_else(|| {
-            if history_system.is_empty() {
-                None
-            } else {
-                Some(history_system.join("\n\n"))
-            }
-        })
+    let system_instruction = (!history_system.is_empty())
+        .then(|| history_system.join("\n\n"))
         .or(params.system_instruction.take());
 
     let mut tools = Vec::new();
@@ -2365,8 +2358,7 @@ mod tests {
         let request = CompletionRequest {
             record_telemetry_content: false,
             model: None,
-            preamble: Some("Be precise.".to_string()),
-            chat_history: vec![prompt],
+            chat_history: vec![Message::system("Be precise."), prompt],
             documents: vec![],
             tools: vec![],
             temperature: Some(0.7),
@@ -2445,7 +2437,6 @@ mod tests {
         let request = CompletionRequest {
             record_telemetry_content: false,
             model: None,
-            preamble: None,
             chat_history: vec![
                 // A driver-built result carries the executed name (a repair
                 // hook renamed the call: `sum` ran, not `add`).
@@ -2681,7 +2672,6 @@ mod tests {
         let request = CompletionRequest {
             record_telemetry_content: false,
             model: None,
-            preamble: None,
             chat_history: vec![Message::User {
                 content: vec![tool_result],
             }],

--- a/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
@@ -131,7 +131,7 @@ where
             CompletionOperation::InteractionsStreaming,
         )
         .system_instructions(
-            completion_request.preamble.as_deref(),
+            completion_request.system_instructions(),
             completion_request.record_telemetry_content,
         )
         .build();

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -406,7 +406,7 @@ where
             CompletionOperation::ChatStreaming,
         )
         .system_instructions(
-            completion_request.preamble.as_deref(),
+            completion_request.system_instructions(),
             completion_request.record_telemetry_content,
         )
         .build();

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -11,22 +11,6 @@ use crate::{
 pub const CODESTRAL: &str = "codestral-latest";
 /// The latest version of the `mistral-large` Mistral model
 pub const MISTRAL_LARGE: &str = "mistral-large-latest";
-/// The latest version of the `pixtral-large` Mistral multimodal model
-///
-/// **Retired.** This identifier is no longer in Mistral's `GET /v1/models`
-/// catalog; requests naming it fail with `400 Invalid model`.
-#[deprecated(
-    note = "Mistral no longer serves this model. Pixtral is retired; use `MISTRAL_SMALL` or `MISTRAL_MEDIUM`, which are vision-capable"
-)]
-pub const PIXTRAL_LARGE: &str = "pixtral-large-latest";
-/// The latest version of the `mistral` Mistral multimodal model, trained on datasets from the Middle East & South Asia
-///
-/// **Retired.** This identifier is no longer in Mistral's `GET /v1/models`
-/// catalog; requests naming it fail with `400 Invalid model`.
-#[deprecated(
-    note = "Mistral no longer serves this model. retired; no replacement in the live catalog"
-)]
-pub const MISTRAL_SABA: &str = "mistral-saba-latest";
 /// The latest version of the `mistral-3b` Mistral completions model
 pub const MINISTRAL_3B: &str = "ministral-3b-latest";
 /// The latest version of the `mistral-8b` Mistral completions model
@@ -34,28 +18,6 @@ pub const MINISTRAL_8B: &str = "ministral-8b-latest";
 
 /// The latest version of the `mistral-small` Mistral completions model
 pub const MISTRAL_SMALL: &str = "mistral-small-latest";
-/// The `24-09` version of the `pixtral-small` Mistral multimodal model
-///
-/// **Retired.** This identifier is no longer in Mistral's `GET /v1/models`
-/// catalog; requests naming it fail with `400 Invalid model`.
-#[deprecated(
-    note = "Mistral no longer serves this model. Pixtral is retired; use `MINISTRAL_3B`, which is vision-capable"
-)]
-pub const PIXTRAL_SMALL: &str = "pixtral-12b-2409";
-/// The `open-mistral-nemo` model
-///
-/// **Retired.** This identifier is no longer in Mistral's `GET /v1/models`
-/// catalog; requests naming it fail with `400 Invalid model`.
-#[deprecated(
-    note = "Mistral no longer serves this model. retired; no replacement in the live catalog"
-)]
-pub const MISTRAL_NEMO: &str = "open-mistral-nemo";
-/// The `open-mistral-mamba` model
-///
-/// **Retired.** This identifier is no longer in Mistral's `GET /v1/models`
-/// catalog; requests naming it fail with `400 Invalid model`.
-#[deprecated(note = "Mistral no longer serves this model. retired; use `CODESTRAL`")]
-pub const CODESTRAL_MAMBA: &str = "open-codestral-mamba";
 
 /// Mistral completion model, driven by the shared OpenAI Chat Completions path.
 pub type CompletionModel<H> = openai::completion::GenericCompletionModel<MistralExt, H>;

--- a/crates/rig-core/src/providers/moonshot.rs
+++ b/crates/rig-core/src/providers/moonshot.rs
@@ -234,7 +234,6 @@ mod tests {
 
         let request = CompletionRequest {
             model: Some("kimi-k2-thinking".to_string()),
-            preamble: None,
             chat_history: vec![assistant],
             documents: vec![],
             tools: vec![],
@@ -268,7 +267,6 @@ mod tests {
 
         let request = CompletionRequest {
             model: Some("kimi-k2-thinking".to_string()),
-            preamble: None,
             chat_history: vec![assistant],
             documents: vec![],
             tools: vec![],
@@ -291,7 +289,6 @@ mod tests {
     fn moonshot_specific_tool_choice_is_rejected() {
         let request = CompletionRequest {
             model: Some("kimi-k2.5".to_string()),
-            preamble: None,
             chat_history: vec![Message::user("Use a tool.")],
             documents: vec![],
             tools: vec![],
@@ -326,7 +323,6 @@ mod tests {
     fn moonshot_required_tool_choice_is_coerced() {
         let request = CompletionRequest {
             model: Some("kimi-k2.5".to_string()),
-            preamble: None,
             chat_history: vec![Message::user("Use a tool.")],
             documents: vec![],
             tools: vec![],

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -554,13 +554,7 @@ impl TryFrom<(&str, CompletionRequest)> for OllamaCompletionRequest {
         // results arrive with an empty name and their call carries it.
         crate::providers::internal::resolve_empty_tool_result_names(&mut partial_history);
 
-        // Add preamble to chat history (if available)
-        let mut full_history: Vec<Message> = req
-            .preamble
-            .as_deref()
-            .map_or_else(Vec::new, |preamble| vec![Message::system(preamble)]);
-
-        // Convert and extend the rest of the history
+        let mut full_history: Vec<Message> = Vec::new();
         full_history.extend(
             partial_history
                 .into_iter()
@@ -778,7 +772,7 @@ where
         &self,
         completion_request: CompletionRequest,
     ) -> Result<CompletionResponse, CompletionError> {
-        let system_instructions = completion_request.preamble.clone();
+        let system_instructions = completion_request.system_instructions().map(str::to_owned);
         let record_telemetry_content = completion_request.record_telemetry_content;
         let request = OllamaCompletionRequest::try_from((self.model.as_ref(), completion_request))?;
         let span =
@@ -833,7 +827,7 @@ where
         &self,
         request: CompletionRequest,
     ) -> Result<RawStreamingResult<StreamingCompletionResponse>, CompletionError> {
-        let system_instructions = request.preamble.clone();
+        let system_instructions = request.system_instructions().map(str::to_owned);
         let record_telemetry_content = request.record_telemetry_content;
         let mut request = OllamaCompletionRequest::try_from((self.model.as_ref(), request))?;
         let span = CompletionSpanBuilder::new(
@@ -2176,10 +2170,12 @@ mod tests {
         // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
         let completion_request = CompletionRequest {
             model: None,
-            preamble: Some("You are a helpful assistant.".to_string()),
-            chat_history: vec![CompletionMessage::User {
-                content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
-            }],
+            chat_history: vec![
+                CompletionMessage::system("You are a helpful assistant."),
+                CompletionMessage::User {
+                    content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
+                },
+            ],
             documents: vec![],
             tools: vec![],
             temperature: Some(0.7),
@@ -2241,10 +2237,12 @@ mod tests {
         // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
         let completion_request = CompletionRequest {
             model: None,
-            preamble: Some("You are a helpful assistant.".to_string()),
-            chat_history: vec![CompletionMessage::User {
-                content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
-            }],
+            chat_history: vec![
+                CompletionMessage::system("You are a helpful assistant."),
+                CompletionMessage::User {
+                    content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
+                },
+            ],
             documents: vec![],
             tools: vec![],
             temperature: Some(0.7),
@@ -2306,10 +2304,12 @@ mod tests {
         // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
         let completion_request = CompletionRequest {
             model: None,
-            preamble: Some("You are a helpful assistant.".to_string()),
-            chat_history: vec![CompletionMessage::User {
-                content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
-            }],
+            chat_history: vec![
+                CompletionMessage::system("You are a helpful assistant."),
+                CompletionMessage::User {
+                    content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
+                },
+            ],
             documents: vec![],
             tools: vec![],
             temperature: Some(0.7),
@@ -2371,10 +2371,12 @@ mod tests {
         // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
         let completion_request = CompletionRequest {
             model: None,
-            preamble: Some("You are a helpful assistant.".to_string()),
-            chat_history: vec![CompletionMessage::User {
-                content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
-            }],
+            chat_history: vec![
+                CompletionMessage::system("You are a helpful assistant."),
+                CompletionMessage::User {
+                    content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
+                },
+            ],
             documents: vec![],
             tools: vec![],
             temperature: Some(0.7),
@@ -2436,10 +2438,12 @@ mod tests {
         // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
         let completion_request = CompletionRequest {
             model: None,
-            preamble: Some("You are a helpful assistant.".to_string()),
-            chat_history: vec![CompletionMessage::User {
-                content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
-            }],
+            chat_history: vec![
+                CompletionMessage::system("You are a helpful assistant."),
+                CompletionMessage::User {
+                    content: vec![UserContent::Text(Text::new("What is 2 + 2?".to_string()))],
+                },
+            ],
             documents: vec![],
             tools: vec![],
             temperature: Some(0.7),
@@ -2470,10 +2474,12 @@ mod tests {
         // Create a CompletionRequest WITHOUT "think" in additional_params
         let completion_request = CompletionRequest {
             model: None,
-            preamble: Some("You are a helpful assistant.".to_string()),
-            chat_history: vec![CompletionMessage::User {
-                content: vec![UserContent::Text(Text::new("Hello!".to_string()))],
-            }],
+            chat_history: vec![
+                CompletionMessage::system("You are a helpful assistant."),
+                CompletionMessage::User {
+                    content: vec![UserContent::Text(Text::new("Hello!".to_string()))],
+                },
+            ],
             documents: vec![],
             tools: vec![],
             temperature: Some(0.5),
@@ -2525,7 +2531,6 @@ mod tests {
 
         let completion_request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![CompletionMessage::User {
                 content: vec![UserContent::Text(Text::new("Hello!".to_string()))],
             }],
@@ -2559,7 +2564,6 @@ mod tests {
 
         let completion_request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![CompletionMessage::User {
                 content: vec![UserContent::Text(Text::new("Hello!".to_string()))],
             }],
@@ -2597,7 +2601,6 @@ mod tests {
 
         let completion_request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![CompletionMessage::User {
                 content: vec![UserContent::Text(Text::new("Hello!".to_string()))],
             }],
@@ -2636,7 +2639,6 @@ mod tests {
 
         let completion_request = CompletionRequest {
             model: Some("llama3.1".to_string()),
-            preamble: None,
             chat_history: vec![CompletionMessage::User {
                 content: vec![UserContent::Text(Text::new(
                     "How old is Ollama?".to_string(),
@@ -2681,7 +2683,6 @@ mod tests {
 
         let completion_request = CompletionRequest {
             model: Some("llama3.1".to_string()),
-            preamble: None,
             chat_history: vec![CompletionMessage::User {
                 content: vec![UserContent::Text(Text::new("Hello!".to_string()))],
             }],

--- a/crates/rig-core/src/providers/openai/client.rs
+++ b/crates/rig-core/src/providers/openai/client.rs
@@ -267,7 +267,7 @@ mod tests {
                     }
                 },
                 {
-                    "type": "audio",
+                    "type": "input_audio",
                     "input_audio": {
                         "data": "...",
                         "format": "mp3"

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -305,9 +305,8 @@ pub enum UserContent {
     Image {
         image_url: ImageUrl,
     },
-    /// Audio content part. Serialized with OpenAI's `input_audio` wire tag;
-    /// the legacy `audio` tag is still accepted on deserialization.
-    #[serde(rename = "input_audio", alias = "audio")]
+    /// Audio content part, OpenAI's `input_audio` wire tag.
+    #[serde(rename = "input_audio")]
     Audio {
         input_audio: InputAudio,
     },
@@ -377,50 +376,13 @@ pub struct FileData {
 /// Some OpenAI-compatible servers do honour an image — llama.cpp delivers one to
 /// the model, measured — so the variant exists and emitting it is gated on
 /// [`super::completion::OpenAICompatibleProvider::SUPPORTS_IMAGE_TOOL_RESULTS`].
-#[derive(Debug, Serialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(tag = "type")]
 pub enum ToolResultContent {
     #[serde(rename = "text")]
     Text { text: String },
     #[serde(rename = "image_url")]
     Image { image_url: ImageUrl },
-}
-
-/// Deserialization is deliberately hand-written rather than derived from the
-/// `tag = "type"` above.
-///
-/// The struct this replaced carried `#[serde(default)] r#type`, so a stored
-/// history whose tool-result parts omit `type` still loaded. A derived
-/// internally-tagged enum makes the tag mandatory, and because
-/// [`ToolResultContentValue`] is `#[serde(untagged)]` the real cause
-/// (`missing field \`type\``) is swallowed into "data did not match any
-/// variant". `Message` is public and derives `Deserialize`, so that tolerance is
-/// load-bearing for anyone replaying a persisted conversation.
-impl<'de> Deserialize<'de> for ToolResultContent {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        #[derive(Deserialize)]
-        struct Wire {
-            #[serde(default)]
-            r#type: Option<String>,
-            #[serde(default)]
-            text: Option<String>,
-            #[serde(default)]
-            image_url: Option<ImageUrl>,
-        }
-
-        let wire = Wire::deserialize(deserializer)?;
-        match (wire.r#type.as_deref(), wire.image_url, wire.text) {
-            (Some("image_url"), Some(image_url), _) => Ok(Self::Image { image_url }),
-            // An absent `type` is the tolerated legacy shape; so is an explicit
-            // `"text"`. Anything else with a `text` field is still text — the
-            // tag is advisory here, never a reason to fail a load.
-            (_, _, Some(text)) => Ok(Self::Text { text }),
-            (_, Some(image_url), None) => Ok(Self::Image { image_url }),
-            _ => Err(serde::de::Error::custom(
-                "tool result content part carried neither `text` nor `image_url`",
-            )),
-        }
-    }
 }
 
 impl ToolResultContent {
@@ -2159,7 +2121,6 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
 
         let CoreCompletionRequest {
             model: request_model,
-            preamble,
             chat_history: _,
             tools,
             temperature,
@@ -2173,9 +2134,7 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
         let mut partial_history = Vec::new();
         partial_history.extend(chat_history);
 
-        let mut full_history: Vec<Message> =
-            preamble.map_or_else(Vec::new, |preamble| vec![Message::system(&preamble)]);
-
+        let mut full_history: Vec<Message> = Vec::new();
         full_history.extend(
             partial_history
                 .into_iter()
@@ -2440,7 +2399,7 @@ where
         &self,
         completion_request: CoreCompletionRequest,
     ) -> Result<(Ext::Response, Option<String>), CompletionError> {
-        let system_instructions = completion_request.preamble.clone();
+        let system_instructions = completion_request.system_instructions().map(str::to_owned);
         let record_telemetry_content = completion_request.record_telemetry_content;
         let options = CompletionModelOptions {
             strict_tools: self.strict_tools,
@@ -2688,7 +2647,6 @@ mod tests {
 
         CoreCompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![message::Message::User {
                 content: vec![message::UserContent::ToolResult(tool_result)],
             }],
@@ -2945,7 +2903,6 @@ mod tests {
     fn test_openai_request_uses_request_model_override() {
         let request = crate::completion::CompletionRequest {
             model: Some("gpt-4.1".to_string()),
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -2977,7 +2934,6 @@ mod tests {
     fn test_openai_request_uses_default_model_when_override_unset() {
         let request = crate::completion::CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -3059,7 +3015,6 @@ mod tests {
     fn openai_chat_direct_request_keeps_documents_after_system_messages() {
         let request = CoreCompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 crate::completion::Message::system("System prompt"),
                 crate::completion::Message::assistant("Earlier assistant turn"),
@@ -3513,7 +3468,6 @@ mod tests {
     fn test_max_tokens_is_forwarded_to_request() {
         let request = crate::completion::CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -3550,7 +3504,6 @@ mod tests {
             model: "gpt-4o-mini".to_string(),
             request: crate::completion::CompletionRequest {
                 model: None,
-                preamble: None,
                 chat_history: vec!["Hello".into()],
                 documents: vec![],
                 tools: vec![],
@@ -3706,7 +3659,6 @@ mod tests {
     fn test_max_tokens_omitted_when_none() {
         let request = crate::completion::CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -3745,7 +3697,6 @@ mod tests {
     fn additional_params_function_tools_merge_and_native_tools_stay() {
         let request = CoreCompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![crate::completion::ToolDefinition {
@@ -3800,7 +3751,6 @@ mod tests {
     fn request_conversion_errors_when_all_messages_are_filtered() {
         let request = CoreCompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![message::Message::Assistant {
                 id: None,
                 content: vec![message::AssistantContent::reasoning("hidden")],
@@ -3832,7 +3782,6 @@ mod tests {
     fn request_conversion_omits_response_format_on_initial_tool_turn() {
         let request = CoreCompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![message::Message::user(
                 "Hello, whats the weather in London?",
             )],
@@ -3891,7 +3840,6 @@ mod tests {
     fn request_conversion_restores_response_format_after_tool_result() {
         let request = CoreCompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 message::Message::user("Hello, whats the weather in London?"),
                 message::Message::Assistant {
@@ -4741,7 +4689,6 @@ mod image_tool_result_gate_tests {
             model: "test-model".to_string(),
             request: crate::completion::CompletionRequest {
                 model: None,
-                preamble: None,
                 chat_history: vec![message::Message::User {
                     content: vec![message::UserContent::ToolResult(message::ToolResult {
                         call: message::ToolCallId::new_or_mint("call_1"),
@@ -4852,23 +4799,6 @@ mod image_tool_result_gate_tests {
             error.to_string().contains("does not accept an image"),
             "{error}"
         );
-    }
-
-    /// The legacy wire shape — a content part with no `type` key — still
-    /// deserializes. The struct this enum replaced carried
-    /// `#[serde(default)] r#type`, and `ToolResultContentValue` is untagged, so
-    /// a derived tagged enum would swallow the real cause into "data did not
-    /// match any variant" and break replay of stored histories.
-    #[test]
-    fn a_content_part_without_a_type_key_still_deserializes() {
-        let parsed: Message = serde_json::from_str(
-            r#"{"role":"tool","tool_call_id":"c1","content":[{"text":"ok"}]}"#,
-        )
-        .expect("a type-less text part is the tolerated legacy shape");
-        let Message::ToolResult { content, .. } = parsed else {
-            panic!("expected a tool result");
-        };
-        assert_eq!(content.as_text(), "ok");
     }
 
     /// A wire tool result carrying an image converts back into rig's types with

--- a/crates/rig-core/src/providers/openai/completion/streaming.rs
+++ b/crates/rig-core/src/providers/openai/completion/streaming.rs
@@ -321,7 +321,7 @@ where
         completion_request: CompletionRequest,
     ) -> Result<RawStreamingResult<StreamingCompletionResponse<Ext::StreamingUsage>>, CompletionError>
     {
-        let preamble = completion_request.preamble.clone();
+        let preamble = completion_request.system_instructions().map(str::to_owned);
         let record_telemetry_content = completion_request.record_telemetry_content;
         let options = CompletionModelOptions {
             strict_tools: self.strict_tools,

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -1338,21 +1338,12 @@ impl TryFrom<ResponsesRequestParams> for CompletionRequest {
         } = params;
         let chat_history = req.chat_history_with_documents();
         let model = req.model.clone().unwrap_or(model);
-        let preamble = req.preamble.take();
         let mut instruction_parts = Vec::new();
         let mut input = {
-            let mut partial_history = vec![];
-            partial_history.extend(chat_history);
-
-            let mut full_history: Vec<InputItem> = preamble
-                .map(InputItem::system_message)
-                .into_iter()
-                .collect();
-
-            for history_item in partial_history {
+            let mut full_history: Vec<InputItem> = Vec::new();
+            for history_item in chat_history {
                 full_history.extend(<Vec<InputItem>>::try_from(history_item)?);
             }
-
             full_history
         };
 
@@ -2527,7 +2518,7 @@ where
         &self,
         completion_request: crate::completion::CompletionRequest,
     ) -> Result<CompletionResponse, CompletionError> {
-        let system_instructions = completion_request.preamble.clone();
+        let system_instructions = completion_request.system_instructions().map(str::to_owned);
         let record_telemetry_content = completion_request.record_telemetry_content;
         let (request_model, request) = self.create_provider_request(completion_request, false)?;
         let span = CompletionSpanBuilder::new(
@@ -3550,7 +3541,6 @@ mod tests {
     fn weather_tool_request() -> completion::CompletionRequest {
         completion::CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![message::Message::user("what's the weather?")],
             documents: Vec::new(),
             tools: vec![weather_tool_definition()],
@@ -3720,8 +3710,10 @@ mod tests {
     fn request_with_preamble(preamble: &str) -> completion::CompletionRequest {
         completion::CompletionRequest {
             model: None,
-            preamble: Some(preamble.to_string()),
-            chat_history: vec![message::Message::user("Hello")],
+            chat_history: vec![
+                message::Message::system(preamble),
+                message::Message::user("Hello"),
+            ],
             documents: Vec::new(),
             tools: Vec::new(),
             temperature: None,
@@ -3736,7 +3728,6 @@ mod tests {
     fn system_only_request(system_text: &str) -> completion::CompletionRequest {
         completion::CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![completion::Message::system(system_text)],
             documents: Vec::new(),
             tools: Vec::new(),
@@ -4177,7 +4168,6 @@ mod tests {
     fn responses_direct_request_keeps_mid_conversation_system_messages_in_input() {
         let request = crate::completion::CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 completion::Message::system("System prompt"),
                 completion::Message::assistant("Earlier assistant turn"),
@@ -5112,8 +5102,8 @@ mod tests {
     fn mocked_second_turn_request_omits_unreplayable_reasoning() {
         let request = crate::completion::CompletionRequest {
             model: None,
-            preamble: Some("You are concise.".to_string()),
             chat_history: vec![
+                completion::Message::system("You are concise."),
                 completion::Message::User {
                     content: vec![message::UserContent::Text(Text::new(
                         "Think briefly, then answer.",
@@ -5619,7 +5609,6 @@ mod tests {
     fn url_pdf_in_full_completion_request_omits_filename() {
         let core_request = crate::completion::CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![url_pdf_message()],
             documents: Vec::new(),
             tools: Vec::new(),

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -1484,7 +1484,7 @@ where
         &self,
         completion_request: crate::completion::CompletionRequest,
     ) -> Result<streaming::RawStreamingResult<StreamingCompletionResponse>, CompletionError> {
-        let system_instructions = completion_request.preamble.clone();
+        let system_instructions = completion_request.system_instructions().map(str::to_owned);
         let record_telemetry_content = completion_request.record_telemetry_content;
         let (request_model, request) = self.create_provider_request(completion_request, true)?;
 

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -1461,10 +1461,7 @@ impl TryFrom<OpenRouterRequestParams<'_>> for OpenrouterCompletionRequest {
         let chat_history = req.chat_history_with_documents();
         let model = req.model.clone().unwrap_or_else(|| model.to_string());
 
-        let mut full_history: Vec<Message> = match &req.preamble {
-            Some(preamble) => vec![Message::system(preamble)],
-            None => vec![],
-        };
+        let mut full_history: Vec<Message> = vec![];
 
         let chat_history: Vec<Message> = chat_history
             .into_iter()
@@ -1728,7 +1725,6 @@ mod tests {
     fn test_openrouter_request_uses_request_model_override() {
         let request = CompletionRequest {
             model: Some("google/gemini-2.5-flash".to_string()),
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -1756,7 +1752,6 @@ mod tests {
     fn openrouter_request_carries_caller_max_tokens() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -1784,7 +1779,6 @@ mod tests {
     fn openrouter_params_include_direct_request_documents() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![crate::message::Message::user("What is glarb-glarb?")],
             documents: vec![crate::completion::request::Document {
                 id: "doc_1".to_string(),
@@ -1818,7 +1812,6 @@ mod tests {
     fn test_openrouter_request_uses_default_model_when_override_unset() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -1889,7 +1882,6 @@ mod tests {
 
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -1941,7 +1933,6 @@ mod tests {
 
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello".into()],
             documents: vec![],
             tools: vec![],
@@ -4438,8 +4429,10 @@ mod tests {
     fn prompt_caching_completion_request() -> CompletionRequest {
         CompletionRequest {
             model: None,
-            preamble: Some("You are a helpful assistant.".to_string()),
-            chat_history: vec![crate::message::Message::user("Hello")],
+            chat_history: vec![
+                crate::message::Message::system("You are a helpful assistant."),
+                crate::message::Message::user("Hello"),
+            ],
             documents: vec![],
             tools: vec![],
             temperature: None,

--- a/crates/rig-core/src/providers/perplexity.rs
+++ b/crates/rig-core/src/providers/perplexity.rs
@@ -166,7 +166,6 @@ mod tests {
         // SUPPORTS_TOOLS = false it must be dropped before that validation.
         let mut request = crate::completion::CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec!["Hello!".into()],
             documents: vec![],
             max_tokens: None,

--- a/crates/rig-core/src/providers/together/completion.rs
+++ b/crates/rig-core/src/providers/together/completion.rs
@@ -176,7 +176,6 @@ mod tests {
     #[test]
     fn together_request_conversion_errors_when_all_messages_are_filtered() {
         let request = crate::completion::CompletionRequest {
-            preamble: None,
             chat_history: vec![message::Message::Assistant {
                 id: None,
                 content: vec![message::AssistantContent::reasoning("hidden")],

--- a/crates/rig-core/src/providers/xai/api.rs
+++ b/crates/rig-core/src/providers/xai/api.rs
@@ -52,10 +52,7 @@ pub(crate) fn create_completion_request(
         tracing::warn!("Structured outputs currently not supported for xAI");
     }
     let model = req.model.clone().unwrap_or(model);
-    let mut input = req
-        .preamble
-        .as_ref()
-        .map_or_else(Vec::new, |p| vec![Message::system(p)]);
+    let mut input = Vec::new();
     for message in chat_history {
         input.extend(Vec::<Message>::try_from(message)?);
     }
@@ -526,7 +523,6 @@ mod tests {
     fn xai_direct_request_keeps_documents_after_system_messages() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 RigMessage::system("System prompt"),
                 RigMessage::assistant("Earlier assistant turn"),

--- a/crates/rig-core/src/test_utils/completion.rs
+++ b/crates/rig-core/src/test_utils/completion.rs
@@ -384,7 +384,6 @@ mod tests {
     fn request(prompt: &str) -> CompletionRequest {
         CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![Message::user(prompt)],
             documents: Vec::new(),
             tools: Vec::new(),

--- a/crates/rig-gemini-grpc/src/completion.rs
+++ b/crates/rig-gemini-grpc/src/completion.rs
@@ -187,7 +187,6 @@ pub(crate) fn create_grpc_request(
 ) -> Result<GenerateContentRequest, CompletionError> {
     let CompletionRequest {
         model: _,
-        preamble,
         chat_history,
         documents: _,
         tools,
@@ -210,13 +209,7 @@ pub(crate) fn create_grpc_request(
         contents.push(rig_message_to_grpc_content(msg)?);
     }
 
-    // Handle system instruction (preamble)
     let mut system_parts = Vec::new();
-    if let Some(preamble) = preamble
-        && !preamble.is_empty()
-    {
-        system_parts.push(text_part(preamble));
-    }
     for content in history_system {
         if !content.is_empty() {
             system_parts.push(text_part(content));
@@ -1062,7 +1055,6 @@ mod tests {
             "gemini-2.5-flash",
             CompletionRequest {
                 model: None,
-                preamble: None,
                 chat_history: vec![
                     // Driver-built: the executed name travels as data (a
                     // repair hook renamed the call: `sum` ran, not `add`).
@@ -1124,7 +1116,6 @@ mod tests {
             "gemini-2.5-flash",
             CompletionRequest {
                 model: None,
-                preamble: None,
                 chat_history: vec![message::Message::user("forecast in Berlin?")],
                 documents: Vec::new(),
                 tools: vec![tool],

--- a/crates/rig-run/src/response.rs
+++ b/crates/rig-run/src/response.rs
@@ -15,7 +15,6 @@ pub struct CompletionCall {
     /// Zero-valued usage is [`Usage`]'s documented sentinel for missing
     /// provider usage metrics; rig does not distinguish "reported all zeros"
     /// from "unreported".
-    #[serde(default, deserialize_with = "usage_null_as_default")]
     pub usage: Usage,
     /// Provider-assigned assistant message ID for this call, when reported.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -106,19 +105,6 @@ impl CompletionCall {
             provider_request_id: self.provider_request_id.clone(),
         }
     }
-}
-
-/// Tolerate `null` usage from data serialized before rig dropped the
-/// `Option<Usage>` encoding of missing provider usage metrics.
-///
-/// This tolerance requires a self-describing format such as JSON; data
-/// serialized with non-self-describing formats (e.g. bincode) from before the
-/// change cannot round-trip.
-fn usage_null_as_default<'de, D>(deserializer: D) -> Result<Usage, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    Ok(Option::<Usage>::deserialize(deserializer)?.unwrap_or_default())
 }
 
 /// The result of an agent run, returned by **both** the blocking

--- a/crates/rig-run/src/run.rs
+++ b/crates/rig-run/src/run.rs
@@ -2876,14 +2876,11 @@ mod tests {
     }
 
     #[test]
-    fn agent_run_deserializes_pre_monoid_suspended_state() {
-        // Pins `CompletionCall.usage`'s null tolerance on a suspended run:
-        // `"usage": null` (the pre-monoid Option encoding) must map to
-        // zero-valued usage and the run must resume. The tool calls use the
-        // current schema — the pre-provider-split `call_id` lift is gone
-        // (its ignore-the-key behavior is pinned in rig-core's message
-        // tests).
-        let fixture = r#"{"max_turns":2,"max_invalid_tool_call_retries":0,"tool_choice":null,"chat_history":null,"new_messages":[{"role":"user","content":[{"type":"text","text":"add things"}]},{"role":"assistant","id":null,"content":[{"type":"toolcall","id":"call_1","function":{"name":"add","arguments":{"x":1}},"signature":null,"additional_params":null}]}],"current_turn":1,"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15,"cached_input_tokens":0,"cache_creation_input_tokens":0,"tool_use_prompt_tokens":0,"reasoning_tokens":0},"completion_calls":[{"call_index":0,"usage":null}],"completion_call_index":1,"invalid_tool_call_retries":0,"rollback_pending":false,"streamed_completion_call_recorded":false,"state":{"ExecutingTools":[{"tool_call":{"id":"call_1","function":{"name":"add","arguments":{"x":1}},"signature":null,"additional_params":null},"preresolved_result":null,"internal_call_id":null}]}}"#;
+    fn agent_run_deserializes_suspended_state() {
+        // A suspended run persisted mid-`ExecutingTools` restores and resumes:
+        // the recorded call's usage loads, the pending tool call is re-issued,
+        // and the run advances to the next model call after results arrive.
+        let fixture = r#"{"max_turns":2,"max_invalid_tool_call_retries":0,"tool_choice":null,"chat_history":null,"new_messages":[{"role":"user","content":[{"type":"text","text":"add things"}]},{"role":"assistant","id":null,"content":[{"type":"toolcall","id":"call_1","function":{"name":"add","arguments":{"x":1}},"signature":null,"additional_params":null}]}],"current_turn":1,"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15,"cached_input_tokens":0,"cache_creation_input_tokens":0,"tool_use_prompt_tokens":0,"reasoning_tokens":0},"completion_calls":[{"call_index":0,"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0,"cached_input_tokens":0,"cache_creation_input_tokens":0,"tool_use_prompt_tokens":0,"reasoning_tokens":0}}],"completion_call_index":1,"invalid_tool_call_retries":0,"rollback_pending":false,"streamed_completion_call_recorded":false,"state":{"ExecutingTools":[{"tool_call":{"id":"call_1","function":{"name":"add","arguments":{"x":1}},"signature":null,"additional_params":null},"preresolved_result":null,"internal_call_id":null}]}}"#;
 
         let mut restored: AgentRun =
             serde_json::from_str(fixture).expect("old-format suspended run should deserialize");

--- a/crates/rig-vertexai/src/types/completion_request.rs
+++ b/crates/rig-vertexai/src/types/completion_request.rs
@@ -34,12 +34,6 @@ impl VertexCompletionRequest {
 
     pub fn system_instruction(&self) -> Option<vertexai::model::Content> {
         let mut system_texts = Vec::new();
-        if let Some(preamble) = self.0.preamble.as_ref()
-            && !preamble.is_empty()
-        {
-            system_texts.push(preamble.clone());
-        }
-
         for message in self.0.chat_history.iter() {
             if let rig_core::completion::Message::System { content } = message
                 && !content.is_empty()
@@ -315,7 +309,6 @@ mod tests {
     fn minimal_request() -> CompletionRequest {
         CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![Message::User {
                 content: vec![UserContent::Text(Text::new("test".to_string()))],
             }],
@@ -552,11 +545,10 @@ mod tests {
     #[test]
     fn test_system_instruction_from_preamble() {
         // Test that preamble converts to system instruction
-        let request = CompletionRequest {
-            model: None,
-            preamble: Some("You are a helpful assistant.".to_string()),
-            ..minimal_request()
-        };
+        let mut request = minimal_request();
+        request
+            .chat_history
+            .insert(0, Message::system("You are a helpful assistant."));
 
         let vertex_request = VertexCompletionRequest(request);
         let system_instruction = vertex_request.system_instruction();
@@ -575,7 +567,6 @@ mod tests {
     fn test_system_instruction_from_system_history_and_contents_skip_system() {
         let request = CompletionRequest {
             model: None,
-            preamble: None,
             chat_history: vec![
                 Message::system("System from history"),
                 Message::User {

--- a/tests/cassette_cache_prefix.rs
+++ b/tests/cassette_cache_prefix.rs
@@ -588,10 +588,12 @@ fn determinism_probe_request() -> CompletionRequest {
     };
 
     CompletionRequest {
-        preamble: Some("You are a deterministic serialization probe.".to_owned()),
-        chat_history: vec![Message::User {
-            content: vec![UserContent::text("probe")],
-        }],
+        chat_history: vec![
+            Message::system("You are a deterministic serialization probe."),
+            Message::User {
+                content: vec![UserContent::text("probe")],
+            },
+        ],
         documents: vec![document],
         tools: vec![
             tool("alpha_probe", "alpha_first", "alpha_second"),

--- a/tests/common/cache_conformance.rs
+++ b/tests/common/cache_conformance.rs
@@ -269,8 +269,9 @@ impl CacheProbe {
     /// harness exists to catch.
     fn request(&self, chat_history: Vec<Message>) -> CompletionRequest {
         CompletionRequest {
-            preamble: Some(self.preamble.clone()),
-            chat_history,
+            chat_history: std::iter::once(Message::system(self.preamble.clone()))
+                .chain(chat_history)
+                .collect(),
             documents: vec![],
             tools: self.tools.clone(),
             temperature: Some(0.0),

--- a/tests/common/reasoning.rs
+++ b/tests/common/reasoning.rs
@@ -254,8 +254,10 @@ pub(crate) async fn run_reasoning_roundtrip_streaming_with_final<M, F>(
     };
 
     let request = completion::CompletionRequest {
-        preamble: Some(agent.preamble.clone()),
-        chat_history: vec![turn1_prompt.clone()],
+        chat_history: vec![
+            Message::system(agent.preamble.clone()),
+            turn1_prompt.clone(),
+        ],
         documents: vec![],
         tools: vec![],
         temperature: None,
@@ -336,8 +338,12 @@ pub(crate) async fn run_reasoning_roundtrip_streaming_with_final<M, F>(
     };
 
     let request2 = completion::CompletionRequest {
-        preamble: Some(agent.preamble.clone()),
-        chat_history: vec![turn1_prompt, turn1_assistant, turn2_prompt],
+        chat_history: vec![
+            Message::system(agent.preamble.clone()),
+            turn1_prompt,
+            turn1_assistant,
+            turn2_prompt,
+        ],
         documents: vec![],
         tools: vec![],
         temperature: None,
@@ -387,8 +393,10 @@ where
     };
 
     let request = completion::CompletionRequest {
-        preamble: Some(agent.preamble.clone()),
-        chat_history: vec![turn1_prompt.clone()],
+        chat_history: vec![
+            Message::system(agent.preamble.clone()),
+            turn1_prompt.clone(),
+        ],
         documents: vec![],
         tools: vec![],
         temperature: None,
@@ -433,8 +441,12 @@ where
     };
 
     let request2 = completion::CompletionRequest {
-        preamble: Some(agent.preamble.clone()),
-        chat_history: vec![turn1_prompt, turn1_assistant, turn2_prompt],
+        chat_history: vec![
+            Message::system(agent.preamble.clone()),
+            turn1_prompt,
+            turn1_assistant,
+            turn2_prompt,
+        ],
         documents: vec![],
         tools: vec![],
         temperature: None,

--- a/tests/providers/gemini/cassette/cached_content_matrix.rs
+++ b/tests/providers/gemini/cassette/cached_content_matrix.rs
@@ -974,7 +974,6 @@ async fn streaming_against_a_cache_reports_the_cache_read() {
                     .with_cached_content(cache.name.clone());
 
                 let request = rig::completion::CompletionRequest {
-                    preamble: None,
                     chat_history: vec![rig::message::Message::User {
                         content: vec![rig::message::UserContent::text(
                             "Reply with exactly: streamed",

--- a/tests/providers/gemini/cassette/prompt_caching.rs
+++ b/tests/providers/gemini/cassette/prompt_caching.rs
@@ -363,7 +363,6 @@ async fn explicit_cache_hits_across_unrelated_conversations() {
                     "Say only the word beta, nothing else",
                 ] {
                     let request = rig::completion::CompletionRequest {
-                        preamble: None,
                         chat_history: vec![rig::message::Message::User {
                             content: vec![rig::message::UserContent::text(prompt)],
                         }],
@@ -474,8 +473,11 @@ fn mutation_request(
     temperature: f64,
 ) -> rig::completion::CompletionRequest {
     rig::completion::CompletionRequest {
-        preamble: system.map(str::to_owned),
-        chat_history: history,
+        chat_history: system
+            .map(rig::message::Message::system)
+            .into_iter()
+            .chain(history)
+            .collect(),
         documents: vec![],
         tools,
         temperature: Some(temperature),

--- a/tests/providers/llamacpp/cassette/sampling_matrix.rs
+++ b/tests/providers/llamacpp/cassette/sampling_matrix.rs
@@ -443,7 +443,6 @@ fn additional_params_wins_over_the_typed_field_it_collides_with() {
 
     let request = rig::completion::CompletionRequest {
         model: None,
-        preamble: None,
         chat_history: vec![rig::message::Message::User {
             content: vec![rig::message::UserContent::text("hi")],
         }],

--- a/tests/providers/openai/cassette/responses_input_item.rs
+++ b/tests/providers/openai/cassette/responses_input_item.rs
@@ -130,7 +130,6 @@ fn assistant_reasoning_mixed_content_serializes_text_content_and_summaries() {
 #[test]
 fn openai_responses_request_auto_adds_reasoning_encrypted_include() {
     let core_request = rig::completion::CompletionRequest {
-        preamble: None,
         chat_history: vec![CompletionMessage::user("hello")],
         documents: vec![],
         tools: vec![],
@@ -304,7 +303,6 @@ fn assistant_reasoning_redacted_only_serializes_as_encrypted_content() {
 fn openai_responses_request_reasoning_without_id_is_omitted_without_panicking() {
     let panic_result = catch_unwind(AssertUnwindSafe(|| {
         let request = rig::completion::CompletionRequest {
-            preamble: None,
             chat_history: vec![CompletionMessage::Assistant {
                 id: Some("assistant_message_id".to_string()),
                 content: vec![AssistantContent::Reasoning(Reasoning::new("thought"))],
@@ -471,7 +469,6 @@ fn user_tool_result_without_provider_id_serializes_the_minted_call_id() {
 fn openai_responses_invalid_additional_params_returns_error_without_panicking() {
     let panic_result = catch_unwind(AssertUnwindSafe(|| {
         let request = rig::completion::CompletionRequest {
-            preamble: None,
             chat_history: vec![CompletionMessage::user("hello")],
             documents: vec![],
             tools: vec![],
@@ -499,7 +496,6 @@ fn openai_responses_invalid_additional_params_returns_error_without_panicking() 
 #[test]
 fn openai_responses_request_preserves_prompt_cache_parameters() {
     let request = rig::completion::CompletionRequest {
-        preamble: None,
         chat_history: vec![CompletionMessage::user("hello")],
         documents: vec![],
         tools: vec![],


### PR DESCRIPTION
## Summary

Removes every remaining backwards-compatibility shim. None had a live producer in the tree; each existed only so an older caller or an older persisted record kept working.

| Shim | Where | Replacement |
|---|---|---|
| `CompletionRequest::preamble` field + `CompletionRequestBuilder::without_preamble` | rig-core + every provider, rig-bedrock, rig-vertexai, rig-candle, rig-gemini-grpc | Leading `Message::System` in `chat_history` (where the builder already put it); new `CompletionRequest::system_instructions() -> Option<&str>` for readers |
| 13 `#[deprecated]` retired model constants | deepseek, cohere, mistral | The dated / current constants their notes named |
| `LlamaModel`, `ModelFamily` aliases | rig-candle | `CandleModel`, `ConversationProtocol` |
| `serde(alias = "audio")` on `UserContent::Audio` | openai | `input_audio` only (the real wire tag) |
| Hand-written type-less-tolerant `ToolResultContent` decoder | openai | Derived `#[serde(tag = "type")]` |
| `usage: null` tolerance on `CompletionCall` | rig-run | A `Usage` object is required |

**Behaviour change worth flagging:** telemetry `gen_ai.system_instructions` was read from the always-`None` `preamble` field, so it never recorded anything. It is now populated from the leading system message.

**Deliberately kept** (real third-party wire behaviour, not our shims): OpenAI `developer` role alias, Gemini-gateway `model` role alias, Ollama `<think>` splitting, rerank `score`/`text` aliases.

`MIGRATING.md` has an entry under `## 0.41 → next`.

## Tests

- No cassette changed — the preamble path was funnel-equivalent, so recorded request bodies are byte-identical.
- 3 tests deleted because their only purpose was pinning a removed tolerance: `without_preamble_removes_legacy_preamble_injection`, `a_content_part_without_a_type_key_still_deserializes`, `prompt_response_deserializes_pre_monoid_null_usage_format` (plus one inline `usage: null` assertion block).
- 2 tests rewritten to current shapes: `agent_run_deserializes_suspended_state` (still covers resume), openai `test_deserialize_message` (`input_audio` tag). One golden JSON dropped `"preamble": null`.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features` (0 warnings), `cargo check --workspace --all-targets`, and `cargo nextest run --features bedrock` over rig-core, rig-agent, rig-run, rig-candle, rig-bedrock, rig-vertexai, rig-gemini-grpc and the facade: 5916 run, all passing.
