### PR TITLE
chore: the workspace toolchain is 1.95.0

### DIFF
--- a/crates/rig-core/src/json_utils.rs
+++ b/crates/rig-core/src/json_utils.rs
@@ -44,7 +44,7 @@ where
     V: Serialize,
 {
     let mut entries: Vec<_> = map.iter().collect();
-    entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+    entries.sort_by_key(|(key, _)| *key);
     serializer.collect_map(entries)
 }
 
@@ -80,7 +80,7 @@ pub fn to_canonical_string(value: &serde_json::Value) -> String {
         match value {
             serde_json::Value::Object(map) => {
                 let mut entries: Vec<_> = map.iter().collect();
-                entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+                entries.sort_by_key(|(key, _)| *key);
                 let mut out = serde_json::Map::new();
                 for (key, value) in entries {
                     out.insert(key.clone(), sorted(value));

--- a/crates/rig-core/src/providers/internal/sequence_law.rs
+++ b/crates/rig-core/src/providers/internal/sequence_law.rs
@@ -108,10 +108,8 @@ impl SequenceLaws {
                 | StreamEvent::BlockDelta {
                     id,
                     delta: Delta::Reasoning { .. },
-                } => {
-                    if id.is_minted() {
-                        self.open_minted_reasoning.insert(id.clone());
-                    }
+                } if id.is_minted() => {
+                    self.open_minted_reasoning.insert(id.clone());
                 }
                 // A close — bare, signed, or a whole-block restatement —
                 // ends the open part. For a never-opened key the remove is a

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.95.0"
 profile = "default"
 components = [ "rust-analyzer", "rust-src" ]
 targets = [ "wasm32-unknown-unknown" ]

--- a/tests/common/cassettes.rs
+++ b/tests/common/cassettes.rs
@@ -1351,15 +1351,11 @@ fn scrub_local_filesystem_paths(text: &str) -> String {
     let mut rest = text;
     let mut consumed = 0usize;
 
-    'outer: loop {
-        let Some((prefix, at)) = HOME_PREFIXES
-            .iter()
-            .filter_map(|p| rest.find(*p).map(|i| (*p, i)))
-            .min_by_key(|(_, i)| *i)
-        else {
-            break;
-        };
-
+    'outer: while let Some((prefix, at)) = HOME_PREFIXES
+        .iter()
+        .filter_map(|p| rest.find(*p).map(|i| (*p, i)))
+        .min_by_key(|(_, i)| *i)
+    {
         // Anchored: the value must begin here. Anything else is a path segment
         // inside a larger string (a URL, prose) and is not ours to rewrite.
         let absolute = consumed + at;

--- a/tests/common/support.rs
+++ b/tests/common/support.rs
@@ -658,11 +658,9 @@ pub(crate) async fn assert_stream_contains_zero_arg_tool_call_named(
             StreamEvent::BlockEnd {
                 block: Some(AssistantContent::ToolCall(tool_call)),
                 ..
-            } => {
-                if tool_call.function.name == expected_name {
-                    assert_eq!(tool_call.function.arguments, json!({}));
-                    saw_matching_tool_call = true;
-                }
+            } if tool_call.function.name == expected_name => {
+                assert_eq!(tool_call.function.arguments, json!({}));
+                saw_matching_tool_call = true;
             }
             _ => {}
         }

--- a/tests/fixtures/bevy_bus_host/rust-toolchain.toml
+++ b/tests/fixtures/bevy_bus_host/rust-toolchain.toml
@@ -1,6 +1,7 @@
-# bevy 0.19.1 requires rustc 1.95; the main workspace pins 1.94. The
-# fixture is its own workspace, so it carries its own pin. The root test
-# runs cargo from this directory so rustup honours it.
+# bevy 0.19.1 requires rustc 1.95; the main workspace pins the same
+# version now. The fixture is its own workspace, so it carries its own pin
+# regardless. The root test runs cargo from this directory so rustup
+# honours it.
 [toolchain]
 channel = "1.95.0"
 targets = ["wasm32-unknown-unknown"]

--- a/tests/providers/anthropic/cassette/messages_thinking.rs
+++ b/tests/providers/anthropic/cassette/messages_thinking.rs
@@ -170,14 +170,12 @@ async fn redacted_thinking_streaming() {
                     StreamEvent::BlockEnd {
                         block: Some(AssistantContent::Reasoning(reasoning)),
                         ..
-                    } => {
-                        if reasoning
-                            .content
-                            .iter()
-                            .any(|item| matches!(item, ReasoningContent::Redacted { .. }))
-                        {
-                            saw_redacted_reasoning = true;
-                        }
+                    } if reasoning
+                        .content
+                        .iter()
+                        .any(|item| matches!(item, ReasoningContent::Redacted { .. })) =>
+                    {
+                        saw_redacted_reasoning = true;
                     }
                     StreamEvent::BlockDelta {
                         delta: Delta::Text { text },

--- a/tests/providers/chatgpt/cassette/streaming_tools.rs
+++ b/tests/providers/chatgpt/cassette/streaming_tools.rs
@@ -106,11 +106,9 @@ async fn stream_tool_call_completed_response_without_output() {
                     StreamEvent::BlockEnd {
                         block: Some(AssistantContent::ToolCall(tool_call)),
                         ..
-                    } => {
-                        if tool_call.function.name == "ping" {
-                            assert_eq!(tool_call.function.arguments, json!({}));
-                            saw_ping_tool_call = true;
-                        }
+                    } if tool_call.function.name == "ping" => {
+                        assert_eq!(tool_call.function.arguments, json!({}));
+                        saw_ping_tool_call = true;
                     }
                     StreamEvent::Final(response) => {
                         final_usage = Some(response.usage);

--- a/tests/providers/groq/agent_tool_sessions.rs
+++ b/tests/providers/groq/agent_tool_sessions.rs
@@ -1019,10 +1019,8 @@ async fn low_latency_streaming_text_surfaces_final_usage() -> Result<()> {
                     StreamEvent::BlockDelta {
                         delta: Delta::Text { text },
                         ..
-                    } => {
-                        if !text.is_empty() {
-                            text_chunks += 1;
-                        }
+                    } if !text.is_empty() => {
+                        text_chunks += 1;
                     }
                     StreamEvent::Final(response) => {
                         final_usage = Some(response.usage);


### PR DESCRIPTION
The prerequisite of the rig-ecs crate (`many_rigs/rig-bevy/rig-ecs-pr1-native-shape-prompt.md`): `bevy_ecs`/`bevy_tasks`/`bevy_app` 0.19.1 need rustc 1.95, and the crate that absorbs the Bevy host fixture will be a workspace member. Its own PR so a toolchain sweep is reviewed on its own, not inside the review of a new crate.

## Commits

- `chore: rust-toolchain 1.95.0` — the pin; the fixture's `rust-toolchain.toml` comment (its `1.95.0` pin was already there; it stays until the fixture is deleted).
- `fix: clippy 1.95` — every finding fixed at its cause, no lint level changed, no `#[allow]`:

| lint | where | change |
|---|---|---|
| `unnecessary_sort_by` | `crates/rig-core/src/json_utils.rs:47`, `:83` | `sort_by` on the key → `sort_by_key` |
| `collapsible_match` | `crates/rig-core/src/providers/internal/sequence_law.rs:112` | the minted-id test becomes the arm's guard; a non-minted reasoning start falls to the existing catch-all, as before |
| `while_let_loop` | `tests/common/cassettes.rs:1354` | the redaction loop's let-else break becomes the `while let` condition |
| `collapsible_match` | `tests/common/support.rs:662`, `tests/providers/groq/agent_tool_sessions.rs:1023`, `tests/providers/anthropic/cassette/messages_thinking.rs:174`, `tests/providers/chatgpt/cassette/streaming_tools.rs:110` | the inner `if` becomes the arm's guard; the catch-all takes what it excludes |

`cargo fmt --all` changed nothing, so there is no formatting commit. No dependency moved: `Cargo.lock` is untouched. No rig behaviour changed.

## Gates run locally on 1.95.0

`cargo fmt --all -- --check`; clippy `--workspace --all-targets` with and without `--all-features` under `-D warnings`; `cargo doc --workspace --no-deps --all-features` with `-D warnings`; `cargo nextest run --features bedrock` (6850 passed); the all-features nextest lane for rig-core, rig-reqwest, rig-tungstenite, rig-agent, rig-rmcp (2443 passed); rig-verify all features (547 passed); `xtask check-test-layout`; `cargo check --target wasm32-unknown-unknown` for the CI matrix's eight packages plus rig-core all-features; the rig-bus wasm test under `wasm-bindgen-test-runner` 0.2.118; loom under `--cfg rig_loom` (9 models); the root `tests/core` guards, the Bevy fixture's included (276 passed). The pin guard passes; `1.94` remains only in the guard script's example comment, on purpose.