### PR TITLE
refactor: bound hygiene — raw Send/Sync in wasm-built code becomes precise

### DIFF
--- a/crates/rig-agent/src/agent/builder.rs
+++ b/crates/rig-agent/src/agent/builder.rs
@@ -433,7 +433,7 @@ forward_into_tool_builder! {
     /// Transitions the builder to the `WithBuilderTools` state.
     retrieved_tools(
         sample: usize,
-        index: impl VectorStoreIndexDyn + Send + Sync + 'static,
+        index: impl VectorStoreIndexDyn + 'static,
         toolset: ToolSet
     );
 }
@@ -491,7 +491,7 @@ impl AgentBuilder<WithBuilderTools> {
     pub fn retrieved_tools(
         self,
         sample: usize,
-        index: impl VectorStoreIndexDyn + Send + Sync + 'static,
+        index: impl VectorStoreIndexDyn + 'static,
         toolset: ToolSet,
     ) -> Self {
         self.map_server(|server| server.retrieved_tools(sample, index, toolset))

--- a/crates/rig-agent/src/tool/server.rs
+++ b/crates/rig-agent/src/tool/server.rs
@@ -32,7 +32,7 @@ pub type ToolRegistrySnapshot = ToolCatalog;
 /// Shared state behind a `ToolServerHandle`.
 struct ToolServerState {
     /// Vector indexes used to select retrieval-only tools for each prompt.
-    retrieval_indexes: Vec<(usize, Arc<dyn VectorStoreIndexDyn + Send + Sync>)>,
+    retrieval_indexes: Vec<(usize, Arc<dyn VectorStoreIndexDyn>)>,
     /// The authoritative ordered registry for execution and exposure.
     toolset: ToolSet,
     /// Generation tokens for registrations owned by external tool sources.
@@ -68,7 +68,7 @@ pub use rig_core::tool::{ManagedToolSink, ManagedToolToken};
 /// Accumulates tools and configuration, then produces a shared handle via
 /// [`run()`](ToolServer::run).
 pub struct ToolServer {
-    retrieval_indexes: Vec<(usize, Arc<dyn VectorStoreIndexDyn + Send + Sync>)>,
+    retrieval_indexes: Vec<(usize, Arc<dyn VectorStoreIndexDyn>)>,
     toolset: ToolSet,
 }
 
@@ -123,7 +123,7 @@ impl ToolServer {
     pub fn retrieved_tools(
         mut self,
         sample: usize,
-        index: impl VectorStoreIndexDyn + Send + Sync + 'static,
+        index: impl VectorStoreIndexDyn + 'static,
         toolset: ToolSet,
     ) -> Self {
         self.retrieval_indexes.push((sample, Arc::new(index)));

--- a/crates/rig-core/src/audio_generation.rs
+++ b/crates/rig-core/src/audio_generation.rs
@@ -14,9 +14,15 @@ crate::provider_response::provider_error_enum!(
     /// returned with a 2xx status surfaces as [`Self::ProviderResponse`] (for
     /// example the Hyperbolic audio path). Both are read by the helpers.
     AudioGenerationError, "audio generation" {
+        #[cfg(not(target_family = "wasm"))]
         /// Error building the audio generation request
         #[error("RequestError: {0}")]
         RequestError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+        #[cfg(target_family = "wasm")]
+        /// Error building the audio generation request
+        #[error("RequestError: {0}")]
+        RequestError(#[from] Box<dyn std::error::Error + 'static>),
     }
 );
 

--- a/crates/rig-core/src/embeddings/builder.rs
+++ b/crates/rig-core/src/embeddings/builder.rs
@@ -90,7 +90,7 @@ where
 impl<M, T> EmbeddingsBuilder<M, T>
 where
     M: EmbeddingModel,
-    T: Embed + Send,
+    T: Embed + crate::wasm_compat::WasmCompatSend,
 {
     /// Generate embeddings for all documents in the builder.
     ///

--- a/crates/rig-core/src/image_generation.rs
+++ b/crates/rig-core/src/image_generation.rs
@@ -9,9 +9,15 @@ use std::sync::Arc;
 
 crate::provider_response::provider_error_enum!(
     ImageGenerationError, "image generation" {
+        #[cfg(not(target_family = "wasm"))]
         /// Error building the image generation request
         #[error("RequestError: {0}")]
         RequestError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+        #[cfg(target_family = "wasm")]
+        /// Error building the image generation request
+        #[error("RequestError: {0}")]
+        RequestError(#[from] Box<dyn std::error::Error + 'static>),
     }
 );
 

--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -272,7 +272,7 @@ impl<H> client::ClientBuilder<ChatGPTBuilder, crate::markers::Missing, H> {
 impl<H> ClientBuilder<H> {
     pub fn on_device_code<F>(self, handler: F) -> Self
     where
-        F: Fn(auth::DeviceCodePrompt) + Send + Sync + 'static,
+        F: Fn(auth::DeviceCodePrompt) + WasmCompatSend + WasmCompatSync + 'static,
     {
         self.over_ext(|mut ext| {
             ext.device_code_handler = auth::DeviceCodeHandler::new(handler);

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -303,7 +303,7 @@ impl<H> client::ClientBuilder<CopilotBuilder, crate::markers::Missing, H> {
 impl<H> ClientBuilder<H> {
     pub fn on_device_code<F>(self, handler: F) -> Self
     where
-        F: Fn(auth::DeviceCodePrompt) + Send + Sync + 'static,
+        F: Fn(auth::DeviceCodePrompt) + WasmCompatSend + WasmCompatSync + 'static,
     {
         self.over_ext(|mut ext| {
             ext.device_code_handler = auth::DeviceCodeHandler::new(handler);

--- a/crates/rig-core/src/providers/gemini/image_generation.rs
+++ b/crates/rig-core/src/providers/gemini/image_generation.rs
@@ -10,6 +10,7 @@ use crate::http_client::HttpClientExt;
 use crate::image_generation::{
     ImageGenerationError, ImageGenerationRequest, NormalizeImageGenerationResponse,
 };
+use crate::wasm_compat::WasmCompatSend;
 use crate::{http_client, image_generation};
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
@@ -58,7 +59,7 @@ impl NormalizeImageGenerationResponse for GenerateContentResponse {
 
 impl<T> ImageGenerationModel<T>
 where
-    T: HttpClientExt + Clone + Send + 'static,
+    T: HttpClientExt + Clone + WasmCompatSend + 'static,
 {
     /// Perform the generation and return Gemini's native
     /// [`GenerateContentResponse`] instead of the normalized
@@ -98,7 +99,7 @@ where
 
 impl<T> image_generation::ImageGenerationModel for ImageGenerationModel<T>
 where
-    T: HttpClientExt + Clone + Send + 'static,
+    T: HttpClientExt + Clone + WasmCompatSend + 'static,
 {
     async fn image_generation(
         &self,
@@ -122,7 +123,7 @@ where
 
 impl<T> crate::client::ConstructImageGenerationModel<Client<T>> for ImageGenerationModel<T>
 where
-    T: HttpClientExt + Clone + Send + 'static,
+    T: HttpClientExt + Clone + WasmCompatSend + 'static,
 {
     fn construct(client: &Client<T>, model: String) -> Self {
         Self::new(client.clone(), model)

--- a/crates/rig-core/src/providers/huggingface/image_generation.rs
+++ b/crates/rig-core/src/providers/huggingface/image_generation.rs
@@ -4,6 +4,7 @@ use crate::image_generation;
 use crate::image_generation::{
     ImageGenerationError, ImageGenerationRequest, NormalizeImageGenerationResponse,
 };
+use crate::wasm_compat::WasmCompatSend;
 use serde_json::json;
 
 #[allow(non_upper_case_globals)]
@@ -49,7 +50,7 @@ impl<T> ImageGenerationModel<T> {
 
 impl<T> ImageGenerationModel<T>
 where
-    T: HttpClientExt + Send + Clone + 'static,
+    T: HttpClientExt + Clone + WasmCompatSend + 'static,
 {
     /// Perform the generation and return the provider's native response (the
     /// image bytes) instead of the normalized
@@ -102,7 +103,7 @@ where
 
 impl<T> image_generation::ImageGenerationModel for ImageGenerationModel<T>
 where
-    T: HttpClientExt + Send + Clone + 'static,
+    T: HttpClientExt + Clone + WasmCompatSend + 'static,
 {
     async fn image_generation(
         &self,
@@ -126,7 +127,7 @@ where
 
 impl<T> crate::client::ConstructImageGenerationModel<Client<T>> for ImageGenerationModel<T>
 where
-    T: HttpClientExt + Send + Clone + 'static,
+    T: HttpClientExt + Clone + WasmCompatSend + 'static,
 {
     fn construct(client: &Client<T>, model: String) -> Self {
         Self::new(client.clone(), model)

--- a/crates/rig-core/src/providers/hyperbolic.rs
+++ b/crates/rig-core/src/providers/hyperbolic.rs
@@ -271,7 +271,7 @@ mod audio_generation {
 
     impl<T> AudioGenerationModel<T>
     where
-        T: HttpClientExt + Clone + Send + 'static,
+        T: HttpClientExt + Clone + crate::wasm_compat::WasmCompatSend + 'static,
     {
         /// Perform the generation and return Hyperbolic's native response
         /// (base64 audio) instead of the normalized
@@ -323,7 +323,7 @@ mod audio_generation {
 
     impl<T> audio_generation::AudioGenerationModel for AudioGenerationModel<T>
     where
-        T: HttpClientExt + Clone + Send + 'static,
+        T: HttpClientExt + Clone + crate::wasm_compat::WasmCompatSend + 'static,
     {
         async fn audio_generation(
             &self,
@@ -345,7 +345,7 @@ mod audio_generation {
 
     impl<T> crate::client::ConstructAudioGenerationModel<Client<T>> for AudioGenerationModel<T>
     where
-        T: HttpClientExt + Clone + Send + 'static,
+        T: HttpClientExt + Clone + crate::wasm_compat::WasmCompatSend + 'static,
     {
         fn construct(client: &Client<T>, language: String) -> Self {
             Self {

--- a/crates/rig-core/src/providers/internal/auth.rs
+++ b/crates/rig-core/src/providers/internal/auth.rs
@@ -2,6 +2,7 @@
 //! Copilot). Re-exported from each provider's `auth` module as `AuthError`.
 
 use crate::http_client::{self, HttpClientExt};
+use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
 use std::sync::Arc;
 
 /// Device authorization details surfaced to a provider callback.
@@ -13,15 +14,23 @@ pub struct DeviceCodePrompt {
     pub user_code: String,
 }
 
+/// The stored device-code callback: thread-safe on every target where the
+/// `WasmCompat*` markers mean `Send`/`Sync`, unconstrained on browser wasm
+/// (where the callback is never invoked — the wasm authenticators ignore it).
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+pub(crate) type DeviceCodeCallback = dyn Fn(DeviceCodePrompt) + Send + Sync;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) type DeviceCodeCallback = dyn Fn(DeviceCodePrompt);
+
 /// Optional callback invoked when an OAuth device flow needs user action.
 #[derive(Clone, Default)]
-pub struct DeviceCodeHandler(pub(crate) Option<Arc<dyn Fn(DeviceCodePrompt) + Send + Sync>>);
+pub struct DeviceCodeHandler(pub(crate) Option<Arc<DeviceCodeCallback>>);
 
 impl DeviceCodeHandler {
     /// Wraps a device-code callback.
     pub fn new<F>(handler: F) -> Self
     where
-        F: Fn(DeviceCodePrompt) + Send + Sync + 'static,
+        F: Fn(DeviceCodePrompt) + WasmCompatSend + WasmCompatSync + 'static,
     {
         Self(Some(Arc::new(handler)))
     }

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -758,7 +758,7 @@ impl NdjsonBuffer {
 
 impl<T> CompletionModel<T>
 where
-    T: HttpClientExt + Clone + Send + 'static,
+    T: HttpClientExt + Clone + WasmCompatSend + 'static,
 {
     /// Execute a completion and return Ollama's own wire response.
     ///
@@ -1037,7 +1037,7 @@ impl internal::adapter::WireAdapter for OllamaAdapter {
 
 impl<T> completion::CompletionModel for CompletionModel<T>
 where
-    T: HttpClientExt + Clone + Send + 'static,
+    T: HttpClientExt + Clone + WasmCompatSend + 'static,
 {
     async fn completion(
         &self,

--- a/crates/rig-core/src/vector_store/in_memory_store.rs
+++ b/crates/rig-core/src/vector_store/in_memory_store.rs
@@ -8,6 +8,7 @@ use ordered_float::OrderedFloat;
 use serde::{Serialize, de::DeserializeOwned};
 
 use super::{IndexStrategy, VectorStoreError, VectorStoreIndex, request::VectorSearchRequest};
+use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
 use crate::{
     embeddings::{Embedding, EmbeddingModel, EmbeddingModelHandle, distance::VectorDistance},
     vector_store::request::Filter,
@@ -418,7 +419,9 @@ impl<D: Serialize> InMemoryVectorIndex<D> {
     }
 }
 
-impl<D: Serialize + Sync + Send + Eq> VectorStoreIndex for InMemoryVectorIndex<D> {
+impl<D: Serialize + WasmCompatSend + WasmCompatSync + Eq> VectorStoreIndex
+    for InMemoryVectorIndex<D>
+{
     type Filter = Filter<serde_json::Value>;
 
     async fn top_n<T: DeserializeOwned>(


### PR DESCRIPTION
## Summary

First implemented theme of the ownership/lifetimes/bounds audit: **bound hygiene**. Every raw `Send`/`Sync` bound in wasm-compiled code was classified; the over-constraining ones become the `WasmCompat*` form, gain their missing wasm sibling, or disappear because a supertrait already provides them.

On native targets every signature is unchanged in effect (`WasmCompatSend: Send` + blanket impl — the native build is the proof). On browser wasm the changed signatures are strict relaxations — more programs compile, none break.

| Finding | Site | Fix |
|---|---|---|
| Copy-drift raw `Send` on inherent impls | ollama, hyperbolic, huggingface + gemini image generation (11 impls) | → `WasmCompatSend`, matching the shared `internal/image_generation` helper these predate |
| Missing wasm error variant | `ImageGenerationError`, `AudioGenerationError` `RequestError` | added the `#[cfg(target_family = "wasm")]` non-`Send` sibling that `TranscriptionError`/`CompletionError`/`VectorStoreError` already have |
| Raw bounds where the trait already uses markers | `InMemoryVectorIndex`'s `VectorStoreIndex` impl; `EmbeddingsBuilder` build impl | → markers |
| `Send + Sync` closures forced on wasm users for a handler wasm ignores | `DeviceCodeHandler` (chatgpt/copilot device flow) | cfg-paired `DeviceCodeCallback` alias (browser-wasm predicate, same as `wasm_compat.rs`); `new`/`on_device_code` take marker bounds |
| Redundant auto-trait bounds | rig-agent retrieval indexes: `Arc<dyn VectorStoreIndexDyn + Send + Sync>`, `impl VectorStoreIndexDyn + Send + Sync + 'static` | dropped outright — `VectorStoreIndexDyn`'s `WasmCompat*` supertraits already provide `Send + Sync` on native and correctly nothing on browser wasm (clippy `implied_bounds_in_impls` confirms) |

**Read in full and deliberately left alone:** the already-cfg-paired boxed-error enums and stream aliases; native-only compile-time `assert_send_sync*` contracts; `#[cfg(test)]` compile-coverage modules; `tokio::spawn` bounds in the rig-reqwest/rig-tungstenite runtimes (load-bearing); `internal/device_auth.rs` (only native authenticators call it); every crate outside the CI wasm matrix, including rmcp (native-only by design).

Raw `+ Send` count 141 → 120, `+ Sync` 116 → 107 workspace-wide; the survivors are all native-only or load-bearing.

## Verification

- `cargo check --target wasm32-unknown-unknown` for the full CI matrix (rig-core, rig-run, rig-reqwest, rig-agent, rig, rig-candle) plus rig-core `--all-features`: green
- `cargo check --workspace --all-targets --all-features`, `cargo clippy --workspace --all-targets --all-features` (0 warnings), `cargo fmt --check`: green
- `cargo nextest run -p rig-core -p rig-agent -p rig`: 5448 passed, 0 failed; rig-agent rerun after the final simplification: 440 passed

No test changed, no cassette touched, no public item removed.
