### PR TITLE
refactor: ownership audit themes 2–7 — 'static precision and clone hygiene; themes 3/5/6/7 dispositioned

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -806,6 +806,15 @@ handed back a silently short list.
 
 ## 0.41 → next
 
+### Ownership audit: relaxed generic bounds, fewer clones
+
+No caller-visible breakage — every public signature change is a relaxation.
+The OpenAI-compatible embeddings impls (`GenericEmbeddingModel` and its
+`ConstructEmbeddingModel` impl) no longer require `H: 'static` /
+`Ext: 'static`; code that compiled before still compiles. Internal clone
+reductions in the agent loop (tool-result assembly, run-spec application)
+change no behaviour and no wire bytes.
+
 ### Compatibility shims are gone: `CompletionRequest::preamble`, retired model constants, `rig-candle` aliases, tolerant decoders
 
 Every remaining backwards-compatibility shim was removed in one sweep. None

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -86,7 +86,8 @@ pub(crate) async fn build_prepared_completion_request(
         .map_err(|_| CompletionError::RequestError("Failed to get tool definitions".into()))?;
 
     let mut spec = runner.config.run_spec();
-    spec.output_tool_description = runner.output_tool_description.clone();
+    spec.output_tool_description
+        .clone_from(&runner.output_tool_description);
     spec.augment_output_preamble = runner.augment_output_preamble;
 
     let prepared = rig_run::prepare_request(
@@ -264,12 +265,12 @@ impl AgentConfig {
         &mut self,
         spec: &rig_run::RunSpec,
     ) -> Result<(), serde_json::Error> {
-        self.preamble = spec.preamble.clone();
-        self.static_context = spec.static_context.clone();
-        self.additional_params = spec.additional_params.clone();
+        self.preamble.clone_from(&spec.preamble);
+        self.static_context.clone_from(&spec.static_context);
+        self.additional_params.clone_from(&spec.additional_params);
         self.max_tokens = spec.max_tokens;
         self.temperature = spec.temperature;
-        self.tool_choice = spec.tool_choice.clone();
+        self.tool_choice.clone_from(&spec.tool_choice);
         self.max_turns = spec.effective_max_turns();
         self.output_schema = spec
             .output_schema

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -735,38 +735,33 @@ pub(crate) async fn run_single_tool(
     // and stop hooks from leaking raw tool output through telemetry.
     record_tool_result(&tool_span, &exec);
 
-    match result_action {
-        ToolResultAction::Stop(reason) => Err(PromptError::prompt_cancelled(
-            error_history.to_vec(),
-            reason,
-        )),
+    let result_content = match result_action {
+        ToolResultAction::Stop(reason) => {
+            return Err(PromptError::prompt_cancelled(
+                error_history.to_vec(),
+                reason,
+            ));
+        }
         ToolResultAction::Rewrite(replacement) => {
             if record_content {
                 tool_span.record("gen_ai.tool.call.result", replacement.render());
             }
-            Ok(ToolCallOutcome {
-                content: tool_result_output(
-                    tool_call.id.clone(),
-                    tool_call.provider.clone(),
-                    tool_call.function.name.clone(),
-                    replacement,
-                ),
-                execution,
-            })
+            replacement
         }
         ToolResultAction::Keep => {
             if record_content {
                 tool_span.record("gen_ai.tool.call.result", exec.output().render());
             }
-            let content = tool_result_output(
-                tool_call.id.clone(),
-                tool_call.provider.clone(),
-                tool_call.function.name.clone(),
-                exec.output().clone(),
-            );
-            Ok(ToolCallOutcome { content, execution })
+            exec.output().clone()
         }
-    }
+    };
+    let content = tool_result_output(
+        tool_call.id.clone(),
+        tool_call.provider.clone(),
+        tool_call.function.name.clone(),
+        result_content,
+    );
+    Ok(ToolCallOutcome { content, execution })
 }
 
 fn record_tool_result(span: &tracing::Span, result: &ToolResult) {

--- a/crates/rig-core/src/client/completion.rs
+++ b/crates/rig-core/src/client/completion.rs
@@ -178,7 +178,7 @@ mod tests {
 
         impl<H> CompletionModel for ExternalGenericModel<H>
         where
-            H: Clone + Send + Sync + std::fmt::Debug + 'static,
+            H: Clone + Send + Sync + std::fmt::Debug,
         {
             async fn completion(
                 &self,
@@ -203,7 +203,7 @@ mod tests {
 
         impl<H> ConstructCompletionModel<Client<ExternalExt, H>> for ExternalGenericModel<H>
         where
-            H: Clone + Send + Sync + std::fmt::Debug + 'static,
+            H: Clone + Send + Sync + std::fmt::Debug,
         {
             fn construct(client: &Client<ExternalExt, H>, model: String) -> Self {
                 Self {

--- a/crates/rig-core/src/providers/openai/embedding.rs
+++ b/crates/rig-core/src/providers/openai/embedding.rs
@@ -233,9 +233,8 @@ pub(crate) fn model_dimensions_from_identifier(identifier: &str) -> Option<usize
 
 impl<Ext, H> GenericEmbeddingModel<Ext, H>
 where
-    crate::client::Client<Ext, H>:
-        HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
-    Ext: OpenAIEmbeddingsCompatible + Clone + 'static,
+    crate::client::Client<Ext, H>: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync,
+    Ext: OpenAIEmbeddingsCompatible + Clone,
 {
     /// Perform the request and return the provider's native wire response
     /// instead of the normalized [`embeddings::EmbeddingResponse`]. Same
@@ -357,9 +356,8 @@ where
 
 impl<Ext, H> embeddings::EmbeddingModel for GenericEmbeddingModel<Ext, H>
 where
-    crate::client::Client<Ext, H>:
-        HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
-    Ext: OpenAIEmbeddingsCompatible + Clone + 'static,
+    crate::client::Client<Ext, H>: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync,
+    Ext: OpenAIEmbeddingsCompatible + Clone,
 {
     fn max_documents(&self) -> usize {
         Ext::MAX_DOCUMENTS
@@ -443,9 +441,8 @@ where
 impl<Ext, H> crate::client::ConstructEmbeddingModel<crate::client::Client<Ext, H>>
     for GenericEmbeddingModel<Ext, H>
 where
-    crate::client::Client<Ext, H>:
-        HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
-    Ext: OpenAIEmbeddingsCompatible + Clone + 'static,
+    crate::client::Client<Ext, H>: HttpClientExt + Clone + WasmCompatSend + WasmCompatSync,
+    Ext: OpenAIEmbeddingsCompatible + Clone,
 {
     fn construct(
         client: &crate::client::Client<Ext, H>,

--- a/crates/rig-run/src/run.rs
+++ b/crates/rig-run/src/run.rs
@@ -1722,7 +1722,7 @@ impl AgentRun {
                     call: invalid.tool_call.id.clone(),
                     provider: invalid.tool_call.provider.clone(),
                     name: invalid.tool_call.function.name.clone(),
-                    content: vec![ToolResultContent::text(reason.clone())],
+                    content: vec![ToolResultContent::text(reason.as_str())],
                 };
                 self.abandon_streamed_turn(
                     partial,


### PR DESCRIPTION
## Summary

Second and final run of the ownership/lifetimes/bounds audit, delivering the remaining themes (2–7) as sanctioned in one PR — **one commit per theme that produced changes**, each independently green. The headline is honest negative results with receipts: after four prior ownership sweeps, most remaining ceremony is load-bearing, and each empty theme carries the evidence in the findings document.

### Commit 1 — theme 2, `'static` precision (`9a674edb4`)

A mechanized per-file experiment (strip every `+ 'static`, let the owning crate's check demand back what's load-bearing, workspace recheck after) over the 16 highest-density files: **13 files' bounds are load-bearing** (http erasure, spawn, `Box<dyn>` storage). Kept removals: the generic OpenAI-compatible embeddings impls no longer require `H: 'static` / `Ext: 'static` (they borrow, never store — public relaxation, nothing breaks), plus two test-module bounds. `embeddings/embedding.rs` passed the experiment but was reverted: its removals were the deliberate symmetric `dyn Error` cfg-pair spellings. Re-read adjudications: `ConversationMemory` is already `<'a>`-bound (the `_owned` companions are documented design), `tool/portable.rs` is already the exemplary HRTB shape, the `IntoFuture` impls require `'static`, `LazyBody`'s `'static` is design.

### Commit 2 — theme 4, clone hygiene (`5eafb0b89`) (+ theme 7's yield)

Root analysis first: of ~520 textual `.clone()` hits in the agent loop, only **107 are production** (the rest are `#[cfg(test)]`), in 9 clusters. Implemented the behaviour-preserving local fixes: tool-result id/provider/name triple hoisted out of the Keep/Rewrite match arms; streamed-skip reason no longer cloned before its move; the five `assigning_clones` sites → `clone_from` — the *entire* yield of a workspace-wide clippy advisory harvest (redundant_clone, unnecessary_to_owned, implicit_clone, option_as_ref_deref, map_clone, needless_collect, trivially_copy_pass_by_ref, …).

### Dispositioned without commits (full evidence in the audit findings doc)

- **Theme 3 (owned strings)**: zero runtime-populated `&'static str` sites; `Box::leak` count 0. All 455 `&'static str` are compile-time metadata.
- **Theme 5 (interior mutability)**: all 92 `Arc<Mutex` / 7 `Arc<RwLock` classified — 7 production fields, every one shared by design (tool server handle, MCP refresh coalescing, auth token refresh serialization, shared conversation memory, prepared-statement cache); the one swap-only candidate (`runner.rs` `error_usage`) is kept because its writers live inside the drive future while the caller holds the other `Arc`, and the real fix (usage in `PromptError`) is error-API design churn.
- **Theme 6 (erasure)**: the boundary decision already exists and is enforced (erased model/tool set in rig-core, preparation in rig-run). Every "single-implementor" trait survived as a seam or blanket extension — several counts were artifacts of macro-generated impls (`AnthropicCompatibleProvider` has 5+, `ColumnValue` 7, `NormalizeEmbeddingResponse` 6+).
- **Theme 7 (Copy/derive/bool)**: derive-hygiene lints returned zero production hits; multi-bool signatures are test fixtures; no bool cluster met the enum-conversion bar outside wire-mirroring fields.

### Recorded design follow-ups (deliberately not in this PR)

`Arc<[PendingToolCall]>`/`Arc<PromptResponse>` in the persisted `RunState` and `Arc<BTreeSet<String>>` tool-name sets (both blocked on enabling serde's `rc` feature); borrowed `AgentRunStep::CallModel`; `Arc<[Message]>`/`Cow` history in `PromptError`+`InvalidToolCallContext`; hook-before-ingestion reordering (declined: changes observable hook timing).

## Metrics

`+ 'static` 473 → 465; production clones in the agent loop 107 → ~99; every other audit metric unchanged by design. MIGRATING.md notes the (purely relaxing) public bound changes.

## Verification

- `cargo fmt --check`; `cargo check --workspace --all-targets --all-features`; `cargo clippy --workspace --all-targets --all-features` 0 warnings
- wasm matrix: rig-core (default + all-features), rig-run, rig-reqwest, rig-agent, rig, rig-candle — all green
- `cargo nextest run --no-fail-fast --features bedrock`: **5893 passed, 0 failed**, 203 skipped
- No test deleted or weakened; no cassette touched.
