### PR TITLE
rig-ecs: the run as a graph, the request as its fold — the completion-only corpus through the world

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -166,6 +166,8 @@ jobs:
             test: wasm
           - package: rig-ecs
             test: bus_wasm
+          - package: rig-ecs
+            test: run_wasm
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10310,6 +10310,7 @@ dependencies = [
  "futures",
  "rig-core",
  "rig-effect-log",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "tracing",

--- a/crates/rig-ecs/CONTRACT.md
+++ b/crates/rig-ecs/CONTRACT.md
@@ -2,7 +2,7 @@
 
 The bytes rig-ecs's agent modules are held to, extracted from the corpus (`crates/rig-verify/fixtures/*.effects.json`) and from `rig_agent::run`'s docs read as a specification. Every row cites the golden(s) that pin it by fixture name and JSON pointer; every `policy::text` constant has a test in `src/policy/tests.rs` that compares it to its golden. Nothing here is read off a function body of the frozen crate.
 
-The set this stage covers: every golden whose records are all `completion` and whose header `hooks` is empty — 43 at 207 goldens (`crates/rig-verify/tests/corpus/world.rs::unsupported` derives the set; `anthropic_memory_history_bypass` is among the 43 but waits for stage 5's memory, since its required row names `golden/memory`).
+The set this stage covers: every golden whose records are all `completion` and whose header `hooks` is empty — 43 at 207 goldens (the superseded prompt counted 32 at an older head; the set is derived, never listed) (`crates/rig-verify/tests/corpus/world.rs::unsupported` derives the set; `anthropic_memory_history_bypass` is among the 43 but waits for stage 5's memory, since its required row names `golden/memory`).
 
 ## 1. The request: a walk over the graph
 
@@ -64,6 +64,8 @@ The fold is the only constructor of a `CompletionRequest` in the crate (`tests/c
 | the output tool called with every required field | the assistant utterance is history; the run settles with the call's arguments serialised | `anthropic_output_tool_unary`; `golden_answer` in the corpus |
 | the output tool called without a required field, reprompts left (`OutputRetries < 1`) and turns left | history gains the assistant call and a user tool result (the missing-field reprompt); another turn | `mock_output_tool_missing_field_reprompt` |
 | text where the output tool was due, reprompts left | history gains the assistant text and the user reprompt; another turn | `mock_output_tool_text_reprompt` |
+| the output tool called with a missing field, or text where it was due, with **no reprompt left** | the run settles with what it has (the partial arguments, or the text) — unpinned: no golden exhausts the budget; rig-agent's docs accept a text that already satisfies the schema and are silent on the rest | (none) |
+| a granted tool named like the minted output tool | `Failed(OutputToolCollision)` | `rig_agent::run::prepare` docs |
 | a call to a tool neither granted nor the output tool | an `InvalidCall` entity `ChildOf` the turn; `resolve_invalid_defaults` writes the run's `InvalidCalls.unhandled` unless a system wrote a `Resolution` first; `Fail` → `Failed(UnknownToolCall)`; `Ignore` → the call is dropped, what is left is the answer (an empty rest settles as `""`) | `mock_outcome_invalid_call_unhandled`, `mock_invalid_mixed_fail` (`Fail`); `mock_invalid_ignore_unary`, `mock_delta_ignore` (`Ignore`) |
 | a call to a granted tool | `Failed(Unsupported)`: tool dispatch is stage 3's | (no golden in this set) |
 | `Retry`, `Repair`, `Skip` written as a resolution | `Failed(Unsupported)`, named | (stage 4) |

--- a/crates/rig-ecs/CONTRACT.md
+++ b/crates/rig-ecs/CONTRACT.md
@@ -1,0 +1,97 @@
+# CONTRACT — the completion-only run, as the goldens pin it
+
+The bytes rig-ecs's agent modules are held to, extracted from the corpus (`crates/rig-verify/fixtures/*.effects.json`) and from `rig_agent::run`'s docs read as a specification. Every row cites the golden(s) that pin it by fixture name and JSON pointer; every `policy::text` constant has a test in `src/policy/tests.rs` that compares it to its golden. Nothing here is read off a function body of the frozen crate.
+
+The set this stage covers: every golden whose records are all `completion` and whose header `hooks` is empty — 43 at 207 goldens (`crates/rig-verify/tests/corpus/world.rs::unsupported` derives the set; `anthropic_memory_history_bypass` is among the 43 but waits for stage 5's memory, since its required row names `golden/memory`).
+
+## 1. The request: a walk over the graph
+
+`CompletionRequest` has nine fields on the wire (`record_telemetry_content` never appears in a recorded request). Each is derived by `policy::fold_request` from one source in the graph, in one order. Source entities and components are `rig_ecs::agent`'s.
+
+| field | source (the walk) | order | pinned by |
+|---|---|---|---|
+| `model` | none: always `null`; the model is the handler key the effect is dispatched to (`UsesModel` on the run, else the agent, → the handler entity's `Bound.key`) | — | every golden `/records/0/kind/request/model` |
+| `chat_history[0]` | the effective preamble as `system`, when there is one: the agent's `Preamble` (the run's override first) joined with the output mode's augmentation by `"\n\n"` (§3); no preamble and no augmentation is no system message | first | `anthropic_completion_smoke` `/…/chat_history/0`; `anthropic_request_shape_without_preamble` (no system message); `anthropic_request_shape_append_preamble` (the preamble's own `"\n"` join is the program's, stored already joined) |
+| `chat_history[1..]` | every `Utterance` `ChildOf` the run, in `Order`: the prior history the run was spawned with, then the prompt, then — turn by turn — the assistant utterance `Materialise` spawned and the reprompt utterance it added | `Order` ascending | `anthropic_request_shape_prior_history` `/…/chat_history` (system, user, assistant(id null), user); `mock_output_tool_text_reprompt` `/records/1/…/chat_history` (…, assistant text, user reprompt); `mock_output_tool_missing_field_reprompt` `/records/1/…/chat_history` (…, assistant call, user tool result) |
+| `documents` | the turn's `Attachment` links, in `Order`, each to a document entity (`DocumentId`, `DocumentText`, `DocumentProps`) — the agent's `Context` links are attached to every turn by `Advance` | link `Order` | `anthropic_request_shape_static_context` `/…/documents` (`static_doc_0`, `static_doc_1`; no `additional_props` key when empty) |
+| `tools` | the turn's `Advert` links, in `Order`, each to a tool handler entity whose `Bound.descriptor.family` is `Tool { name, description, parameters }` — the agent's `Grant` links, advertised by `Advance`; then the output tool (§3) when the resolved mode is `Tool` | grant `Order`, output tool last | `anthropic_request_shape_tool_choice_none` `/…/tools/0` (`add`, its description and parameters verbatim from the descriptor); `anthropic_output_tool_unary` `/…/tools/0` (`final_result`) |
+| `temperature` | `Temperature` (run, else agent) | — | `anthropic_completion_smoke` (`null`), `anthropic_output_tool_unary` (`0.0`) |
+| `max_tokens` | `MaxTokens` | — | `anthropic_request_shape_max_tokens` (`32`) |
+| `tool_choice` | `ToolChoiceSpec`, unchanged (`"none"`, `"required"`, `{"specific":{"function_names":[…]}}`) | — | `anthropic_request_shape_tool_choice_none`; `anthropic_output_tool_choice_required`; `anthropic_output_tool_choice_specific_output` |
+| `additional_params` | `AdditionalParams`, verbatim | — | `anthropic_request_shape_thinking_unary` (`{"thinking":{"type":"enabled","budget_tokens":1024}}`) |
+| `output_schema` | `Output.schema` when the resolved mode is `Native`; `null` otherwise | — | `anthropic_request_shape_output_schema_unary` (the schema verbatim, unsorted); `anthropic_output_prompted_unary` (`null`); `anthropic_output_tool_under_none_degrades` (the schema: `Tool` degraded to `Native`) |
+| `stream` (the effect's, beside the request) | the run's `Streamed` | — | every `*_streamed` golden |
+
+The fold is the only constructor of a `CompletionRequest` in the crate (`tests/core/rig_ecs_bus_module.rs::the_agent_modules_hold_the_discipline`).
+
+## 2. The verbatim strings
+
+| string | value | pinned by |
+|---|---|---|
+| the output tool's name | `final_result`; on a collision with a granted tool's name, `final_result_1`, `final_result_2`, … | `anthropic_output_tool_unary` `/…/tools/0/name`; numbering: `rig_agent::run::prepare` docs (no golden collides) |
+| the output tool's description | `Call this tool exactly once with your final answer when you are done. Its arguments are the structured result and must satisfy the output schema.` | `anthropic_output_tool_unary` `/…/tools/0/description` |
+| the output tool's parameters | the program's schema, unchanged | `anthropic_output_tool_unary` `/…/tools/0/parameters` |
+| the tool-mode augmentation | ``When you have gathered enough information to answer, call the `{name}` tool exactly once with your final answer. Its arguments are the structured result and must satisfy the required schema. Do not return the final answer as plain text.`` | `anthropic_output_tool_unary` `/…/chat_history/0/content` |
+| the prompted augmentation | `Respond with ONLY a single JSON object that conforms to this JSON Schema. Do not include any prose, explanation, or markdown code fences.` + `"\n"` + `to_canonical_string(schema)` (keys sorted, no whitespace) | `anthropic_output_prompted_unary` `/…/chat_history/0/content` |
+| the augmentation separator | `"\n\n"` between the preamble and an augmentation | the two rows above |
+| the text-answer reprompt | ``Provide your final answer by calling the `{name}` tool with the structured result as its arguments, not as plain text.`` — a plain user message | `mock_output_tool_text_reprompt` `/records/1/…/chat_history/3` |
+| the missing-field reprompt | ``The `{name}` arguments were missing required field(s): {a, b}. Call `{name}` again with every required field.`` — a tool result on the call (`call`, `provider`, `name`, one text part) | `mock_output_tool_missing_field_reprompt` `/records/1/…/chat_history/3` |
+
+## 3. Output modes
+
+`resolve_output(mode, has_schema, granted_tools, callable, provider_composes_native)`, never `Auto`:
+
+| program | resolved | request | pinned by |
+|---|---|---|---|
+| no schema | `Native` (plain text) | no augmentation, no output tool, `output_schema: null` | `anthropic_completion_smoke` |
+| `Native` + schema | `Native` | `output_schema` set | (by construction; no golden asks `Native` explicitly) |
+| `Auto` + schema, provider composes native output with tools (`Bound.descriptor.family.capabilities.composes_native_output_with_tools`) | `Native` | `output_schema` set, no augmentation | `anthropic_request_shape_output_schema_unary` |
+| `Auto` + schema + a granted tool + a permitting choice, provider does not compose | `Tool` | as `Tool` | `rig_agent::run::prepare` docs (no golden in this set) |
+| `Tool` + schema, choice permits | `Tool` | the output tool advertised last, the augmentation, `output_schema: null` | `anthropic_output_tool_unary`, `gemini_breadth_output_tool_unary`, `openai_output_tool_unary` |
+| `Tool` + schema, `tool_choice: none` | `Native` (degrades; the constraint is still enforced) | `output_schema` set, no augmentation, `tools: []` | `anthropic_output_tool_under_none_degrades` |
+| `Prompted` + schema | `Prompted` | the augmentation with the canonical schema, `tools: []`, `output_schema: null` | `anthropic_output_prompted_unary`, `mock_oracle_prompted_unvalidated` |
+
+`callable`: `None`/`Auto`/`Required` permit; `None` forbids; `Specific` permits iff it names the output tool (`anthropic_output_tool_choice_specific_output`). The mode is pinned on the turn (`systems::Folded`) once folded.
+
+## 4. Reading the answer (`Materialise`)
+
+| the turn | what happens | pinned by |
+|---|---|---|
+| a provider error | the run fails `Provider(report)` at the record | `anthropic_outcome_model_error` (`provider_response`, 401) |
+| the effect despawned mid-stream | the record is `Cancelled`; the run is `Failed(Cancelled)` | `anthropic_cancelled_stream`, `anthropic_outcome_cancel_after_tool_call_delta` |
+| an empty turn (no parts, or one unannotated empty text) | not history; the run settles with `""` | `anthropic_request_shape_tool_choice_none` (`choice: []`, the run settles) |
+| text, mode `Native`/`Prompted` | the assistant utterance is history; the run settles with the text (prompted output is never validated) | `anthropic_completion_smoke`; `mock_oracle_prompted_unvalidated` (`"not an object"`) |
+| the output tool called with every required field | the assistant utterance is history; the run settles with the call's arguments serialised | `anthropic_output_tool_unary`; `golden_answer` in the corpus |
+| the output tool called without a required field, reprompts left (`OutputRetries < 1`) and turns left | history gains the assistant call and a user tool result (the missing-field reprompt); another turn | `mock_output_tool_missing_field_reprompt` |
+| text where the output tool was due, reprompts left | history gains the assistant text and the user reprompt; another turn | `mock_output_tool_text_reprompt` |
+| a call to a tool neither granted nor the output tool | an `InvalidCall` entity `ChildOf` the turn; `resolve_invalid_defaults` writes the run's `InvalidCalls.unhandled` unless a system wrote a `Resolution` first; `Fail` → `Failed(UnknownToolCall)`; `Ignore` → the call is dropped, what is left is the answer (an empty rest settles as `""`) | `mock_outcome_invalid_call_unhandled`, `mock_invalid_mixed_fail` (`Fail`); `mock_invalid_ignore_unary`, `mock_delta_ignore` (`Ignore`) |
+| a call to a granted tool | `Failed(Unsupported)`: tool dispatch is stage 3's | (no golden in this set) |
+| `Retry`, `Repair`, `Skip` written as a resolution | `Failed(Unsupported)`, named | (stage 4) |
+
+## 5. Budgets and endings
+
+| rule | pinned by |
+|---|---|
+| `MaxTurns` counts model calls; `Advance` fails a run whose `Cursor.turn` reached it (`Failed(MaxTurns { limit })`); the default is 1 | `rig_agent::run::spec` docs (`effective_max_turns`) |
+| the output-tool reprompt budget is 1 | `rig_agent::run::spec` docs (`DEFAULT_OUTPUT_RETRIES`) |
+| every record of a `MaxTurns` run is a success; the run is not | corpus `Ending::MaxTurns` docs |
+
+## 6. The header
+
+`replay::spec_json(agent)` is the JSON the header's `run_spec` hashes (`rig_effect_log::stable_hash`, keys canonicalised): the agent's identity, not a run's.
+
+```json
+{"preamble": <Preamble>, "static_context": [{"id","text",…props}], "additional_params": <AdditionalParams>,
+ "max_tokens": <MaxTokens>, "temperature": <Temperature>, "tool_choice": <ToolChoiceSpec>,
+ "max_turns": <DefaultMaxTurns or 1>, "max_invalid_tool_call_retries": 0, "output_schema": <Output.schema>,
+ "output_mode": "Auto"|"Native"|"Tool"|"Prompted", "output_tool_name": null, "output_tool_description": null,
+ "augment_output_preamble": true, "unhandled_invalid_tool_call": "fail"}
+```
+
+Pinned by every golden's `/header/run_spec` (`anthropic_completion_smoke` = `171082663332529849`); the world interpreter asserts equality for all 42 it replays. A run's `max_turns`, its history, its stream flag and its invalid-call policy are **not** identity: `mock_delta_fail` and `mock_delta_ignore` share one hash.
+
+`required`: the model's key as `completion`, every granted tool's key by its family (`anthropic_request_shape_tool_choice_none` `/header/required`). `hooks`: `[]`. `signature`: written by the recorder from what was dispatched.
+
+## 7. Keys
+
+`<owner>/model:<label>` (`golden/model:default`), `<owner>/tool:<name>#<n>` (`golden/tool:add#0`), `<owner>/memory`. `replay::{model_key, tool_key}`; `HandlerKey::parts()` reads them.

--- a/crates/rig-ecs/Cargo.toml
+++ b/crates/rig-ecs/Cargo.toml
@@ -32,6 +32,7 @@ bevy_ecs = { workspace = true }
 bevy_tasks = { workspace = true }
 bevy_app = { workspace = true }
 futures = { workspace = true }
+schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rig-ecs/README.md
+++ b/crates/rig-ecs/README.md
@@ -1,6 +1,54 @@
 # rig-ecs
 
-rig inside a Bevy `World`. One module today, `rig_ecs::bus`: the effect bus as a plugin, in the native shape — effects are entities, handlers are entities, the driver is a system, an outcome is a component, causality is `ChildOf`, a scene is a checkpoint. Nothing awaits, nothing blocks, nothing is probed; rig-bus is not in the graph.
+rig inside a Bevy `World`. Two layers: `rig_ecs::bus`, the effect bus as a plugin in the native shape — effects are entities, handlers are entities, the driver is a system, an outcome is a component, causality is `ChildOf`, a scene is a checkpoint — and the agent runtime over it (`agent`, `policy`, `systems`, `replay`): the run as a graph, the request as its fold. Nothing awaits, nothing blocks, nothing is probed; rig-bus is not in the graph; nothing is copied from rig-agent.
+
+## The run as a graph
+
+The request the model sees is derived, never authored: a run entity, utterances `ChildOf` it in `Order`, documents as their own entities attached to a turn by link entities, tools as the handler entities the bus already has (granted by link entities), the model as a relationship, every setting a component — and one function, `policy::fold_request`, that walks the graph at `RigSet::Assemble` and writes the wire `CompletionRequest` into the turn's `PendingEffect`. `CONTRACT.md` names the walk field by field with the golden that pins each; the corpus's third interpreter (`crates/rig-verify/tests/corpus/world.rs`) replays every completion-only golden through it.
+
+| design (§3.1) | here |
+|---|---|
+| Agent | `Owner`, `Preamble`, `Temperature`, `MaxTokens`, `AdditionalParams`, `ToolChoiceSpec`, `Output { mode, schema }`, `MaxTurns`, `DefaultMaxTurns`, `InvalidCalls`; `UsesModel` → the model's handler entity; `Grant` link entities → tool handler entities; `Context` link entities → documents |
+| Document | `DocumentId`, `DocumentText`, `DocumentProps`; attached to a turn by an `Attachment` link |
+| Utterance | `Utterance`, `Role`, `Parts` (the message's parts, verbatim), `Order`; `ChildOf` the run |
+| Run | `Run`, `RunOf` → agent, `RunSeq`, `Streamed`, `Cursor`, a phase (`Assembling`, `AwaitingModel`, `Settled`, `Failed(Failure)`), `RunResult`, `Usage`, `OutputRetries`, `OutputToolName`, the run's own overrides of the agent's settings, the bus's `Scope` |
+| Turn | `Turn`, `ChildOf` the run, `Order`; `Advert` links → the tools it advertised; `Attachment` links → its documents; `Outputs` (per tick for a stream); `Reprompt`; `systems::{Fresh, Folded, Materialised}` |
+| Effect | the bus module's, `ChildOf` the turn |
+| Invalid call | `InvalidCall` + `Resolution`, `ChildOf` the turn |
+| the scene | `agent::scene::RunScene` beside the bus's `Scene` |
+
+The agent's sets, around the bus's:
+
+| set | true before | written during |
+|---|---|---|
+| `RigSet::Advance` | a run in `Assembling` has no fresh turn | a turn with its adverts and attachments, or `Failed(MaxTurns)` |
+| `RigSet::Select` | a run may lack a model of its own | the agent's `UsesModel`, copied — a routing system before it gives the run another |
+| `RigSet::Assemble` | a fresh turn's graph is complete | the fold spawns the effect; the run is `AwaitingModel` |
+| `RigSet::Patch` | the folded effect is a `PendingEffect` | the second steering slot: a user system rewrites the folded request |
+| *`BusSet::Gate` … `BusSet::Judge`* | | |
+| `RigSet::Fold` | the effect may have streamed or landed | `Outputs` on the turn |
+| `RigSet::Judge` | the turn's outputs are complete | a user system may rewrite them |
+| `RigSet::Materialise` | a complete turn is unread | the assistant utterance, the answer, a reprompt, an invalid call, or a failure |
+| `RigSet::Settle` | a run settled or failed | observers on `Settled` / `Failed` |
+
+The first steering slot is any system before `Assemble`: it edits the graph. `tests/run_graph.rs` pins the wins: an utterance despawned leaves the next request; one document entity feeds two runs; a grant link advertises a tool and its removal un-advertises it; a model swapped on the run changes the next key; a `Patch` system's rewrite reaches the handler and the record; a system before `Assemble` rewrites an utterance. `tests/run_scene.rs` pins that the graph is the state: a run saved mid-turn resumes in a fresh world to the same second request.
+
+## Every rig-agent hook action, as a system
+
+| rig-agent | here |
+|---|---|
+| `on_run_start` | an observer `On<Add, Run>` |
+| `on_model_select` / routing | a system before `RigSet::Select` inserting `UsesModel` on the run |
+| `on_completion_call` — patch the request | a system in `RigSet::Patch` editing the `PendingEffect`; or, before `Assemble`, editing the graph (utterances, `Attachment`s, `Grant`s, settings) |
+| `on_completion_call` — stop | a system in `Patch` despawning the effect (the run fails `Cancelled`) |
+| `on_dispatch` deny / patch | the bus's `Gate`: `Held`, `EffectOutcome(Err(Denied))`, or a rewrite |
+| `on_outcome` replace | the bus's `Judge` (an `EffectOutcome`), or `RigSet::Judge` (the turn's `Outputs`) |
+| deltas | `Changed<Streamed>` on the effect, `Changed<Outputs>` on the turn |
+| `on_invalid_tool_call` | a system before `Materialise` writing `Resolution` on an `InvalidCall` entity |
+| `on_turn_finished` / `on_run_settled` | observers on `Materialised`, `Settled`, `Failed` |
+
+None of these exists yet as a shipped policy; stage 4 reproduces every hook-recorded golden as one of them.
+
 
 The `bus` module is written as if it were already its own crate (every item `pub` or private to its file, no import from a sibling module, no agent-shaped identifier, its tests in `tests/bus_*.rs`, a root guard enforcing all four) and becomes `rig-bevy` by a `git mv` when a second consumer exists. The agent runtime the later modules add consumes it through its public items only.
 
@@ -104,7 +152,7 @@ The Bevy host fixture's fourteen proofs and the eight unproven behaviours of `ri
 
 ## What it deliberately does not have
 
-No agent, no loop, no memory semantics, no hook trait, no policy vocabulary: those are the crate's later modules, and nothing here may anticipate them. No streaming answers from a system yet (a later PR). No `reflect` yet: `Scene` is the crate's own serde form and stores what this module owns; a host's other components are its own to save until the `reflect` PR extends it. No `Now`, no `Random`: nondeterminism is an effect a host registers, and the guard refuses a clock or a random draw in this crate.
+No hook trait, no history vector, no step enum, no run struct copied from anywhere: steering is a system between sets. Not yet: tool dispatch (stage 3), hooks as shipped systems (stage 4), memory, retrieval, routing and two runs on one agent (stage 5); a run that calls a granted tool fails `Unsupported`, named. The `bus` module still has no agent-shaped item and its suite is agent-free (the guard checks). No streaming answers from a system yet (a later PR). No `reflect` yet: `Scene` is the crate's own serde form and stores what this module owns; a host's other components are its own to save until the `reflect` PR extends it. No `Now`, no `Random`: nondeterminism is an effect a host registers, and the guard refuses a clock or a random draw in this crate.
 
 ## On wasm
 

--- a/crates/rig-ecs/src/agent/mod.rs
+++ b/crates/rig-ecs/src/agent/mod.rs
@@ -1,0 +1,477 @@
+//! The run as a graph: the entity vocabulary of the agent runtime.
+//!
+//! Every setting is one component; every link is a Bevy relationship (a
+//! many-to-many link is a link entity, `ChildOf` its owner, with a
+//! relationship to what it links); every payload is serde and holds no
+//! `Entity`. The request the model sees is derived from this graph by one
+//! fold ([`crate::policy::fold_request`]) at [`crate::systems::RigSet::Assemble`];
+//! nothing here holds a `CompletionRequest` or a `Vec<Message>`.
+//!
+//! | design (§3.1) | here |
+//! |---|---|
+//! | Agent | an entity with [`Owner`], [`Preamble`], [`Temperature`], [`MaxTokens`], [`AdditionalParams`], [`ToolChoiceSpec`], [`Output`], [`MaxTurns`], [`InvalidCalls`]; [`UsesModel`] → the model's handler entity; [`Grant`] link entities → tool handler entities; [`Context`] link entities → document entities |
+//! | Model, Tool | the bus module's handler entities (`Bound`) |
+//! | Document | [`DocumentId`], [`DocumentText`], [`DocumentProps`]; attached to a turn by an [`Attachment`] link entity |
+//! | Utterance | [`Utterance`] + [`Role`] + content parts ([`Text`], [`Reasoning`], [`ToolCallPart`], [`ToolResultPart`]), [`Order`]; `ChildOf` the run |
+//! | Run | [`Run`] + [`RunOf`] → agent; [`RunSeq`]; a phase marker ([`Assembling`], [`AwaitingModel`], [`Settled`], [`Failed`]); [`Cursor`]; [`RunResult`]; [`Usage`]; retries; [`OutputToolName`]; the run's own overrides of the agent's settings |
+//! | Turn | [`Turn`], `ChildOf` the run; [`Advert`] link entities → the tools it advertised; [`Attachment`] link entities → the documents it carried; [`Outputs`]; [`Reprompt`] |
+//! | Effect | the bus module's, `ChildOf` the turn |
+//! | Invalid call | [`InvalidCall`] + [`Resolution`], `ChildOf` the turn |
+
+pub mod scene;
+
+use bevy_ecs::prelude::*;
+use rig_core::{
+    completion::{
+        Usage as WireUsage,
+        message::{AssistantContent, Message, ToolChoice, UserContent},
+    },
+    error::ErrorReport,
+};
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Agent: one component per setting.
+
+/// The agent's name: the owner of every key it mints (`<owner>/model:..`),
+/// the scope of every run's records.
+#[derive(Component, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Owner(pub String);
+
+/// The system prompt: `None` is "no system message" (a run without a
+/// preamble), `Some("")` an empty one that is still sent.
+#[derive(Component, Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Preamble(pub Option<String>);
+
+/// Sampling temperature, if the request names one.
+#[derive(Component, Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+pub struct Temperature(pub Option<f64>);
+
+/// The answer's token budget, if the request names one.
+#[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MaxTokens(pub Option<u64>);
+
+/// Provider-specific parameters the request carries verbatim.
+#[derive(Component, Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdditionalParams(pub Option<serde_json::Value>);
+
+/// The program's tool choice: what the request's `tool_choice` starts
+/// from before the output mode has its say.
+#[derive(Component, Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ToolChoiceSpec(pub Option<ToolChoice>);
+
+/// How the run's answer is asked for and read.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputKind {
+    /// Resolve at request time: `Tool` when there is a schema and at least
+    /// one tool and the tool choice permits it, else `Native`.
+    #[default]
+    Auto,
+    /// The provider's native structured output (`output_schema`), or plain
+    /// text when there is no schema.
+    Native,
+    /// A synthetic output tool the model must call with the answer.
+    Tool,
+    /// The schema in the preamble; the answer is the text, unvalidated.
+    Prompted,
+}
+
+/// The output mode and its schema, if any.
+#[derive(Component, Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Output {
+    /// The mode.
+    pub mode: OutputKind,
+    /// The JSON schema of the answer, raw.
+    pub schema: Option<serde_json::Value>,
+}
+
+/// The model-call budget of a run.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MaxTurns(pub usize);
+
+/// What to do with a tool call the program does not advertise when no
+/// system resolved it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Unhandled {
+    /// The run fails at the record.
+    #[default]
+    Fail,
+    /// The call is dropped; the run goes on.
+    Ignore,
+}
+
+/// The invalid-call policy: how many retries before `unhandled` applies.
+#[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InvalidCalls {
+    /// Retries the program allows an invalid call.
+    pub retries: usize,
+    /// What happens when they are spent.
+    pub unhandled: Unhandled,
+}
+
+/// The default `max_turns` the agent was built with, part of its identity
+/// (a run-level override is not).
+#[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DefaultMaxTurns(pub Option<usize>);
+
+/// The agent uses this model: a relationship to the model's handler
+/// entity (the bus module's `Bound`). A run may carry its own to override.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
+#[relationship(relationship_target = ModelOf)]
+pub struct UsesModel(pub Entity);
+
+/// The agents and runs using this model.
+#[derive(Component, Debug, Default)]
+#[relationship_target(relationship = UsesModel)]
+pub struct ModelOf(Vec<Entity>);
+
+impl ModelOf {
+    /// Who uses the model.
+    pub fn users(&self) -> &[Entity] {
+        &self.0
+    }
+}
+
+/// A grant: a link entity, `ChildOf` the agent, naming one tool the agent
+/// advertises. Advertisement order is [`Order`].
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
+#[relationship(relationship_target = Grants)]
+pub struct Grant(pub Entity);
+
+/// The grants naming this tool.
+#[derive(Component, Debug, Default)]
+#[relationship_target(relationship = Grant)]
+pub struct Grants(Vec<Entity>);
+
+/// A context link: a link entity, `ChildOf` the agent, naming one document
+/// every turn carries as static context, in [`Order`].
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
+#[relationship(relationship_target = ContextOf)]
+pub struct Context(pub Entity);
+
+/// The context links naming this document.
+#[derive(Component, Debug, Default)]
+#[relationship_target(relationship = Context)]
+pub struct ContextOf(Vec<Entity>);
+
+/// The order of a link, an utterance or a turn among its siblings: the
+/// agent modules' own counter ([`OrderCounter`]), never the bus module's
+/// `Seq`, which is reserved for effects.
+#[derive(
+    Component,
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+)]
+pub struct Order(pub u64);
+
+/// The world's one order counter for [`Order`].
+#[derive(Resource, Debug, Default)]
+pub struct OrderCounter(pub u64);
+
+// ---------------------------------------------------------------------------
+// Documents: entities of their own, shared by attachment.
+
+/// The document's stable id.
+#[derive(Component, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DocumentId(pub String);
+
+/// The document's text.
+#[derive(Component, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DocumentText(pub String);
+
+/// The document's string metadata, rendered before its text.
+#[derive(Component, Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DocumentProps(pub std::collections::HashMap<String, String>);
+
+/// An attachment: a link entity, `ChildOf` a turn, naming one document the
+/// turn's request carries, in [`Order`].
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
+#[relationship(relationship_target = AttachedTo)]
+pub struct Attachment(pub Entity);
+
+/// The attachments naming this document.
+#[derive(Component, Debug, Default)]
+#[relationship_target(relationship = Attachment)]
+pub struct AttachedTo(Vec<Entity>);
+
+impl AttachedTo {
+    /// The attachment link entities.
+    pub fn attachments(&self) -> &[Entity] {
+        &self.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Utterances: the conversation, one entity per message, `ChildOf` the run.
+
+/// An utterance: one message of the conversation, `ChildOf` its run, in
+/// [`Order`]. Its parts are content components.
+#[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Utterance;
+
+/// Who spoke.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Role {
+    /// The user, or a tool result the user side reports.
+    User,
+    /// The model.
+    Assistant,
+}
+
+/// The utterance's parts, in order, as the wire's content: kept as the
+/// wire type so the fold writes the message verbatim.
+#[derive(Component, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Parts(pub MessageParts);
+
+/// The content of one message, by role.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "role", rename_all = "snake_case")]
+pub enum MessageParts {
+    /// A user message's parts.
+    User {
+        /// The parts.
+        content: Vec<UserContent>,
+    },
+    /// An assistant message's parts and provider id.
+    Assistant {
+        /// The provider-assigned message id, when the wire had one.
+        id: Option<String>,
+        /// The parts.
+        content: Vec<AssistantContent>,
+    },
+}
+
+impl MessageParts {
+    /// The message, verbatim.
+    pub fn to_message(&self) -> Message {
+        match self {
+            Self::User { content } => Message::User {
+                content: content.clone(),
+            },
+            Self::Assistant { id, content } => Message::Assistant {
+                id: id.clone(),
+                content: content.clone(),
+            },
+        }
+    }
+
+    /// From a message; a system message is not an utterance (it is the
+    /// preamble) and is refused.
+    pub fn from_message(message: &Message) -> Option<Self> {
+        match message {
+            Message::System { .. } => None,
+            Message::User { content } => Some(Self::User {
+                content: content.clone(),
+            }),
+            Message::Assistant { id, content } => Some(Self::Assistant {
+                id: id.clone(),
+                content: content.clone(),
+            }),
+        }
+    }
+
+    /// The role.
+    pub fn role(&self) -> Role {
+        match self {
+            Self::User { .. } => Role::User,
+            Self::Assistant { .. } => Role::Assistant,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Runs and turns.
+
+/// A run: one prompt through the agent to an answer or a failure.
+#[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Run;
+
+/// The run's agent.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
+#[relationship(relationship_target = Runs)]
+pub struct RunOf(pub Entity);
+
+/// The agent's runs.
+#[derive(Component, Debug, Default)]
+#[relationship_target(relationship = RunOf)]
+pub struct Runs(Vec<Entity>);
+
+impl Runs {
+    /// The run entities.
+    pub fn runs(&self) -> &[Entity] {
+        &self.0
+    }
+}
+
+/// The run's place among the world's runs: the order `Assemble` visits
+/// them, so effects are minted in a stable order. Stamped at spawn from
+/// [`RunCounter`].
+#[derive(
+    Component, Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+pub struct RunSeq(pub u64);
+
+/// The world's one run counter.
+#[derive(Resource, Debug, Default)]
+pub struct RunCounter(pub u64);
+
+/// Whether the model is asked for a stream.
+#[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Streamed(pub bool);
+
+/// Where the run is: the turn it is on.
+#[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Cursor {
+    /// Turns begun so far (the next turn's index).
+    pub turn: usize,
+}
+
+/// The run wants a turn: `Advance` spawns one and `Assemble` folds it.
+#[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Assembling;
+
+/// The run's current turn has an effect in flight.
+#[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AwaitingModel;
+
+/// The run ended with an answer.
+#[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Settled;
+
+/// The run ended without one.
+#[derive(Component, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Failed(pub Failure);
+
+/// Why a run failed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "failure", rename_all = "snake_case")]
+pub enum Failure {
+    /// The model-call budget ran out.
+    MaxTurns {
+        /// The budget.
+        limit: usize,
+    },
+    /// The model called a tool the program does not advertise, and nothing
+    /// resolved it.
+    UnknownToolCall {
+        /// The tool's name.
+        name: String,
+    },
+    /// The completion failed.
+    Provider(ErrorReport),
+    /// The run was cancelled: the effect in flight was despawned or its
+    /// stream dropped.
+    Cancelled(ErrorReport),
+    /// The run needs what a later stage brings (a tool dispatch, a
+    /// resolution kind); named, never silent.
+    Unsupported(String),
+}
+
+/// The run's answer.
+#[derive(Component, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunResult(pub String);
+
+/// The run's token usage, summed over its completions.
+#[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Usage(pub WireUsage);
+
+/// Output-tool reprompts spent.
+#[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutputRetries(pub usize);
+
+/// Invalid-call retries spent.
+#[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InvalidRetries(pub usize);
+
+/// The name the run's output tool was minted under, once a turn minted it.
+#[derive(Component, Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutputToolName(pub Option<String>);
+
+/// A turn: one model call of a run, `ChildOf` the run, in [`Order`].
+#[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Turn;
+
+/// An advert: a link entity, `ChildOf` a turn, naming one tool the turn's
+/// request advertised, in [`Order`].
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
+#[relationship(relationship_target = AdvertisedOn)]
+pub struct Advert(pub Entity);
+
+/// The adverts naming this tool.
+#[derive(Component, Debug, Default)]
+#[relationship_target(relationship = Advert)]
+pub struct AdvertisedOn(Vec<Entity>);
+
+/// The turn's folded assistant content, as it lands (per tick for a
+/// stream).
+#[derive(Component, Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Outputs {
+    /// The parts so far.
+    pub content: Vec<AssistantContent>,
+    /// The provider's message id, when the answer carried one.
+    pub message_id: Option<String>,
+    /// Whether the answer is complete.
+    pub done: bool,
+}
+
+/// A reprompt the next turn carries as its last user message: the output
+/// tool was not called, or was called without a required field.
+#[derive(Component, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Reprompt(pub Message);
+
+/// A tool call the program does not advertise, `ChildOf` the turn that
+/// made it, awaiting a [`Resolution`].
+#[derive(Component, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InvalidCall {
+    /// The call's id.
+    pub id: String,
+    /// The tool's name.
+    pub name: String,
+    /// The arguments, verbatim.
+    pub arguments: serde_json::Value,
+}
+
+/// What to do with an invalid call. Written by a user system before
+/// `Materialise` consumes it, else by the default-policy system from the
+/// run's [`InvalidCalls`].
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Resolution {
+    /// The run fails with `UnknownToolCall`.
+    Fail,
+    /// The call is dropped from the turn.
+    Ignore,
+    /// Ask the model again (a later PR; refused now).
+    Retry,
+    /// Repair the call (a later PR; refused now).
+    Repair,
+    /// Skip the call and answer the model with feedback (a later PR;
+    /// refused now).
+    Skip,
+}
+
+// Every state component is serde and entity-free: relationships are the
+// only holders of an `Entity`, and a scene remaps them.
+const _: () = {
+    const fn assert_serde<T: Serialize + serde::de::DeserializeOwned>() {}
+    assert_serde::<Owner>();
+    assert_serde::<Preamble>();
+    assert_serde::<Output>();
+    assert_serde::<Parts>();
+    assert_serde::<Failed>();
+    assert_serde::<Outputs>();
+    assert_serde::<InvalidCall>();
+    assert_serde::<Resolution>();
+};

--- a/crates/rig-ecs/src/agent/mod.rs
+++ b/crates/rig-ecs/src/agent/mod.rs
@@ -12,7 +12,7 @@
 //! | Agent | an entity with [`Owner`], [`Preamble`], [`Temperature`], [`MaxTokens`], [`AdditionalParams`], [`ToolChoiceSpec`], [`Output`], [`MaxTurns`], [`InvalidCalls`]; [`UsesModel`] → the model's handler entity; [`Grant`] link entities → tool handler entities; [`Context`] link entities → document entities |
 //! | Model, Tool | the bus module's handler entities (`Bound`) |
 //! | Document | [`DocumentId`], [`DocumentText`], [`DocumentProps`]; attached to a turn by an [`Attachment`] link entity |
-//! | Utterance | [`Utterance`] + [`Role`] + content parts ([`Text`], [`Reasoning`], [`ToolCallPart`], [`ToolResultPart`]), [`Order`]; `ChildOf` the run |
+//! | Utterance | [`Utterance`] + [`Role`] + [`Parts`] (the message's parts, verbatim), [`Order`]; `ChildOf` the run |
 //! | Run | [`Run`] + [`RunOf`] → agent; [`RunSeq`]; a phase marker ([`Assembling`], [`AwaitingModel`], [`Settled`], [`Failed`]); [`Cursor`]; [`RunResult`]; [`Usage`]; retries; [`OutputToolName`]; the run's own overrides of the agent's settings |
 //! | Turn | [`Turn`], `ChildOf` the run; [`Advert`] link entities → the tools it advertised; [`Attachment`] link entities → the documents it carried; [`Outputs`]; [`Reprompt`] |
 //! | Effect | the bus module's, `ChildOf` the turn |
@@ -377,6 +377,11 @@ pub enum Failure {
     /// The run needs what a later stage brings (a tool dispatch, a
     /// resolution kind); named, never silent.
     Unsupported(String),
+    /// A granted tool took the output tool's name after it was minted.
+    OutputToolCollision {
+        /// The name.
+        name: String,
+    },
 }
 
 /// The run's answer.

--- a/crates/rig-ecs/src/agent/scene.rs
+++ b/crates/rig-ecs/src/agent/scene.rs
@@ -83,25 +83,30 @@ pub struct RunScene {
 }
 
 macro_rules! take {
-    ($world:expr, $entity:expr, $components:expr, $($ty:ty => $name:literal),* $(,)?) => {
+    ($world:expr, $entity:expr, $components:expr, $errors:expr, $($ty:ty => $name:literal),* $(,)?) => {
         $(
             if let Some(value) = $world.get::<$ty>($entity) {
-                $components.insert(
-                    $name.to_owned(),
-                    serde_json::to_value(value).unwrap_or(serde_json::Value::Null),
-                );
+                match serde_json::to_value(value) {
+                    Ok(json) => {
+                        $components.insert($name.to_owned(), json);
+                    }
+                    Err(error) => $errors.push(format!("{}: {error}", $name)),
+                }
             }
         )*
     };
 }
 
 macro_rules! give {
-    ($world:expr, $entity:expr, $components:expr, $($ty:ty => $name:literal),* $(,)?) => {
+    ($world:expr, $entity:expr, $components:expr, $errors:expr, $($ty:ty => $name:literal),* $(,)?) => {
         $(
-            if let Some(value) = $components.get($name)
-                && let Ok(component) = serde_json::from_value::<$ty>(value.clone())
-            {
-                $world.entity_mut($entity).insert(component);
+            if let Some(value) = $components.get($name) {
+                match serde_json::from_value::<$ty>(value.clone()) {
+                    Ok(component) => {
+                        $world.entity_mut($entity).insert(component);
+                    }
+                    Err(error) => $errors.push(format!("{}: {error}", $name)),
+                }
             }
         )*
     };
@@ -111,7 +116,7 @@ impl RunScene {
     /// Take the graph of `world`: agents and documents first, then their
     /// links, then runs, then utterances, turns and invalid calls, each
     /// after its parent.
-    pub fn save(world: &mut World) -> Self {
+    pub fn save(world: &mut World) -> Result<Self, rig_core::error::ErrorReport> {
         let mut order: Vec<(u8, Entity)> = Vec::new();
         for (entity, _) in world.query::<(Entity, &Owner)>().iter(world) {
             order.push((0, entity));
@@ -168,7 +173,8 @@ impl RunScene {
                 _ => SceneKind::InvalidCall,
             };
             let mut components = serde_json::Map::new();
-            take!(world, entity, components,
+            let mut errors: Vec<String> = Vec::new();
+            take!(world, entity, components, errors,
                 Owner => "owner", Preamble => "preamble", Temperature => "temperature",
                 MaxTokens => "max_tokens", AdditionalParams => "additional_params",
                 ToolChoiceSpec => "tool_choice", Output => "output", MaxTurns => "max_turns",
@@ -184,6 +190,16 @@ impl RunScene {
                 Scope => "scope", Turn => "turn", Outputs => "outputs", Reprompt => "reprompt",
                 InvalidCall => "invalid_call", Resolution => "resolution",
             );
+            if !errors.is_empty() {
+                return Err(rig_core::error::ErrorReport::new(
+                    rig_core::error::ErrorKind::Internal,
+                    format!(
+                        "a component of entity {} did not serialize: {}",
+                        saved.len(),
+                        errors.join("; ")
+                    ),
+                ));
+            }
             if world.get::<crate::systems::Fresh>(entity).is_some() {
                 components.insert("fresh".to_owned(), serde_json::Value::Bool(true));
             }
@@ -238,11 +254,11 @@ impl RunScene {
                 relations,
             });
         }
-        Self {
+        Ok(Self {
             entities: saved,
             next_order: world.get_resource::<OrderCounter>().map_or(0, |c| c.0),
             next_run: world.get_resource::<RunCounter>().map_or(0, |c| c.0),
-        }
+        })
     }
 
     /// Spawn the graph into `world`. Handlers are the host's to bind first:
@@ -272,7 +288,8 @@ impl RunScene {
                 continue;
             };
             let components = &saved.components;
-            give!(world, entity, components,
+            let mut errors: Vec<String> = Vec::new();
+            give!(world, entity, components, errors,
                 Owner => "owner", Preamble => "preamble", Temperature => "temperature",
                 MaxTokens => "max_tokens", AdditionalParams => "additional_params",
                 ToolChoiceSpec => "tool_choice", Output => "output", MaxTurns => "max_turns",
@@ -288,6 +305,15 @@ impl RunScene {
                 Scope => "scope", Turn => "turn", Outputs => "outputs", Reprompt => "reprompt",
                 InvalidCall => "invalid_call", Resolution => "resolution",
             );
+            if !errors.is_empty() {
+                return Err(rig_core::error::ErrorReport::new(
+                    rig_core::error::ErrorKind::Internal,
+                    format!(
+                        "a component of scene entity {index} did not deserialize: {}",
+                        errors.join("; ")
+                    ),
+                ));
+            }
             if components.get("fresh").is_some() {
                 world.entity_mut(entity).insert(crate::systems::Fresh);
             }

--- a/crates/rig-ecs/src/agent/scene.rs
+++ b/crates/rig-ecs/src/agent/scene.rs
@@ -1,0 +1,356 @@
+//! The run graph as a scene: every agent, document, link, utterance, run,
+//! turn and invalid call as serde, relationships as indices into the scene
+//! (or, for a handler entity, its bound key), so a fresh world rebuilds the
+//! graph exactly and the driver re-issues what has no outcome. Saved
+//! beside the bus module's `Scene`, which carries the effects.
+
+use bevy_ecs::prelude::*;
+use rig_core::effect::HandlerKey;
+use serde::{Deserialize, Serialize};
+
+use super::{
+    AdditionalParams, Advert, Assembling, Attachment, AwaitingModel, Context, Cursor,
+    DefaultMaxTurns, DocumentId, DocumentProps, DocumentText, Failed, Grant, InvalidCall,
+    InvalidCalls, InvalidRetries, MaxTokens, MaxTurns, Order, OrderCounter, Output, OutputRetries,
+    OutputToolName, Outputs, Owner, Parts, Preamble, Reprompt, Resolution, Role, Run, RunCounter,
+    RunOf, RunResult, RunSeq, Settled, Streamed, Temperature, ToolChoiceSpec, Turn, Usage,
+    UsesModel, Utterance,
+};
+use crate::bus::{Bound, Scope};
+
+/// What a scene entity is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SceneKind {
+    /// An agent.
+    Agent,
+    /// A document.
+    Document,
+    /// A grant, context, attachment or advert link.
+    Link,
+    /// An utterance.
+    Utterance,
+    /// A run.
+    Run,
+    /// A turn.
+    Turn,
+    /// An invalid call awaiting or holding its resolution.
+    InvalidCall,
+}
+
+/// A link's target: another scene entity, or a handler by its bound key.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "target", rename_all = "snake_case")]
+pub enum Target {
+    /// Another entity of the scene, by index.
+    Scene {
+        /// The index in [`RunScene::entities`].
+        index: usize,
+    },
+    /// A handler entity, by its key: bound again by the host at load.
+    Handler {
+        /// The bound key.
+        key: HandlerKey,
+    },
+}
+
+/// One entity of the graph: its kind, its serde components by name, its
+/// parent by index, and its relationships by name and target.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SceneEntity {
+    /// What it is.
+    pub kind: SceneKind,
+    /// Its components, each under its name.
+    pub components: serde_json::Map<String, serde_json::Value>,
+    /// Its `ChildOf`, by index.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<usize>,
+    /// Its relationships: `uses_model`, `run_of`, `grant`, `context`,
+    /// `attachment`, `advert`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub relations: Vec<(String, Target)>,
+}
+
+/// The run graph as data.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RunScene {
+    /// The entities, parents before children.
+    pub entities: Vec<SceneEntity>,
+    /// The order counter, so loaded orders never collide with new ones.
+    pub next_order: u64,
+    /// The run counter, likewise.
+    pub next_run: u64,
+}
+
+macro_rules! take {
+    ($world:expr, $entity:expr, $components:expr, $($ty:ty => $name:literal),* $(,)?) => {
+        $(
+            if let Some(value) = $world.get::<$ty>($entity) {
+                $components.insert(
+                    $name.to_owned(),
+                    serde_json::to_value(value).unwrap_or(serde_json::Value::Null),
+                );
+            }
+        )*
+    };
+}
+
+macro_rules! give {
+    ($world:expr, $entity:expr, $components:expr, $($ty:ty => $name:literal),* $(,)?) => {
+        $(
+            if let Some(value) = $components.get($name)
+                && let Ok(component) = serde_json::from_value::<$ty>(value.clone())
+            {
+                $world.entity_mut($entity).insert(component);
+            }
+        )*
+    };
+}
+
+impl RunScene {
+    /// Take the graph of `world`: agents and documents first, then their
+    /// links, then runs, then utterances, turns and invalid calls, each
+    /// after its parent.
+    pub fn save(world: &mut World) -> Self {
+        let mut order: Vec<(u8, Entity)> = Vec::new();
+        for (entity, _) in world.query::<(Entity, &Owner)>().iter(world) {
+            order.push((0, entity));
+        }
+        for (entity, _) in world.query::<(Entity, &DocumentId)>().iter(world) {
+            order.push((1, entity));
+        }
+        for entity in world
+            .query_filtered::<Entity, Or<(With<Grant>, With<Context>)>>()
+            .iter(world)
+        {
+            order.push((2, entity));
+        }
+        for (entity, _) in world.query::<(Entity, &Run)>().iter(world) {
+            order.push((3, entity));
+        }
+        for (entity, _) in world.query::<(Entity, &Utterance)>().iter(world) {
+            order.push((4, entity));
+        }
+        for (entity, _) in world.query::<(Entity, &Turn)>().iter(world) {
+            order.push((5, entity));
+        }
+        for entity in world
+            .query_filtered::<Entity, Or<(With<Attachment>, With<Advert>)>>()
+            .iter(world)
+        {
+            order.push((6, entity));
+        }
+        for (entity, _) in world.query::<(Entity, &InvalidCall)>().iter(world) {
+            order.push((7, entity));
+        }
+        order.sort_by_key(|(rank, entity)| (*rank, entity.index()));
+        let entities: Vec<Entity> = order.iter().map(|(_, entity)| *entity).collect();
+        let index_of = |entity: Entity| entities.iter().position(|e| *e == entity);
+        let target_of = |world: &World, entity: Entity| -> Option<Target> {
+            if let Some(index) = index_of(entity) {
+                return Some(Target::Scene { index });
+            }
+            world.get::<Bound>(entity).map(|bound| Target::Handler {
+                key: bound.key.clone(),
+            })
+        };
+
+        let mut saved = Vec::with_capacity(entities.len());
+        for (rank, entity) in &order {
+            let entity = *entity;
+            let kind = match rank {
+                0 => SceneKind::Agent,
+                1 => SceneKind::Document,
+                2 | 6 => SceneKind::Link,
+                3 => SceneKind::Run,
+                4 => SceneKind::Utterance,
+                5 => SceneKind::Turn,
+                _ => SceneKind::InvalidCall,
+            };
+            let mut components = serde_json::Map::new();
+            take!(world, entity, components,
+                Owner => "owner", Preamble => "preamble", Temperature => "temperature",
+                MaxTokens => "max_tokens", AdditionalParams => "additional_params",
+                ToolChoiceSpec => "tool_choice", Output => "output", MaxTurns => "max_turns",
+                InvalidCalls => "invalid_calls", DefaultMaxTurns => "default_max_turns",
+                DocumentId => "document_id", DocumentText => "document_text",
+                DocumentProps => "document_props", Order => "order",
+                Utterance => "utterance", Role => "role", Parts => "parts",
+                Run => "run", RunSeq => "run_seq", Streamed => "streamed", Cursor => "cursor",
+                Assembling => "assembling", AwaitingModel => "awaiting_model",
+                Settled => "settled", Failed => "failed", RunResult => "run_result",
+                Usage => "usage", OutputRetries => "output_retries",
+                InvalidRetries => "invalid_retries", OutputToolName => "output_tool_name",
+                Scope => "scope", Turn => "turn", Outputs => "outputs", Reprompt => "reprompt",
+                InvalidCall => "invalid_call", Resolution => "resolution",
+            );
+            if world.get::<crate::systems::Fresh>(entity).is_some() {
+                components.insert("fresh".to_owned(), serde_json::Value::Bool(true));
+            }
+            if let Some(crate::systems::Folded(mode)) = world.get::<crate::systems::Folded>(entity)
+            {
+                components.insert(
+                    "folded".to_owned(),
+                    serde_json::to_value(mode).unwrap_or(serde_json::Value::Null),
+                );
+            }
+            if world.get::<crate::systems::Materialised>(entity).is_some() {
+                components.insert("materialised".to_owned(), serde_json::Value::Bool(true));
+            }
+            let parent = world
+                .get::<ChildOf>(entity)
+                .and_then(|child_of| index_of(child_of.parent()));
+            let mut relations = Vec::new();
+            if let Some(UsesModel(model)) = world.get::<UsesModel>(entity)
+                && let Some(target) = target_of(world, *model)
+            {
+                relations.push(("uses_model".to_owned(), target));
+            }
+            if let Some(RunOf(agent)) = world.get::<RunOf>(entity)
+                && let Some(target) = target_of(world, *agent)
+            {
+                relations.push(("run_of".to_owned(), target));
+            }
+            if let Some(Grant(tool)) = world.get::<Grant>(entity)
+                && let Some(target) = target_of(world, *tool)
+            {
+                relations.push(("grant".to_owned(), target));
+            }
+            if let Some(Context(document)) = world.get::<Context>(entity)
+                && let Some(target) = target_of(world, *document)
+            {
+                relations.push(("context".to_owned(), target));
+            }
+            if let Some(Attachment(document)) = world.get::<Attachment>(entity)
+                && let Some(target) = target_of(world, *document)
+            {
+                relations.push(("attachment".to_owned(), target));
+            }
+            if let Some(Advert(tool)) = world.get::<Advert>(entity)
+                && let Some(target) = target_of(world, *tool)
+            {
+                relations.push(("advert".to_owned(), target));
+            }
+            saved.push(SceneEntity {
+                kind,
+                components,
+                parent,
+                relations,
+            });
+        }
+        Self {
+            entities: saved,
+            next_order: world.get_resource::<OrderCounter>().map_or(0, |c| c.0),
+            next_run: world.get_resource::<RunCounter>().map_or(0, |c| c.0),
+        }
+    }
+
+    /// Spawn the graph into `world`. Handlers are the host's to bind first:
+    /// a relationship to a handler key nothing is bound to is an error
+    /// naming the key. Returns the spawned entities by scene index.
+    pub fn load(&self, world: &mut World) -> Result<Vec<Entity>, rig_core::error::ErrorReport> {
+        let mut spawned: Vec<Entity> = Vec::with_capacity(self.entities.len());
+        for _ in &self.entities {
+            spawned.push(world.spawn_empty().id());
+        }
+        let handler =
+            |world: &mut World, key: &HandlerKey| -> Result<Entity, rig_core::error::ErrorReport> {
+                world
+                    .query::<(Entity, &Bound)>()
+                    .iter(world)
+                    .find(|(_, bound)| &bound.key == key)
+                    .map(|(entity, _)| entity)
+                    .ok_or_else(|| {
+                        rig_core::error::ErrorReport::new(
+                            rig_core::error::ErrorKind::HandlerUnavailable,
+                            format!("the scene needs `{key}` bound before it loads"),
+                        )
+                    })
+            };
+        for (index, saved) in self.entities.iter().enumerate() {
+            let Some(entity) = spawned.get(index).copied() else {
+                continue;
+            };
+            let components = &saved.components;
+            give!(world, entity, components,
+                Owner => "owner", Preamble => "preamble", Temperature => "temperature",
+                MaxTokens => "max_tokens", AdditionalParams => "additional_params",
+                ToolChoiceSpec => "tool_choice", Output => "output", MaxTurns => "max_turns",
+                InvalidCalls => "invalid_calls", DefaultMaxTurns => "default_max_turns",
+                DocumentId => "document_id", DocumentText => "document_text",
+                DocumentProps => "document_props", Order => "order",
+                Utterance => "utterance", Role => "role", Parts => "parts",
+                Run => "run", RunSeq => "run_seq", Streamed => "streamed", Cursor => "cursor",
+                Assembling => "assembling", AwaitingModel => "awaiting_model",
+                Settled => "settled", Failed => "failed", RunResult => "run_result",
+                Usage => "usage", OutputRetries => "output_retries",
+                InvalidRetries => "invalid_retries", OutputToolName => "output_tool_name",
+                Scope => "scope", Turn => "turn", Outputs => "outputs", Reprompt => "reprompt",
+                InvalidCall => "invalid_call", Resolution => "resolution",
+            );
+            if components.get("fresh").is_some() {
+                world.entity_mut(entity).insert(crate::systems::Fresh);
+            }
+            if let Some(mode) = components.get("folded")
+                && let Ok(mode) = serde_json::from_value(mode.clone())
+            {
+                world
+                    .entity_mut(entity)
+                    .insert(crate::systems::Folded(mode));
+            }
+            if components.get("materialised").is_some() {
+                world
+                    .entity_mut(entity)
+                    .insert(crate::systems::Materialised);
+            }
+            if let Some(parent) = saved.parent.and_then(|at| spawned.get(at).copied()) {
+                world.entity_mut(entity).insert(ChildOf(parent));
+            }
+            for (name, target) in &saved.relations {
+                let to = match target {
+                    Target::Scene { index } => spawned.get(*index).copied().ok_or_else(|| {
+                        rig_core::error::ErrorReport::new(
+                            rig_core::error::ErrorKind::Internal,
+                            format!("the scene's `{name}` names entity {index}, which it lacks"),
+                        )
+                    })?,
+                    Target::Handler { key } => handler(world, key)?,
+                };
+                let mut entity = world.entity_mut(entity);
+                match name.as_str() {
+                    "uses_model" => {
+                        entity.insert(UsesModel(to));
+                    }
+                    "run_of" => {
+                        entity.insert(RunOf(to));
+                    }
+                    "grant" => {
+                        entity.insert(Grant(to));
+                    }
+                    "context" => {
+                        entity.insert(Context(to));
+                    }
+                    "attachment" => {
+                        entity.insert(Attachment(to));
+                    }
+                    "advert" => {
+                        entity.insert(Advert(to));
+                    }
+                    other => {
+                        return Err(rig_core::error::ErrorReport::new(
+                            rig_core::error::ErrorKind::Internal,
+                            format!("the scene names a relationship `{other}` this crate has not"),
+                        ));
+                    }
+                }
+            }
+        }
+        if let Some(mut counter) = world.get_resource_mut::<OrderCounter>() {
+            counter.0 = counter.0.max(self.next_order);
+        }
+        if let Some(mut counter) = world.get_resource_mut::<RunCounter>() {
+            counter.0 = counter.0.max(self.next_run);
+        }
+        Ok(spawned)
+    }
+}

--- a/crates/rig-ecs/src/lib.rs
+++ b/crates/rig-ecs/src/lib.rs
@@ -1,14 +1,32 @@
 //! rig inside a Bevy `World`.
 //!
-//! One module today, [`bus`]: the effect bus as a plugin — effects are
-//! entities, handlers are entities, the driver is a system, an outcome is a
-//! component, causality is `ChildOf`, a scene is a checkpoint. Nothing in
-//! this crate awaits, blocks, or holds a future for a host to probe.
+//! Two layers. [`bus`]: the effect bus as a plugin — effects are entities,
+//! handlers are entities, the driver is a system, an outcome is a
+//! component, causality is `ChildOf`, a scene is a checkpoint. And the
+//! agent runtime over it — [`agent`] (the run as a graph: agents,
+//! documents, utterances, runs, turns, as entities and relationships),
+//! [`policy`] (the verbatim strings and the one fold from the graph to the
+//! wire `CompletionRequest`), [`systems`] (one system per named set, in the
+//! bus's schedule) and [`replay`] (the log header from components). Nothing
+//! in this crate awaits, blocks, or holds a future for a host to probe;
+//! nothing is copied from `rig-agent`, and a guard refuses its name.
+//!
+//! The request is a graph in the world and a struct on the wire, with
+//! [`policy::fold_request`] as the one function between them. What the
+//! agent runtime does today: the completion-only run — request assembly,
+//! the stream fold, the three output modes and their reprompts, invalid
+//! calls as entities with a resolution, endings, the header. Not yet: tool
+//! dispatch (stage 3 of the programme), hooks as user systems (stage 4),
+//! memory, retrieval, routing and resume across runs (stage 5).
 //!
 //! The `bus` module is written as if it were already its own crate (every
-//! item `pub`, no import from a sibling module, no agent-shaped item, its
-//! tests in `tests/bus_*.rs`): the agent runtime the later modules add
-//! consumes it through its public items only, and it becomes `rig-bevy` by
+//! item `pub` or private to its file, no import from a sibling module, no
+//! agent-shaped item, its tests in `tests/bus_*.rs`): the agent modules
+//! consume it through its public items only, and it becomes `rig-bevy` by
 //! a `git mv` when a second consumer exists.
 
+pub mod agent;
 pub mod bus;
+pub mod policy;
+pub mod replay;
+pub mod systems;

--- a/crates/rig-ecs/src/policy/mod.rs
+++ b/crates/rig-ecs/src/policy/mod.rs
@@ -150,7 +150,7 @@ pub fn reprompt_missing_fields(name: &str, missing: &[String]) -> String {
 
 /// Whether an assistant turn belongs in history: not when it has no parts,
 /// or exactly one unannotated empty text part.
-pub fn is_empty_assistant_turn(content: &[AssistantContent]) -> bool {
+pub fn turn_is_empty(content: &[AssistantContent]) -> bool {
     match content {
         [] => true,
         [AssistantContent::Text(text)] => text.text.is_empty() && text.additional_params.is_none(),
@@ -212,7 +212,8 @@ pub fn fold_request(graph: &RequestGraph<'_>) -> CompletionRequest {
 
     let output_schema = match (graph.output, graph.schema) {
         (OutputKind::Native, Some(schema)) => schemars::Schema::try_from(schema.clone()).ok(),
-        _ => None,
+        (OutputKind::Native, None)
+        | (OutputKind::Auto | OutputKind::Tool | OutputKind::Prompted, _) => None,
     };
 
     CompletionRequest {
@@ -237,7 +238,9 @@ fn system_message(graph: &RequestGraph<'_>) -> Option<String> {
         (OutputKind::Prompted, _, Some(schema)) => {
             Some(text::prompted_augmentation(&to_canonical_string(schema)))
         }
-        _ => None,
+        (OutputKind::Tool, None, _)
+        | (OutputKind::Prompted, _, None)
+        | (OutputKind::Auto | OutputKind::Native, _, _) => None,
     };
     match (graph.preamble, augmentation) {
         (None, None) => None,

--- a/crates/rig-ecs/src/policy/mod.rs
+++ b/crates/rig-ecs/src/policy/mod.rs
@@ -1,0 +1,296 @@
+//! The pure policy: the verbatim strings the goldens pin, the one fold
+//! from the run graph to the wire request, and the small derivations the
+//! systems share. Every function here is over plain data and has its own
+//! tests; nothing here touches the world.
+
+use rig_core::{
+    completion::{
+        CompletionRequest, Document, ToolDefinition,
+        message::{AssistantContent, Message, ToolChoice, UserContent},
+    },
+    effect::HandlerDescriptor,
+    json_utils::to_canonical_string,
+};
+
+use crate::agent::{MessageParts, OutputKind};
+
+/// The strings the goldens pin, written once. Each has a test in
+/// `policy::tests` that compares it to the golden that pins it, cited by
+/// fixture and JSON pointer in `CONTRACT.md`.
+pub mod text {
+    /// The output tool's default name.
+    pub const OUTPUT_TOOL_NAME: &str = "final_result";
+
+    /// The output tool's description.
+    pub const OUTPUT_TOOL_DESCRIPTION: &str = "Call this tool exactly once with your final answer when you are done. Its arguments are the structured result and must satisfy the output schema.";
+
+    /// Appended to the preamble (after a blank line) when the answer is
+    /// asked for through the output tool; `{name}` is the tool's name.
+    pub fn output_tool_augmentation(name: &str) -> String {
+        format!(
+            "When you have gathered enough information to answer, call the `{name}` tool exactly once with your final answer. Its arguments are the structured result and must satisfy the required schema. Do not return the final answer as plain text."
+        )
+    }
+
+    /// Appended to the preamble (after a blank line) when the answer is
+    /// asked for as prompted JSON; `{schema}` is the schema's canonical
+    /// rendering.
+    pub fn prompted_augmentation(schema: &str) -> String {
+        format!(
+            "Respond with ONLY a single JSON object that conforms to this JSON Schema. Do not include any prose, explanation, or markdown code fences.\n{schema}"
+        )
+    }
+
+    /// The reprompt when the model answered as text instead of calling
+    /// the output tool.
+    pub fn reprompt_text_answer(name: &str) -> String {
+        format!(
+            "Provide your final answer by calling the `{name}` tool with the structured result as its arguments, not as plain text."
+        )
+    }
+
+    /// The separator between the preamble and an augmentation.
+    pub const AUGMENTATION_SEPARATOR: &str = "\n\n";
+}
+
+/// Whether the tool choice permits the output tool's call.
+pub fn output_tool_callable(choice: Option<&ToolChoice>, name: &str) -> bool {
+    match choice {
+        None | Some(ToolChoice::Auto) | Some(ToolChoice::Required) => true,
+        Some(ToolChoice::None) => false,
+        Some(ToolChoice::Specific { function_names }) => {
+            function_names.iter().any(|named| named == name)
+        }
+    }
+}
+
+/// The output mode a turn runs under once `Auto` is resolved, never `Auto`:
+/// no schema is `Native`; an explicit `Tool` the choice forbids degrades to
+/// `Native` (the constraint is still enforced, natively); `Auto` is `Tool`
+/// only with a real tool of the program's own, a permitting choice, and a
+/// provider that does not compose native output with tools — else
+/// `Native`.
+pub fn resolve_output(
+    mode: OutputKind,
+    has_schema: bool,
+    granted_tools: usize,
+    callable: bool,
+    provider_composes_native: bool,
+) -> OutputKind {
+    if !has_schema {
+        return OutputKind::Native;
+    }
+    match mode {
+        OutputKind::Native => OutputKind::Native,
+        OutputKind::Prompted => OutputKind::Prompted,
+        OutputKind::Tool => {
+            if callable {
+                OutputKind::Tool
+            } else {
+                OutputKind::Native
+            }
+        }
+        OutputKind::Auto => {
+            if granted_tools > 0 && callable && !provider_composes_native {
+                OutputKind::Tool
+            } else {
+                OutputKind::Native
+            }
+        }
+    }
+}
+
+/// The output tool's name for a run: the default, numbered from 1 on a
+/// collision with a granted tool's name (`final_result`, `final_result_1`,
+/// `final_result_2`, ...).
+pub fn output_tool_name(granted: &[&str]) -> String {
+    let base = text::OUTPUT_TOOL_NAME;
+    if !granted.contains(&base) {
+        return base.to_owned();
+    }
+    let mut suffix = 1;
+    loop {
+        let candidate = format!("{base}_{suffix}");
+        if !granted.contains(&candidate.as_str()) {
+            return candidate;
+        }
+        suffix += 1;
+    }
+}
+
+/// The required fields of an object schema the arguments lack, in the
+/// schema's order; a non-object argument lacks every one.
+pub fn missing_required_fields(
+    schema: &serde_json::Value,
+    arguments: &serde_json::Value,
+) -> Vec<String> {
+    let required: Vec<&str> = schema
+        .get("required")
+        .and_then(serde_json::Value::as_array)
+        .map(|names| names.iter().filter_map(serde_json::Value::as_str).collect())
+        .unwrap_or_default();
+    match arguments.as_object() {
+        Some(object) => required
+            .into_iter()
+            .filter(|name| !object.contains_key(*name))
+            .map(str::to_owned)
+            .collect(),
+        None => required.into_iter().map(str::to_owned).collect(),
+    }
+}
+
+/// The reprompt when the output tool was called without every required
+/// field: a tool result on the call, naming the fields.
+pub fn reprompt_missing_fields(name: &str, missing: &[String]) -> String {
+    format!(
+        "The `{name}` arguments were missing required field(s): {}. Call `{name}` again with every required field.",
+        missing.join(", ")
+    )
+}
+
+/// Whether an assistant turn belongs in history: not when it has no parts,
+/// or exactly one unannotated empty text part.
+pub fn is_empty_assistant_turn(content: &[AssistantContent]) -> bool {
+    match content {
+        [] => true,
+        [AssistantContent::Text(text)] => text.text.is_empty() && text.additional_params.is_none(),
+        _ => false,
+    }
+}
+
+/// What the fold reads: the graph, gathered by `Assemble` in order. Borrows
+/// the world's data; owns nothing.
+pub struct RequestGraph<'a> {
+    /// The preamble, if the program has one.
+    pub preamble: Option<&'a str>,
+    /// The utterances in order.
+    pub utterances: Vec<&'a MessageParts>,
+    /// The documents attached to the turn, in order.
+    pub documents: Vec<Document>,
+    /// The tools granted, in advertisement order, by their descriptors.
+    pub tools: Vec<&'a HandlerDescriptor>,
+    /// Sampling.
+    pub temperature: Option<f64>,
+    /// The token budget.
+    pub max_tokens: Option<u64>,
+    /// Provider parameters.
+    pub additional_params: Option<&'a serde_json::Value>,
+    /// The program's tool choice.
+    pub tool_choice: Option<&'a ToolChoice>,
+    /// The output mode, resolved, and its schema.
+    pub output: OutputKind,
+    /// The schema, if any.
+    pub schema: Option<&'a serde_json::Value>,
+    /// The output tool's name, when the mode is `Tool`.
+    pub output_tool: Option<&'a str>,
+}
+
+/// The one fold: the wire request from the graph. The only constructor of
+/// a `CompletionRequest` in the crate (a root guard refuses another).
+pub fn fold_request(graph: &RequestGraph<'_>) -> CompletionRequest {
+    let mut chat_history: Vec<Message> = Vec::with_capacity(graph.utterances.len() + 2);
+    let system = system_message(graph);
+    if let Some(content) = system {
+        chat_history.push(Message::System { content });
+    }
+    chat_history.extend(graph.utterances.iter().map(|parts| parts.to_message()));
+
+    let mut tools: Vec<ToolDefinition> = graph
+        .tools
+        .iter()
+        .filter_map(|descriptor| tool_definition(descriptor))
+        .collect();
+    if graph.output == OutputKind::Tool
+        && let (Some(name), Some(schema)) = (graph.output_tool, graph.schema)
+    {
+        tools.push(ToolDefinition {
+            name: name.to_owned(),
+            description: text::OUTPUT_TOOL_DESCRIPTION.to_owned(),
+            parameters: schema.clone(),
+        });
+    }
+
+    let output_schema = match (graph.output, graph.schema) {
+        (OutputKind::Native, Some(schema)) => schemars::Schema::try_from(schema.clone()).ok(),
+        _ => None,
+    };
+
+    CompletionRequest {
+        model: None,
+        chat_history,
+        documents: graph.documents.clone(),
+        tools,
+        temperature: graph.temperature,
+        max_tokens: graph.max_tokens,
+        tool_choice: graph.tool_choice.cloned(),
+        additional_params: graph.additional_params.cloned(),
+        output_schema,
+        record_telemetry_content: false,
+    }
+}
+
+/// The system message: the preamble with the output mode's augmentation,
+/// or none when the program has no preamble and nothing to add.
+fn system_message(graph: &RequestGraph<'_>) -> Option<String> {
+    let augmentation = match (graph.output, graph.output_tool, graph.schema) {
+        (OutputKind::Tool, Some(name), _) => Some(text::output_tool_augmentation(name)),
+        (OutputKind::Prompted, _, Some(schema)) => {
+            Some(text::prompted_augmentation(&to_canonical_string(schema)))
+        }
+        _ => None,
+    };
+    match (graph.preamble, augmentation) {
+        (None, None) => None,
+        (Some(preamble), None) => Some(preamble.to_owned()),
+        (None, Some(augmentation)) => Some(augmentation),
+        (Some(preamble), Some(augmentation)) => Some(format!(
+            "{preamble}{}{augmentation}",
+            text::AUGMENTATION_SEPARATOR
+        )),
+    }
+}
+
+/// A tool handler's descriptor as the definition the model sees.
+pub fn tool_definition(descriptor: &HandlerDescriptor) -> Option<ToolDefinition> {
+    match &descriptor.family {
+        rig_core::effect::FamilyDescriptor::Tool {
+            name,
+            description,
+            parameters,
+            ..
+        } => Some(ToolDefinition {
+            name: name.clone(),
+            description: description.clone(),
+            parameters: parameters.clone(),
+        }),
+        rig_core::effect::FamilyDescriptor::Completion { .. }
+        | rig_core::effect::FamilyDescriptor::Embed { .. }
+        | rig_core::effect::FamilyDescriptor::Rerank { .. }
+        | rig_core::effect::FamilyDescriptor::Memory { .. }
+        | rig_core::effect::FamilyDescriptor::Retrieve { .. }
+        | rig_core::effect::FamilyDescriptor::Custom { .. } => None,
+    }
+}
+
+/// The text of an assistant answer: its text parts concatenated.
+pub fn answer_text(content: &[AssistantContent]) -> String {
+    content
+        .iter()
+        .filter_map(|part| match part {
+            AssistantContent::Text(text) => Some(text.text.as_str()),
+            AssistantContent::Reasoning(_)
+            | AssistantContent::Image(_)
+            | AssistantContent::ToolCall(_) => None,
+        })
+        .collect()
+}
+
+/// A user message of one text part.
+pub fn user_text(text: &str) -> Message {
+    Message::User {
+        content: vec![UserContent::text(text)],
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/rig-ecs/src/policy/tests.rs
+++ b/crates/rig-ecs/src/policy/tests.rs
@@ -164,9 +164,9 @@ fn the_output_tool_name_numbers_from_one() {
 /// (`anthropic_request_shape_tool_choice_none` `/records/0/outcome`).
 #[test]
 fn an_empty_turn_is_not_history() {
-    assert!(is_empty_assistant_turn(&[]));
-    assert!(is_empty_assistant_turn(&[AssistantContent::text("")]));
-    assert!(!is_empty_assistant_turn(&[AssistantContent::text("x")]));
+    assert!(turn_is_empty(&[]));
+    assert!(turn_is_empty(&[AssistantContent::text("")]));
+    assert!(!turn_is_empty(&[AssistantContent::text("x")]));
 }
 
 /// CONTRACT §derivation: the fold over the smoke golden's graph is the

--- a/crates/rig-ecs/src/policy/tests.rs
+++ b/crates/rig-ecs/src/policy/tests.rs
@@ -1,0 +1,288 @@
+//! The strings and the fold against the goldens that pin them. Each test
+//! names its CONTRACT row; the goldens are read from `rig-verify`'s
+//! fixtures, never restated.
+
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+
+use rig_core::{
+    completion::message::{Message, ToolChoice, UserContent},
+    effect::{EffectKind, FamilyDescriptor, HandlerDescriptor, HandlerKey},
+};
+
+use super::*;
+use crate::agent::OutputKind;
+
+fn golden(name: &str) -> serde_json::Value {
+    let path = format!(
+        "{}/../rig-verify/fixtures/{name}.effects.json",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    serde_json::from_str(&std::fs::read_to_string(path).expect("the golden is committed"))
+        .expect("the golden loads")
+}
+
+fn request(name: &str, record: usize) -> serde_json::Value {
+    golden(name)["records"][record]["kind"]["request"].clone()
+}
+
+fn system_content(request: &serde_json::Value) -> Option<String> {
+    request["chat_history"]
+        .as_array()?
+        .first()
+        .filter(|message| message["role"] == "system")
+        .and_then(|message| message["content"].as_str())
+        .map(str::to_owned)
+}
+
+/// CONTRACT §strings: the output tool's name and description
+/// (`anthropic_output_tool_unary` `/records/0/kind/request/tools/0`).
+#[test]
+fn the_output_tool_is_the_goldens() {
+    let tool = request("anthropic_output_tool_unary", 0)["tools"][0].clone();
+    assert_eq!(tool["name"], text::OUTPUT_TOOL_NAME);
+    assert_eq!(tool["description"], text::OUTPUT_TOOL_DESCRIPTION);
+}
+
+/// CONTRACT §strings: the tool-mode augmentation after a blank line
+/// (`anthropic_output_tool_unary` `/records/0/kind/request/chat_history/0`).
+#[test]
+fn the_tool_augmentation_is_the_goldens() {
+    let system =
+        system_content(&request("anthropic_output_tool_unary", 0)).expect("a system message");
+    let expected = format!(
+        "You are a concise assistant. Answer directly.{}{}",
+        text::AUGMENTATION_SEPARATOR,
+        text::output_tool_augmentation("final_result")
+    );
+    assert_eq!(system, expected);
+}
+
+/// CONTRACT §strings: the prompted augmentation with the canonical schema
+/// (`anthropic_output_prompted_unary` `/records/0/kind/request/chat_history/0`).
+#[test]
+fn the_prompted_augmentation_is_the_goldens() {
+    let system =
+        system_content(&request("anthropic_output_prompted_unary", 0)).expect("a system message");
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "title": {"type": "string"},
+            "category": {"type": "string"},
+            "summary": {"type": "string"}
+        },
+        "required": ["title", "category", "summary"]
+    });
+    let expected = format!(
+        "You are a concise assistant. Answer directly.{}{}",
+        text::AUGMENTATION_SEPARATOR,
+        text::prompted_augmentation(&to_canonical_string(&schema))
+    );
+    assert_eq!(system, expected);
+}
+
+/// CONTRACT §reprompts: the text-answer reprompt
+/// (`mock_output_tool_text_reprompt` `/records/1/kind/request/chat_history/3`).
+#[test]
+fn the_text_reprompt_is_the_goldens() {
+    let last = request("mock_output_tool_text_reprompt", 1)["chat_history"][3].clone();
+    assert_eq!(last["role"], "user");
+    assert_eq!(
+        last["content"][0]["text"],
+        text::reprompt_text_answer("final_result")
+    );
+}
+
+/// CONTRACT §reprompts: the missing-field reprompt as a tool result
+/// (`mock_output_tool_missing_field_reprompt` `/records/1/kind/request/chat_history/3`).
+#[test]
+fn the_missing_field_reprompt_is_the_goldens() {
+    let last = request("mock_output_tool_missing_field_reprompt", 1)["chat_history"][3].clone();
+    assert_eq!(last["content"][0]["type"], "toolresult");
+    assert_eq!(last["content"][0]["name"], "final_result");
+    assert_eq!(
+        last["content"][0]["content"][0]["text"],
+        reprompt_missing_fields("final_result", &["summary".to_owned()])
+    );
+}
+
+/// CONTRACT §output: `Auto` with a schema is `Native` when the provider
+/// composes native output with tools (`anthropic_request_shape_output_schema_unary`),
+/// `Tool` is `Native` under `tool_choice: none`
+/// (`anthropic_output_tool_under_none_degrades`), no schema is `Native`.
+#[test]
+fn output_resolution_follows_the_goldens() {
+    assert_eq!(
+        resolve_output(OutputKind::Auto, true, 0, true, true),
+        OutputKind::Native
+    );
+    assert_eq!(
+        resolve_output(OutputKind::Auto, true, 1, true, false),
+        OutputKind::Tool
+    );
+    assert_eq!(
+        resolve_output(OutputKind::Tool, true, 0, false, true),
+        OutputKind::Native
+    );
+    assert_eq!(
+        resolve_output(OutputKind::Tool, true, 0, true, true),
+        OutputKind::Tool
+    );
+    assert_eq!(
+        resolve_output(OutputKind::Prompted, false, 0, true, true),
+        OutputKind::Native
+    );
+    assert!(!output_tool_callable(
+        Some(&ToolChoice::None),
+        "final_result"
+    ));
+    assert!(output_tool_callable(
+        Some(&ToolChoice::Specific {
+            function_names: vec!["final_result".to_owned()]
+        }),
+        "final_result"
+    ));
+}
+
+/// CONTRACT §output: the output tool's name is numbered from 1 on a
+/// collision (`rig_agent::run::prepare` docs; no golden collides).
+#[test]
+fn the_output_tool_name_numbers_from_one() {
+    assert_eq!(output_tool_name(&["add"]), "final_result");
+    assert_eq!(output_tool_name(&["final_result"]), "final_result_1");
+    assert_eq!(
+        output_tool_name(&["final_result", "final_result_1"]),
+        "final_result_2"
+    );
+}
+
+/// CONTRACT §history: an empty turn is no history
+/// (`anthropic_request_shape_tool_choice_none` `/records/0/outcome`).
+#[test]
+fn an_empty_turn_is_not_history() {
+    assert!(is_empty_assistant_turn(&[]));
+    assert!(is_empty_assistant_turn(&[AssistantContent::text("")]));
+    assert!(!is_empty_assistant_turn(&[AssistantContent::text("x")]));
+}
+
+/// CONTRACT §derivation: the fold over the smoke golden's graph is the
+/// smoke golden's request, field for field
+/// (`anthropic_completion_smoke` `/records/0/kind/request`).
+#[test]
+fn the_fold_reproduces_the_smoke_request() {
+    let prompt = MessageParts::User {
+        content: vec![UserContent::text(
+            "In one or two sentences, explain what Rust programming language is and why memory safety matters.",
+        )],
+    };
+    let graph = RequestGraph {
+        preamble: Some("You are a concise assistant. Answer directly."),
+        utterances: vec![&prompt],
+        documents: Vec::new(),
+        tools: Vec::new(),
+        temperature: None,
+        max_tokens: None,
+        additional_params: None,
+        tool_choice: None,
+        output: OutputKind::Native,
+        schema: None,
+        output_tool: None,
+    };
+    let folded = serde_json::to_value(fold_request(&graph)).expect("serde");
+    assert_eq!(folded, request("anthropic_completion_smoke", 0));
+}
+
+/// CONTRACT §derivation: static context is the attachments in order
+/// (`anthropic_request_shape_static_context` `/records/0/kind/request/documents`),
+/// and a granted tool is its descriptor
+/// (`anthropic_request_shape_tool_choice_none` `/records/0/kind/request/tools`).
+#[test]
+fn documents_and_tools_fold_from_the_graph() {
+    let golden = request("anthropic_request_shape_static_context", 0);
+    let documents: Vec<Document> =
+        serde_json::from_value(golden["documents"].clone()).expect("serde");
+    let prompt = MessageParts::User {
+        content: vec![UserContent::text("What does \"glarb-glarb\" mean?")],
+    };
+    let graph = RequestGraph {
+        preamble: Some("You are a concise assistant. Answer directly."),
+        utterances: vec![&prompt],
+        documents,
+        tools: Vec::new(),
+        temperature: Some(0.0),
+        max_tokens: None,
+        additional_params: None,
+        tool_choice: None,
+        output: OutputKind::Native,
+        schema: None,
+        output_tool: None,
+    };
+    assert_eq!(
+        serde_json::to_value(fold_request(&graph)).expect("serde"),
+        golden
+    );
+
+    let golden = request("anthropic_request_shape_tool_choice_none", 0);
+    let tool = &golden["tools"][0];
+    let descriptor = HandlerDescriptor {
+        key: HandlerKey::from("golden/tool:add#0"),
+        family: FamilyDescriptor::Tool {
+            name: tool["name"].as_str().expect("name").to_owned(),
+            description: tool["description"]
+                .as_str()
+                .expect("description")
+                .to_owned(),
+            parameters: tool["parameters"].clone(),
+            embedding: None,
+        },
+        layers: Vec::new(),
+    };
+    let prompt = MessageParts::User {
+        content: vec![UserContent::text(
+            "What is 17 + 25? Reply with just the number.",
+        )],
+    };
+    let graph = RequestGraph {
+        preamble: Some("You are a concise assistant. Answer directly."),
+        utterances: vec![&prompt],
+        documents: Vec::new(),
+        tools: vec![&descriptor],
+        temperature: Some(0.0),
+        max_tokens: None,
+        additional_params: None,
+        tool_choice: Some(&ToolChoice::None),
+        output: OutputKind::Native,
+        schema: None,
+        output_tool: None,
+    };
+    assert_eq!(
+        serde_json::to_value(fold_request(&graph)).expect("serde"),
+        golden
+    );
+}
+
+/// A system message is never an utterance; user and assistant parts round
+/// trip through `MessageParts`.
+#[test]
+fn message_parts_round_trip_but_never_a_system_message() {
+    assert!(
+        MessageParts::from_message(&Message::System {
+            content: "x".to_owned()
+        })
+        .is_none()
+    );
+    let user = user_text("hi");
+    let parts = MessageParts::from_message(&user).expect("a user message");
+    assert_eq!(
+        serde_json::to_value(parts.to_message()).expect("serde"),
+        serde_json::to_value(&user).expect("serde")
+    );
+    let _ = EffectKind::Custom {
+        kind: std::sync::Arc::from("unused"),
+        payload: serde_json::Value::Null,
+    };
+}

--- a/crates/rig-ecs/src/replay/mod.rs
+++ b/crates/rig-ecs/src/replay/mod.rs
@@ -1,0 +1,142 @@
+//! The header from components: a run's program identity as the log names
+//! it, computed from the agent entity — never from a spec struct.
+
+use bevy_ecs::prelude::*;
+use rig_core::effect::{EffectFamily, EffectRow, HandlerKey};
+use rig_effect_log::{EffectLogRecorder, stable_hash};
+
+use crate::{
+    agent::{
+        AdditionalParams, Context, DefaultMaxTurns, DocumentId, DocumentProps, DocumentText, Grant,
+        MaxTokens, Order, Output, OutputKind, Preamble, Temperature, ToolChoiceSpec, UsesModel,
+    },
+    bus::Bound,
+};
+
+/// The JSON the header's `run_spec` hashes for `agent`: the shape
+/// `CONTRACT.md` names, built from components, canonicalised by
+/// [`stable_hash`]. The builder's identity: the default turn budget, no
+/// retries, `fail` — a run's own overrides are not identity.
+pub fn spec_json(world: &mut World, agent: Entity) -> serde_json::Value {
+    let preamble = world.get::<Preamble>(agent).and_then(|p| p.0.clone());
+    let temperature = world.get::<Temperature>(agent).and_then(|t| t.0);
+    let max_tokens = world.get::<MaxTokens>(agent).and_then(|m| m.0);
+    let additional_params = world
+        .get::<AdditionalParams>(agent)
+        .and_then(|p| p.0.clone());
+    let tool_choice = world
+        .get::<ToolChoiceSpec>(agent)
+        .and_then(|c| c.0.clone())
+        .map(|choice| serde_json::to_value(choice).unwrap_or(serde_json::Value::Null));
+    let output = world.get::<Output>(agent).cloned().unwrap_or_default();
+    let max_turns = world
+        .get::<DefaultMaxTurns>(agent)
+        .and_then(|d| d.0)
+        .unwrap_or(1);
+    let mut context: Vec<(Order, serde_json::Value)> = Vec::new();
+    if let Some(children) = world.get::<Children>(agent) {
+        let links: Vec<Entity> = children.iter().collect();
+        for child in links {
+            if let (Some(Context(document)), Some(order)) =
+                (world.get::<Context>(child), world.get::<Order>(child))
+            {
+                let document = *document;
+                let order = *order;
+                let id = world.get::<DocumentId>(document).map(|d| d.0.clone());
+                let text = world.get::<DocumentText>(document).map(|d| d.0.clone());
+                let props = world
+                    .get::<DocumentProps>(document)
+                    .map(|p| p.0.clone())
+                    .unwrap_or_default();
+                if let (Some(id), Some(text)) = (id, text) {
+                    let mut json = serde_json::Map::new();
+                    json.insert("id".to_owned(), serde_json::Value::String(id));
+                    json.insert("text".to_owned(), serde_json::Value::String(text));
+                    for (key, value) in props {
+                        json.insert(key, serde_json::Value::String(value));
+                    }
+                    context.push((order, serde_json::Value::Object(json)));
+                }
+            }
+        }
+    }
+    context.sort_by_key(|(order, _)| *order);
+    let output_mode = match output.mode {
+        OutputKind::Auto => "Auto",
+        OutputKind::Native => "Native",
+        OutputKind::Tool => "Tool",
+        OutputKind::Prompted => "Prompted",
+    };
+    serde_json::json!({
+        "preamble": preamble,
+        "static_context": context.into_iter().map(|(_, document)| document).collect::<Vec<_>>(),
+        "additional_params": additional_params,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "tool_choice": tool_choice,
+        "max_turns": max_turns,
+        "max_invalid_tool_call_retries": 0,
+        "output_schema": output.schema,
+        "output_mode": output_mode,
+        "output_tool_name": serde_json::Value::Null,
+        "output_tool_description": serde_json::Value::Null,
+        "augment_output_preamble": true,
+        "unhandled_invalid_tool_call": "fail",
+    })
+}
+
+/// The header's `run_spec` for `agent`.
+pub fn spec_hash(world: &mut World, agent: Entity) -> Option<u64> {
+    stable_hash(&spec_json(world, agent)).ok()
+}
+
+/// The agent's required effect row: its model, and every tool it grants,
+/// by their bound keys.
+pub fn required_row(world: &mut World, agent: Entity) -> EffectRow {
+    let mut row = EffectRow::new();
+    let model = world.get::<UsesModel>(agent).map(|uses| uses.0);
+    if let Some(model) = model
+        && let Some(bound) = world.get::<Bound>(model)
+    {
+        row.insert(bound.key.clone(), EffectFamily::Completion);
+    }
+    let links: Vec<Entity> = world
+        .get::<Children>(agent)
+        .map(|children| children.iter().collect())
+        .unwrap_or_default();
+    for link in links {
+        let tool = world.get::<Grant>(link).map(|grant| grant.0);
+        if let Some(tool) = tool
+            && let Some(bound) = world.get::<Bound>(tool)
+        {
+            row.insert(bound.key.clone(), bound.descriptor.family.family());
+        }
+    }
+    row
+}
+
+/// Stamp `recorder`'s header with `agent`'s identity: the spec hash, an
+/// empty hook list (the world has no hooks), the required row, and the
+/// bus policy the world runs under.
+pub fn stamp_header(
+    world: &mut World,
+    agent: Entity,
+    recorder: &EffectLogRecorder,
+    bus: Option<rig_core::serve::ServingPolicy>,
+) {
+    if let Some(hash) = spec_hash(world, agent) {
+        recorder.set_run_spec(hash);
+    }
+    let required = required_row(world, agent);
+    recorder.set_program(Vec::new(), required, bus);
+}
+
+/// The key an agent mints for its model: `<owner>/model:<label>`.
+pub fn model_key(owner: &str, label: &str) -> HandlerKey {
+    HandlerKey::from(format!("{owner}/model:{label}"))
+}
+
+/// The key an agent mints for a tool: `<owner>/tool:<name>#<n>`.
+pub fn tool_key(owner: &str, name: &str, generation: u32) -> HandlerKey {
+    HandlerKey::from(format!("{owner}/tool:{name}#{generation}"))
+}

--- a/crates/rig-ecs/src/systems/mod.rs
+++ b/crates/rig-ecs/src/systems/mod.rs
@@ -104,6 +104,7 @@ impl Plugin for AgentPlugin {
         );
         app.init_resource::<OrderCounter>()
             .init_resource::<RunCounter>();
+        app.add_observer(effect_cancelled);
         let mut schedules = app.world_mut().resource_mut::<Schedules>();
         let Some(schedule) = schedules.get_mut(RigSchedule) else {
             return;
@@ -426,6 +427,20 @@ pub fn assemble(
             callable,
             composes,
         );
+        if let Some(name) = &minted.0
+            && granted_names.contains(&name.as_str())
+        {
+            // A tool granted after the mint took the output tool's name: a
+            // request that advertised both would be ambiguous, so the run
+            // fails here, named, as rig-agent's docs say it must.
+            commands.entity(turn).remove::<Fresh>();
+            commands
+                .entity(run)
+                .remove::<Assembling>()
+                .insert(Failed(Failure::OutputToolCollision { name: name.clone() }));
+            progress.mark();
+            continue;
+        }
         if resolved == OutputKind::Tool && minted.0.is_none() {
             commands
                 .entity(run)
@@ -668,7 +683,7 @@ pub fn materialise(
         let content = &response.choice;
 
         // An empty turn is not history, and answers nothing.
-        if policy::is_empty_assistant_turn(content) {
+        if policy::turn_is_empty(content) {
             commands
                 .entity(run)
                 .remove::<AwaitingModel>()
@@ -835,7 +850,8 @@ pub fn materialise(
                     }
                 }
             }
-            _ => {
+            (OutputKind::Tool, None)
+            | (OutputKind::Auto | OutputKind::Native | OutputKind::Prompted, _) => {
                 commands
                     .entity(run)
                     .remove::<AwaitingModel>()
@@ -844,4 +860,33 @@ pub fn materialise(
         }
         progress.mark();
     }
+}
+
+/// An effect despawned while its turn was unread — a system in `Patch`
+/// stopping the run, a host cancelling — ends the run `Cancelled`: the
+/// record says so (the bus's cancel observer), and so does the run.
+pub fn effect_cancelled(
+    removed: On<bevy_ecs::lifecycle::Remove, PendingEffect>,
+    effects: Query<&ChildOf, With<PendingEffect>>,
+    turns: Query<&ChildOf, (With<Turn>, Without<Materialised>)>,
+    runs: Query<(), With<AwaitingModel>>,
+    mut commands: Commands,
+) {
+    let effect = removed.event().entity;
+    let Ok(turn_of) = effects.get(effect) else {
+        return;
+    };
+    let turn = turn_of.parent();
+    let Ok(run_of) = turns.get(turn) else {
+        return;
+    };
+    let run = run_of.parent();
+    if runs.get(run).is_err() {
+        return;
+    }
+    commands.entity(turn).insert(Materialised);
+    commands
+        .entity(run)
+        .remove::<AwaitingModel>()
+        .insert(Failed(Failure::Cancelled(rig_core::serve::cancelled())));
 }

--- a/crates/rig-ecs/src/systems/mod.rs
+++ b/crates/rig-ecs/src/systems/mod.rs
@@ -1,0 +1,847 @@
+//! The agent's systems: one per named set of [`RigSet`], in the bus
+//! module's `RigSchedule`, run to quiescence by its runner.
+//!
+//! | set | true before | written during |
+//! |---|---|---|
+//! | `Advance` | a run in `Assembling` has no fresh turn | a turn is spawned `ChildOf` the run with its adverts and attachments, or the run fails `MaxTurns` |
+//! | `Select` | a run may lack a model of its own | the agent's `UsesModel` is copied to the run |
+//! | `Assemble` | a fresh turn's graph is complete | the fold spawns the turn's effect; the run is `AwaitingModel` |
+//! | `Patch` | the folded effect is a `PendingEffect` | a user system may rewrite it (the second steering slot) |
+//! | *the bus's `Gate`, `Dispatch`, `Collect`, `Judge`* | | |
+//! | `Fold` | the effect may have streamed or landed | `Outputs` on the turn, per tick |
+//! | `Judge` | the turn's outputs are complete | a user system may rewrite them |
+//! | `Materialise` | a complete turn is unread | the assistant utterance, the answer, a reprompt, an invalid call, or a failure |
+//! | `Settle` | a run settled or failed this pass | nothing yet (observers fire on `Settled`/`Failed`) |
+//!
+//! The first steering slot is any system before `Assemble`: it edits the
+//! graph (utterances, documents, grants, settings).
+
+use bevy_app::{App, Plugin};
+use bevy_ecs::{prelude::*, schedule::LogLevel};
+use rig_core::{
+    completion::message::{AssistantContent, ToolResultContent, UserContent},
+    effect::{EffectKind, FamilyDescriptor, Outcome},
+    error::ErrorKind,
+};
+
+use crate::{
+    agent::{
+        AdditionalParams, Advert, Assembling, Attachment, AwaitingModel, Context, Cursor,
+        DocumentId, DocumentProps, DocumentText, Failed, Failure, Grant, InvalidCall, InvalidCalls,
+        MaxTokens, MaxTurns, MessageParts, Order, OrderCounter, Output, OutputKind, OutputRetries,
+        OutputToolName, Outputs, Parts, Preamble, Reprompt, Resolution, Run, RunCounter, RunOf,
+        RunResult, RunSeq, Settled, Streamed, Temperature, ToolChoiceSpec, Turn, Unhandled, Usage,
+        UsesModel, Utterance,
+    },
+    bus::{
+        Bound, BusPlugin, BusSet, EffectOutcome, PendingEffect, Progress, RigSchedule, Scope,
+        Streamed as BusStreamed,
+    },
+    policy::{self, RequestGraph},
+};
+
+/// The agent's sets, in order, around the bus module's.
+#[derive(SystemSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RigSet {
+    /// A run that wants a turn gets one, or fails its budget.
+    Advance,
+    /// A run without a model of its own takes the agent's.
+    Select,
+    /// The fold: the turn's graph becomes the turn's effect.
+    Assemble,
+    /// The second steering slot: the folded effect, before the bus.
+    Patch,
+    /// The turn's outputs from the effect's stream or answer.
+    Fold,
+    /// The agent's judge: the turn's outputs, before they are read.
+    Judge,
+    /// The turn is read into the graph.
+    Materialise,
+    /// A run settled or failed.
+    Settle,
+}
+
+/// A run that wants a turn: `Assembling`, not failed.
+pub type Wanting = (With<Assembling>, Without<Failed>);
+/// A run with no model of its own yet.
+pub type Unselected = (With<Run>, Without<UsesModel>);
+/// What `Fold` reads of an effect.
+pub type EffectView = (
+    &'static ChildOf,
+    Option<&'static BusStreamed>,
+    Option<&'static EffectOutcome>,
+);
+/// An invalid call nothing resolved.
+pub type Unresolved = (With<InvalidCall>, Without<Resolution>);
+/// A turn `Materialise` has not read.
+pub type Unread = (With<Turn>, Without<Materialised>);
+
+/// A fresh turn: spawned by `Advance`, not yet folded by `Assemble`.
+#[derive(Component, Debug, Clone, Copy, Default)]
+pub struct Fresh;
+
+/// The output mode the turn was folded under, pinned.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Folded(pub OutputKind);
+
+/// A turn `Materialise` has read.
+#[derive(Component, Debug, Clone, Copy, Default)]
+pub struct Materialised;
+
+/// The agent runtime: [`BusPlugin`] must be added first (it owns the
+/// schedule); this adds the sets, the counters and the systems.
+#[derive(Debug, Clone, Default)]
+pub struct AgentPlugin {
+    /// Ambiguity detection for the agent's systems' ordering.
+    pub ambiguity: Option<LogLevel>,
+}
+
+impl Plugin for AgentPlugin {
+    fn build(&self, app: &mut App) {
+        assert!(
+            app.is_plugin_added::<BusPlugin>(),
+            "AgentPlugin needs BusPlugin added first: it runs in the bus's RigSchedule"
+        );
+        app.init_resource::<OrderCounter>()
+            .init_resource::<RunCounter>();
+        let mut schedules = app.world_mut().resource_mut::<Schedules>();
+        let Some(schedule) = schedules.get_mut(RigSchedule) else {
+            return;
+        };
+        schedule.configure_sets(
+            (
+                RigSet::Advance,
+                RigSet::Select,
+                RigSet::Assemble,
+                RigSet::Patch,
+            )
+                .chain()
+                .before(BusSet::Gate),
+        );
+        schedule.configure_sets(
+            (
+                RigSet::Fold,
+                RigSet::Judge,
+                RigSet::Materialise,
+                RigSet::Settle,
+            )
+                .chain()
+                .after(BusSet::Judge),
+        );
+        schedule.add_systems((
+            advance.in_set(RigSet::Advance),
+            select.in_set(RigSet::Select),
+            assemble.in_set(RigSet::Assemble),
+            fold.in_set(RigSet::Fold),
+            (resolve_invalid_defaults, materialise)
+                .chain()
+                .in_set(RigSet::Materialise),
+        ));
+    }
+}
+
+/// Spawn a run of `agent` with `prompt` as its first utterance, after
+/// `history`: the host's one entry point. Returns the run entity.
+pub fn spawn_run(
+    world: &mut World,
+    agent: Entity,
+    history: &[MessageParts],
+    prompt: &str,
+    streamed: bool,
+    max_turns: Option<usize>,
+) -> Entity {
+    let seq = {
+        let mut counter = world.resource_mut::<RunCounter>();
+        let seq = counter.0;
+        counter.0 += 1;
+        seq
+    };
+    let owner = world
+        .get::<crate::agent::Owner>(agent)
+        .map(|owner| owner.0.clone())
+        .unwrap_or_default();
+    let mut run = world.spawn((
+        Run,
+        RunOf(agent),
+        RunSeq(seq),
+        Streamed(streamed),
+        Cursor::default(),
+        Assembling,
+        OutputRetries::default(),
+        crate::agent::InvalidRetries::default(),
+        OutputToolName::default(),
+        Usage::default(),
+        Scope(format!("{owner}/run#{seq}")),
+    ));
+    if let Some(limit) = max_turns {
+        run.insert(MaxTurns(limit));
+    }
+    let run = run.id();
+    for parts in history {
+        spawn_utterance(world, run, parts.clone());
+    }
+    spawn_utterance(
+        world,
+        run,
+        MessageParts::User {
+            content: vec![UserContent::text(prompt)],
+        },
+    );
+    run
+}
+
+/// Spawn one utterance `ChildOf` `run`, next in order.
+pub fn spawn_utterance(world: &mut World, run: Entity, parts: MessageParts) -> Entity {
+    let order = next_order(world);
+    world
+        .spawn((Utterance, parts.role(), Parts(parts), order, ChildOf(run)))
+        .id()
+}
+
+/// The next [`Order`].
+pub fn next_order(world: &mut World) -> Order {
+    let mut counter = world.resource_mut::<OrderCounter>();
+    let order = Order(counter.0);
+    counter.0 += 1;
+    order
+}
+
+fn next_order_in(counter: &mut OrderCounter) -> Order {
+    let order = Order(counter.0);
+    counter.0 += 1;
+    order
+}
+
+/// A run's effective setting: its own component, else its agent's.
+fn setting<'a, C: Component>(run: Entity, agent: Entity, query: &'a Query<&C>) -> Option<&'a C> {
+    query.get(run).ok().or_else(|| query.get(agent).ok())
+}
+
+/// The links of one kind under `owner`, in order.
+fn links_in_order<'a, L: Component>(
+    owner: Entity,
+    children: &Query<&Children>,
+    links: &'a Query<(&L, &Order)>,
+) -> Vec<&'a L> {
+    let mut found: Vec<(&Order, &L)> = children
+        .get(owner)
+        .map(|children| {
+            children
+                .iter()
+                .filter_map(|child| links.get(child).ok().map(|(link, order)| (order, link)))
+                .collect()
+        })
+        .unwrap_or_default();
+    found.sort_by_key(|(order, _)| **order);
+    found.into_iter().map(|(_, link)| link).collect()
+}
+
+/// `RigSet::Advance`: a run in `Assembling` with no fresh turn gets one —
+/// `ChildOf` the run, with an advert per grant and an attachment per
+/// context link, in the agent's order — or, at its budget, fails
+/// `MaxTurns`.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "one system, one pass: every parameter is a distinct world access it needs"
+)]
+pub fn advance(
+    mut commands: Commands,
+    runs: Query<(Entity, &RunOf, &Cursor, &RunSeq), Wanting>,
+    fresh: Query<&ChildOf, With<Fresh>>,
+    children: Query<&Children>,
+    grants: Query<(&Grant, &Order)>,
+    contexts: Query<(&Context, &Order)>,
+    max_turns: Query<&MaxTurns>,
+    mut orders: ResMut<OrderCounter>,
+    mut progress: ResMut<Progress>,
+) {
+    let mut runs: Vec<_> = runs.iter().collect();
+    runs.sort_by_key(|(_, _, _, seq)| **seq);
+    for (run, RunOf(agent), cursor, _) in runs {
+        if fresh.iter().any(|child_of| child_of.parent() == run) {
+            continue;
+        }
+        let limit = setting(run, *agent, &max_turns).map_or(1, |limit| limit.0);
+        if cursor.turn >= limit {
+            commands
+                .entity(run)
+                .remove::<Assembling>()
+                .insert(Failed(Failure::MaxTurns { limit }));
+            progress.mark();
+            continue;
+        }
+        let turn = commands
+            .spawn((Turn, Fresh, next_order_in(&mut orders), ChildOf(run)))
+            .id();
+        for Grant(tool) in links_in_order(*agent, &children, &grants) {
+            commands.spawn((Advert(*tool), next_order_in(&mut orders), ChildOf(turn)));
+        }
+        for Context(document) in links_in_order(*agent, &children, &contexts) {
+            commands.spawn((
+                Attachment(*document),
+                next_order_in(&mut orders),
+                ChildOf(turn),
+            ));
+        }
+        commands.entity(run).insert(Cursor {
+            turn: cursor.turn + 1,
+        });
+        progress.mark();
+    }
+}
+
+/// `RigSet::Select`: a run without a model of its own takes its agent's.
+/// A routing system before this one gives the run another.
+pub fn select(
+    mut commands: Commands,
+    runs: Query<(Entity, &RunOf), Unselected>,
+    models: Query<&UsesModel>,
+) {
+    for (run, RunOf(agent)) in &runs {
+        if let Ok(UsesModel(model)) = models.get(*agent) {
+            commands.entity(run).insert(UsesModel(*model));
+        }
+    }
+}
+
+/// `RigSet::Assemble`: for every fresh turn, in run order, gather the
+/// graph — the run's settings over the agent's, the utterances in order,
+/// the attachments in order, the adverts in order, the model's descriptor
+/// — resolve the output mode, mint the output tool's name once per run,
+/// fold, and spawn the effect `ChildOf` the turn. The run is then
+/// `AwaitingModel`.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "one system, one pass: every parameter is a distinct world access it needs"
+)]
+pub fn assemble(
+    mut commands: Commands,
+    fresh: Query<(Entity, &ChildOf), With<Fresh>>,
+    runs: Query<(&RunOf, &RunSeq, &Streamed, &UsesModel, &OutputToolName), With<Run>>,
+    children: Query<&Children>,
+    utterances: Query<(&Parts, &Order), With<Utterance>>,
+    adverts: Query<(&Advert, &Order)>,
+    attachments: Query<(&Attachment, &Order)>,
+    documents: Query<(&DocumentId, &DocumentText, Option<&DocumentProps>)>,
+    bound: Query<&Bound>,
+    preambles: Query<&Preamble>,
+    temperatures: Query<&Temperature>,
+    max_tokens: Query<&MaxTokens>,
+    params: Query<&AdditionalParams>,
+    choices: Query<&ToolChoiceSpec>,
+    outputs: Query<&Output>,
+    mut progress: ResMut<Progress>,
+) {
+    let mut turns: Vec<(Entity, Entity, RunSeq)> = fresh
+        .iter()
+        .filter_map(|(turn, child_of)| {
+            let run = child_of.parent();
+            runs.get(run)
+                .ok()
+                .map(|(_, seq, _, _, _)| (turn, run, *seq))
+        })
+        .collect();
+    turns.sort_by_key(|(_, _, seq)| *seq);
+
+    for (turn, run, _) in turns {
+        let Ok((RunOf(agent), _, Streamed(stream), UsesModel(model), minted)) = runs.get(run)
+        else {
+            continue;
+        };
+        let agent = *agent;
+        let Ok(model_bound) = bound.get(*model) else {
+            continue;
+        };
+        let composes = match &model_bound.descriptor.family {
+            FamilyDescriptor::Completion { capabilities, .. } => {
+                capabilities.composes_native_output_with_tools
+            }
+            FamilyDescriptor::Tool { .. }
+            | FamilyDescriptor::Embed { .. }
+            | FamilyDescriptor::Rerank { .. }
+            | FamilyDescriptor::Memory { .. }
+            | FamilyDescriptor::Retrieve { .. }
+            | FamilyDescriptor::Custom { .. } => false,
+        };
+
+        let mut history: Vec<(&Order, &Parts)> = children
+            .get(run)
+            .map(|children| {
+                children
+                    .iter()
+                    .filter_map(|child| {
+                        utterances
+                            .get(child)
+                            .ok()
+                            .map(|(parts, order)| (order, parts))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        history.sort_by_key(|(order, _)| **order);
+
+        let tools: Vec<&Bound> = links_in_order(turn, &children, &adverts)
+            .into_iter()
+            .filter_map(|Advert(tool)| bound.get(*tool).ok())
+            .collect();
+        let attached: Vec<rig_core::completion::Document> =
+            links_in_order(turn, &children, &attachments)
+                .into_iter()
+                .filter_map(|Attachment(document)| documents.get(*document).ok())
+                .map(|(id, text, props)| rig_core::completion::Document {
+                    id: id.0.clone(),
+                    text: text.0.clone(),
+                    additional_props: props.map(|props| props.0.clone()).unwrap_or_default(),
+                })
+                .collect();
+
+        let preamble = setting(run, agent, &preambles).and_then(|preamble| preamble.0.as_deref());
+        let temperature = setting(run, agent, &temperatures).and_then(|t| t.0);
+        let max_tokens = setting(run, agent, &max_tokens).and_then(|m| m.0);
+        let additional_params = setting(run, agent, &params).and_then(|p| p.0.as_ref());
+        let tool_choice = setting(run, agent, &choices).and_then(|c| c.0.as_ref());
+        let output = setting(run, agent, &outputs).cloned().unwrap_or_default();
+
+        let granted_names: Vec<&str> = tools
+            .iter()
+            .filter_map(|bound| match &bound.descriptor.family {
+                FamilyDescriptor::Tool { name, .. } => Some(name.as_str()),
+                FamilyDescriptor::Completion { .. }
+                | FamilyDescriptor::Embed { .. }
+                | FamilyDescriptor::Rerank { .. }
+                | FamilyDescriptor::Memory { .. }
+                | FamilyDescriptor::Retrieve { .. }
+                | FamilyDescriptor::Custom { .. } => None,
+            })
+            .collect();
+        let output_tool = minted
+            .0
+            .clone()
+            .unwrap_or_else(|| policy::output_tool_name(&granted_names));
+        let callable = policy::output_tool_callable(tool_choice, &output_tool);
+        let resolved = policy::resolve_output(
+            output.mode,
+            output.schema.is_some(),
+            granted_names.len(),
+            callable,
+            composes,
+        );
+        if resolved == OutputKind::Tool && minted.0.is_none() {
+            commands
+                .entity(run)
+                .insert(OutputToolName(Some(output_tool.clone())));
+        }
+
+        let graph = RequestGraph {
+            preamble,
+            utterances: history.iter().map(|(_, parts)| &parts.0).collect(),
+            documents: attached,
+            tools: tools.iter().map(|bound| &bound.descriptor).collect(),
+            temperature,
+            max_tokens,
+            additional_params,
+            tool_choice,
+            output: resolved,
+            schema: output.schema.as_ref(),
+            output_tool: (resolved == OutputKind::Tool).then_some(output_tool.as_str()),
+        };
+        let request = policy::fold_request(&graph);
+        commands.spawn((
+            PendingEffect::new(
+                model_bound.key.clone(),
+                EffectKind::Completion {
+                    request,
+                    stream: *stream,
+                },
+            ),
+            ChildOf(turn),
+        ));
+        commands
+            .entity(turn)
+            .remove::<Fresh>()
+            .insert((Folded(resolved), Outputs::default()));
+        commands
+            .entity(run)
+            .remove::<Assembling>()
+            .insert(AwaitingModel);
+        progress.mark();
+    }
+}
+
+/// `RigSet::Fold`: the turn's outputs from its effect — the text so far
+/// while it streams (`Changed<Outputs>` is the delta signal), the folded
+/// answer when it lands.
+pub fn fold(
+    effects: Query<EffectView, With<PendingEffect>>,
+    mut turns: Query<&mut Outputs, With<Turn>>,
+    mut progress: ResMut<Progress>,
+) {
+    for (child_of, streamed, outcome) in &effects {
+        let Ok(mut outputs) = turns.get_mut(child_of.parent()) else {
+            continue;
+        };
+        if outputs.done {
+            continue;
+        }
+        match outcome {
+            Some(EffectOutcome(Ok(Outcome::Completion(response)))) => {
+                outputs.content = response.choice.clone();
+                outputs.message_id = response.message_id.clone();
+                outputs.done = true;
+                progress.mark();
+            }
+            Some(EffectOutcome(Ok(_))) | Some(EffectOutcome(Err(_))) => {
+                outputs.done = true;
+                progress.mark();
+            }
+            None => {
+                if let Some(streamed) = streamed
+                    && !streamed.text.is_empty()
+                {
+                    let current = policy::answer_text(&outputs.content);
+                    if current != streamed.text {
+                        outputs.content = vec![AssistantContent::text(&streamed.text)];
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// The default policy for an invalid call nothing resolved: the run's
+/// `InvalidCalls.unhandled`, written last in `Materialise`'s chain so a
+/// user system before it wins.
+pub fn resolve_invalid_defaults(
+    mut commands: Commands,
+    calls: Query<(Entity, &ChildOf), Unresolved>,
+    turns: Query<&ChildOf, With<Turn>>,
+    runs: Query<&RunOf>,
+    policies: Query<&InvalidCalls>,
+) {
+    for (call, turn_of) in &calls {
+        let Ok(run_of) = turns.get(turn_of.parent()) else {
+            continue;
+        };
+        let run = run_of.parent();
+        let Ok(RunOf(agent)) = runs.get(run) else {
+            continue;
+        };
+        let unhandled = setting(run, *agent, &policies).map_or(Unhandled::Fail, |p| p.unhandled);
+        commands.entity(call).insert(match unhandled {
+            Unhandled::Fail => Resolution::Fail,
+            Unhandled::Ignore => Resolution::Ignore,
+        });
+    }
+}
+
+/// `RigSet::Materialise`: a complete, unread turn becomes graph — the
+/// assistant utterance (unless the turn is empty), the answer and
+/// `Settled`, a reprompt and another turn, an invalid call awaiting its
+/// resolution, or `Failed`.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "one system, one pass: every parameter is a distinct world access it needs"
+)]
+pub fn materialise(
+    mut commands: Commands,
+    turns: Query<(Entity, &ChildOf, &Outputs, &Folded), Unread>,
+    effects: Query<(&ChildOf, &EffectOutcome), With<PendingEffect>>,
+    runs: Query<(&RunOf, &Cursor, &OutputRetries, &OutputToolName, &Usage), With<AwaitingModel>>,
+    children: Query<&Children>,
+    adverts: Query<(&Advert, &Order)>,
+    bound: Query<&Bound>,
+    outputs: Query<&Output>,
+    max_turns: Query<&MaxTurns>,
+    invalid_calls: Query<(Entity, &ChildOf, &InvalidCall, &Resolution)>,
+    mut orders: ResMut<OrderCounter>,
+    mut progress: ResMut<Progress>,
+) {
+    for (turn, turn_of, outs, Folded(mode)) in &turns {
+        let run = turn_of.parent();
+        let Ok((RunOf(agent), cursor, retries, minted, usage)) = runs.get(run) else {
+            continue;
+        };
+        let agent = *agent;
+
+        // Pending invalid calls of this turn: consumed first.
+        let pending: Vec<(Entity, &InvalidCall, Resolution)> = invalid_calls
+            .iter()
+            .filter(|(_, child_of, _, _)| child_of.parent() == turn)
+            .map(|(entity, _, call, resolution)| (entity, call, *resolution))
+            .collect();
+        if !pending.is_empty() {
+            let mut failed = None;
+            let mut ignored = false;
+            for (entity, call, resolution) in &pending {
+                match resolution {
+                    Resolution::Fail => {
+                        failed = Some(Failure::UnknownToolCall {
+                            name: call.name.clone(),
+                        });
+                    }
+                    Resolution::Ignore => {
+                        ignored = true;
+                    }
+                    Resolution::Retry | Resolution::Repair | Resolution::Skip => {
+                        failed = Some(Failure::Unsupported(format!(
+                            "resolution {resolution:?} for `{}`: a later stage's",
+                            call.name
+                        )));
+                    }
+                }
+                commands.entity(*entity).despawn();
+            }
+            if let Some(failure) = failed {
+                commands.entity(turn).insert(Materialised);
+                commands
+                    .entity(run)
+                    .remove::<AwaitingModel>()
+                    .insert(Failed(failure));
+                progress.mark();
+                continue;
+            }
+            if ignored {
+                // The invalid calls are dropped from the turn; what is left
+                // is read as the answer, and an empty turn is an empty one.
+                let kept: Vec<AssistantContent> = outs
+                    .content
+                    .iter()
+                    .filter(|part| match part {
+                        AssistantContent::ToolCall(call) => !pending
+                            .iter()
+                            .any(|(_, invalid, _)| invalid.id == call.id.to_string()),
+                        AssistantContent::Text(_)
+                        | AssistantContent::Reasoning(_)
+                        | AssistantContent::Image(_) => true,
+                    })
+                    .cloned()
+                    .collect();
+                commands.entity(turn).insert(Materialised);
+                commands
+                    .entity(run)
+                    .remove::<AwaitingModel>()
+                    .insert((RunResult(policy::answer_text(&kept)), Settled));
+                progress.mark();
+                continue;
+            }
+        }
+
+        if !outs.done {
+            continue;
+        }
+        let Some((_, EffectOutcome(outcome))) = effects
+            .iter()
+            .find(|(child_of, _)| child_of.parent() == turn)
+        else {
+            continue;
+        };
+        commands.entity(turn).insert(Materialised);
+
+        let response = match outcome {
+            Ok(Outcome::Completion(response)) => response,
+            Ok(other) => {
+                commands
+                    .entity(run)
+                    .remove::<AwaitingModel>()
+                    .insert(Failed(Failure::Unsupported(format!(
+                        "a {} answer to a completion",
+                        other.family()
+                    ))));
+                progress.mark();
+                continue;
+            }
+            Err(report) => {
+                let failure = if report.kind == ErrorKind::Cancelled {
+                    Failure::Cancelled(report.clone())
+                } else {
+                    Failure::Provider(report.clone())
+                };
+                commands
+                    .entity(run)
+                    .remove::<AwaitingModel>()
+                    .insert(Failed(failure));
+                progress.mark();
+                continue;
+            }
+        };
+        commands.entity(run).insert(Usage(usage.0 + response.usage));
+        let content = &response.choice;
+
+        // An empty turn is not history, and answers nothing.
+        if policy::is_empty_assistant_turn(content) {
+            commands
+                .entity(run)
+                .remove::<AwaitingModel>()
+                .insert((RunResult(String::new()), Settled));
+            progress.mark();
+            continue;
+        }
+
+        let granted: Vec<String> = links_in_order(turn, &children, &adverts)
+            .into_iter()
+            .filter_map(|Advert(tool)| bound.get(*tool).ok())
+            .filter_map(|bound| match &bound.descriptor.family {
+                FamilyDescriptor::Tool { name, .. } => Some(name.clone()),
+                FamilyDescriptor::Completion { .. }
+                | FamilyDescriptor::Embed { .. }
+                | FamilyDescriptor::Rerank { .. }
+                | FamilyDescriptor::Memory { .. }
+                | FamilyDescriptor::Retrieve { .. }
+                | FamilyDescriptor::Custom { .. } => None,
+            })
+            .collect();
+        let output_tool = minted.0.as_deref();
+        let schema = setting(run, agent, &outputs).and_then(|output| output.schema.clone());
+        let limit = setting(run, agent, &max_turns).map_or(1, |limit| limit.0);
+
+        let calls: Vec<&rig_core::completion::message::ToolCall> = content
+            .iter()
+            .filter_map(|part| match part {
+                AssistantContent::ToolCall(call) => Some(call),
+                AssistantContent::Text(_)
+                | AssistantContent::Reasoning(_)
+                | AssistantContent::Image(_) => None,
+            })
+            .collect();
+
+        // Invalid calls: tools neither granted nor the output tool. They
+        // become entities awaiting a resolution; the turn stays unread
+        // until then.
+        let invalid: Vec<&rig_core::completion::message::ToolCall> = calls
+            .iter()
+            .copied()
+            .filter(|call| {
+                !granted.contains(&call.function.name)
+                    && output_tool != Some(call.function.name.as_str())
+            })
+            .collect();
+        if !invalid.is_empty() {
+            commands.entity(turn).remove::<Materialised>();
+            for call in invalid {
+                commands.spawn((
+                    InvalidCall {
+                        id: call.id.to_string(),
+                        name: call.function.name.clone(),
+                        arguments: call.function.arguments.clone(),
+                    },
+                    ChildOf(turn),
+                ));
+            }
+            progress.mark();
+            continue;
+        }
+
+        // A call to a granted tool: dispatched as a tool effect in a later
+        // stage; here the run cannot go on.
+        if let Some(call) = calls
+            .iter()
+            .find(|call| granted.contains(&call.function.name))
+        {
+            commands
+                .entity(run)
+                .remove::<AwaitingModel>()
+                .insert(Failed(Failure::Unsupported(format!(
+                    "the tool call `{}`: tool dispatch is stage 3's",
+                    call.function.name
+                ))));
+            progress.mark();
+            continue;
+        }
+
+        // The assistant turn is history.
+        let assistant = MessageParts::Assistant {
+            id: response.message_id.clone(),
+            content: content.clone(),
+        };
+        commands.spawn((
+            Utterance,
+            assistant.role(),
+            Parts(assistant),
+            next_order_in(&mut orders),
+            ChildOf(run),
+        ));
+
+        match (*mode, output_tool) {
+            (OutputKind::Tool, Some(name)) => {
+                let output_call = calls.iter().find(|call| call.function.name == name);
+                let can_reprompt = retries.0 < 1 && cursor.turn < limit;
+                match output_call {
+                    Some(call) => {
+                        let missing = schema
+                            .as_ref()
+                            .map(|schema| {
+                                policy::missing_required_fields(schema, &call.function.arguments)
+                            })
+                            .unwrap_or_default();
+                        if missing.is_empty() || !can_reprompt {
+                            commands
+                                .entity(run)
+                                .remove::<AwaitingModel>()
+                                .insert((RunResult(call.function.arguments.to_string()), Settled));
+                        } else {
+                            let feedback = policy::reprompt_missing_fields(name, &missing);
+                            let reprompt = MessageParts::User {
+                                content: vec![UserContent::ToolResult(
+                                    rig_core::completion::message::ToolResult {
+                                        call: call.id.clone(),
+                                        provider: call.provider.clone(),
+                                        name: name.to_owned(),
+                                        content: vec![ToolResultContent::text(feedback)],
+                                    },
+                                )],
+                            };
+                            commands
+                                .entity(turn)
+                                .insert(Reprompt(reprompt.to_message()));
+                            commands.spawn((
+                                Utterance,
+                                reprompt.role(),
+                                Parts(reprompt),
+                                next_order_in(&mut orders),
+                                ChildOf(run),
+                            ));
+                            commands
+                                .entity(run)
+                                .remove::<AwaitingModel>()
+                                .insert((OutputRetries(retries.0 + 1), Assembling));
+                        }
+                    }
+                    None if can_reprompt => {
+                        let reprompt = MessageParts::User {
+                            content: vec![UserContent::text(policy::text::reprompt_text_answer(
+                                name,
+                            ))],
+                        };
+                        commands
+                            .entity(turn)
+                            .insert(Reprompt(reprompt.to_message()));
+                        commands.spawn((
+                            Utterance,
+                            reprompt.role(),
+                            Parts(reprompt),
+                            next_order_in(&mut orders),
+                            ChildOf(run),
+                        ));
+                        commands
+                            .entity(run)
+                            .remove::<AwaitingModel>()
+                            .insert((OutputRetries(retries.0 + 1), Assembling));
+                    }
+                    None => {
+                        commands
+                            .entity(run)
+                            .remove::<AwaitingModel>()
+                            .insert((RunResult(policy::answer_text(content)), Settled));
+                    }
+                }
+            }
+            _ => {
+                commands
+                    .entity(run)
+                    .remove::<AwaitingModel>()
+                    .insert((RunResult(policy::answer_text(content)), Settled));
+            }
+        }
+        progress.mark();
+    }
+}

--- a/crates/rig-ecs/tests/run_graph.rs
+++ b/crates/rig-ecs/tests/run_graph.rs
@@ -275,3 +275,45 @@ fn a_system_before_assemble_rewrites_an_utterance() {
     };
     assert_eq!(content.len(), 1);
 }
+
+fn stop_the_run(effects: Query<Entity, Added<PendingEffect>>, mut commands: Commands) {
+    for effect in &effects {
+        commands.entity(effect).despawn();
+    }
+}
+
+/// A system in `Patch` that despawns the folded effect stops the run: the
+/// record says `Cancelled`, and so does the run (the README's spelling of
+/// `on_completion_call` — stop).
+#[test]
+fn despawning_the_effect_in_patch_fails_the_run_cancelled() {
+    let mut app = app();
+    let (model, requests) = Capturing::new("t/model:default", "ok");
+    let model = register(&mut app, "t/model:default", model);
+    EffectLogResource::install(app.world_mut(), EffectLogRecorder::new());
+    app.world_mut()
+        .resource_mut::<Schedules>()
+        .add_systems(RigSchedule, stop_the_run.in_set(RigSet::Patch));
+    let agent = spawn_agent(app.world_mut(), "t", model);
+    let run = spawn_run(app.world_mut(), agent, &[], "one", false, Some(1));
+    tick_until(&mut app, "cancelled", |world| {
+        world.get::<rig_ecs::agent::Failed>(run).is_some()
+    });
+    let failed = app
+        .world()
+        .get::<rig_ecs::agent::Failed>(run)
+        .expect("failed");
+    assert!(
+        matches!(&failed.0, rig_ecs::agent::Failure::Cancelled(report) if report.kind == rig_core::error::ErrorKind::Cancelled),
+        "{failed:?}"
+    );
+    assert!(
+        requests.lock().expect("requests").is_empty(),
+        "the handler never saw it"
+    );
+    let log = app.world().resource::<EffectLogResource>().log();
+    assert!(
+        log.records.is_empty(),
+        "despawned before dispatch: no record"
+    );
+}

--- a/crates/rig-ecs/tests/run_graph.rs
+++ b/crates/rig-ecs/tests/run_graph.rs
@@ -1,0 +1,277 @@
+//! The graph's wins, as tests (prompt ruling 8): what the request-as-graph
+//! gives that a request builder cannot.
+//!
+//! | claim (CONTRACT §derivation / design §2) | test |
+//! |---|---|
+//! | chat history is entities: despawn one and the next request lacks it | `an_utterance_despawned_before_assemble_leaves_the_next_request` |
+//! | documents are shared: one entity, two runs, both requests | `one_document_attached_to_two_runs_appears_in_both_requests` |
+//! | tools are the handler entities: a grant link advertises, its removal un-advertises | `a_tool_granted_by_a_relationship_is_advertised_and_gone_after_removal` |
+//! | the model is a relationship: swap it on the run and the next request's key follows | `uses_model_swapped_on_a_run_changes_the_next_requests_key` |
+//! | the second slot: a `Patch` system rewrites the folded effect and the record holds the patch | `a_patch_system_rewrites_the_folded_request_and_the_record_holds_it` |
+//! | the first slot: a system before `Assemble` rewrites an utterance and the request carries it | `a_system_before_assemble_rewrites_an_utterance` |
+
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::type_complexity
+)]
+
+mod run_support;
+
+use bevy_ecs::prelude::*;
+use rig_core::{
+    effect::EffectKind,
+    message::{Message, UserContent},
+};
+use rig_ecs::{
+    agent::{
+        Context, DocumentId, DocumentText, Grant, MessageParts, Order, Parts, RunResult, Settled,
+        UsesModel, Utterance,
+    },
+    bus::{EffectLogResource, PendingEffect, RigSchedule},
+    systems::{RigSet, spawn_run},
+};
+use rig_effect_log::EffectLogRecorder;
+use run_support::*;
+
+fn add_before_assemble<M>(
+    app: &mut bevy_app::App,
+    system: impl IntoScheduleConfigs<bevy_ecs::system::ScheduleSystem, M>,
+) {
+    app.world_mut()
+        .resource_mut::<Schedules>()
+        .add_systems(RigSchedule, system.before(RigSet::Assemble));
+}
+
+fn settle(app: &mut bevy_app::App, run: Entity, what: &str) -> String {
+    tick_until(app, what, |world| world.get::<Settled>(run).is_some());
+    app.world()
+        .get::<RunResult>(run)
+        .expect("settled with an answer")
+        .0
+        .clone()
+}
+
+#[derive(Resource, Default)]
+struct Once(bool);
+
+fn despawn_the_assistant_utterance(
+    utterances: Query<(Entity, &Parts), With<Utterance>>,
+    mut once: ResMut<Once>,
+    mut commands: Commands,
+) {
+    if once.0 {
+        return;
+    }
+    for (entity, Parts(parts)) in &utterances {
+        if let MessageParts::Assistant { .. } = parts {
+            commands.entity(entity).despawn();
+            once.0 = true;
+        }
+    }
+}
+
+#[test]
+fn an_utterance_despawned_before_assemble_leaves_the_next_request() {
+    let mut app = app();
+    let (model, requests) = Capturing::new("t/model:default", "ok");
+    let model = register(&mut app, "t/model:default", model);
+    let agent = spawn_agent(app.world_mut(), "t", model);
+    app.init_resource::<Once>();
+    add_before_assemble(&mut app, despawn_the_assistant_utterance);
+    let history = vec![
+        MessageParts::User {
+            content: vec![UserContent::text("A")],
+        },
+        MessageParts::Assistant {
+            id: None,
+            content: vec![rig_core::message::AssistantContent::text("B")],
+        },
+    ];
+    let run = spawn_run(app.world_mut(), agent, &history, "C", false, Some(1));
+    settle(&mut app, run, "answered");
+    let requests = requests.lock().expect("requests");
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        texts(&requests[0]),
+        vec!["system:You are terse.", "user:A", "user:C"],
+        "the assistant utterance left the history before the fold"
+    );
+}
+
+#[test]
+fn one_document_attached_to_two_runs_appears_in_both_requests() {
+    let mut app = app();
+    let (model, requests) = Capturing::new("t/model:default", "ok");
+    let model = register(&mut app, "t/model:default", model);
+    let agent = spawn_agent(app.world_mut(), "t", model);
+    let document = app
+        .world_mut()
+        .spawn((
+            DocumentId("shared".to_owned()),
+            DocumentText("one document, many turns".to_owned()),
+        ))
+        .id();
+    app.world_mut()
+        .spawn((Context(document), Order(0), ChildOf(agent)));
+    let first = spawn_run(app.world_mut(), agent, &[], "first?", false, Some(1));
+    let second = spawn_run(app.world_mut(), agent, &[], "second?", false, Some(1));
+    settle(&mut app, first, "first");
+    settle(&mut app, second, "second");
+    let requests = requests.lock().expect("requests");
+    assert_eq!(requests.len(), 2);
+    for request in requests.iter() {
+        assert_eq!(request.documents.len(), 1);
+        assert_eq!(request.documents[0].id, "shared");
+        assert_eq!(request.documents[0].text, "one document, many turns");
+    }
+    let documents = app
+        .world_mut()
+        .query::<&DocumentId>()
+        .iter(app.world())
+        .count();
+    assert_eq!(documents, 1, "one entity, two requests");
+}
+
+#[test]
+fn a_tool_granted_by_a_relationship_is_advertised_and_gone_after_removal() {
+    let mut app = app();
+    let (model, requests) = Capturing::new("t/model:default", "ok");
+    let model = register(&mut app, "t/model:default", model);
+    let tool = register(
+        &mut app,
+        "t/tool:add#0",
+        NeverCalled {
+            name: "add".to_owned(),
+        },
+    );
+    let agent = spawn_agent(app.world_mut(), "t", model);
+    let before = spawn_run(app.world_mut(), agent, &[], "one", false, Some(1));
+    settle(&mut app, before, "before the grant");
+    let grant = app
+        .world_mut()
+        .spawn((Grant(tool), Order(0), ChildOf(agent)))
+        .id();
+    let during = spawn_run(app.world_mut(), agent, &[], "two", false, Some(1));
+    settle(&mut app, during, "with the grant");
+    app.world_mut().despawn(grant);
+    let after = spawn_run(app.world_mut(), agent, &[], "three", false, Some(1));
+    settle(&mut app, after, "after the grant");
+    let requests = requests.lock().expect("requests");
+    let advertised: Vec<Vec<String>> = requests
+        .iter()
+        .map(|request| request.tools.iter().map(|tool| tool.name.clone()).collect())
+        .collect();
+    assert_eq!(
+        advertised,
+        vec![Vec::<String>::new(), vec!["add".to_owned()], Vec::new()]
+    );
+}
+
+#[test]
+fn uses_model_swapped_on_a_run_changes_the_next_requests_key() {
+    let mut app = app();
+    let (default_model, default_requests) = Capturing::new("t/model:default", "from default");
+    let (fast_model, fast_requests) = Capturing::new("t/model:fast", "from fast");
+    let default_model = register(&mut app, "t/model:default", default_model);
+    let fast_model = register(&mut app, "t/model:fast", fast_model);
+    EffectLogResource::install(app.world_mut(), EffectLogRecorder::new());
+    let agent = spawn_agent(app.world_mut(), "t", default_model);
+    let first = spawn_run(app.world_mut(), agent, &[], "one", false, Some(1));
+    assert_eq!(settle(&mut app, first, "default"), "from default");
+    // A routing system's spelling: the run's own model, before Assemble.
+    let second = spawn_run(app.world_mut(), agent, &[], "two", false, Some(1));
+    app.world_mut()
+        .entity_mut(second)
+        .insert(UsesModel(fast_model));
+    assert_eq!(settle(&mut app, second, "fast"), "from fast");
+    assert_eq!(default_requests.lock().expect("requests").len(), 1);
+    assert_eq!(fast_requests.lock().expect("requests").len(), 1);
+    let log = app.world().resource::<EffectLogResource>().log();
+    let keys: Vec<String> = log
+        .records
+        .iter()
+        .map(|record| record.key.to_string())
+        .collect();
+    assert_eq!(keys, vec!["t/model:default", "t/model:fast"]);
+}
+
+fn patch_temperature(mut effects: Query<&mut PendingEffect, Added<PendingEffect>>) {
+    for mut effect in &mut effects {
+        if let EffectKind::Completion { request, .. } = &mut effect.kind {
+            request.temperature = Some(0.5);
+        }
+    }
+}
+
+#[test]
+fn a_patch_system_rewrites_the_folded_request_and_the_record_holds_it() {
+    let mut app = app();
+    let (model, requests) = Capturing::new("t/model:default", "ok");
+    let model = register(&mut app, "t/model:default", model);
+    EffectLogResource::install(app.world_mut(), EffectLogRecorder::new());
+    app.world_mut()
+        .resource_mut::<Schedules>()
+        .add_systems(RigSchedule, patch_temperature.in_set(RigSet::Patch));
+    let agent = spawn_agent(app.world_mut(), "t", model);
+    let run = spawn_run(app.world_mut(), agent, &[], "one", false, Some(1));
+    settle(&mut app, run, "patched");
+    assert_eq!(
+        requests.lock().expect("requests")[0].temperature,
+        Some(0.5),
+        "the handler saw the patch"
+    );
+    let log = app.world().resource::<EffectLogResource>().log();
+    let EffectKind::Completion { request, .. } = &log.records[0].kind else {
+        panic!("a completion");
+    };
+    assert_eq!(
+        request.temperature,
+        Some(0.5),
+        "the record is the patched request"
+    );
+    // And the graph is untouched: the agent's own temperature is unset.
+    assert_eq!(
+        app.world()
+            .get::<rig_ecs::agent::Temperature>(agent)
+            .expect("a temperature")
+            .0,
+        None
+    );
+}
+
+fn shout_the_prompt(mut utterances: Query<&mut Parts, With<Utterance>>) {
+    for mut parts in &mut utterances {
+        if let MessageParts::User { content } = &mut parts.0 {
+            for part in content.iter_mut() {
+                if let UserContent::Text(text) = part
+                    && !text.text.ends_with('!')
+                {
+                    text.text.push('!');
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn a_system_before_assemble_rewrites_an_utterance() {
+    let mut app = app();
+    let (model, requests) = Capturing::new("t/model:default", "ok");
+    let model = register(&mut app, "t/model:default", model);
+    add_before_assemble(&mut app, shout_the_prompt);
+    let agent = spawn_agent(app.world_mut(), "t", model);
+    let run = spawn_run(app.world_mut(), agent, &[], "quietly", false, Some(1));
+    settle(&mut app, run, "shouted");
+    let requests = requests.lock().expect("requests");
+    assert_eq!(
+        texts(&requests[0]),
+        vec!["system:You are terse.", "user:quietly!"]
+    );
+    let Message::User { content } = &requests[0].chat_history[1] else {
+        panic!("the prompt");
+    };
+    assert_eq!(content.len(), 1);
+}

--- a/crates/rig-ecs/tests/run_scene.rs
+++ b/crates/rig-ecs/tests/run_scene.rs
@@ -138,7 +138,7 @@ fn a_run_saved_mid_turn_resumes_to_the_same_request_and_answer() {
         .iter(app.world())
         .count();
     assert_eq!(utterances, 3, "prompt, the text answer, the reprompt");
-    let saved = RunScene::save(app.world_mut());
+    let saved = RunScene::save(app.world_mut()).expect("every component serializes");
     let json = serde_json::to_string(&saved).expect("serde");
     assert!(!json.contains("Entity"), "no entity ids in a scene");
     let head = app.world().resource::<EffectLogResource>().log();

--- a/crates/rig-ecs/tests/run_scene.rs
+++ b/crates/rig-ecs/tests/run_scene.rs
@@ -1,0 +1,208 @@
+//! The graph is the state (prompt ruling 6): a run saved after its first
+//! turn was answered resumes in a fresh world to the same second request
+//! and the same answer — the two-record golden
+//! `mock_output_tool_text_reprompt`, split at its first record.
+
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::type_complexity
+)]
+
+mod run_support;
+
+use std::time::Instant;
+
+use bevy_app::App;
+use bevy_ecs::{prelude::*, schedule::LogLevel};
+use rig_core::{effect::HandlerKey, serve::ServingPolicy};
+use rig_ecs::{
+    agent::{
+        AdditionalParams, Assembling, Cursor, DefaultMaxTurns, InvalidCalls, MaxTokens, MaxTurns,
+        Output, OutputKind, Owner, Preamble, RunResult, Settled, Temperature, ToolChoiceSpec,
+        UsesModel, Utterance, scene::RunScene,
+    },
+    bus::{BusPlugin, EffectLogResource, Handlers, IdCounter, RigSchedule},
+    systems::{AgentPlugin, spawn_run},
+};
+use rig_effect_log::{EffectLog, EffectLogRecorder, EffectLogReplayer};
+use run_support::GUARD;
+
+fn golden(name: &str) -> EffectLog {
+    let path = format!(
+        "{}/../rig-verify/fixtures/{name}.effects.json",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    serde_json::from_str(&std::fs::read_to_string(path).expect("the golden is committed"))
+        .expect("the golden loads")
+}
+
+fn world_with(log: &EffectLog) -> (App, Entity) {
+    let mut app = App::new();
+    app.add_plugins((
+        BusPlugin::with_policy(ServingPolicy::default()).ambiguity_detection(LogLevel::Error),
+        AgentPlugin::default(),
+    ));
+    app.finish();
+    app.cleanup();
+    let key = HandlerKey::from("golden/model:default");
+    let model = Handlers::with(app.world_mut(), |handlers| {
+        handlers
+            .register_erased(
+                key.clone(),
+                rig_core::serve::ErasedHandler::new(
+                    EffectLogReplayer::for_key(log, &key).expect("the model's records"),
+                ),
+            )
+            .expect("a fresh key")
+    })
+    .expect("a bus");
+    EffectLogResource::install(app.world_mut(), EffectLogRecorder::new());
+    (app, model)
+}
+
+fn event_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "title": {"type": "string"},
+            "category": {"type": "string"},
+            "summary": {"type": "string"}
+        },
+        "required": ["title", "category", "summary"]
+    })
+}
+
+#[test]
+fn a_run_saved_mid_turn_resumes_to_the_same_request_and_answer() {
+    let log = golden("mock_output_tool_text_reprompt");
+    assert_eq!(log.records.len(), 2);
+    let (mut app, model) = world_with(&log);
+    app.world_mut().resource_mut::<IdCounter>().0 = 1;
+    let agent = app
+        .world_mut()
+        .spawn((
+            Owner("golden".to_owned()),
+            Preamble(Some(
+                "You are a concise assistant. Answer directly.".to_owned(),
+            )),
+            Temperature(None),
+            MaxTokens(None),
+            AdditionalParams(None),
+            ToolChoiceSpec(None),
+            Output {
+                mode: OutputKind::Tool,
+                schema: Some(event_schema()),
+            },
+            DefaultMaxTurns(None),
+            MaxTurns(3),
+            InvalidCalls::default(),
+            UsesModel(model),
+        ))
+        .id();
+    let run = spawn_run(
+        app.world_mut(),
+        agent,
+        &[],
+        "Return a concise event object for a local Rust meetup in Seattle.",
+        false,
+        Some(3),
+    );
+
+    // One pass at a time, until the first turn was read and the run wants
+    // its second: the reprompt is in the graph, the second request is not
+    // yet folded.
+    let start = Instant::now();
+    loop {
+        app.world_mut().run_schedule(RigSchedule);
+        let world = app.world_mut();
+        let wants_second = world.get::<Assembling>(run).is_some()
+            && world
+                .get::<Cursor>(run)
+                .is_some_and(|cursor| cursor.turn == 1);
+        if wants_second {
+            break;
+        }
+        assert!(
+            world.get::<Settled>(run).is_none(),
+            "settled before the reprompt"
+        );
+        assert!(start.elapsed() < GUARD, "the first turn never came back");
+        std::thread::yield_now();
+    }
+    let utterances = app
+        .world_mut()
+        .query::<&Utterance>()
+        .iter(app.world())
+        .count();
+    assert_eq!(utterances, 3, "prompt, the text answer, the reprompt");
+    let saved = RunScene::save(app.world_mut());
+    let json = serde_json::to_string(&saved).expect("serde");
+    assert!(!json.contains("Entity"), "no entity ids in a scene");
+    let head = app.world().resource::<EffectLogResource>().log();
+    assert_eq!(head.records.len(), 1, "the first record was recorded here");
+    drop(app);
+
+    // A fresh world over the log's tail: the graph loaded, the second turn
+    // folded from it, answered by record 2, settled to the golden's answer.
+    let saved: RunScene = serde_json::from_str(&json).expect("serde");
+    let (mut app, _model) = world_with(&log.tail(1));
+    app.world_mut().resource_mut::<IdCounter>().0 = 2;
+    let loaded = saved.load(app.world_mut()).expect("the model is bound");
+    let run = loaded
+        .into_iter()
+        .find(|entity| app.world().get::<rig_ecs::agent::Run>(*entity).is_some())
+        .expect("the run");
+    let start = Instant::now();
+    loop {
+        app.update();
+        if app.world().get::<Settled>(run).is_some() {
+            break;
+        }
+        assert!(
+            app.world().get::<rig_ecs::agent::Failed>(run).is_none(),
+            "{:?}",
+            app.world().get::<rig_ecs::agent::Failed>(run)
+        );
+        assert!(start.elapsed() < GUARD, "the resumed run never settled");
+        std::thread::yield_now();
+    }
+    let answer = app
+        .world()
+        .get::<RunResult>(run)
+        .expect("settled")
+        .0
+        .clone();
+    let expected = match &log.records[1].outcome {
+        Ok(rig_core::effect::Outcome::Completion(response)) => response
+            .choice
+            .iter()
+            .find_map(|part| match part {
+                rig_core::message::AssistantContent::ToolCall(call) => {
+                    Some(call.function.arguments.to_string())
+                }
+                rig_core::message::AssistantContent::Text(_)
+                | rig_core::message::AssistantContent::Reasoning(_)
+                | rig_core::message::AssistantContent::Image(_) => None,
+            })
+            .expect("the output tool's call"),
+        other => panic!("a completion: {other:?}"),
+    };
+    assert_eq!(answer, expected, "the golden's answer");
+    let tail = app.world().resource::<EffectLogResource>().log();
+    assert_eq!(tail.records.len(), 1);
+    let mine = &tail.records[0];
+    let theirs = &log.records[1];
+    assert_eq!(mine.id, theirs.id);
+    assert_eq!(
+        serde_json::to_value(&mine.kind).expect("serde"),
+        serde_json::to_value(&theirs.kind).expect("serde"),
+        "the second request, folded from the loaded graph, is the golden's"
+    );
+    assert_eq!(
+        serde_json::to_value(&mine.outcome).expect("serde"),
+        serde_json::to_value(&theirs.outcome).expect("serde")
+    );
+}

--- a/crates/rig-ecs/tests/run_support/mod.rs
+++ b/crates/rig-ecs/tests/run_support/mod.rs
@@ -1,0 +1,204 @@
+//! Shared by the `run_*` suites: a request-capturing model, a tool handler
+//! that is never called, an app with both plugins, and the tick guard.
+
+#![allow(dead_code, reason = "each suite uses the part of the support it needs")]
+
+use std::{
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+use bevy_app::App;
+use bevy_ecs::{prelude::*, schedule::LogLevel};
+use rig_core::{
+    completion::{CompletionRequest, CompletionResponse, ModelRef, ProviderCapabilities, Usage},
+    effect::{EffectKind, FamilyDescriptor, HandlerDescriptor, HandlerKey, Outcome},
+    error::{ErrorKind, ErrorReport},
+    message::AssistantContent,
+    serve::{OutcomeSink, Serve, ServingPolicy},
+};
+use rig_ecs::{
+    agent::{
+        AdditionalParams, DefaultMaxTurns, InvalidCalls, MaxTokens, MaxTurns, Output, Owner,
+        Preamble, Temperature, ToolChoiceSpec, UsesModel,
+    },
+    bus::{BusPlugin, Handlers},
+    systems::AgentPlugin,
+};
+
+pub const GUARD: Duration = Duration::from_secs(10);
+
+/// A model that keeps every request it is asked and answers a fixed text.
+pub struct Capturing {
+    pub label: String,
+    pub requests: Arc<Mutex<Vec<CompletionRequest>>>,
+    pub answer: String,
+}
+
+impl Capturing {
+    pub fn new(label: &str, answer: &str) -> (Self, Arc<Mutex<Vec<CompletionRequest>>>) {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                label: label.to_owned(),
+                requests: Arc::clone(&requests),
+                answer: answer.to_owned(),
+            },
+            requests,
+        )
+    }
+}
+
+impl Serve for Capturing {
+    type Family = rig_core::effect::family::Completion;
+
+    fn descriptor(&self) -> HandlerDescriptor {
+        HandlerDescriptor {
+            key: HandlerKey::from(self.label.as_str()),
+            family: FamilyDescriptor::Completion {
+                model: ModelRef::new(self.label.as_str()),
+                capabilities: ProviderCapabilities::default(),
+            },
+            layers: Vec::new(),
+        }
+    }
+
+    async fn serve(&self, kind: EffectKind, sink: OutcomeSink) {
+        match kind {
+            EffectKind::Completion { request, .. } => {
+                self.requests.lock().expect("requests").push(request);
+                let response = CompletionResponse::new(
+                    vec![AssistantContent::text(&self.answer)],
+                    Usage::new(),
+                    "capturing",
+                );
+                sink.resolve(Ok(Outcome::Completion(response))).await;
+            }
+            other => {
+                sink.resolve(Err(ErrorReport::new(
+                    ErrorKind::HandlerUnavailable,
+                    format!("a model cannot serve {}", other.name()),
+                )))
+                .await;
+            }
+        }
+    }
+}
+
+/// A tool handler that is advertised and never called.
+pub struct NeverCalled {
+    pub name: String,
+}
+
+impl Serve for NeverCalled {
+    type Family = rig_core::effect::family::Tool;
+
+    fn descriptor(&self) -> HandlerDescriptor {
+        HandlerDescriptor {
+            key: HandlerKey::from(self.name.as_str()),
+            family: FamilyDescriptor::Tool {
+                name: self.name.clone(),
+                description: format!("the {} tool", self.name),
+                parameters: serde_json::json!({"type": "object"}),
+                embedding: None,
+            },
+            layers: Vec::new(),
+        }
+    }
+
+    async fn serve(&self, _kind: EffectKind, sink: OutcomeSink) {
+        sink.resolve(Err(ErrorReport::new(
+            ErrorKind::Internal,
+            "a tool advertised and never called was called",
+        )))
+        .await;
+    }
+}
+
+/// An app with both plugins, ambiguity detection at error level.
+pub fn app() -> App {
+    let mut app = App::new();
+    app.add_plugins((
+        BusPlugin::with_policy(ServingPolicy::default()).ambiguity_detection(LogLevel::Error),
+        AgentPlugin::default(),
+    ));
+    app.finish();
+    app.cleanup();
+    app
+}
+
+/// Register `handler` under `key` from outside a system.
+pub fn register(app: &mut App, key: &str, handler: impl Serve + 'static) -> Entity {
+    Handlers::with(app.world_mut(), |handlers| handlers.register(key, handler))
+        .expect("the world has a bus")
+        .expect("a fresh key")
+}
+
+/// An agent entity over `model`, with a preamble and defaults.
+pub fn spawn_agent(world: &mut World, owner: &str, model: Entity) -> Entity {
+    world
+        .spawn((
+            Owner(owner.to_owned()),
+            Preamble(Some("You are terse.".to_owned())),
+            Temperature(None),
+            MaxTokens(None),
+            AdditionalParams(None),
+            ToolChoiceSpec(None),
+            Output::default(),
+            DefaultMaxTurns(None),
+            MaxTurns(1),
+            InvalidCalls::default(),
+            UsesModel(model),
+        ))
+        .id()
+}
+
+/// Tick the app until `done` holds, or fail after [`GUARD`].
+pub fn tick_until(app: &mut App, what: &str, mut done: impl FnMut(&mut World) -> bool) {
+    let start = Instant::now();
+    loop {
+        app.update();
+        if done(app.world_mut()) {
+            return;
+        }
+        assert!(start.elapsed() < GUARD, "{what}: not done within {GUARD:?}");
+        std::thread::yield_now();
+    }
+}
+
+/// The text parts of a request's user messages, in order.
+pub fn texts(request: &CompletionRequest) -> Vec<String> {
+    request
+        .chat_history
+        .iter()
+        .map(|message| match message {
+            rig_core::message::Message::System { content } => format!("system:{content}"),
+            rig_core::message::Message::User { content } => format!(
+                "user:{}",
+                content
+                    .iter()
+                    .filter_map(|part| match part {
+                        rig_core::message::UserContent::Text(text) => Some(text.text.clone()),
+                        rig_core::message::UserContent::ToolResult(_)
+                        | rig_core::message::UserContent::Image(_)
+                        | rig_core::message::UserContent::Audio(_)
+                        | rig_core::message::UserContent::Video(_)
+                        | rig_core::message::UserContent::Document(_) => None,
+                    })
+                    .collect::<String>()
+            ),
+            rig_core::message::Message::Assistant { content, .. } => format!(
+                "assistant:{}",
+                content
+                    .iter()
+                    .filter_map(|part| match part {
+                        AssistantContent::Text(text) => Some(text.text.clone()),
+                        AssistantContent::ToolCall(_)
+                        | AssistantContent::Reasoning(_)
+                        | AssistantContent::Image(_) => None,
+                    })
+                    .collect::<String>()
+            ),
+        })
+        .collect()
+}

--- a/crates/rig-ecs/tests/run_wasm.rs
+++ b/crates/rig-ecs/tests/run_wasm.rs
@@ -26,7 +26,8 @@ use rig_ecs::{
 use rig_effect_log::{EffectLog, EffectLogRecorder, EffectLogReplayer};
 use wasm_bindgen_test::wasm_bindgen_test;
 
-const SMOKE: &str = include_str!("../../rig-verify/fixtures/anthropic_completion_smoke.effects.json");
+const SMOKE: &str =
+    include_str!("../../rig-verify/fixtures/anthropic_completion_smoke.effects.json");
 const REPROMPT: &str =
     include_str!("../../rig-verify/fixtures/mock_output_tool_text_reprompt.effects.json");
 
@@ -103,7 +104,9 @@ async fn the_smoke_golden_replays_through_the_graph_on_wasm() {
         .world_mut()
         .spawn((
             Owner("golden".to_owned()),
-            Preamble(Some("You are a concise assistant. Answer directly.".to_owned())),
+            Preamble(Some(
+                "You are a concise assistant. Answer directly.".to_owned(),
+            )),
             Temperature(None),
             MaxTokens(None),
             AdditionalParams(None),
@@ -136,7 +139,9 @@ async fn the_text_reprompt_golden_replays_through_the_graph_on_wasm() {
         .world_mut()
         .spawn((
             Owner("golden".to_owned()),
-            Preamble(Some("You are a concise assistant. Answer directly.".to_owned())),
+            Preamble(Some(
+                "You are a concise assistant. Answer directly.".to_owned(),
+            )),
             Temperature(None),
             MaxTokens(None),
             AdditionalParams(None),

--- a/crates/rig-ecs/tests/run_wasm.rs
+++ b/crates/rig-ecs/tests/run_wasm.rs
@@ -1,0 +1,173 @@
+//! The agent on `wasm32-unknown-unknown`, executed: two goldens of the
+//! completion-only corpus — the smoke and the two-record text reprompt —
+//! replayed through the run graph on the browser target, driven by hand
+//! as `bus_wasm` is. Every other wasm claim about the agent modules is
+//! `cargo check`.
+
+#![cfg(target_arch = "wasm32")]
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+
+use bevy_app::App;
+use bevy_ecs::{prelude::*, schedule::LogLevel};
+use rig_core::{effect::HandlerKey, serve::ServingPolicy};
+use rig_ecs::{
+    agent::{
+        AdditionalParams, DefaultMaxTurns, Failed, InvalidCalls, MaxTokens, MaxTurns, Output,
+        OutputKind, Owner, Preamble, RunResult, Settled, Temperature, ToolChoiceSpec, UsesModel,
+    },
+    bus::{BusPlugin, EffectLogResource, Handlers, IdCounter, run_to_quiescence},
+    systems::{AgentPlugin, spawn_run},
+};
+use rig_effect_log::{EffectLog, EffectLogRecorder, EffectLogReplayer};
+use wasm_bindgen_test::wasm_bindgen_test;
+
+const SMOKE: &str = include_str!("../../rig-verify/fixtures/anthropic_completion_smoke.effects.json");
+const REPROMPT: &str =
+    include_str!("../../rig-verify/fixtures/mock_output_tool_text_reprompt.effects.json");
+
+fn app(log: &EffectLog) -> (App, Entity) {
+    bevy_tasks::ComputeTaskPool::get_or_init(bevy_tasks::TaskPool::default);
+    bevy_tasks::AsyncComputeTaskPool::get_or_init(bevy_tasks::TaskPool::default);
+    let mut app = App::new();
+    app.add_plugins((
+        BusPlugin::with_policy(ServingPolicy::default()).ambiguity_detection(LogLevel::Error),
+        AgentPlugin::default(),
+    ));
+    app.finish();
+    app.cleanup();
+    app.world_mut().resource_mut::<IdCounter>().0 = 1;
+    let key = HandlerKey::from("golden/model:default");
+    let model = Handlers::with(app.world_mut(), |handlers| {
+        handlers
+            .register_erased(
+                key.clone(),
+                rig_core::serve::ErasedHandler::new(
+                    EffectLogReplayer::for_key(log, &key).expect("records"),
+                ),
+            )
+            .expect("a fresh key")
+    })
+    .expect("a bus");
+    EffectLogResource::install(app.world_mut(), EffectLogRecorder::new());
+    (app, model)
+}
+
+async fn tick(app: &mut App) {
+    run_to_quiescence(app.world_mut());
+    bevy_tasks::futures_lite::future::yield_now().await;
+    bevy_tasks::tick_global_task_pools_on_main_thread();
+}
+
+async fn settle(app: &mut App, run: Entity) -> String {
+    for _ in 0..500 {
+        tick(app).await;
+        if let Some(result) = app.world().get::<RunResult>(run) {
+            assert!(app.world().get::<Settled>(run).is_some());
+            return result.0.clone();
+        }
+        assert!(
+            app.world().get::<Failed>(run).is_none(),
+            "{:?}",
+            app.world().get::<Failed>(run)
+        );
+    }
+    panic!("the run never settled");
+}
+
+fn same_records(replayed: &EffectLog, log: &EffectLog) {
+    assert_eq!(replayed.records.len(), log.records.len());
+    for (mine, theirs) in replayed.records.iter().zip(&log.records) {
+        assert_eq!(mine.id, theirs.id);
+        assert_eq!(mine.key, theirs.key);
+        assert_eq!(
+            serde_json::to_value(&mine.kind).expect("serde"),
+            serde_json::to_value(&theirs.kind).expect("serde")
+        );
+        assert_eq!(
+            serde_json::to_value(&mine.outcome).expect("serde"),
+            serde_json::to_value(&theirs.outcome).expect("serde")
+        );
+    }
+}
+
+#[wasm_bindgen_test]
+async fn the_smoke_golden_replays_through_the_graph_on_wasm() {
+    let log: EffectLog = serde_json::from_str(SMOKE).expect("the golden loads");
+    let (mut app, model) = app(&log);
+    let agent = app
+        .world_mut()
+        .spawn((
+            Owner("golden".to_owned()),
+            Preamble(Some("You are a concise assistant. Answer directly.".to_owned())),
+            Temperature(None),
+            MaxTokens(None),
+            AdditionalParams(None),
+            ToolChoiceSpec(None),
+            Output::default(),
+            DefaultMaxTurns(None),
+            MaxTurns(1),
+            InvalidCalls::default(),
+            UsesModel(model),
+        ))
+        .id();
+    let run = spawn_run(
+        app.world_mut(),
+        agent,
+        &[],
+        "In one or two sentences, explain what Rust programming language is and why memory safety matters.",
+        false,
+        Some(1),
+    );
+    let answer = settle(&mut app, run).await;
+    assert!(answer.starts_with("Rust is a systems programming language"));
+    same_records(&app.world().resource::<EffectLogResource>().log(), &log);
+}
+
+#[wasm_bindgen_test]
+async fn the_text_reprompt_golden_replays_through_the_graph_on_wasm() {
+    let log: EffectLog = serde_json::from_str(REPROMPT).expect("the golden loads");
+    let (mut app, model) = app(&log);
+    let agent = app
+        .world_mut()
+        .spawn((
+            Owner("golden".to_owned()),
+            Preamble(Some("You are a concise assistant. Answer directly.".to_owned())),
+            Temperature(None),
+            MaxTokens(None),
+            AdditionalParams(None),
+            ToolChoiceSpec(None),
+            Output {
+                mode: OutputKind::Tool,
+                schema: Some(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string"},
+                        "category": {"type": "string"},
+                        "summary": {"type": "string"}
+                    },
+                    "required": ["title", "category", "summary"]
+                })),
+            },
+            DefaultMaxTurns(None),
+            MaxTurns(3),
+            InvalidCalls::default(),
+            UsesModel(model),
+        ))
+        .id();
+    let run = spawn_run(
+        app.world_mut(),
+        agent,
+        &[],
+        "Return a concise event object for a local Rust meetup in Seattle.",
+        false,
+        Some(3),
+    );
+    let answer = settle(&mut app, run).await;
+    assert!(answer.contains("Seattle Rust Meetup"));
+    same_records(&app.world().resource::<EffectLogResource>().log(), &log);
+}

--- a/crates/rig-verify/tests/corpus/mod.rs
+++ b/crates/rig-verify/tests/corpus/mod.rs
@@ -4116,5 +4116,18 @@ macro_rules! both_interpreters {
                 }
             )*
         }
+        /// The third interpreter: the program as an agent graph in a Bevy
+        /// world. A program the world does not support yet prints its
+        /// reason and passes (`corpus::world::unsupported`).
+        mod world_agent {
+            $(
+                #[test]
+                fn $test() {
+                    $crate::corpus::world::world_agent_reproduces(&super::$program);
+                }
+            )*
+        }
     };
 }
+
+pub mod world;

--- a/crates/rig-verify/tests/corpus/world.rs
+++ b/crates/rig-verify/tests/corpus/world.rs
@@ -1,0 +1,341 @@
+//! The corpus's third interpreter, agent half: a `Program` as an agent
+//! graph in a Bevy `World`, its run through `rig_ecs`'s systems against
+//! the golden's replayers, its log compared to the golden as the other two
+//! interpreters' are.
+//!
+//! What this interpreter supports is what stage 2 builds: a completion-only
+//! program with no hooks, no memory, no routes, no retrieval, no nesting,
+//! no layers, one prompt. Every other program is reported `unsupported`
+//! with the set or entity it waits for, and passes; the union of those
+//! lines over the corpus is the status table the PR prints.
+
+use std::time::{Duration, Instant};
+
+use bevy_app::App;
+use bevy_ecs::{prelude::*, schedule::LogLevel};
+use rig_core::{
+    effect::{EffectFamily, HandlerKey},
+    error::ErrorKind,
+    serve::ServingPolicy,
+};
+use rig_ecs::{
+    agent::{
+        AdditionalParams, Context, DefaultMaxTurns, DocumentId, DocumentText, Failed, Failure,
+        Grant, InvalidCalls, MaxTokens, MaxTurns, MessageParts, Order, Output, OutputKind, Owner,
+        Preamble, RunResult, Settled, Temperature, ToolChoiceSpec, Unhandled as WorldUnhandled,
+        UsesModel,
+    },
+    bus::{BusPlugin, EffectLogResource, Handlers, IdCounter},
+    replay::stamp_header,
+    systems::{AgentPlugin, spawn_run},
+};
+use rig_effect_log::{EffectLogRecorder, EffectLogReplayer};
+
+use super::{
+    Ending, Output as CorpusOutput, Program, Unhandled, assert_same_records, golden, golden_answer,
+    keeps_events, run_spec,
+};
+
+const GUARD: Duration = Duration::from_secs(30);
+
+/// Why a program is not this interpreter's yet: the set or entity it waits
+/// for, by stage.
+pub fn unsupported(program: &Program) -> Option<&'static str> {
+    if !program.hooks.is_empty() {
+        return Some("hooks as systems and observers (stage 4)");
+    }
+    if program.conversation.is_some() {
+        return Some("conversation memory (stage 5)");
+    }
+    if program.route.is_some() || program.late_route.is_some() {
+        return Some("model routing (stage 4)");
+    }
+    if program.dynamic_context.is_some() || program.retrieved_tools.is_some() {
+        return Some("retrieval (stage 4)");
+    }
+    if program.nesting.is_some() || program.cancel_when_reached {
+        return Some("nested dispatch from a tool (stage 3)");
+    }
+    if !program.layers.is_empty() {
+        return Some("layers on the program's handlers (stage 4)");
+    }
+    if program.second_prompt.is_some() {
+        return Some("two runs on one agent (stage 5)");
+    }
+    let log = golden(program.fixture);
+    if log
+        .records
+        .iter()
+        .any(|record| record.kind.family() != EffectFamily::Completion)
+    {
+        return Some("tool, memory or retrieval dispatches (stage 3 and 5)");
+    }
+    None
+}
+
+/// The world interpreter's cell: replays `program` through a world, or
+/// reports why it cannot yet.
+pub fn world_agent_reproduces(program: &Program) {
+    if let Some(why) = unsupported(program) {
+        eprintln!("world_agent: {} — unsupported: {why}", program.fixture);
+        return;
+    }
+    let log = golden(program.fixture);
+    EffectLogReplayer::check_header(&log).expect("a current format");
+    let policy = log.header.bus.unwrap_or_default();
+    let mut app = App::new();
+    app.add_plugins((
+        BusPlugin::with_policy(ServingPolicy {
+            command_capacity: 1_000,
+            ..policy
+        })
+        .ambiguity_detection(LogLevel::Error),
+        AgentPlugin::default(),
+    ));
+    app.finish();
+    app.cleanup();
+    let world = app.world_mut();
+    // rig-bus mints from 1; so does the world here, so ids read alike.
+    world.resource_mut::<IdCounter>().0 = 1;
+
+    // The golden's replayers, by position per key, as the other
+    // interpreters register them: the world mints its own ids.
+    let mut handler_entities: Vec<(HandlerKey, Entity)> = Vec::new();
+    Handlers::with(world, |handlers| {
+        for replayer in EffectLogReplayer::for_log(&log).expect("the golden's replayers") {
+            let key = replayer.key().clone();
+            let entity = handlers
+                .register_erased(key.clone(), rig_core::serve::ErasedHandler::new(replayer))
+                .expect("a fresh key");
+            handler_entities.push((key, entity));
+        }
+    })
+    .expect("a bus");
+    let recorder = if keeps_events(&log) {
+        EffectLogRecorder::keeping_stream_events()
+    } else {
+        EffectLogRecorder::new()
+    };
+    EffectLogResource::install(world, recorder);
+
+    let agent = spawn_agent(world, program, &handler_entities);
+    stamp_header(
+        world,
+        agent,
+        &world.resource::<EffectLogResource>().0.clone(),
+        log.header.bus,
+    );
+    let history: Vec<MessageParts> = program
+        .history
+        .map(|history| {
+            history()
+                .iter()
+                .filter_map(MessageParts::from_message)
+                .collect()
+        })
+        .unwrap_or_default();
+    let run = spawn_run(
+        world,
+        agent,
+        &history,
+        program.prompt,
+        program.streamed,
+        program.max_turns,
+    );
+
+    let start = Instant::now();
+    loop {
+        app.update();
+        let world = app.world();
+        if world.get::<Settled>(run).is_some() || world.get::<Failed>(run).is_some() {
+            break;
+        }
+        if program.cancel_after_first_delta
+            && world.get::<rig_ecs::agent::AwaitingModel>(run).is_some()
+            && cancel_if_delivered(app.world_mut(), run)
+        {
+            // The effect is despawned mid-stream: the record is `Cancelled`.
+            tick(&mut app, 3);
+            break;
+        }
+        assert!(
+            start.elapsed() < GUARD,
+            "{}: the run did not end within {GUARD:?}",
+            program.fixture
+        );
+        std::thread::yield_now();
+    }
+
+    let world = app.world();
+    let ending = (
+        world.get::<RunResult>(run).cloned(),
+        world.get::<Failed>(run).cloned(),
+    );
+    match (&ending, program.ending) {
+        (_, _) if program.cancel_after_first_delta => {}
+        ((Some(result), None), Ending::Answer) => {
+            assert_eq!(
+                result.0,
+                program
+                    .expected_output
+                    .map_or_else(|| golden_answer(&log), str::to_owned),
+                "{}: the answer",
+                program.fixture
+            );
+        }
+        ((None, Some(Failed(Failure::MaxTurns { .. }))), Ending::MaxTurns)
+        | ((None, Some(Failed(Failure::UnknownToolCall { .. }))), Ending::UnknownToolCall) => {}
+        ((None, Some(Failed(Failure::Provider(report)))), Ending::ProviderError)
+            if report.kind == ErrorKind::ProviderResponse => {}
+        ((None, Some(Failed(Failure::Provider(report)))), Ending::Failed(kind))
+            if report.kind == kind => {}
+        (other, ending) => panic!(
+            "{}: the run ends in {ending:?}, the world says {other:?}",
+            program.fixture
+        ),
+    }
+
+    let replayed = world.resource::<EffectLogResource>().log();
+    let mut replayed_sorted = replayed.clone();
+    replayed_sorted.records.sort_by_key(|record| record.id);
+    assert_same_records(&replayed_sorted, &log, "world agent");
+    assert_eq!(
+        replayed.header.run_spec, log.header.run_spec,
+        "{}: the header's spec hash is this program's",
+        program.fixture
+    );
+    assert_eq!(
+        replayed.header.hooks, log.header.hooks,
+        "{}: the hook list",
+        program.fixture
+    );
+    for (key, family) in log.header.required.iter() {
+        assert_eq!(
+            replayed.header.required.get(key),
+            Some(family),
+            "{}: the required row names `{key}`",
+            program.fixture
+        );
+    }
+    assert_eq!(
+        replayed.header.signature, log.header.signature,
+        "{}: the signature",
+        program.fixture
+    );
+    // The world's own identity computation agrees with the harness's.
+    let expected = rig_effect_log::stable_hash(&rig_agent::run::RunSpec {
+        max_turns: Some(program.default_max_turns.unwrap_or(1)),
+        max_invalid_tool_call_retries: 0,
+        unhandled_invalid_tool_call: rig_agent::run::UnhandledInvalidToolCall::Fail,
+        ..run_spec(program)
+    })
+    .ok();
+    assert_eq!(
+        replayed.header.run_spec, expected,
+        "{}: run_spec",
+        program.fixture
+    );
+}
+
+/// The program as an agent graph: the agent entity with one component per
+/// setting, `UsesModel` to the golden's model handler entity, a grant per
+/// advertised tool (the required row's tool keys, in key order), a context
+/// link per static document.
+fn spawn_agent(world: &mut World, program: &Program, handlers: &[(HandlerKey, Entity)]) -> Entity {
+    let model_key = HandlerKey::from(format!("{}/model:default", program.owner));
+    let model = handlers
+        .iter()
+        .find(|(key, _)| *key == model_key)
+        .map(|(_, entity)| *entity)
+        .expect("the golden serves the model");
+    let mode = match program.output_mode {
+        None => OutputKind::Auto,
+        Some(CorpusOutput::Native) => OutputKind::Native,
+        Some(CorpusOutput::Tool) => OutputKind::Tool,
+        Some(CorpusOutput::Prompted) => OutputKind::Prompted,
+    };
+    let agent = world
+        .spawn((
+            Owner(program.owner.to_owned()),
+            Preamble(program.spec_preamble()),
+            Temperature(program.temperature),
+            MaxTokens(program.max_tokens),
+            AdditionalParams(program.additional_params.map(|params| params())),
+            ToolChoiceSpec(program.tool_choice.map(super::Choice::tool_choice)),
+            Output {
+                mode,
+                schema: program.output_schema.map(|schema| schema()),
+            },
+            DefaultMaxTurns(program.default_max_turns),
+            MaxTurns(program.max_turns.or(program.default_max_turns).unwrap_or(1)),
+            InvalidCalls {
+                retries: program.invalid_retries,
+                unhandled: match program.unhandled {
+                    Unhandled::Fail => WorldUnhandled::Fail,
+                    Unhandled::Ignore => WorldUnhandled::Ignore,
+                },
+            },
+            UsesModel(model),
+        ))
+        .id();
+    let mut order = 0u64;
+    for (n, text) in program.context.iter().enumerate() {
+        let document = world
+            .spawn((
+                DocumentId(format!("static_doc_{n}")),
+                DocumentText((*text).to_owned()),
+            ))
+            .id();
+        world.spawn((Context(document), Order(order), ChildOf(agent)));
+        order += 1;
+    }
+    let log = golden(program.fixture);
+    let mut tools: Vec<&HandlerKey> = log
+        .header
+        .required
+        .iter()
+        .filter(|(_, family)| **family == EffectFamily::Tool)
+        .map(|(key, _)| key)
+        .collect();
+    tools.sort();
+    for key in tools {
+        let tool = handlers
+            .iter()
+            .find(|(bound, _)| bound == key)
+            .map(|(_, entity)| *entity)
+            .expect("the golden describes every required tool");
+        world.spawn((Grant(tool), Order(order), ChildOf(agent)));
+        order += 1;
+    }
+    world.resource_mut::<rig_ecs::agent::OrderCounter>().0 = order;
+    agent
+}
+
+/// Despawn the run's streaming effect once its first delta landed: the
+/// producer's `cancel_after_first_delta`. Returns whether it did.
+fn cancel_if_delivered(world: &mut World, run: Entity) -> bool {
+    let mut delivered = None;
+    let mut query = world.query::<(Entity, &ChildOf, &rig_ecs::bus::Streamed)>();
+    let turns: Vec<Entity> = world
+        .get::<Children>(run)
+        .map(|children| children.iter().collect())
+        .unwrap_or_default();
+    for (effect, child_of, streamed) in query.iter(world) {
+        if turns.contains(&child_of.parent()) && !streamed.events.is_empty() {
+            delivered = Some(effect);
+        }
+    }
+    match delivered {
+        Some(effect) => {
+            world.despawn(effect);
+            true
+        }
+        None => false,
+    }
+}
+
+fn tick(app: &mut App, n: usize) {
+    for _ in 0..n {
+        app.update();
+    }
+}

--- a/crates/rig-verify/tests/corpus/world.rs
+++ b/crates/rig-verify/tests/corpus/world.rs
@@ -62,6 +62,12 @@ pub fn unsupported(program: &Program) -> Option<&'static str> {
     if program.second_prompt.is_some() {
         return Some("two runs on one agent (stage 5)");
     }
+    if program.invalid_retries > 0 {
+        return Some("invalid-call retries as systems (stage 4)");
+    }
+    if matches!(program.ending, Ending::Cancelled(_) | Ending::MemoryError) {
+        return Some("a hook's stop or a memory failure (stage 4 and 5)");
+    }
     let log = golden(program.fixture);
     if log
         .records
@@ -150,14 +156,6 @@ pub fn world_agent_reproduces(program: &Program) {
         if world.get::<Settled>(run).is_some() || world.get::<Failed>(run).is_some() {
             break;
         }
-        if program.cancel_after_first_delta
-            && world.get::<rig_ecs::agent::AwaitingModel>(run).is_some()
-            && cancel_if_delivered(app.world_mut(), run)
-        {
-            // The effect is despawned mid-stream: the record is `Cancelled`.
-            tick(&mut app, 3);
-            break;
-        }
         assert!(
             start.elapsed() < GUARD,
             "{}: the run did not end within {GUARD:?}",
@@ -172,7 +170,10 @@ pub fn world_agent_reproduces(program: &Program) {
         world.get::<Failed>(run).cloned(),
     );
     match (&ending, program.ending) {
-        (_, _) if program.cancel_after_first_delta => {}
+        // The producer dropped its stream at the first delta; the replayer
+        // answers the record as the cancel it was, and the run ends there.
+        ((None, Some(Failed(Failure::Cancelled(report)))), _)
+            if program.cancel_after_first_delta && report.kind == ErrorKind::Cancelled => {}
         ((Some(result), None), Ending::Answer) => {
             assert_eq!(
                 result.0,
@@ -195,10 +196,11 @@ pub fn world_agent_reproduces(program: &Program) {
         ),
     }
 
+    // The world's log is in begin order, as rig-bus's; the oracle asserts
+    // it is dispatch order. The records carry the run's `Scope`, which the
+    // goldens do not have and `as_data` does not compare.
     let replayed = world.resource::<EffectLogResource>().log();
-    let mut replayed_sorted = replayed.clone();
-    replayed_sorted.records.sort_by_key(|record| record.id);
-    assert_same_records(&replayed_sorted, &log, "world agent");
+    assert_same_records(&replayed, &log, "world agent");
     assert_eq!(
         replayed.header.run_spec, log.header.run_spec,
         "{}: the header's spec hash is this program's",
@@ -309,33 +311,4 @@ fn spawn_agent(world: &mut World, program: &Program, handlers: &[(HandlerKey, En
     }
     world.resource_mut::<rig_ecs::agent::OrderCounter>().0 = order;
     agent
-}
-
-/// Despawn the run's streaming effect once its first delta landed: the
-/// producer's `cancel_after_first_delta`. Returns whether it did.
-fn cancel_if_delivered(world: &mut World, run: Entity) -> bool {
-    let mut delivered = None;
-    let mut query = world.query::<(Entity, &ChildOf, &rig_ecs::bus::Streamed)>();
-    let turns: Vec<Entity> = world
-        .get::<Children>(run)
-        .map(|children| children.iter().collect())
-        .unwrap_or_default();
-    for (effect, child_of, streamed) in query.iter(world) {
-        if turns.contains(&child_of.parent()) && !streamed.events.is_empty() {
-            delivered = Some(effect);
-        }
-    }
-    match delivered {
-        Some(effect) => {
-            world.despawn(effect);
-            true
-        }
-        None => false,
-    }
-}
-
-fn tick(app: &mut App, n: usize) {
-    for _ in 0..n {
-        app.update();
-    }
 }

--- a/tests/core/rig_ecs_bus_module.rs
+++ b/tests/core/rig_ecs_bus_module.rs
@@ -247,7 +247,7 @@ fn no_serde_type_holds_an_entity() {
                     if body_line.contains('{') {
                         opened = true;
                     }
-                    if body_line.contains("Entity") {
+                    if mentions_word(body_line, "Entity") {
                         offenders.push(format!(
                             "{}:{}: {}",
                             relative(&path),
@@ -273,19 +273,87 @@ fn no_serde_type_holds_an_entity() {
 }
 
 /// The crate's tests live where the module guard can find them: every
-/// integration test file is a `bus_*` file (the substrate's own suite) —
-/// until a later module adds its own.
+/// integration test file is a `bus_*` file (the substrate's own suite) or
+/// a `run_*` file (the agent's), and no `bus_*` file imports an agent
+/// module — the substrate's suite is the future rig-bevy suite verbatim.
 #[test]
-fn every_test_file_belongs_to_the_bus_suite() {
+fn every_test_file_belongs_to_a_suite_and_the_bus_suite_is_agent_free() {
     let tests = crate_root().join("tests");
     let offenders: Vec<String> = std::fs::read_dir(&tests)
         .expect("rig-ecs has tests")
         .flatten()
         .map(|entry| entry.file_name().to_string_lossy().into_owned())
-        .filter(|name| !name.starts_with("bus_"))
+        .filter(|name| !name.starts_with("bus_") && !name.starts_with("run_"))
         .collect();
     assert!(
         offenders.is_empty(),
-        "a test file outside the bus suite: {offenders:?}"
+        "a test file outside the bus and run suites: {offenders:?}"
+    );
+    let mut imports = Vec::new();
+    for path in rust_files(&tests) {
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        if !name.starts_with("bus_") && !path.to_string_lossy().contains("bus_support") {
+            continue;
+        }
+        let text = read(&path);
+        for (number, line) in code_lines(&text) {
+            for module in [
+                "rig_ecs::agent",
+                "rig_ecs::systems",
+                "rig_ecs::policy",
+                "rig_ecs::replay",
+            ] {
+                if line.contains(module) {
+                    imports.push(format!("{}:{number}: {module}", relative(&path)));
+                }
+            }
+        }
+    }
+    assert!(
+        imports.is_empty(),
+        "the bus suite imports an agent module:\n{}",
+        imports.join("\n")
+    );
+}
+
+/// The agent modules' discipline: nothing from the frozen crate, no
+/// history vector or document vector outside the fold, no
+/// `CompletionRequest` built outside the fold, and (with the bus module's
+/// rules) no clock, no random draw, no `Entity` in a serde payload.
+#[test]
+fn the_agent_modules_hold_the_discipline() {
+    let src = crate_root().join("src");
+    let mut offenders = Vec::new();
+    for path in rust_files(&src) {
+        let relative_path = relative(&path);
+        let is_fold =
+            relative_path == "src/policy/mod.rs" || relative_path == "src/policy/tests.rs";
+        let text = read(&path);
+        for (number, line) in code_lines(&text) {
+            for needle in ["rig_agent", "rig::agent"] {
+                if line.contains(needle) {
+                    offenders.push(format!(
+                        "{relative_path}:{number}: `{needle}` — nothing from the frozen crate"
+                    ));
+                }
+            }
+            if !is_fold {
+                for needle in ["Vec<Message>", "Vec<Document>", "CompletionRequest {"] {
+                    if line.contains(needle) {
+                        offenders.push(format!(
+                            "{relative_path}:{number}: `{needle}` — the fold is the only place a request or a history vector exists"
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "the agent modules break the discipline:\n{}",
+        offenders.join("\n")
     );
 }


### PR DESCRIPTION
# rig-ecs: the run as a graph, the request as its fold — the completion-only corpus through the world

Branch `feat/rig-ecs-run` on `feat/effect-bus` (after #2456). Stage 2 of `many_rigs/rig-bevy/rig-ideal-shape-programme-prompt.md`; executes `many_rigs/rig-bevy/rig-ecs-pr2-run-graph-prompt.md`.

## What this PR does

Above the bus module's boundary — `PendingEffect { key, kind }`, the moment intent leaves the world and becomes data a handler can hold — the world is now an entity graph: a run, its utterances, its turns, documents as entities of their own, tools as the handler entities the bus already has, the model as a relationship, every setting a component. Below it nothing changed: `CompletionRequest` is still one serde struct, which is what keeps the goldens byte-comparable. Between the two there is exactly one function, `policy::fold_request`, and a guard refuses any other constructor of a request in the crate.

The agent runtime, in four modules over `rig_ecs::bus` (which is unedited):

- **`agent`** — the vocabulary. An agent's settings one component each (`Owner`, `Preamble`, `Temperature`, `MaxTokens`, `AdditionalParams`, `ToolChoiceSpec`, `Output`, `MaxTurns`, `DefaultMaxTurns`, `InvalidCalls`); `UsesModel` → the model's handler entity; `Grant` and `Context` link entities (in `Order`) → tool handlers and document entities; documents (`DocumentId`, `DocumentText`, `DocumentProps`); utterances `ChildOf` the run in `Order` (`Role`, `Parts` — the message's parts verbatim); runs (`Run`, `RunOf`, `RunSeq`, `Streamed`, `Cursor`, a phase marker, `RunResult`, `Usage`, retries, `OutputToolName`, the run's own overrides, the bus's `Scope`); turns (`Turn`, `Advert` and `Attachment` links, `Outputs`, `Reprompt`); invalid calls (`InvalidCall` + `Resolution`). `agent::scene::RunScene` saves and loads the graph, relationships as indices or bound keys.
- **`policy`** — the verbatim strings the goldens pin, output-mode resolution, and the fold. Pure functions over plain data, each with a golden-cited test.
- **`systems`** — `RigSet::{Advance, Select, Assemble, Patch}` before the bus's `Gate`, `RigSet::{Fold, Judge, Materialise, Settle}` after its `Judge`, in the bus's `RigSchedule`, run to quiescence by its runner. Two steering slots need no hook: any system before `Assemble` edits the graph; a system in `Patch` edits the folded effect.
- **`replay`** — the header from components: the spec hash (`CONTRACT.md` §6 names the JSON; the smoke golden's `171082663332529849` reproduces from an agent entity), the required row, `stamp_header`. No spec struct exists.

`CONTRACT.md` is the specification: the request as a walk (source entity and component per field, in order), the strings, the modes, how a turn is read, the budgets, the header, the keys — every row citing the golden and JSON pointer that pin it.

## Commits

| # | commit | what |
|---|---|---|
| 1 | `docs(ecs): CONTRACT.md` | The specification, before any system. |
| 2 | `feat(ecs): the run as a graph, the request as its fold` | The four modules. (The prompt's R1–R6 landed as one commit: the modules reference each other and a file-wise split would not build at each step.) |
| 3 | `test(ecs): the graph's wins, the scene, the agent on wasm; the guard grows` | `run_graph.rs` (ruling 8's six), `run_scene.rs` (ruling 6), `run_wasm.rs` (two goldens through the graph on wasm, executed), the policy tests, the root guard's new rules. |
| 4 | `test(verify): the corpus's third interpreter, agent half` | `corpus/world.rs` and the `world_agent` arm of `both_interpreters!`. |
| 5 | `docs(ecs): the run graph in the README and the crate doc` | Vocabulary, sets, the hook-action mapping table, what is not yet. |
| 6 | `ci: the agent's wasm suite runs beside the bus's` | `run_wasm` in the wasm test matrix. |
| 7 | `fix(ecs): the independent review's findings` | One P1 (a despawned effect never ended its run — now an observer fails it `Cancelled`, pinned by a test), three P2s (the cancel cells' ending asserted, `RunScene` errors surfaced, three tuple `_ =>` arms spelled), the P3s; the commit message lists each. |

## The corpus

Every corpus cell now runs three interpreters. The world's agent half replays the completion-only, hook-free goldens byte for byte (records by id, order across keys, the answer, the ending, the header's spec hash, hook list, required row, signature) and reports every other program as `unsupported(<what it waits for>)` — the status table, printed by `cargo nextest run -p rig-verify -E 'test(world_agent)' --no-capture`:

| status | goldens |
|---|---|
| replayed byte for byte | **42** |
| hooks as systems and observers (stage 4) | 85 |
| tool, memory or retrieval dispatches (stage 3 and 5) | 30 |
| nested dispatch from a tool (stage 3) | 13 |
| conversation memory (stage 5) | 12 (`anthropic_memory_history_bypass` among them: its required row names `golden/memory`) |
| layers on the program's handlers (stage 4) | 12 |
| retrieval (stage 4) | 12 |
| model routing (stage 4) | 1 |
| | **207** |

The 42: `anthropic_cancelled_stream`, `anthropic_completion_smoke`, `anthropic_outcome_cancel_after_tool_call_delta`, `anthropic_outcome_model_error{,_streamed}`, `anthropic_output_prompted_{unary,streamed}`, `anthropic_output_tool_{unary,streamed,thinking,choice_required,choice_specific_output,under_none_degrades}`, `anthropic_request_shape_{append_preamble,max_tokens,output_schema_unary,output_schema_streamed,prior_history,static_context,thinking_unary,thinking_streamed,tool_choice_none,without_preamble}`, `gemini_breadth_output_tool_{unary,streamed}`, `mock_delta_{fail,ignore,output_tool}`, `mock_invalid_{ignore_unary,ignore_streamed,mixed_fail}`, `mock_leftovers_required_{custom,embed,rerank}`, `mock_oracle_prompted_unvalidated`, `mock_outcome_invalid_call_unhandled`, `mock_output_tool_{text,missing_field}_reprompt`, `openai_breadth_{output_tool_streamed,prompted_streamed}`, `openai_output_{prompted,tool}_unary`.

The superseded prompt counted 32 completion-only goldens at an older head; the corpus has 43 now, and the set is derived by `corpus::world::unsupported` rather than listed.

## The graph's wins, as tests

`crates/rig-ecs/tests/run_graph.rs`: an utterance despawned before `Assemble` leaves the next request; one document entity attached to two runs appears in both requests and exists once; a `Grant` link inserted at runtime advertises the tool on the next turn and its removal un-advertises it; `UsesModel` swapped on a run changes the next request's key and the log's; a `Patch` system's rewrite reaches the handler and is the record's request while the graph is untouched; a system before `Assemble` rewrites an utterance and the request carries it. `run_scene.rs`: the two-record text-reprompt golden, saved after its first turn was read (three utterances: the prompt, the text answer, the reprompt), resumes in a fresh world over the log's tail to the golden's second request and answer.

## Migration

- `rig-ecs` gains `agent`, `policy`, `systems`, `replay`; `schemars` joins its dependencies (the `output_schema` field). The `bus` module and its public items are unchanged.
- `rig-verify`'s `both_interpreters!` macro runs a third module, `world_agent`, per program; no test was removed.
- CI's wasm test matrix runs `rig-ecs`'s `run_wasm` beside `bus_wasm`.
- No golden moved; the format stays 4; `crates/rig-agent` is untouched.

## Deviations from the prompt, named

- The interpreter's supported set is 42, not 43: `anthropic_memory_history_bypass` needs a memory relationship for its required row (stage 5).
- The corpus's world interpreter runs natively (rig-verify is a tokio test crate); the crate's own `run_wasm.rs` replays two of the goldens through the graph on wasm, executed in CI.
- The interpreter lives in `corpus/world.rs` and runs from the `both_interpreters!` macro, not a `world_agent.rs` file: that is how every program reaches it without a second list. The status table's completeness guard is the corpus's pairing guard plus the macro; the run above counts 207 lines for 207 fixtures.
- The world's records carry the run's `Scope`; the goldens carry none, and `as_data` does not compare it. Unasserted on purpose (ruling 2).
- A `RunScene` saved with an effect in flight is not supported yet (the effect's `ChildOf` a turn is not carried across the two scenes); the mid-turn test saves between turns, as ruling 6 asks.
- R1–R6 landed as one commit (above).

## Gates

Run locally after the commits: fmt; clippy `--workspace --all-targets` with and without `--all-features` under `-D warnings`; `cargo doc --workspace --no-deps --all-features` with `-D warnings`; `nextest --features bedrock`; the all-features lane; rig-verify all features (three interpreters); `xtask check-test-layout`; the wasm check matrix; rig-bus's and rig-ecs's wasm suites (`wasm`, `bus_wasm`, `run_wasm`) under `wasm-bindgen-test-runner`; loom; the root `tests/core` guards (the module guard extended); the `hello_model` example.

## Independent review

A fresh reviewer read every commit against the prompt and the census. Its P1 — a despawned effect never ended its run, while CONTRACT and the README said it did — is fixed by an observer and pinned by a test; the P2s and P3s are applied in commit 7, whose message lists each. Nothing found in: the fold against CONTRACT, ordering across the quiescence loop, invalid-call handling, `select`, the scene's target resolution, the guard's fold detection, rig-agent's shapes.

## Remaining risks

- **A call to a granted tool** ends the run `Failed(Unsupported)`, named; stage 3 dispatches it. No golden in the supported set makes one.
- **`Retry`/`Repair`/`Skip` resolutions** are refused, named; stage 4 writes them from user systems.
- **The spec hash is the agent's identity.** A run-level override (`MaxTurns` on the run) is not identity, as rig-agent's header has it; a program that expects otherwise will see a hash mismatch in the interpreter, which is the finding it should be.
