### PR TITLE
fix(effect-bus): correct persistence and replay guarantees

### DIFF
--- a/crates/rig-agent/src/bus/dispatcher.rs
+++ b/crates/rig-agent/src/bus/dispatcher.rs
@@ -824,7 +824,8 @@ impl Dispatcher {
     ) -> Pending {
         let (reply, receiver) = oneshot::channel();
         let (cancel_guard, cancel) = oneshot::channel();
-        let published = context.as_ref().map(|_| PublishedContext::new());
+        let published = (context.is_some() || matches!(kind, EffectKind::ToolCall { .. }))
+            .then(PublishedContext::new);
         Pending {
             id,
             parent: self.parent,
@@ -1040,16 +1041,15 @@ pub struct Pending {
     parked: Arc<AtomicWaker>,
     /// Dropped with the value: the driver's cancel signal.
     _cancel_guard: oneshot::Sender<()>,
-    /// Where a tool call's published context comes back
-    /// ([`Dispatcher::dispatch_tool_with_id`]); `None` for any other
-    /// dispatch.
+    /// Where a tool call's published context comes back, including raw
+    /// tool dispatches without explicit inputs.
     published: Option<Arc<PublishedContext>>,
 }
 
 impl Pending {
     /// Where the tool's published context lands once this dispatch resolved
-    /// (clone it before awaiting the dispatch): `Some` for a
-    /// [`Dispatcher::dispatch_tool_with_id`], `None` otherwise.
+    /// (clone it before awaiting the dispatch): `Some` for tool calls,
+    /// including raw dispatches, and explicit context-bearing dispatches.
     pub fn published_context(&self) -> Option<Arc<PublishedContext>> {
         self.published.clone()
     }

--- a/crates/rig-agent/src/bus/driver.rs
+++ b/crates/rig-agent/src/bus/driver.rs
@@ -45,12 +45,20 @@ struct Recording {
 
 /// The record's view of one dispatch: the recorder, told by id.
 struct Recorded<R> {
+    published: Option<Arc<rig_core::tool::PublishedContext>>,
     recorder: R,
     id: EffectId,
 }
 
 impl<R: Recorder + Send + Sync> Observe for Recorded<R> {
     fn outcome(&mut self, outcome: &Result<Outcome, ErrorReport>) {
+        if let Some(output) = self
+            .published
+            .as_ref()
+            .and_then(|published| published.result_context())
+        {
+            self.recorder.tool_output(self.id, output);
+        }
         self.recorder.resolve(self.id, outcome.clone());
     }
 
@@ -78,7 +86,9 @@ impl Recording {
         let for_begin = recorder.clone();
         let begin = Box::new(move |id, key, kind, origin| for_begin.begin(id, key, kind, origin));
         let observe = Box::new(move |sink: OutcomeSink, id: EffectId| {
+            let published = sink.scope::<rig_core::tool::PublishedContext>();
             sink.with_observer(Box::new(Recorded {
+                published,
                 recorder: recorder.clone(),
                 id,
             }))

--- a/crates/rig-agent/src/bus/loom_models.rs
+++ b/crates/rig-agent/src/bus/loom_models.rs
@@ -322,6 +322,7 @@ struct Begun {
 }
 
 impl rig_core::serve::Recorder for Begun {
+    fn tool_output(&self, _: EffectId, _: rig_core::tool::ToolResultContext) {}
     fn handlers(&self, _handlers: Vec<HandlerDescriptor>) {}
     fn begin(
         &self,

--- a/crates/rig-agent/src/bus/replay/tests.rs
+++ b/crates/rig-agent/src/bus/replay/tests.rs
@@ -35,6 +35,88 @@ use rig_core::{
 
 const TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Raw tool dispatches also get a publication slot; recording must not
+/// consume it before the pending caller can read it.
+#[tokio::test]
+async fn raw_tool_dispatch_records_and_replays_published_output() {
+    use rig_core::tool::{ContextValue, PublishedContext, ToolOutput, ToolResult};
+    #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+    struct Artifact(String);
+    impl ContextValue for Artifact {
+        const KEY: &'static str = "artifact.v1";
+    }
+    struct Publisher;
+    impl Serve for Publisher {
+        type Family = rig_core::effect::family::Tool;
+        fn descriptor(&self) -> HandlerDescriptor {
+            HandlerDescriptor {
+                key: HandlerKey::from("tool:publish"),
+                family: FamilyDescriptor::Tool {
+                    name: "publish".into(),
+                    description: "artifact".into(),
+                    parameters: json!({}),
+                    embedding: None,
+                },
+                layers: vec![],
+            }
+        }
+        async fn serve(&self, _: EffectKind, sink: OutcomeSink) {
+            let mut context = ToolContext::new();
+            context
+                .insert_result(Artifact("result-123".into()))
+                .expect("encodes");
+            sink.scope::<PublishedContext>()
+                .expect("raw dispatch has a slot")
+                .publish(context);
+            sink.resolve(Ok(Outcome::ToolResult {
+                result: ToolResult::success(ToolOutput::text("ok")),
+            }))
+            .await;
+        }
+    }
+    let key = HandlerKey::from("tool:publish");
+    let kind = EffectKind::ToolCall {
+        name: "publish".into(),
+        args: "{}".into(),
+    };
+    let recorder = EffectLogRecorder::new();
+    let (dispatcher, _registrar, mut driver) = Bus::channel();
+    driver.register(key.clone(), Publisher).expect("fresh");
+    driver.record_to(recorder.clone());
+    let _task = spawn(driver);
+    let pending = dispatcher.dispatch(&key, kind.clone());
+    let published = pending.published_context().expect("slot");
+    let original = within(pending).await.expect("answer");
+    assert_eq!(
+        published
+            .take()
+            .expect("caller retains output")
+            .result::<Artifact>()
+            .expect("decodes"),
+        Some(Artifact("result-123".into()))
+    );
+    let json = serde_json::to_string(&recorder.log()).expect("serializes");
+    let log = serde_json::from_str(&json).expect("deserializes");
+    let (dispatcher, _registrar, mut driver) = Bus::channel();
+    super::register_all(&log, &mut driver).expect("replayers");
+    let _task = spawn(driver);
+    let pending = dispatcher.dispatch(&key, kind);
+    let published = pending.published_context().expect("slot");
+    let replayed = within(pending).await.expect("answer");
+    assert_eq!(
+        serde_json::to_value(original).expect("serializes"),
+        serde_json::to_value(replayed).expect("serializes")
+    );
+    assert_eq!(
+        published
+            .take()
+            .expect("replayed output")
+            .result::<Artifact>()
+            .expect("decodes"),
+        Some(Artifact("result-123".into()))
+    );
+}
+
 async fn within<T>(future: impl Future<Output = T>) -> T {
     tokio::time::timeout(TIMEOUT, future)
         .await
@@ -709,6 +791,7 @@ async fn a_tool_call_under_a_different_context_is_the_same_record() {
     let log: EffectLog = EffectLog {
         header: LogHeader::default(),
         records: vec![EffectRecord {
+            tool_output: None,
             parent: None,
             scope: None,
             id: EffectId::from_raw(1),

--- a/crates/rig-agent/src/bus/replay/tests.rs
+++ b/crates/rig-agent/src/bus/replay/tests.rs
@@ -16,7 +16,7 @@ use serde_json::json;
 
 use crate::bus::{Bus, BusDriver};
 
-use rig_effect_log::{EFFECT_LOG_FORMAT, EffectLog, EffectLogRecorder};
+use rig_effect_log::{EffectLog, EffectLogRecorder};
 
 use rig_core::serve::{
     OutcomeSink, Serve,
@@ -573,7 +573,6 @@ async fn a_log_carries_its_header_and_a_replay_checks_it() {
         .await
         .expect("served");
     let log = recorder.take();
-    assert_eq!(log.header.format, EFFECT_LOG_FORMAT);
     assert_eq!(log.header.run_spec, None, "a bare-bus record names no spec");
     assert_eq!(
         log.header
@@ -591,22 +590,10 @@ async fn a_log_carries_its_header_and_a_replay_checks_it() {
     );
     let json = serde_json::to_value(&log).expect("serializes");
     assert!(json.get("header").is_some() && json.get("records").is_some());
+    assert!(json["header"].get("format").is_none());
     let back: EffectLog = serde_json::from_value(json).expect("restores");
     assert_eq!(back.header, log.header);
     assert_eq!(back.len(), 1);
-
-    // A future format is refused with the version in the message.
-    let mut future = back.clone();
-    future.header.format = EFFECT_LOG_FORMAT + 1;
-    let (_dispatcher, _registrar, mut driver) = Bus::channel();
-    let report = super::register_all(&future, &mut driver).expect_err("refused");
-    assert!(
-        report
-            .message
-            .contains(&format!("format {}", EFFECT_LOG_FORMAT + 1)),
-        "{}",
-        report.message
-    );
 
     // A signature that names a family the records do not answer is refused
     // at registration, not at the first dispatch.

--- a/crates/rig-agent/src/bus/tests.rs
+++ b/crates/rig-agent/src/bus/tests.rs
@@ -1851,6 +1851,7 @@ struct Counting {
 }
 
 impl rig_core::serve::Recorder for Counting {
+    fn tool_output(&self, _: rig_core::effect::EffectId, _: rig_core::tool::ToolResultContext) {}
     fn handlers(&self, _handlers: Vec<HandlerDescriptor>) {}
     fn begin(
         &self,

--- a/crates/rig-core/src/effect/mod.rs
+++ b/crates/rig-core/src/effect/mod.rs
@@ -945,8 +945,10 @@ pub enum RetrievedDocuments {
 pub struct EffectRecord {
     /// Explicitly published tool-result metadata, including on errors. Never
     /// inbound authentication values or runtime scopes. `None` means the tool
-    /// did not publish a context before resolving.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// did not publish a context before resolving. The wire field is required:
+    /// `null` explicitly records no publication; omission cannot establish
+    /// whether an older recorder lost output and is rejected when decoding.
+    #[serde(deserialize_with = "Option::deserialize")]
     pub tool_output: Option<crate::tool::ToolResultContext>,
     /// The dispatch's id.
     pub id: EffectId,

--- a/crates/rig-core/src/effect/mod.rs
+++ b/crates/rig-core/src/effect/mod.rs
@@ -943,6 +943,11 @@ pub enum RetrievedDocuments {
 /// One recorded exchange: the effect, who served it, and the answer.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EffectRecord {
+    /// Explicitly published tool-result metadata, including on errors. Never
+    /// inbound authentication values or runtime scopes. `None` means the tool
+    /// did not publish a context before resolving.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_output: Option<crate::tool::ToolResultContext>,
     /// The dispatch's id.
     pub id: EffectId,
     /// The handler the effect was routed to.

--- a/crates/rig-core/src/serve/recorder.rs
+++ b/crates/rig-core/src/serve/recorder.rs
@@ -54,6 +54,9 @@ pub trait Recorder: WasmCompatSend + WasmCompatSync + 'static {
     fn keep_events(&self) -> bool;
     /// One streamed event of `id`.
     fn event(&self, id: EffectId, event: &StreamEvent);
+    /// Explicitly published tool output, delivered before `resolve`. A driver
+    /// snapshots it without consuming the caller's published context.
+    fn tool_output(&self, id: EffectId, output: crate::tool::ToolResultContext);
     /// The outcome of `id`.
     fn resolve(&self, id: EffectId, outcome: Result<Outcome, ErrorReport>);
 }

--- a/crates/rig-core/src/tool/context.rs
+++ b/crates/rig-core/src/tool/context.rs
@@ -152,8 +152,12 @@ impl TypeMap {
 /// values nor result metadata are sent to the model.
 ///
 /// Every value is **data**: inserting serializes it, reading deserializes it,
-/// and the whole context is itself `Serialize + Deserialize`, so it crosses
-/// tasks, channels, scenes, and record/replay logs unchanged. Values with
+/// and the whole context is itself `Serialize + Deserialize`. Explicit scene
+/// serialization can therefore contain sensitive inbound values and must be
+/// protected by the host. Effect logs record only [`ToolResultContext`]:
+/// values explicitly published through `insert_result`, never inbound slots
+/// or runtime scopes. Replay uses the current dispatch's inbound context;
+/// code must not treat mutations to inbound slots as durable output. Values with
 /// interior sharing (`Arc<Mutex<_>>`, atomics, channels) do not belong here;
 /// they belong to the tool instance.
 ///
@@ -178,6 +182,28 @@ pub struct ToolContext {
     /// built over it, descends from this call. Empty for an inline call.
     #[serde(skip)]
     scopes: Vec<std::sync::Arc<dyn Any + Send + Sync>>,
+}
+
+/// Explicitly published, durable tool-result metadata. Unlike [`ToolContext`],
+/// this contains no inbound credentials or live runtime scopes. Values are
+/// keyed by [`ContextValue::KEY`]; applications own their schema versions.
+#[derive(Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ToolResultContext(BTreeMap<String, serde_json::Value>);
+
+impl std::fmt::Debug for ToolResultContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("ToolResultContext")
+            .field(&self.0.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+impl ToolResultContext {
+    /// Read a published value without exposing ambient execution inputs.
+    pub fn get<T: ContextValue>(&self) -> Result<Option<T>, ToolContextError> {
+        get_slot(&self.0)
+    }
 }
 
 impl PartialEq for ToolContext {
@@ -355,6 +381,17 @@ impl ToolContext {
         self.result = dispatched.result;
     }
 
+    /// Snapshot only the values explicitly published with `insert_result`.
+    pub fn result_context(&self) -> ToolResultContext {
+        ToolResultContext(self.result.clone())
+    }
+
+    /// Restore durable output while preserving this dispatch's inbound values.
+    pub fn with_result_context(mut self, result: ToolResultContext) -> Self {
+        self.result = result.0;
+        self
+    }
+
     /// Drop the previous dispatch's result metadata before starting another.
     pub fn clear_dispatch_result(&mut self) {
         self.result.clear();
@@ -384,7 +421,20 @@ impl PublishedContext {
         std::sync::Arc::new(Self::default())
     }
 
+    /// The recorder's non-consuming snapshot. Publish before resolving the
+    /// sink; values published after resolution are not part of that outcome.
+    pub fn result_context(&self) -> Option<ToolResultContext> {
+        self.0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .map(ToolContext::result_context)
+    }
+
     /// The adapter's write: the context after the tool ran, scopes cleared.
+    /// All publication must finish before resolving the sink. Publishing
+    /// afterward violates the delivery contract: consumers and recorders may
+    /// observe different versions. The slot does not enforce this ordering.
     pub fn publish(&self, mut context: ToolContext) {
         context.clear_scope();
         *self

--- a/crates/rig-core/src/tool/mod.rs
+++ b/crates/rig-core/src/tool/mod.rs
@@ -21,7 +21,9 @@ pub mod managed;
 mod output;
 pub mod portable;
 mod result;
-pub use context::{ContextValue, PublishedContext, ToolContext, ToolContextError};
+pub use context::{
+    ContextValue, PublishedContext, ToolContext, ToolContextError, ToolResultContext,
+};
 pub use contextual::{DynamicTool, ErasedTool, Tool, ToolEmbedding, tool_definition};
 pub use managed::{ManagedToolSink, ManagedToolToken};
 pub use output::{IntoToolOutput, ToolOutput};

--- a/crates/rig-ecs/CONTRACT.md
+++ b/crates/rig-ecs/CONTRACT.md
@@ -231,8 +231,8 @@ A layer is the handler's: the world registers the layered `ErasedHandler` (`hand
 | what | where | pinned by |
 |---|---|---|
 | `LogHeader::hooks` | the program's declaration — the corpus's `hook_name` list, then `layer_names` — passed to `replay::stamp_header(world, agent, recorder, bus, hooks)`; the world has no hook stack to name | every golden's `/header/hooks`, asserted by the interpreter |
-| `LogHeader::programs: BTreeMap<String, ProgramIdentity { required: EffectRow, policy: u64 }>` | written per run scope by `stamp_header` (`policy` = `stable_hash(spec_json)`), `#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]`: rig-agent's goldens carry none, no re-stamp; a world's own log carries its scopes | `rig-effect-log`'s round-trip test |
-| `replay::check_replayable(world, agent, &log)` | refuses a foreign golden: the scope's `required` not served by the log's handlers, or its `policy` ≠ the agent's `spec_hash`; falls back to `run_spec`/`required` for a golden without `programs` | `run_identity.rs` |
+| `LogHeader::programs: BTreeMap<String, ProgramIdentity { required: EffectRow, policy: u64 }>` | written per run scope by `stamp_run` (`policy` = `stable_hash(spec_json(world, run))`), using supported effective run-over-agent settings; rig-agent's builder-only goldens carry none | `run_identity.rs`, `run_replay_policy.rs` |
+| `replay::check_replayable(world, run, &log)` | selects the run's exact `Scope`; rejects policy/row differences and missing handlers. Missing scoped identity or nonempty `PolicyVersion` declaration is unverified, with no builder-header fallback. Custom systems, ordering and otherwise-unhashed settings are the application's version declaration, not automatically fingerprinted code | `run_identity.rs`, `run_replay_policy.rs` |
 | `required` with a route | the agent's `Route` links' keys as `completion` | `anthropic_serving_model_route{,_unselected}` `/header/required` |
 
 ## 11. Memory is the graph
@@ -266,6 +266,13 @@ The required row names `<owner>/memory` as `memory` from `Remembers`. `Memory { 
 | a route never selected | in the row, never dispatched | `anthropic_serving_model_route_unselected` |
 
 ## 13. Resume is a scene load; two runs
+
+The live-handler regressions in `tests/memory_resume.rs` cover memory finalization before
+scheduling, while queued, after an external write but before its outcome,
+and after completion. `MemoryAppendScheduled` and the child effect persist
+separately from Bevy change-detection ticks: loading `Settled` is not a new
+append transition. An unanswered write is retried under its saved effect id;
+external deduplication or reconciliation is the host's responsibility.
 
 | what | how | pinned by |
 |---|---|---|

--- a/crates/rig-ecs/README.md
+++ b/crates/rig-ecs/README.md
@@ -4,6 +4,26 @@ rig inside a Bevy `World`. Two layers: `rig_ecs::bus`, the effect bus as a plugi
 
 ## The run as a graph
 
+`agent::scene::WorldScene` saves the library's supported graph/effect state,
+not arbitrary world state. Install `agent::scene::SceneExtensions` in both
+worlds to register application components under stable, versioned names.
+Registered serde components on saved graph entities round-trip with those
+entities; a saved but unregistered name is rejected on load. Component payloads
+must be entity-independent and their serde implementations pure and
+deterministic. Embedded entity IDs are not remapped. Resources, custom effect
+components, extra entities, system-local state and live tasks remain host-owned.
+Bind handlers and install registrations before loading; install application
+insertion observers afterward to avoid reacting to partially restored state.
+
+`replay::stamp_run` captures supported effective configuration, including
+run-over-agent overrides. `check_replayable` checks the requested run's exact
+`Scope`; it does not search for another matching policy hash. Applications
+must declare a nonempty `agent::PolicyVersion` for their custom systems,
+ordering and otherwise-unhashed configuration. A missing declaration is
+reported as unverified. This declaration is not an automatic code fingerprint
+or a check of ambient credentials and external state. The builder-only
+`stamp_header` remains a corpus header, not an effective compatibility check.
+
 The request the model sees is derived, never authored: a run entity, utterances `ChildOf` it in `Order`, documents as their own entities attached to a turn by link entities, tools as the handler entities the bus already has (granted by link entities), the model as a relationship, every setting a component — and one function, `policy::fold_request`, that walks the graph at `RigSet::Assemble` and writes the wire `CompletionRequest` into the turn's `PendingEffect`. `CONTRACT.md` names the walk field by field with the golden that pins each; the corpus's third interpreter (`crates/rig-verify/tests/corpus/world.rs`) replays every completion-only golden through it.
 
 | design (§3.1) | here |
@@ -151,6 +171,30 @@ The Bevy host fixture's fourteen proofs and the eight unproven behaviours of `ri
 ## What it deliberately does not have
 
 No hook trait, no history vector, no step enum, no run struct copied from anywhere, no batch machine (the batch is the turn's children and a query): steering is a system between sets. Program identity is data: `replay::stamp_run` writes the run's scope into `LogHeader::programs` and `replay::check_replayable` refuses a foreign log by policy or by row (`tests/run_identity.rs`). Memory is the graph and retrieval attaches (`tests/memory_graph.rs`); two runs on one agent are two `spawn_run`s; resume is a scene load (`agent::scene::{save_world, load_world}`, every resume and checkpoint row of the corpus as a world cell, CONTRACT §13). The `bus` module still has no agent-shaped item and its suite is agent-free (the guard checks). No streaming answers from a system yet (a later PR). `Scene` is the crate's own serde form and stores what this module owns; a host's other components are its own to save. No `Now`, no `Random`: nondeterminism is an effect a host registers, and the guard refuses a clock or a random draw in this crate.
+
+## Memory finalization across snapshots
+
+`Settled` means the model run produced its answer, not that external memory
+has committed it. `MemoryAppendScheduled` persists the fact that finalization
+created an append; its child effect carries the request, dispatch id and
+outcome. Loading a snapshot before finalization schedules that append;
+loading a queued, in-flight or completed append does not create another
+operation. See `tests/memory_resume.rs` for live-handler tests at these cuts.
+
+An unanswered effect is retried on load under its saved id. The external
+write may already have happened: a process can stop between the write and
+collecting its answer. This is not exactly-once execution. A host needing
+deduplication must durably associate an external idempotency key with the
+operation (including a session/log namespace, since `EffectId` alone is not
+globally unique), use an idempotent handler, or reconcile ambiguous writes
+before resuming. Despawning or abandoning a world does not roll back writes.
+
+Save only at a schedule boundary after deferred commands have been applied,
+and persist the scene together with its matching log/checkpoint. Inserting
+components while loading invokes Bevy insertion observers and change
+detection; application observers must not interpret rehydration as a new
+business event. Install such observers after loading or explicitly guard
+them during restoration.
 
 ## The prelude and the features
 

--- a/crates/rig-ecs/src/agent/mod.rs
+++ b/crates/rig-ecs/src/agent/mod.rs
@@ -135,6 +135,15 @@ pub struct InvalidCalls {
     pub unhandled: Unhandled,
 }
 
+/// The application's versioned declaration of its policy systems, ordering,
+/// and configuration not represented by the library's policy components.
+/// Set on the agent or override on the run before stamping its identity.
+/// Change this value when that policy changes. It is a declaration, not an
+/// automatic fingerprint of executable code or ambient credentials.
+#[derive(Component, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "reflect", derive(bevy_reflect::Reflect), reflect(Component))]
+pub struct PolicyVersion(pub String);
+
 /// How many of a turn's tool calls may be in flight at once: 1 (the
 /// default) runs them one after another in call order; N keeps N going.
 /// The run's, else the agent's.
@@ -216,6 +225,14 @@ pub struct Remembered;
 #[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "reflect", derive(bevy_reflect::Reflect), reflect(Component))]
 pub struct Remembering;
+
+/// Finalization has created this run's memory append intent. Persisted so
+/// rehydrating `Settled` cannot schedule a second operation. The child
+/// effect owns the request, saved dispatch id, and eventual outcome; this
+/// marker does not claim that the external write succeeded exactly once.
+#[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "reflect", derive(bevy_reflect::Reflect), reflect(Component))]
+pub struct MemoryAppendScheduled;
 
 /// The run's memory load is out; its first turn waits for it.
 #[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/rig-ecs/src/agent/scene.rs
+++ b/crates/rig-ecs/src/agent/scene.rs
@@ -9,16 +9,18 @@
 use bevy_ecs::prelude::*;
 use rig_core::effect::HandlerKey;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
+use super::PolicyVersion;
 use super::{
     AdditionalParams, Advert, Assembling, Attachment, AwaitingModel, Batch, Cancelled, Context,
     Conversation, Cursor, DefaultMaxTurns, DocumentId, DocumentProps, DocumentText, Failed, Grant,
-    InvalidCall, InvalidCalls, InvalidRetries, LoadingMemory, MaxTokens, MaxTurns, Order,
-    OrderCounter, Output, OutputRetries, OutputToolName, Outputs, Owner, Parts, Preamble,
-    Remembered, Remembering, Remembers, Reprompt, RequestPatch, Resolution, ResolvingTools,
-    Retrievable, Retrieval, Retrieves, Retrieving, Retry, Role, Route, Run, RunCounter, RunOf,
-    RunResult, RunSeq, Settled, Streamed, Temperature, ToolCallSlot, ToolChoiceSpec,
-    ToolContextSpec, ToolPolicy, Turn, Usage, UsesModel, Utterance,
+    InvalidCall, InvalidCalls, InvalidRetries, LoadingMemory, MaxTokens, MaxTurns,
+    MemoryAppendScheduled, Order, OrderCounter, Output, OutputRetries, OutputToolName, Outputs,
+    Owner, Parts, Preamble, Remembered, Remembering, Remembers, Reprompt, RequestPatch, Resolution,
+    ResolvingTools, Retrievable, Retrieval, Retrieves, Retrieving, Retry, Role, Route, Run,
+    RunCounter, RunOf, RunResult, RunSeq, Settled, Streamed, Temperature, ToolCallSlot,
+    ToolChoiceSpec, ToolContextSpec, ToolPolicy, Turn, Usage, UsesModel, Utterance,
 };
 use crate::bus::{Bound, Scope};
 
@@ -116,11 +118,15 @@ macro_rules! give {
     };
 }
 
-/// The whole state of the agent runtime in a world: the run graph and the
+/// The supported persistent state of the agent runtime: the run graph and the
 /// bus module's effects, saved together so an effect `ChildOf` a turn is
 /// `ChildOf` it again after a load — which is what lets a run saved with
 /// its model call in flight resume: the effect is re-issued under its saved
 /// id, answered, and read by the turn it belongs to.
+///
+/// Only the library's listed components and components explicitly registered
+/// with [`SceneExtensions`] are captured. Resources, arbitrary entities,
+/// system-local state, tasks and live handles remain the host's responsibility.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct WorldScene {
     /// The graph.
@@ -136,6 +142,71 @@ pub struct WorldScene {
     /// index into `effects.effects`: a run cut while retrieving resumes.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub retrievals: Vec<(usize, Retrieval)>,
+    /// Registered extension components on graph entities, keyed by graph index
+    /// and the application's versioned component name.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extensions: BTreeMap<usize, BTreeMap<String, serde_json::Value>>,
+}
+
+/// Explicit persistence registration for application components on entities
+/// already captured by [`WorldScene::graph`]. Install the same registrations
+/// in the source and destination worlds before saving or loading.
+///
+/// Payloads must be entity-independent serde data with pure, deterministic
+/// serialization and deserialization (loading validates then deserializes).
+/// Entity references inside a
+/// payload are **not** remapped; use the library's graph relationships for
+/// ownership and links. Registrations do not capture resources, additional
+/// entities, system-local state or effects' custom components. Version names
+/// when the payload's schema or meaning changes. Unregistered components are
+/// outside the contract; a saved name missing at load is an error.
+#[derive(Resource, Default, Clone)]
+pub struct SceneExtensions {
+    components: BTreeMap<String, ComponentCodec>,
+}
+
+#[derive(Clone)]
+struct ComponentCodec {
+    save: fn(&World, Entity) -> Result<Option<serde_json::Value>, serde_json::Error>,
+    validate: fn(serde_json::Value) -> Result<(), serde_json::Error>,
+    load: fn(&mut World, Entity, serde_json::Value) -> Result<(), serde_json::Error>,
+}
+
+impl SceneExtensions {
+    /// Register one component under a nonempty, unique, application-owned name
+    /// such as `acme/retry-budget/v1`. Duplicate names are rejected, including
+    /// repeated registration of the same type. The host must use one name per
+    /// type and register the same type for that name in both worlds.
+    pub fn register_component<T>(
+        &mut self,
+        name: impl Into<String>,
+    ) -> Result<(), rig_core::error::ErrorReport>
+    where
+        T: Component + Serialize + serde::de::DeserializeOwned,
+    {
+        let name = name.into();
+        if name.trim().is_empty() || self.components.contains_key(&name) {
+            return Err(extension_error("empty or duplicate extension name"));
+        }
+        self.components.insert(
+            name,
+            ComponentCodec {
+                save: |world, entity| world.get::<T>(entity).map(serde_json::to_value).transpose(),
+                validate: |value| serde_json::from_value::<T>(value).map(|_| ()),
+                load: |world, entity, value| {
+                    world
+                        .entity_mut(entity)
+                        .insert(serde_json::from_value::<T>(value)?);
+                    Ok(())
+                },
+            },
+        );
+        Ok(())
+    }
+}
+
+fn extension_error(message: impl Into<String>) -> rig_core::error::ErrorReport {
+    rig_core::error::ErrorReport::new(rig_core::error::ErrorKind::Request, message)
 }
 
 /// What [`load_world`] spawned, by scene index.
@@ -150,6 +221,21 @@ pub struct Loaded {
 /// Save the graph and the effects of `world` as one [`WorldScene`].
 pub fn save_world(world: &mut World) -> Result<WorldScene, rig_core::error::ErrorReport> {
     let (graph, entities) = RunScene::take(world)?;
+    let mut extensions = BTreeMap::<usize, BTreeMap<String, serde_json::Value>>::new();
+    if let Some(registry) = world.get_resource::<SceneExtensions>() {
+        for (index, entity) in entities.iter().enumerate() {
+            for (name, codec) in &registry.components {
+                if let Some(value) = (codec.save)(world, *entity)
+                    .map_err(|error| extension_error(format!("extension {name}: {error}")))?
+                {
+                    extensions
+                        .entry(index)
+                        .or_default()
+                        .insert(name.clone(), value);
+                }
+            }
+        }
+    }
     let effects = crate::bus::Scene::save_with(world, |parent| {
         entities.iter().position(|entity| *entity == parent)
     });
@@ -183,16 +269,39 @@ pub fn save_world(world: &mut World) -> Result<WorldScene, rig_core::error::Erro
         effects,
         slots,
         retrievals,
+        extensions,
     })
 }
 
 /// Load `scene` into `world`: the graph first, then the effects, each
 /// effect `ChildOf` the graph entity its `parent_ref` names. Handlers are
 /// the host's to bind first, as for [`RunScene::load`].
+/// Registered extensions are validated before spawning and inserted after the
+/// graph and effects have loaded. Install application observers after loading:
+/// insertion observers can otherwise see a partially restored entity. Loading
+/// is not transactional if a graph error, extension insertion/deserialization
+/// or application observer fails.
 pub fn load_world(
     scene: &WorldScene,
     world: &mut World,
 ) -> Result<Loaded, rig_core::error::ErrorReport> {
+    let registry = world
+        .get_resource::<SceneExtensions>()
+        .cloned()
+        .unwrap_or_default();
+    for (index, components) in &scene.extensions {
+        if *index >= scene.graph.entities.len() {
+            return Err(extension_error("extension graph index is out of bounds"));
+        }
+        for (name, value) in components {
+            let codec = registry
+                .components
+                .get(name)
+                .ok_or_else(|| extension_error(format!("unregistered scene extension {name}")))?;
+            (codec.validate)(value.clone())
+                .map_err(|error| extension_error(format!("extension {name}: {error}")))?;
+        }
+    }
     let graph = scene.graph.load(world)?;
     let effects = scene
         .effects
@@ -205,6 +314,16 @@ pub fn load_world(
     for (index, retrieval) in &scene.retrievals {
         if let Some(effect) = effects.get(*index).copied() {
             world.entity_mut(effect).insert(*retrieval);
+        }
+    }
+    for (index, components) in &scene.extensions {
+        if let Some(entity) = graph.get(*index).copied() {
+            for (name, value) in components {
+                if let Some(codec) = registry.components.get(name) {
+                    (codec.load)(world, entity, value.clone())
+                        .map_err(|error| extension_error(format!("extension {name}: {error}")))?;
+                }
+            }
         }
     }
     Ok(Loaded { graph, effects })
@@ -297,6 +416,8 @@ impl RunScene {
                 Cancelled => "cancelled", Retry => "retry", RequestPatch => "request_patch",
                 Conversation => "conversation", Remembered => "remembered",
                 Remembering => "remembering", LoadingMemory => "loading_memory",
+                MemoryAppendScheduled => "memory_append_scheduled",
+                PolicyVersion => "policy_version",
                 Retrieval => "retrieval", Retrievable => "retrievable", Retrieving => "retrieving",
             );
             if !errors.is_empty() {
@@ -436,6 +557,8 @@ impl RunScene {
                 Cancelled => "cancelled", Retry => "retry", RequestPatch => "request_patch",
                 Conversation => "conversation", Remembered => "remembered",
                 Remembering => "remembering", LoadingMemory => "loading_memory",
+                MemoryAppendScheduled => "memory_append_scheduled",
+                PolicyVersion => "policy_version",
                 Retrieval => "retrieval", Retrievable => "retrievable", Retrieving => "retrieving",
             );
             if !errors.is_empty() {

--- a/crates/rig-ecs/src/bus/collect.rs
+++ b/crates/rig-ecs/src/bus/collect.rs
@@ -32,9 +32,10 @@ pub fn collect_tasks(
                 .remove::<Serving>()
                 .insert(EffectOutcome(outcome));
             if let Some(Publishing(published)) = publishing {
-                entity_commands
-                    .remove::<Publishing>()
-                    .insert(ToolOutputs(published.take().unwrap_or_default()));
+                entity_commands.remove::<Publishing>();
+                if let Some(context) = published.take() {
+                    entity_commands.insert(ToolOutputs(context));
+                }
             }
             progress.mark();
         }
@@ -113,17 +114,26 @@ pub type StreamingView = (
 /// An outcome that landed on an effect still in flight.
 pub type Landed = (Added<EffectOutcome>, With<InFlight>);
 
+/// The outcome and durable tool output needed to close a dispatch's record.
+pub type LandedView = (
+    Entity,
+    &'static Issued,
+    &'static EffectOutcome,
+    Option<&'static Observed>,
+    Option<&'static ToolOutputs>,
+);
+
 /// An outcome landed on an in-flight effect: the record closes with it and
 /// the effect leaves flight. The one place records close, so a `Gate`
 /// denial (never in flight) is no record and a `Judge` rewrite (after this)
 /// is not re-recorded: decisions are program, never record.
 pub fn settle(
     mut commands: Commands,
-    landed: Query<(Entity, &Issued, &EffectOutcome, Option<&Observed>), Landed>,
+    landed: Query<LandedView, Landed>,
     recording: Option<Res<Recording>>,
     mut progress: ResMut<Progress>,
 ) {
-    for (entity, &Issued(id), outcome, observed) in &landed {
+    for (entity, &Issued(id), outcome, observed, outputs) in &landed {
         // A layered handler: the record holds what the innermost handler
         // answered (the observer's), never a layer's verdict; a dispatch a
         // layer discarded is no record.
@@ -132,6 +142,13 @@ pub fn settle(
             .and_then(|observed| observed.0.take_outcome())
             .unwrap_or_else(|| outcome.0.clone());
         if let (Some(recording), false) = (&recording, discarded) {
+            // Layered dispatches captured output at the inner handler's
+            // terminal, before an outer verdict could change it.
+            if observed.is_none()
+                && let Some(outputs) = outputs
+            {
+                recording.tool_output(id, outputs.0.result_context());
+            }
             recording.resolve(id, recorded);
         }
         commands.entity(entity).remove::<(InFlight, Observed)>();

--- a/crates/rig-ecs/src/bus/dispatch.rs
+++ b/crates/rig-ecs/src/bus/dispatch.rs
@@ -153,13 +153,19 @@ pub fn dispatch(
                     entity_commands.insert(super::record::Observed(Arc::clone(&observed)));
                     observed
                 });
-                let observe = |sink: OutcomeSink| match &observed {
-                    Some(observed) => sink.with_observer(Box::new(super::record::WorldObserver {
-                        id,
-                        recording: recording.as_ref().map(|r| (**r).clone()),
-                        observed: Arc::clone(observed),
-                    })),
-                    None => sink,
+                let observe = |sink: OutcomeSink| {
+                    let published = sink.scope::<rig_core::tool::PublishedContext>();
+                    match &observed {
+                        Some(observed) => {
+                            sink.with_observer(Box::new(super::record::WorldObserver {
+                                published,
+                                id,
+                                recording: recording.as_ref().map(|r| (**r).clone()),
+                                observed: Arc::clone(observed),
+                            }))
+                        }
+                        None => sink,
+                    }
                 };
                 if effect.is_stream() {
                     let (events, receiver) = mpsc::channel(policy.stream_capacity);
@@ -177,7 +183,7 @@ pub fn dispatch(
                     ));
                 } else {
                     let (reply, receiver) = oneshot::channel();
-                    let mut sink = observe(OutcomeSink::unary(id, reply));
+                    let mut sink = OutcomeSink::unary(id, reply);
                     // A tool call's context travels beside the effect
                     // (format 5): the inbound values on the sink, and the
                     // slot the tool publishes into, read by `Collect`.
@@ -190,6 +196,7 @@ pub fn dispatch(
                                 as std::sync::Arc<dyn std::any::Any + Send + Sync>);
                         entity_commands.insert(Publishing(published));
                     }
+                    let sink = observe(sink);
                     let task = IoTaskPool::get().spawn(async move {
                         handler.handle(kind, sink).await;
                         match receiver.await {

--- a/crates/rig-ecs/src/bus/record.rs
+++ b/crates/rig-ecs/src/bus/record.rs
@@ -73,6 +73,11 @@ impl Recording {
         self.0.resolve(id, outcome);
     }
 
+    /// Durable output published before this dispatch's terminal outcome.
+    pub fn tool_output(&self, id: EffectId, output: rig_core::tool::ToolResultContext) {
+        self.0.tool_output(id, output);
+    }
+
     /// A layer decided `id` before any handler served it: no record.
     pub fn discard(&self, id: EffectId) {
         self.0.discard(id);
@@ -120,6 +125,8 @@ impl ObservedState {
 /// it is told are the innermost handler's — what the record holds,
 /// whatever verdict the outer channel carries to the world.
 pub struct WorldObserver {
+    /// Tool output shared with the caller, read without consuming it.
+    pub published: Option<Arc<rig_core::tool::PublishedContext>>,
     /// The dispatch.
     pub id: EffectId,
     /// The world's recorder, if any.
@@ -130,6 +137,14 @@ pub struct WorldObserver {
 
 impl rig_core::serve::Observe for WorldObserver {
     fn outcome(&mut self, outcome: &Result<Outcome, ErrorReport>) {
+        if let (Some(recording), Some(output)) = (
+            &self.recording,
+            self.published
+                .as_ref()
+                .and_then(|published| published.result_context()),
+        ) {
+            recording.tool_output(self.id, output);
+        }
         *self
             .observed
             .outcome
@@ -166,18 +181,32 @@ impl rig_core::serve::Observe for WorldObserver {
     }
 }
 
+/// State needed to record cancellation and any output published before it.
+pub type CancellationView = (
+    &'static Issued,
+    Option<&'static EffectOutcome>,
+    Option<&'static super::effect::Publishing>,
+    Option<&'static super::effect::ToolOutputs>,
+);
+
 /// An in-flight effect losing `InFlight` without an outcome — a despawn,
 /// its own or an ancestor's — is a cancelled dispatch: the record says so,
 /// as it does when a consumer drops its `Pending` on rig-bus.
 pub fn record_cancelled(
     removed: On<Remove, InFlight>,
-    effects: Query<(&Issued, Option<&EffectOutcome>)>,
+    effects: Query<CancellationView>,
     recording: Option<Res<Recording>>,
 ) {
     let Some(recording) = recording else {
         return;
     };
-    if let Ok((Issued(id), None)) = effects.get(removed.event().entity) {
+    if let Ok((Issued(id), None, publishing, outputs)) = effects.get(removed.event().entity) {
+        let output = publishing
+            .and_then(|published| published.0.result_context())
+            .or_else(|| outputs.map(|outputs| outputs.0.result_context()));
+        if let Some(output) = output {
+            recording.tool_output(*id, output);
+        }
         recording.resolve(*id, Err(cancelled()));
     }
 }

--- a/crates/rig-ecs/src/reflect.rs
+++ b/crates/rig-ecs/src/reflect.rs
@@ -97,6 +97,8 @@ pub fn register(app: &mut App) {
             agent::Conversation,
             agent::Remembered,
             agent::Remembering,
+            agent::MemoryAppendScheduled,
+            agent::PolicyVersion,
             agent::LoadingMemory,
             agent::Retrieves,
             agent::RetrievedBy,

--- a/crates/rig-ecs/src/replay/mod.rs
+++ b/crates/rig-ecs/src/replay/mod.rs
@@ -7,9 +7,10 @@ use rig_effect_log::{EffectLogRecorder, stable_hash};
 
 use crate::{
     agent::{
-        AdditionalParams, Context, DefaultMaxTurns, DocumentId, DocumentProps, DocumentText, Grant,
-        MaxTokens, Order, Output, OutputKind, Preamble, Remembers, Retrieves, Route, RunOf,
-        Temperature, ToolChoiceSpec, UsesModel,
+        AdditionalParams, Context, Conversation, DefaultMaxTurns, DocumentId, DocumentProps,
+        DocumentText, Grant, InvalidCalls, MaxTokens, MaxTurns, Order, Output, OutputKind,
+        PolicyVersion, Preamble, Remembers, Retrievable, Retrieval, Retrieves, Route, RunOf,
+        Streamed, Temperature, ToolChoiceSpec, ToolPolicy, UsesModel,
     },
     bus::{Bound, Scope},
 };
@@ -17,8 +18,9 @@ use crate::{
 /// The JSON the header's `run_spec` hashes for `agent`: the shape
 /// `CONTRACT.md` names, built from components, canonicalised by
 /// [`stable_hash`]. The builder's identity: the default turn budget, no
-/// retries, `fail` — a run's own overrides are not identity.
-pub fn spec_json(world: &mut World, agent: Entity) -> serde_json::Value {
+/// retries, `fail`. Retained solely for builder/corpus header interoperability;
+/// effective replay compatibility uses [`stamp_run`] instead.
+fn builder_spec_json(world: &mut World, agent: Entity) -> serde_json::Value {
     let preamble = world.get::<Preamble>(agent).and_then(|p| p.0.clone());
     let temperature = world.get::<Temperature>(agent).and_then(|t| t.0);
     let max_tokens = world.get::<MaxTokens>(agent).and_then(|m| m.0);
@@ -86,7 +88,112 @@ pub fn spec_json(world: &mut World, agent: Entity) -> serde_json::Value {
     })
 }
 
-/// The header's `run_spec` for `agent`.
+fn effective<T: Component>(world: &World, subject: Entity) -> Option<&T> {
+    world.get::<T>(subject).or_else(|| {
+        world
+            .get::<RunOf>(subject)
+            .and_then(|agent| world.get::<T>(agent.0))
+    })
+}
+
+/// Effective policy from components, using the same run-over-agent precedence
+/// as execution. This is not the legacy builder-only `LogHeader::run_spec`.
+/// Custom systems and their ordering are represented by `PolicyVersion`.
+/// Ambient tool inputs are not serialized or automatically fingerprinted.
+pub fn spec_json(world: &mut World, subject: Entity) -> serde_json::Value {
+    let agent = world.get::<RunOf>(subject).map_or(subject, |run| run.0);
+    let mut spec = builder_spec_json(world, agent);
+    if let Some(fields) = spec.as_object_mut() {
+        fields.insert(
+            "preamble".into(),
+            serde_json::json!(effective::<Preamble>(world, subject).and_then(|v| v.0.as_ref())),
+        );
+        fields.insert(
+            "temperature".into(),
+            serde_json::json!(effective::<Temperature>(world, subject).and_then(|v| v.0)),
+        );
+        fields.insert(
+            "max_tokens".into(),
+            serde_json::json!(effective::<MaxTokens>(world, subject).and_then(|v| v.0)),
+        );
+        fields.insert(
+            "additional_params".into(),
+            serde_json::json!(
+                effective::<AdditionalParams>(world, subject).and_then(|v| v.0.as_ref())
+            ),
+        );
+        fields.insert(
+            "tool_choice".into(),
+            serde_json::json!(
+                effective::<ToolChoiceSpec>(world, subject).and_then(|v| v.0.as_ref())
+            ),
+        );
+        fields.insert(
+            "max_turns".into(),
+            serde_json::json!(effective::<MaxTurns>(world, subject).map_or(1, |v| v.0)),
+        );
+        let invalid = effective::<InvalidCalls>(world, subject)
+            .copied()
+            .unwrap_or_default();
+        fields.insert(
+            "max_invalid_tool_call_retries".into(),
+            serde_json::json!(invalid.retries),
+        );
+        fields.insert(
+            "unhandled_invalid_tool_call".into(),
+            serde_json::json!(invalid.unhandled),
+        );
+        let output = effective::<Output>(world, subject)
+            .cloned()
+            .unwrap_or_default();
+        fields.insert("output_mode".into(), serde_json::json!(output.mode));
+        fields.insert("output_schema".into(), serde_json::json!(output.schema));
+        fields.insert(
+            "tool_concurrency".into(),
+            serde_json::json!(
+                effective::<ToolPolicy>(world, subject).map_or(1, |v| v.concurrency.max(1))
+            ),
+        );
+        fields.insert(
+            "policy_version".into(),
+            serde_json::json!(effective::<PolicyVersion>(world, subject).map(|v| &v.0)),
+        );
+        fields.insert(
+            "streamed".into(),
+            serde_json::json!(world.get::<Streamed>(subject).is_some_and(|v| v.0)),
+        );
+        fields.insert(
+            "conversation".into(),
+            serde_json::json!(effective::<Conversation>(world, subject).map(|v| &v.0)),
+        );
+        fields.insert(
+            "model".into(),
+            serde_json::json!(
+                effective::<UsesModel>(world, subject)
+                    .and_then(|model| world.get::<Bound>(model.0))
+                    .map(|bound| &bound.descriptor)
+            ),
+        );
+        let mut links: Vec<_> = world
+            .get::<Children>(agent)
+            .into_iter()
+            .flat_map(|children| children.iter())
+            .filter_map(|link| world.get::<Order>(link).map(|order| (*order, link)))
+            .collect();
+        links.sort_by_key(|(order, _)| *order);
+        let dependencies: Vec<_> = links.into_iter().filter_map(|(_, link)| {
+            if let Some(Grant(tool)) = world.get::<Grant>(link) {
+                Some(serde_json::json!({"tool": world.get::<Bound>(*tool).map(|b| &b.descriptor), "retrievable": world.get::<Retrievable>(link).is_some()}))
+            } else if let Some(Retrieves(index)) = world.get::<Retrieves>(link) {
+                Some(serde_json::json!({"index": world.get::<Bound>(*index).map(|b| &b.descriptor), "retrieval": world.get::<Retrieval>(link)}))
+            } else { None }
+        }).collect();
+        fields.insert("dependencies".into(), serde_json::json!(dependencies));
+    }
+    spec
+}
+
+/// The effective policy hash for an agent or run, not a code fingerprint.
 pub fn spec_hash(world: &mut World, agent: Entity) -> Option<u64> {
     stable_hash(&spec_json(world, agent)).ok()
 }
@@ -95,8 +202,10 @@ pub fn spec_hash(world: &mut World, agent: Entity) -> Option<u64> {
 /// grants (retrievable or not), every index it retrieves from, and its
 /// memory, by their bound keys.
 pub fn required_row(world: &mut World, agent: Entity) -> EffectRow {
+    let subject = agent;
+    let agent = world.get::<RunOf>(subject).map_or(subject, |run| run.0);
     let mut row = EffectRow::new();
-    let model = world.get::<UsesModel>(agent).map(|uses| uses.0);
+    let model = effective::<UsesModel>(world, subject).map(|uses| uses.0);
     if let Some(model) = model
         && let Some(bound) = world.get::<Bound>(model)
     {
@@ -135,7 +244,8 @@ pub fn required_row(world: &mut World, agent: Entity) -> EffectRow {
     row
 }
 
-/// Stamp `recorder`'s header with `agent`'s identity: the spec hash, the
+/// Stamp `recorder`'s legacy builder header for corpus interoperability, not
+/// a claim of effective run compatibility: the builder spec hash, the
 /// program's hook list as it declares it (`hooks` — the world has no hook
 /// stack to name; a program with none passes an empty list), the required
 /// row, and the bus policy the world runs under.
@@ -146,7 +256,7 @@ pub fn stamp_header(
     bus: Option<rig_core::serve::ServingPolicy>,
     hooks: Vec<String>,
 ) {
-    if let Some(hash) = spec_hash(world, agent) {
+    if let Ok(hash) = stable_hash(&builder_spec_json(world, agent)) {
         recorder.set_run_spec(hash);
     }
     let required = required_row(world, agent);
@@ -154,63 +264,58 @@ pub fn stamp_header(
 }
 
 /// Stamp `run`'s program identity under its scope
-/// ([`rig_effect_log::LogHeader::programs`]): the agent's required row and
-/// policy hash, keyed by the run's `Scope`. A world running several
+/// ([`rig_effect_log::LogHeader::programs`]): the effective run's required row
+/// and policy hash, keyed by the run's `Scope`. A world running several
 /// programs into one log names each this way.
 pub fn stamp_run(world: &mut World, run: Entity, recorder: &EffectLogRecorder) {
-    let Some(agent) = world.get::<RunOf>(run).map(|run_of| run_of.0) else {
+    let Some(_) = world.get::<RunOf>(run) else {
         return;
     };
     let Some(scope) = world.get::<Scope>(run).map(|scope| scope.0.clone()) else {
         return;
     };
-    let Some(policy) = spec_hash(world, agent) else {
+    let Some(policy) = spec_hash(world, run) else {
         return;
     };
-    let required = required_row(world, agent);
+    let required = required_row(world, run);
     recorder.set_program_identity(scope, rig_effect_log::ProgramIdentity { required, policy });
 }
 
-/// Whether `agent` is the program `log` was recorded by: refused by name
-/// when the log's identity (a `programs` entry with this agent's policy,
-/// else the header's `run_spec`) is not this agent's, when the required
-/// row differs (every difference named), or when the log's handlers do
-/// not serve the row.
+/// Check `run` against its explicitly named `Scope` in `log`, before dispatch.
+/// Requires a nonempty `PolicyVersion`: arbitrary systems cannot be
+/// automatically fingerprinted. A missing declaration or a builder-only log
+/// is reported as unverified, not accepted as replay-compatible. Success
+/// verifies the declared policy and supported configuration, not ambient
+/// inputs, execution ordering beyond that declaration, or external state.
 pub fn check_replayable(
     world: &mut World,
-    agent: Entity,
+    run: Entity,
     log: &rig_effect_log::EffectLog,
 ) -> Result<(), rig_core::error::ErrorReport> {
     use rig_core::error::{ErrorKind, ErrorReport};
-    let policy = spec_hash(world, agent)
+    rig_effect_log::EffectLogReplayer::check_header(log)?;
+    if world.get::<RunOf>(run).is_none() {
+        return Err(ErrorReport::new(
+            ErrorKind::Request,
+            "replay compatibility unverified: provide a run with an explicit Scope, not an agent",
+        ));
+    }
+    let scope = world
+        .get::<Scope>(run)
+        .ok_or_else(|| {
+            ErrorReport::new(
+                ErrorKind::Request,
+                "replay compatibility unverified: the run has no Scope",
+            )
+        })?
+        .0
+        .clone();
+    let policy = spec_hash(world, run)
         .ok_or_else(|| ErrorReport::new(ErrorKind::Internal, "the agent's policy does not hash"))?;
-    let required = required_row(world, agent);
-    let (recorded_policy, recorded_row) = if log.header.programs.is_empty() {
-        (log.header.run_spec, log.header.required.clone())
-    } else {
-        match log
-            .header
-            .programs
-            .values()
-            .find(|identity| identity.policy == policy)
-        {
-            Some(identity) => (Some(identity.policy), identity.required.clone()),
-            None => {
-                return Err(ErrorReport::new(
-                    ErrorKind::Internal,
-                    format!(
-                        "replay refused: no program in the log has this agent's policy ({policy:#018x}); the log names {}",
-                        log.header
-                            .programs
-                            .keys()
-                            .map(String::as_str)
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    ),
-                ));
-            }
-        }
-    };
+    let required = required_row(world, run);
+    let identity = log.header.programs.get(&scope).ok_or_else(|| ErrorReport::new(ErrorKind::Request,
+        format!("replay compatibility unverified: the log has no program for scope `{scope}`; builder identity is insufficient")))?;
+    let (recorded_policy, recorded_row) = (Some(identity.policy), &identity.required);
     if recorded_policy != Some(policy) {
         return Err(ErrorReport::new(
             ErrorKind::Internal,
@@ -220,7 +325,7 @@ pub fn check_replayable(
             ),
         ));
     }
-    let differences = required.diff(&recorded_row);
+    let differences = required.diff(recorded_row);
     if !differences.is_empty() {
         return Err(ErrorReport::new(
             ErrorKind::Internal,
@@ -238,6 +343,12 @@ pub fn check_replayable(
         return Err(ErrorReport::new(
             ErrorKind::HandlerUnavailable,
             format!("replay refused: the log's handlers do not serve the row: {gap}"),
+        ));
+    }
+    if effective::<PolicyVersion>(world, run).is_none_or(|version| version.0.trim().is_empty()) {
+        return Err(ErrorReport::new(
+            ErrorKind::Request,
+            "replay compatibility unverified: declare a nonempty PolicyVersion for custom systems, ordering and configuration",
         ));
     }
     Ok(())

--- a/crates/rig-ecs/src/systems/mod.rs
+++ b/crates/rig-ecs/src/systems/mod.rs
@@ -30,12 +30,12 @@ use crate::{
         AdditionalParams, Advert, Assembling, Attachment, AwaitingModel, Batch, Cancelled, Context,
         Conversation, Cursor, DocumentId, DocumentProps, DocumentText, Failed, Failure, Grant,
         InvalidCall, InvalidCalls, InvalidRetries, LoadingMemory, MaxTokens, MaxTurns,
-        MessageParts, Order, OrderCounter, Output, OutputKind, OutputRetries, OutputToolName,
-        Outputs, Parts, Preamble, Remembered, Remembering, Remembers, Reprompt, RequestPatch,
-        Resolution, ResolvingTools, Retrievable, Retrieval, RetrievalKind, Retrieves, Retrieving,
-        Retry, Run, RunCounter, RunOf, RunResult, RunSeq, Settled, Streamed, Temperature,
-        ToolCallSlot, ToolChoiceSpec, ToolContextSpec, ToolPolicy, Turn, Unhandled, Usage,
-        UsesModel, Utterance,
+        MemoryAppendScheduled, MessageParts, Order, OrderCounter, Output, OutputKind,
+        OutputRetries, OutputToolName, Outputs, Parts, Preamble, Remembered, Remembering,
+        Remembers, Reprompt, RequestPatch, Resolution, ResolvingTools, Retrievable, Retrieval,
+        RetrievalKind, Retrieves, Retrieving, Retry, Run, RunCounter, RunOf, RunResult, RunSeq,
+        Settled, Streamed, Temperature, ToolCallSlot, ToolChoiceSpec, ToolContextSpec, ToolPolicy,
+        Turn, Unhandled, Usage, UsesModel, Utterance,
     },
     bus::{
         Bound, BusPlugin, BusSet, EffectOutcome, Held, Issued, PendingEffect, Progress,
@@ -115,8 +115,12 @@ pub type FreshView = (
 );
 /// A fresh turn whose retrievals are out.
 pub type RetrievingTurn = (With<Fresh>, With<Retrieving>);
-/// A remembering run that just settled.
-pub type JustSettled = (Added<Settled>, With<Remembering>);
+/// A remembering run whose persisted finalization has not scheduled an append.
+pub type NeedsMemoryAppend = (
+    With<Settled>,
+    With<Remembering>,
+    Without<MemoryAppendScheduled>,
+);
 /// A completion effect: any effect of a turn that is not a retrieval.
 pub type NotRetrieval = (With<PendingEffect>, Without<Retrieval>);
 /// What `materialise` reads of a run awaiting its model.
@@ -641,10 +645,11 @@ pub fn land_memory(
 
 /// `RigSet::Settle`: a run that loaded its conversation appends what it
 /// said — every utterance not `Remembered`, in order — when it settles
-/// (CONTRACT §11).
+/// (CONTRACT §11). The persisted marker distinguishes new work from scene
+/// rehydration; Bevy change-detection ticks are not durable transitions.
 pub fn append_memory(
     mut commands: Commands,
-    settled: Query<(Entity, &RunOf, &Conversation), JustSettled>,
+    settled: Query<(Entity, &RunOf, &Conversation), NeedsMemoryAppend>,
     memories: Query<&Remembers>,
     bound: Query<&Bound>,
     children: Query<&Children>,
@@ -686,6 +691,7 @@ pub fn append_memory(
             ),
             ChildOf(run),
         ));
+        commands.entity(run).insert(MemoryAppendScheduled);
     }
 }
 

--- a/crates/rig-ecs/tests/bus_tool_replay.rs
+++ b/crates/rig-ecs/tests/bus_tool_replay.rs
@@ -1,0 +1,461 @@
+//! Durable published results are observable output, not ambient inputs.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+
+mod bus_support;
+
+use bevy_ecs::prelude::*;
+use bus_support::*;
+use rig_core::{
+    effect::{EffectKind, FamilyDescriptor, HandlerDescriptor, HandlerKey, Outcome},
+    error::{ErrorKind, ErrorReport},
+    serve::{OutcomeSink, Serve},
+    tool::{ContextValue, PublishedContext, ToolContext, ToolOutput, ToolResult},
+};
+use rig_ecs::bus::{
+    EffectLogResource, EffectOutcome, Handlers, PendingEffect, Replay, ToolInputs, ToolOutputs,
+};
+
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+struct Artifact(String);
+impl ContextValue for Artifact {
+    const KEY: &'static str = "test.artifact.v1";
+}
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+struct Secret(String);
+impl ContextValue for Secret {
+    const KEY: &'static str = "test.secret";
+}
+
+struct Publish {
+    fail: bool,
+}
+impl Serve for Publish {
+    type Family = rig_core::effect::family::Tool;
+    fn descriptor(&self) -> HandlerDescriptor {
+        HandlerDescriptor {
+            key: HandlerKey::from("tool:publish"),
+            family: FamilyDescriptor::Tool {
+                name: "publish".into(),
+                description: "publishes an artifact".into(),
+                parameters: serde_json::json!({"type":"object"}),
+                embedding: None,
+            },
+            layers: vec![],
+        }
+    }
+    async fn serve(&self, _: EffectKind, sink: OutcomeSink) {
+        let mut context = sink.scope::<ToolContext>().unwrap().for_dispatch();
+        context
+            .insert_result(Artifact("artifact-123".into()))
+            .unwrap();
+        sink.scope::<PublishedContext>().unwrap().publish(context);
+        let answer = if self.fail {
+            Err(ErrorReport::new(ErrorKind::Request, "tool refused"))
+        } else {
+            Ok(Outcome::ToolResult {
+                result: ToolResult::success(ToolOutput::text("ok")),
+            })
+        };
+        sink.resolve(answer).await;
+    }
+}
+
+fn dispatch(world: &mut World, secret: &str) -> Entity {
+    let mut context = ToolContext::new();
+    context.insert(Secret(secret.into())).unwrap();
+    // Opaque runtime capabilities must never be serialized by the recorder.
+    context = context.with_scope(std::sync::Arc::new(std::sync::Mutex::new(7_u32)));
+    world
+        .spawn((
+            PendingEffect::new(
+                "tool:publish",
+                EffectKind::ToolCall {
+                    name: "publish".into(),
+                    args: "{}".into(),
+                },
+            ),
+            ToolInputs(context),
+        ))
+        .id()
+}
+
+#[test]
+fn serialized_replay_preserves_results_on_success_and_error_without_recording_credentials() {
+    for fail in [false, true] {
+        let mut live = app();
+        EffectLogResource::install(live.world_mut(), rig_effect_log::EffectLogRecorder::new());
+        register(&mut live, "tool:publish", Publish { fail });
+        let effect = dispatch(live.world_mut(), "recording-secret-do-not-log");
+        tick_until(&mut live, "live publication", |w| {
+            w.get::<EffectOutcome>(effect).is_some()
+        });
+        let answer = live.world().get::<EffectOutcome>(effect).unwrap().0.clone();
+        let output = live
+            .world()
+            .get::<ToolOutputs>(effect)
+            .unwrap()
+            .0
+            .result::<Artifact>()
+            .unwrap();
+        let json =
+            serde_json::to_string(&live.world().resource::<EffectLogResource>().log()).unwrap();
+        assert!(json.contains("artifact-123"));
+        assert!(!json.contains("recording-secret-do-not-log"));
+        assert!(!json.contains("test.secret"));
+        let log = serde_json::from_str(&json).unwrap();
+        let mut replay = app();
+        Handlers::with(replay.world_mut(), |handlers| {
+            Replay::default().register(handlers, &log)
+        })
+        .unwrap()
+        .unwrap();
+        let effect = dispatch(replay.world_mut(), "current-secret");
+        tick_until(&mut replay, "replayed publication", |w| {
+            w.get::<EffectOutcome>(effect).is_some()
+        });
+        assert_eq!(
+            serde_json::to_value(&replay.world().get::<EffectOutcome>(effect).unwrap().0).unwrap(),
+            serde_json::to_value(answer).unwrap()
+        );
+        let context = &replay.world().get::<ToolOutputs>(effect).unwrap().0;
+        assert_eq!(context.result::<Artifact>().unwrap(), output);
+        assert_eq!(
+            context.get::<Secret>().unwrap(),
+            Some(Secret("current-secret".into()))
+        );
+        // A downstream policy consumes the metadata, not just its wire bytes.
+        let artifact = context.require_result::<Artifact>().unwrap();
+        replay
+            .world_mut()
+            .insert_resource(SelectedArtifact(artifact.0));
+        assert_eq!(
+            replay.world().resource::<SelectedArtifact>().0,
+            "artifact-123"
+        );
+    }
+}
+
+#[derive(Resource)]
+struct SelectedArtifact(String);
+
+struct ReplaceAnswer;
+impl rig_core::serve::Intercept for ReplaceAnswer {
+    fn name(&self) -> String {
+        "replace-answer".into()
+    }
+    async fn before(
+        &self,
+        _: rig_core::effect::EffectId,
+        _: &EffectKind,
+    ) -> rig_core::serve::Decision {
+        rig_core::serve::Decision::Proceed
+    }
+    async fn after(
+        &self,
+        _: rig_core::effect::EffectId,
+        _: &EffectKind,
+        _: &Result<Outcome, ErrorReport>,
+    ) -> rig_core::serve::Verdict {
+        rig_core::serve::Verdict::Replace(Err(ErrorReport::new(
+            ErrorKind::Timeout,
+            "outer verdict",
+        )))
+    }
+}
+
+#[test]
+fn layered_verdict_keeps_nonempty_inner_output_in_the_record_and_replay() {
+    let mut live = app();
+    EffectLogResource::install(live.world_mut(), rig_effect_log::EffectLogRecorder::new());
+    Handlers::with(live.world_mut(), |handlers| {
+        handlers.register_erased(
+            "tool:publish",
+            rig_core::serve::ErasedHandler::new(Publish { fail: false }).layered(ReplaceAnswer),
+        )
+    })
+    .unwrap()
+    .unwrap();
+    let effect = dispatch(live.world_mut(), "private");
+    tick_until(&mut live, "layered answer", |world| {
+        world.get::<EffectOutcome>(effect).is_some()
+    });
+    assert_eq!(
+        live.world()
+            .get::<EffectOutcome>(effect)
+            .unwrap()
+            .0
+            .as_ref()
+            .unwrap_err()
+            .kind,
+        ErrorKind::Timeout
+    );
+    assert_eq!(
+        live.world()
+            .get::<ToolOutputs>(effect)
+            .unwrap()
+            .0
+            .result::<Artifact>()
+            .unwrap(),
+        Some(Artifact("artifact-123".into()))
+    );
+    let json = serde_json::to_string(&live.world().resource::<EffectLogResource>().log()).unwrap();
+    let log: rig_effect_log::EffectLog = serde_json::from_str(&json).unwrap();
+    assert!(
+        log.records[0].outcome.is_ok(),
+        "record is the inner handler, not the verdict"
+    );
+    assert_eq!(
+        log.records[0]
+            .tool_output
+            .as_ref()
+            .unwrap()
+            .get::<Artifact>()
+            .unwrap(),
+        Some(Artifact("artifact-123".into()))
+    );
+    let mut replay = app();
+    let replayer =
+        rig_effect_log::EffectLogReplayer::for_key(&log, &HandlerKey::from("tool:publish"))
+            .unwrap();
+    Handlers::with(replay.world_mut(), |handlers| {
+        handlers.register_erased(
+            "tool:publish",
+            rig_core::serve::ErasedHandler::new(replayer).layered(ReplaceAnswer),
+        )
+    })
+    .unwrap()
+    .unwrap();
+    let effect = dispatch(replay.world_mut(), "new-private");
+    tick_until(&mut replay, "layered replay", |world| {
+        world.get::<EffectOutcome>(effect).is_some()
+    });
+    assert_eq!(
+        replay
+            .world()
+            .get::<EffectOutcome>(effect)
+            .unwrap()
+            .0
+            .as_ref()
+            .unwrap_err()
+            .kind,
+        ErrorKind::Timeout
+    );
+    assert_eq!(
+        replay
+            .world()
+            .get::<ToolOutputs>(effect)
+            .unwrap()
+            .0
+            .result::<Artifact>()
+            .unwrap(),
+        Some(Artifact("artifact-123".into()))
+    );
+}
+
+struct PublishThenWait;
+impl Serve for PublishThenWait {
+    type Family = rig_core::effect::family::Tool;
+    fn descriptor(&self) -> HandlerDescriptor {
+        Publish { fail: false }.descriptor()
+    }
+    async fn serve(&self, _: EffectKind, sink: OutcomeSink) {
+        let mut context = ToolContext::new();
+        context
+            .insert_result(Artifact("before-cancel".into()))
+            .unwrap();
+        sink.scope::<PublishedContext>().unwrap().publish(context);
+        std::future::pending::<()>().await;
+        drop(sink);
+    }
+}
+
+#[test]
+fn cancellation_records_already_published_output() {
+    let mut live = app();
+    EffectLogResource::install(live.world_mut(), rig_effect_log::EffectLogRecorder::new());
+    register(&mut live, "tool:publish", PublishThenWait);
+    let effect = dispatch(live.world_mut(), "private");
+    tick_until(&mut live, "published before cancellation", |world| {
+        world
+            .get::<rig_ecs::bus::Publishing>(effect)
+            .is_some_and(|published| published.0.result_context().is_some())
+    });
+    live.world_mut().despawn(effect);
+    let log = live.world().resource::<EffectLogResource>().log();
+    assert_eq!(log.records.len(), 1);
+    assert_eq!(
+        log.records[0].outcome.as_ref().unwrap_err().kind,
+        ErrorKind::Cancelled
+    );
+    assert_eq!(
+        log.records[0]
+            .tool_output
+            .as_ref()
+            .unwrap()
+            .get::<Artifact>()
+            .unwrap(),
+        Some(Artifact("before-cancel".into()))
+    );
+    let mut replay = app();
+    Handlers::with(replay.world_mut(), |handlers| {
+        Replay::default().register(handlers, &log)
+    })
+    .unwrap()
+    .unwrap();
+    let effect = dispatch(replay.world_mut(), "new-private");
+    tick_until(&mut replay, "cancelled output replay", |world| {
+        world.get::<EffectOutcome>(effect).is_some()
+    });
+    assert_eq!(
+        replay
+            .world()
+            .get::<EffectOutcome>(effect)
+            .unwrap()
+            .0
+            .as_ref()
+            .unwrap_err()
+            .kind,
+        ErrorKind::Cancelled
+    );
+    assert_eq!(
+        replay
+            .world()
+            .get::<ToolOutputs>(effect)
+            .unwrap()
+            .0
+            .result::<Artifact>()
+            .unwrap(),
+        Some(Artifact("before-cancel".into()))
+    );
+}
+
+#[test]
+fn world_native_cancellation_records_output_without_a_publishing_slot() {
+    let mut live = app();
+    EffectLogResource::install(live.world_mut(), rig_effect_log::EffectLogRecorder::new());
+    Handlers::with(live.world_mut(), |handlers| {
+        handlers.register_open("tool:publish", Publish { fail: false }.descriptor().family)
+    })
+    .unwrap()
+    .unwrap();
+    let effect = dispatch(live.world_mut(), "private");
+    tick_until(&mut live, "world dispatch", |world| {
+        world.get::<rig_ecs::bus::InFlight>(effect).is_some()
+    });
+    assert!(
+        live.world()
+            .get::<rig_ecs::bus::Publishing>(effect)
+            .is_none()
+    );
+    let mut context = ToolContext::new();
+    context
+        .insert_result(Artifact("world-before-cancel".into()))
+        .unwrap();
+    live.world_mut()
+        .entity_mut(effect)
+        .insert(ToolOutputs(context));
+    live.world_mut().despawn(effect);
+    let log = live.world().resource::<EffectLogResource>().log();
+    assert_eq!(log.records.len(), 1);
+    assert_eq!(
+        log.records[0].outcome.as_ref().unwrap_err().kind,
+        ErrorKind::Cancelled
+    );
+    assert_eq!(
+        log.records[0]
+            .tool_output
+            .as_ref()
+            .unwrap()
+            .get::<Artifact>()
+            .unwrap(),
+        Some(Artifact("world-before-cancel".into()))
+    );
+}
+
+#[test]
+fn world_native_published_output_is_recorded_and_mismatched_replay_does_not_publish() {
+    let mut live = app();
+    EffectLogResource::install(live.world_mut(), rig_effect_log::EffectLogRecorder::new());
+    Handlers::with(live.world_mut(), |handlers| {
+        handlers.register_open("tool:publish", Publish { fail: false }.descriptor().family)
+    })
+    .unwrap()
+    .unwrap();
+    let effect = dispatch(live.world_mut(), "private");
+    tick_until(&mut live, "world dispatch", |world| {
+        world.get::<rig_ecs::bus::InFlight>(effect).is_some()
+    });
+    let mut output = ToolContext::new();
+    output
+        .insert_result(Artifact("world-result".into()))
+        .unwrap();
+    live.world_mut().entity_mut(effect).insert((
+        ToolOutputs(output),
+        EffectOutcome(Ok(Outcome::ToolResult {
+            result: ToolResult::success(ToolOutput::text("world-answer")),
+        })),
+    ));
+    live.update();
+    let log = live.world().resource::<EffectLogResource>().log();
+    assert_eq!(
+        log.records[0]
+            .tool_output
+            .as_ref()
+            .unwrap()
+            .get::<Artifact>()
+            .unwrap(),
+        Some(Artifact("world-result".into()))
+    );
+
+    for matches in [true, false] {
+        let mut replay = app();
+        Handlers::with(replay.world_mut(), |handlers| {
+            Replay::default().register(handlers, &log)
+        })
+        .unwrap()
+        .unwrap();
+        let effect = dispatch(replay.world_mut(), "new-private");
+        if !matches {
+            replay
+                .world_mut()
+                .entity_mut(effect)
+                .insert(PendingEffect::new(
+                    "tool:publish",
+                    EffectKind::ToolCall {
+                        name: "publish".into(),
+                        args: "{\"different\":true}".into(),
+                    },
+                ));
+        }
+        tick_until(&mut replay, "world output replay", |world| {
+            world.get::<EffectOutcome>(effect).is_some()
+        });
+        if matches {
+            assert_eq!(
+                replay
+                    .world()
+                    .get::<ToolOutputs>(effect)
+                    .unwrap()
+                    .0
+                    .result::<Artifact>()
+                    .unwrap(),
+                Some(Artifact("world-result".into()))
+            );
+        } else {
+            assert!(
+                replay
+                    .world()
+                    .get::<EffectOutcome>(effect)
+                    .unwrap()
+                    .0
+                    .is_err()
+            );
+            assert!(replay.world().get::<ToolOutputs>(effect).is_none());
+        }
+    }
+}

--- a/crates/rig-ecs/tests/memory_resume.rs
+++ b/crates/rig-ecs/tests/memory_resume.rs
@@ -1,0 +1,251 @@
+//! Snapshot cuts around memory finalization, using a live scripted store.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+
+mod run_support;
+
+use std::sync::{Arc, Mutex};
+
+use bevy_ecs::prelude::*;
+use rig_core::{
+    effect::{
+        EffectId, EffectKind, FamilyDescriptor, HandlerDescriptor, HandlerKey, MemoryOp,
+        MemoryOutcome, Outcome,
+    },
+    serve::{OutcomeSink, Serve},
+};
+use rig_ecs::{
+    agent::{
+        Conversation, Remembers, Run, Settled,
+        scene::{load_world, save_world},
+    },
+    bus::{EffectOutcome, Held, Issued, PendingEffect, RigSchedule},
+    systems::{RigSet, spawn_run},
+};
+use run_support::*;
+
+const MODEL: &str = "t/model:default";
+const MEMORY: &str = "t/memory";
+
+struct Store {
+    calls: Arc<Mutex<Vec<EffectId>>>,
+    hold_after_write: bool,
+}
+
+impl Serve for Store {
+    type Family = rig_core::effect::family::Memory;
+
+    fn descriptor(&self) -> HandlerDescriptor {
+        HandlerDescriptor {
+            key: HandlerKey::from(MEMORY),
+            family: FamilyDescriptor::Memory {},
+            layers: vec![],
+        }
+    }
+
+    async fn serve(&self, kind: EffectKind, sink: OutcomeSink) {
+        let answer = match kind {
+            EffectKind::Memory {
+                op: MemoryOp::Load { .. },
+            } => MemoryOutcome::Loaded { messages: vec![] },
+            EffectKind::Memory {
+                op: MemoryOp::Append { .. },
+            } => {
+                // The external write happens before an outcome is observable.
+                self.calls.lock().unwrap().push(sink.id());
+                if self.hold_after_write {
+                    futures::future::pending::<()>().await;
+                }
+                MemoryOutcome::Appended
+            }
+            other => panic!("unexpected operation: {other:?}"),
+        };
+        sink.resolve(Ok(Outcome::Memory(answer))).await;
+    }
+}
+
+fn setup(calls: Arc<Mutex<Vec<EffectId>>>, hold: bool) -> (bevy_app::App, Entity, Entity) {
+    let mut app = app();
+    let (model, _) = Capturing::new(MODEL, "ok");
+    let model = register(&mut app, MODEL, model);
+    let memory = register(
+        &mut app,
+        MEMORY,
+        Store {
+            calls,
+            hold_after_write: hold,
+        },
+    );
+    (app, model, memory)
+}
+
+fn start(app: &mut bevy_app::App, model: Entity, memory: Entity) -> Entity {
+    let agent = spawn_agent(app.world_mut(), "t", model);
+    app.world_mut()
+        .entity_mut(agent)
+        .insert((Remembers(memory), Conversation("conversation".into())));
+    spawn_run(app.world_mut(), agent, &[], "go", false, None)
+}
+
+fn appends(world: &mut World) -> Vec<Entity> {
+    world
+        .query::<(Entity, &PendingEffect)>()
+        .iter(world)
+        .filter(|(_, effect)| {
+            matches!(
+                effect.kind,
+                EffectKind::Memory {
+                    op: MemoryOp::Append { .. }
+                }
+            )
+        })
+        .map(|(entity, _)| entity)
+        .collect()
+}
+
+fn appended(world: &mut World) -> bool {
+    appends(world)
+        .into_iter()
+        .any(|entity| world.get::<EffectOutcome>(entity).is_some())
+}
+
+#[derive(Resource)]
+struct BeforeAppend(rig_ecs::agent::scene::WorldScene);
+
+#[test]
+fn settled_snapshot_before_finalization_schedules_one_append() {
+    let calls = Arc::new(Mutex::new(vec![]));
+    let (mut first, model, memory) = setup(calls.clone(), false);
+    first.add_systems(
+        RigSchedule,
+        (|world: &mut World| {
+            if !world.contains_resource::<BeforeAppend>()
+                && world
+                    .query_filtered::<Entity, With<Settled>>()
+                    .iter(world)
+                    .next()
+                    .is_some()
+            {
+                assert!(appends(world).is_empty());
+                let scene = save_world(world).unwrap();
+                world.insert_resource(BeforeAppend(scene));
+            }
+        })
+        .after(RigSet::Materialise)
+        .before(RigSet::Settle),
+    );
+    start(&mut first, model, memory);
+    tick_until(&mut first, "snapshot before finalization", |w| {
+        w.contains_resource::<BeforeAppend>()
+    });
+    let scene = first
+        .world_mut()
+        .remove_resource::<BeforeAppend>()
+        .unwrap()
+        .0;
+    drop(first);
+    // A separate external store: this asserts what the saved branch does,
+    // not that abandoning another live branch undoes its writes.
+    let calls = Arc::new(Mutex::new(vec![]));
+    let (mut restored, _, _) = setup(calls.clone(), false);
+    load_world(&scene, restored.world_mut()).unwrap();
+    tick_until(&mut restored, "new finalization completed", appended);
+    assert_eq!(appends(restored.world_mut()).len(), 1);
+    assert_eq!(calls.lock().unwrap().len(), 1);
+}
+
+#[test]
+fn completed_append_is_not_scheduled_again_after_load() {
+    let calls = Arc::new(Mutex::new(vec![]));
+    let (mut first, model, memory) = setup(calls.clone(), false);
+    start(&mut first, model, memory);
+    tick_until(&mut first, "append completed", appended);
+    let scene = save_world(first.world_mut()).unwrap();
+    drop(first);
+    let (mut restored, _, _) = setup(calls.clone(), false);
+    load_world(&scene, restored.world_mut()).unwrap();
+    for _ in 0..10 {
+        restored.update();
+    }
+    assert_eq!(
+        appends(restored.world_mut()).len(),
+        1,
+        "restoration scheduled a second operation"
+    );
+    assert_eq!(calls.lock().unwrap().len(), 1);
+}
+
+#[test]
+fn queued_append_survives_without_a_second_operation() {
+    let calls = Arc::new(Mutex::new(vec![]));
+    let (mut first, model, memory) = setup(calls.clone(), false);
+    first.add_systems(
+        RigSchedule,
+        (|mut commands: Commands, effects: Query<(Entity, &PendingEffect), Without<Issued>>| {
+            for (entity, effect) in &effects {
+                if matches!(
+                    effect.kind,
+                    EffectKind::Memory {
+                        op: MemoryOp::Append { .. }
+                    }
+                ) {
+                    commands.entity(entity).insert(Held);
+                }
+            }
+        })
+        .after(RigSet::Settle),
+    );
+    let run = start(&mut first, model, memory);
+    tick_until(&mut first, "append queued", |w| {
+        w.get::<Settled>(run).is_some() && !appends(w).is_empty()
+    });
+    assert!(calls.lock().unwrap().is_empty());
+    let scene = save_world(first.world_mut()).unwrap();
+    drop(first);
+    let (mut restored, _, _) = setup(calls.clone(), false);
+    let loaded = load_world(&scene, restored.world_mut()).unwrap();
+    for effect in loaded.effects {
+        restored.world_mut().entity_mut(effect).remove::<Held>();
+    }
+    tick_until(&mut restored, "restored append completed", appended);
+    assert_eq!(appends(restored.world_mut()).len(), 1);
+    assert_eq!(calls.lock().unwrap().len(), 1);
+}
+
+#[test]
+fn unresolved_external_write_reissues_the_same_operation_identity() {
+    let calls = Arc::new(Mutex::new(vec![]));
+    let (mut first, model, memory) = setup(calls.clone(), true);
+    start(&mut first, model, memory);
+    tick_until(&mut first, "external write happened", |_| {
+        !calls.lock().unwrap().is_empty()
+    });
+    assert!(!appended(first.world_mut()));
+    let scene = save_world(first.world_mut()).unwrap();
+    drop(first);
+    let (mut restored, _, _) = setup(calls.clone(), false);
+    let loaded = load_world(&scene, restored.world_mut()).unwrap();
+    assert!(
+        loaded
+            .graph
+            .iter()
+            .any(|entity| restored.world().get::<Run>(*entity).is_some())
+    );
+    tick_until(&mut restored, "retried append completed", appended);
+    assert_eq!(appends(restored.world_mut()).len(), 1);
+    let calls = calls.lock().unwrap();
+    assert_eq!(
+        calls.len(),
+        2,
+        "a scene cannot prove whether an unanswered external write happened"
+    );
+    assert_eq!(
+        calls.first(),
+        calls.last(),
+        "the host can deduplicate by the saved operation id within this log"
+    );
+}

--- a/crates/rig-ecs/tests/reflect_roundtrip.rs
+++ b/crates/rig-ecs/tests/reflect_roundtrip.rs
@@ -32,10 +32,10 @@ use rig_core::{
 };
 use rig_ecs::{
     agent::{
-        Cancelled, Conversation, Failed, Failure, InvalidCall, LoadingMemory, MessageParts,
-        Remembered, Remembering, Reprompt, RequestPatch, Resolution, Retrievable, Retrieval,
-        RetrievalKind, Retrieves, Retrieving, Retry, Route, Streamed as RunStreamed,
-        ToolChoiceSpec, ToolContextSpec, ToolPolicy, Utterance,
+        Cancelled, Conversation, Failed, Failure, InvalidCall, LoadingMemory,
+        MemoryAppendScheduled, MessageParts, Remembered, Remembering, Reprompt, RequestPatch,
+        Resolution, Retrievable, Retrieval, RetrievalKind, Retrieves, Retrieving, Retry, Route,
+        Streamed as RunStreamed, ToolChoiceSpec, ToolContextSpec, ToolPolicy, Utterance,
     },
     bus::{EffectOutcome, Held, IdCounter, PendingEffect, Reserved, Streamed},
     systems::spawn_run,
@@ -121,6 +121,11 @@ fn populated() -> bevy_app::App {
         Conversation("c".to_owned()),
         Remembered,
         Remembering,
+        (
+            MemoryAppendScheduled,
+            rig_ecs::agent::PolicyVersion("reflect-test/v1".into()),
+            rig_ecs::bus::ToolOutputs(rig_core::tool::ToolContext::new()),
+        ),
         LoadingMemory,
         Retrievable,
         Retrieving,

--- a/crates/rig-ecs/tests/run_identity.rs
+++ b/crates/rig-ecs/tests/run_identity.rs
@@ -19,7 +19,7 @@ mod run_support;
 use bevy_ecs::prelude::*;
 use rig_core::effect::{EffectFamily, HandlerKey};
 use rig_ecs::{
-    agent::{Grant, Order, Preamble},
+    agent::{Grant, Order, PolicyVersion, Preamble},
     bus::{EffectLogResource, Scope},
     replay::{check_replayable, required_row, spec_hash, stamp_header, stamp_run},
     systems::spawn_run,
@@ -52,9 +52,13 @@ fn a_worlds_log_names_its_program_by_scope() {
     let scope = app.world().get::<Scope>(run).expect("scoped").0.clone();
     let header = recorder.header();
     let identity = header.programs.get(&scope).expect("the run's identity");
-    assert_eq!(Some(identity.policy), spec_hash(app.world_mut(), agent));
+    assert_eq!(Some(identity.policy), spec_hash(app.world_mut(), run));
     assert_eq!(identity.required, required_row(app.world_mut(), agent));
-    assert_eq!(header.run_spec, Some(identity.policy));
+    assert_ne!(
+        header.run_spec,
+        Some(identity.policy),
+        "builder identity is not effective run identity"
+    );
     // rig-agent's goldens carry no `programs`.
     assert!(
         golden("anthropic_completion_smoke")
@@ -73,15 +77,29 @@ fn check_replayable_refuses_a_foreign_log_by_name() {
     app.world_mut().entity_mut(agent).insert(Preamble(Some(
         "You are a concise assistant. Answer directly.".to_owned(),
     )));
-    let smoke = golden("anthropic_completion_smoke");
-    check_replayable(app.world_mut(), agent, &smoke).expect("the smoke's own program");
+    let run = spawn_run(app.world_mut(), agent, &[], "go", false, None);
+    app.world_mut()
+        .entity_mut(agent)
+        .insert(PolicyVersion("identity-test/v1".into()));
+    let legacy = golden("anthropic_completion_smoke");
+    assert!(
+        check_replayable(app.world_mut(), run, &legacy)
+            .expect_err("builder-only identity")
+            .message
+            .contains("unverified")
+    );
+    let recorder = EffectLogRecorder::new();
+    EffectLogResource::install(app.world_mut(), recorder.clone());
+    stamp_run(app.world_mut(), run, &recorder);
+    let smoke = recorder.log();
+    check_replayable(app.world_mut(), run, &smoke).expect("the run's own program");
 
     // Another policy: a different preamble.
     let other = app.world_mut();
     other
         .entity_mut(agent)
         .insert(Preamble(Some("Another program.".to_owned())));
-    let refused = check_replayable(other, agent, &smoke).expect_err("another policy");
+    let refused = check_replayable(other, run, &smoke).expect_err("another policy");
     assert!(
         refused
             .message
@@ -105,7 +123,11 @@ fn check_replayable_refuses_a_foreign_log_by_name() {
         .world_mut()
         .spawn((Grant(tool), Order(0), ChildOf(agent)))
         .id();
-    let refused = check_replayable(app.world_mut(), agent, &smoke).expect_err("another row");
+    let mut wrong_row = smoke.clone();
+    let scope = app.world().get::<Scope>(run).unwrap().0.clone();
+    wrong_row.header.programs.get_mut(&scope).unwrap().policy =
+        spec_hash(app.world_mut(), run).unwrap();
+    let refused = check_replayable(app.world_mut(), run, &wrong_row).expect_err("another row");
     assert!(
         refused
             .message
@@ -117,6 +139,7 @@ fn check_replayable_refuses_a_foreign_log_by_name() {
 
     // A log whose programs name another policy: refused by the scopes it names.
     let mut foreign = smoke.clone();
+    foreign.header.programs.clear();
     foreign.header.programs.insert(
         "other/run#0".to_owned(),
         rig_effect_log::ProgramIdentity {
@@ -124,17 +147,13 @@ fn check_replayable_refuses_a_foreign_log_by_name() {
             policy: 1,
         },
     );
-    let refused = check_replayable(app.world_mut(), agent, &foreign).expect_err("no such program");
-    assert!(
-        refused.message.contains("other/run#0"),
-        "{}",
-        refused.message
-    );
+    let refused = check_replayable(app.world_mut(), run, &foreign).expect_err("no such program");
+    assert!(refused.message.contains(&scope), "{}", refused.message);
 
     // The row served: the log's handlers must serve every key of the row.
     let mut unserved = smoke.clone();
     unserved.header.handlers.clear();
-    let refused = check_replayable(app.world_mut(), agent, &unserved).expect_err("unserved");
+    let refused = check_replayable(app.world_mut(), run, &unserved).expect_err("unserved");
     assert!(
         refused.message.contains("do not serve the row"),
         "{}",

--- a/crates/rig-ecs/tests/run_replay_policy.rs
+++ b/crates/rig-ecs/tests/run_replay_policy.rs
@@ -1,0 +1,117 @@
+//! Effective configuration, explicit scope and declared custom policy identity.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+mod run_support;
+use bevy_ecs::prelude::*;
+use rig_ecs::{
+    agent::{InvalidCalls, MaxTurns, PolicyVersion, Preamble, ToolPolicy, Unhandled},
+    bus::{EffectLogResource, Scope},
+    replay::{check_replayable, spec_hash, stamp_run},
+    systems::spawn_run,
+};
+use rig_effect_log::{EffectLog, EffectLogRecorder};
+use run_support::*;
+
+fn setup() -> (bevy_app::App, Entity, Entity, EffectLog) {
+    let mut app = app();
+    let (model, _) = Capturing::new("t/model:default", "ok");
+    let model = register(&mut app, "t/model:default", model);
+    let agent = spawn_agent(app.world_mut(), "t", model);
+    app.world_mut()
+        .entity_mut(agent)
+        .insert(PolicyVersion("test/v1".into()));
+    let run = spawn_run(app.world_mut(), agent, &[], "go", false, None);
+    let recorder = EffectLogRecorder::new();
+    EffectLogResource::install(app.world_mut(), recorder.clone());
+    stamp_run(app.world_mut(), run, &recorder);
+    (app, agent, run, recorder.log())
+}
+
+#[test]
+fn retries_and_unhandled_policy_each_change_identity() {
+    for policy in [
+        InvalidCalls {
+            retries: 2,
+            unhandled: Unhandled::Fail,
+        },
+        InvalidCalls {
+            retries: 0,
+            unhandled: Unhandled::Ignore,
+        },
+    ] {
+        for on_run in [false, true] {
+            let (mut app, agent, run, log) = setup();
+            check_replayable(app.world_mut(), run, &log).unwrap();
+            app.world_mut()
+                .entity_mut(if on_run { run } else { agent })
+                .insert(policy);
+            assert!(
+                check_replayable(app.world_mut(), run, &log)
+                    .unwrap_err()
+                    .message
+                    .contains("policy")
+            );
+        }
+    }
+}
+
+#[test]
+fn run_overrides_win_and_mask_changes_to_agent_defaults() {
+    let (mut app, agent, run, log) = setup();
+    app.world_mut().entity_mut(run).insert((
+        MaxTurns(7),
+        Preamble(Some("run".into())),
+        ToolPolicy { concurrency: 3 },
+    ));
+    assert!(check_replayable(app.world_mut(), run, &log).is_err());
+    let before = spec_hash(app.world_mut(), run);
+    app.world_mut().entity_mut(agent).insert((
+        MaxTurns(9),
+        Preamble(Some("different agent".into())),
+        ToolPolicy { concurrency: 9 },
+    ));
+    assert_eq!(before, spec_hash(app.world_mut(), run));
+}
+
+#[test]
+fn scope_selection_never_searches_for_another_matching_policy() {
+    let (mut app, _, run, mut log) = setup();
+    let scope = app.world().get::<Scope>(run).unwrap().0.clone();
+    let own = log.header.programs.get(&scope).unwrap().clone();
+    let mut other = own.clone();
+    other
+        .required
+        .insert("tool:foreign".into(), rig_core::effect::EffectFamily::Tool);
+    log.header.programs.insert("aaa/other".into(), other);
+    check_replayable(app.world_mut(), run, &log).unwrap();
+    log.header.programs.remove(&scope);
+    assert!(
+        check_replayable(app.world_mut(), run, &log)
+            .unwrap_err()
+            .message
+            .contains(&scope)
+    );
+}
+
+#[test]
+fn custom_policy_requires_an_explicit_version_and_detects_changes() {
+    let (mut app, agent, run, log) = setup();
+    app.world_mut()
+        .entity_mut(agent)
+        .insert(PolicyVersion("test/v2".into()));
+    assert!(check_replayable(app.world_mut(), run, &log).is_err());
+    app.world_mut().entity_mut(agent).remove::<PolicyVersion>();
+    let recorder = EffectLogRecorder::new();
+    EffectLogResource::install(app.world_mut(), recorder.clone());
+    stamp_run(app.world_mut(), run, &recorder);
+    assert!(
+        check_replayable(app.world_mut(), run, &recorder.log())
+            .unwrap_err()
+            .message
+            .contains("unverified")
+    );
+}

--- a/crates/rig-ecs/tests/run_scene_extensions.rs
+++ b/crates/rig-ecs/tests/run_scene_extensions.rs
@@ -1,0 +1,124 @@
+//! Registered application state is durable; omitted state is explicitly host-owned.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+
+use bevy_ecs::prelude::*;
+use rig_ecs::agent::{
+    Owner, Run, RunOf,
+    scene::{SceneExtensions, WorldScene, load_world, save_world},
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Component, Debug, PartialEq, Serialize, Deserialize)]
+struct RetryBudget(u32);
+
+#[derive(Resource)]
+struct HostState(u32);
+
+fn register(world: &mut World) {
+    let mut registry = SceneExtensions::default();
+    registry
+        .register_component::<RetryBudget>("test/retry-budget/v1")
+        .unwrap();
+    world.insert_resource(registry);
+}
+
+fn scene() -> WorldScene {
+    let mut world = World::new();
+    register(&mut world);
+    let agent = world.spawn(Owner("test".into())).id();
+    world.spawn((Run, RunOf(agent), ChildOf(agent), RetryBudget(3)));
+    world.insert_resource(HostState(8));
+    let saved = save_world(&mut world).unwrap();
+    serde_json::from_str(&serde_json::to_string(&saved).unwrap()).unwrap()
+}
+
+#[test]
+fn custom_policy_roundtrips_on_remapped_graph_with_host_owned_resources() {
+    let saved = scene();
+    let mut world = World::new();
+    register(&mut world);
+    // Ensure the old entity ids cannot accidentally appear to work.
+    for _ in 0..10 {
+        world.spawn_empty();
+    }
+    world.insert_resource(HostState(99));
+    let loaded = load_world(&saved, &mut world).unwrap();
+    let run = loaded
+        .graph
+        .iter()
+        .copied()
+        .find(|e| world.get::<Run>(*e).is_some())
+        .unwrap();
+    assert_eq!(world.get::<RetryBudget>(run), Some(&RetryBudget(3)));
+    let agent = world.get::<RunOf>(run).unwrap().0;
+    assert_eq!(world.get::<ChildOf>(run).unwrap().parent(), agent);
+    assert_eq!(world.get::<Owner>(agent).unwrap().0, "test");
+    assert_eq!(world.resource::<HostState>().0, 99);
+    // A subsequent policy consumes the restored state, not merely its JSON.
+    let mut policy = Schedule::default();
+    policy.add_systems(|mut budgets: Query<&mut RetryBudget, With<Run>>| {
+        for mut budget in &mut budgets {
+            budget.0 -= 1;
+        }
+    });
+    policy.run(&mut world);
+    assert_eq!(world.get::<RetryBudget>(run), Some(&RetryBudget(2)));
+}
+
+#[test]
+fn missing_registration_and_invalid_payload_are_refused_before_spawning() {
+    let saved = scene();
+    let mut world = World::new();
+    let count = world.entities().len();
+    assert!(
+        load_world(&saved, &mut world)
+            .unwrap_err()
+            .message
+            .contains("unregistered")
+    );
+    assert_eq!(world.entities().len(), count);
+    register(&mut world);
+    let mut invalid = saved.clone();
+    for components in invalid.extensions.values_mut() {
+        components.insert(
+            "test/retry-budget/v1".into(),
+            serde_json::json!("not a budget"),
+        );
+    }
+    assert!(load_world(&invalid, &mut world).is_err());
+    assert_eq!(world.entities().len(), count);
+    let mut invalid = saved;
+    invalid.extensions.insert(usize::MAX, Default::default());
+    assert!(
+        load_world(&invalid, &mut world)
+            .unwrap_err()
+            .message
+            .contains("index")
+    );
+    assert_eq!(world.entities().len(), count);
+}
+
+#[test]
+fn unregistered_state_is_outside_the_scene_contract() {
+    let mut world = World::new();
+    world.spawn((Owner("test".into()), RetryBudget(5)));
+    let saved = save_world(&mut world).unwrap();
+    assert!(saved.extensions.is_empty());
+    let mut restored = World::new();
+    let loaded = load_world(&saved, &mut restored).unwrap();
+    assert!(restored.get::<RetryBudget>(loaded.graph[0]).is_none());
+}
+
+#[test]
+fn names_must_be_nonempty_and_unique() {
+    let mut registry = SceneExtensions::default();
+    assert!(registry.register_component::<RetryBudget>(" ").is_err());
+    registry
+        .register_component::<RetryBudget>("budget/v1")
+        .unwrap();
+    assert!(
+        registry
+            .register_component::<RetryBudget>("budget/v1")
+            .is_err()
+    );
+}

--- a/crates/rig-effect-log/src/lib.rs
+++ b/crates/rig-effect-log/src/lib.rs
@@ -23,6 +23,14 @@
 //! log with another
 //! [`EFFECT_LOG_FORMAT`] does not load: there is no tolerant decoder.
 //!
+//! Format 6 records explicitly published tool result values separately from
+//! the ordinary outcome, including error outcomes. Replayers publish these
+//! values before resolving the outcome. The recorded map excludes inbound
+//! tool context and live scopes; handlers must publish before resolving and
+//! must not put secrets or live capabilities into durable result values.
+//! Older logs cannot establish whether published values were lost, so format
+//! 5 is rejected rather than interpreted as having no published output.
+//!
 //! The vocabulary is rig-core's, the runtimes are rig-agent's bus and rig-ecs; this crate is
 //! the persistence story over both, and what a host that saves and restores
 //! in-flight effects (a scene, a durable run) depends on.

--- a/crates/rig-effect-log/src/lib.rs
+++ b/crates/rig-effect-log/src/lib.rs
@@ -11,7 +11,7 @@
 )]
 //! Record and replay for the effect bus.
 //!
-//! An [`EffectLog`] is a recorded run: a [`LogHeader`] — the format, the
+//! An [`EffectLog`] is a recorded run: a [`LogHeader`] — the
 //! run-spec hash an agent stamps, the handlers registered when recording
 //! began, the effect signature — and every exchange in dispatch order
 //! (`rig_core::effect::EffectRecord`). The [`EffectLogRecorder`] is the
@@ -20,16 +20,18 @@
 //! [`EffectLogReplayer`] is a handler that answers the same dispatches from
 //! the record instead of a provider, one per key (a runtime registers
 //! them: `rig_agent::bus::replay::register_all`, rig-ecs's `Replay`). A
-//! log with another
-//! [`EFFECT_LOG_FORMAT`] does not load: there is no tolerant decoder.
+//! log is checked by its data, not a global format number in its header.
 //!
-//! Format 6 records explicitly published tool result values separately from
+//! Records hold explicitly published tool result values separately from
 //! the ordinary outcome, including error outcomes. Replayers publish these
 //! values before resolving the outcome. The recorded map excludes inbound
 //! tool context and live scopes; handlers must publish before resolving and
 //! must not put secrets or live capabilities into durable result values.
-//! Older logs cannot establish whether published values were lost, so format
-//! 5 is rejected rather than interpreted as having no published output.
+//! The `tool_output` field is required: `null` explicitly records no
+//! publication, an object records published values (possibly empty). Omission
+//! cannot establish whether values were lost and is rejected when decoding.
+//! Legacy header `format` fields are ignored and are never written. The
+//! separate [`Checkpoint`] envelope still has its own [`CHECKPOINT_FORMAT`].
 //!
 //! The vocabulary is rig-core's, the runtimes are rig-agent's bus and rig-ecs; this crate is
 //! the persistence story over both, and what a host that saves and restores
@@ -39,7 +41,7 @@ mod log;
 mod recorder;
 mod replay;
 
-pub use log::{Checkpoint, EFFECT_LOG_FORMAT, EffectLog, LogHeader, ProgramIdentity, stable_hash};
+pub use log::{CHECKPOINT_FORMAT, Checkpoint, EffectLog, LogHeader, ProgramIdentity, stable_hash};
 pub use recorder::EffectLogRecorder;
 pub use replay::{EffectLogReplayer, RequestCheck};
 

--- a/crates/rig-effect-log/src/log.rs
+++ b/crates/rig-effect-log/src/log.rs
@@ -9,7 +9,9 @@ use serde::{Deserialize, Serialize};
 
 /// The log format this crate writes and reads. A log with another format
 /// does not load: there is no tolerant decoder.
-pub const EFFECT_LOG_FORMAT: u32 = 5;
+/// Format 6 records explicitly published tool output. Format 5 cannot tell
+/// absence of output from output lost by its recorder and is not replay-safe.
+pub const EFFECT_LOG_FORMAT: u32 = 6;
 
 /// What a log says about the run it records, so a replay can refuse a log
 /// the program has outgrown before the first dispatch diverges.

--- a/crates/rig-effect-log/src/log.rs
+++ b/crates/rig-effect-log/src/log.rs
@@ -7,18 +7,14 @@ use rig_core::error::{ErrorKind, ErrorReport};
 use rig_core::serve::ServingPolicy;
 use serde::{Deserialize, Serialize};
 
-/// The log format this crate writes and reads. A log with another format
-/// does not load: there is no tolerant decoder.
-/// Format 6 records explicitly published tool output. Format 5 cannot tell
-/// absence of output from output lost by its recorder and is not replay-safe.
-pub const EFFECT_LOG_FORMAT: u32 = 6;
+/// The checkpoint envelope format this crate writes and reads. This versions
+/// [`Checkpoint`], not [`LogHeader`]; logs have no global format number.
+pub const CHECKPOINT_FORMAT: u32 = 6;
 
 /// What a log says about the run it records, so a replay can refuse a log
 /// the program has outgrown before the first dispatch diverges.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LogHeader {
-    /// The log format version ([`EFFECT_LOG_FORMAT`]).
-    pub format: u32,
     /// A hash of the run spec the run was recorded under, when an agent
     /// recorded it (`None` for a bare-bus record). An agent that replays
     /// compares it with its own.
@@ -72,7 +68,6 @@ pub struct ProgramIdentity {
 impl Default for LogHeader {
     fn default() -> Self {
         Self {
-            format: EFFECT_LOG_FORMAT,
             run_spec: None,
             handlers: Vec::new(),
             signature: EffectRow::new(),
@@ -124,7 +119,7 @@ impl EffectLog {
     /// the end is a checkpoint with an empty tail.
     pub fn checkpoint<S>(&self, at: usize, state: S) -> (Checkpoint<S>, Self) {
         let checkpoint = Checkpoint {
-            format: EFFECT_LOG_FORMAT,
+            format: CHECKPOINT_FORMAT,
             at,
             next: self.records.get(at).map(|record| record.id),
             state,
@@ -135,24 +130,14 @@ impl EffectLog {
     /// The continuation `checkpoint` names, over `tail`: refused by name
     /// when the checkpoint is of another format, when the tail's first
     /// record is not the one the checkpoint expects next (ids are total, so
-    /// a tail begins exactly at the checkpoint's next id), or when the
-    /// tail's own header is of another format.
+    /// a tail begins exactly at the checkpoint's next id).
     pub fn from_checkpoint<S>(checkpoint: &Checkpoint<S>, tail: Self) -> Result<Self, ErrorReport> {
-        if checkpoint.format != EFFECT_LOG_FORMAT {
+        if checkpoint.format != CHECKPOINT_FORMAT {
             return Err(ErrorReport::new(
                 ErrorKind::Internal,
                 format!(
                     "resume refused: the checkpoint is format {}, this rig reads format {}",
-                    checkpoint.format, EFFECT_LOG_FORMAT
-                ),
-            ));
-        }
-        if tail.header.format != EFFECT_LOG_FORMAT {
-            return Err(ErrorReport::new(
-                ErrorKind::Internal,
-                format!(
-                    "resume refused: the tail is format {}, this rig reads format {}",
-                    tail.header.format, EFFECT_LOG_FORMAT
+                    checkpoint.format, CHECKPOINT_FORMAT
                 ),
             ));
         }
@@ -195,7 +180,7 @@ fn unreachable_refusal() -> String {
 /// serialized run is a `serde_json::Value`, until it retires.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Checkpoint<S> {
-    /// The log format the checkpoint was cut under ([`EFFECT_LOG_FORMAT`]).
+    /// The checkpoint envelope format ([`CHECKPOINT_FORMAT`]).
     pub format: u32,
     /// The position in the log: `at` records were performed before it.
     pub at: usize,

--- a/crates/rig-effect-log/src/recorder.rs
+++ b/crates/rig-effect-log/src/recorder.rs
@@ -37,6 +37,7 @@ pub struct EffectLogRecorder {
 /// One dispatch the recorder has seen: opened at serve time, filled at
 /// resolution.
 struct RecordSlot {
+    tool_output: Option<rig_core::tool::ToolResultContext>,
     id: EffectId,
     origin: Origin,
     key: HandlerKey,
@@ -48,6 +49,7 @@ struct RecordSlot {
 impl RecordSlot {
     fn record(&self) -> Option<EffectRecord> {
         self.outcome.as_ref().map(|outcome| EffectRecord {
+            tool_output: self.tool_output.clone(),
             parent: self.origin.parent,
             scope: self.origin.scope.clone(),
             id: self.id,
@@ -201,6 +203,7 @@ impl EffectLogRecorder {
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .push(RecordSlot {
+                tool_output: None,
                 id,
                 origin,
                 key,
@@ -278,6 +281,16 @@ impl fmt::Debug for EffectLogRecorder {
 }
 
 impl Recorder for EffectLogRecorder {
+    fn tool_output(&self, id: EffectId, output: rig_core::tool::ToolResultContext) {
+        let mut slots = self.slots.lock().unwrap_or_else(PoisonError::into_inner);
+        if let Some(slot) = slots
+            .iter_mut()
+            .rev()
+            .find(|slot| slot.id == id && slot.outcome.is_none())
+        {
+            slot.tool_output = Some(output);
+        }
+    }
     fn handlers(&self, handlers: Vec<HandlerDescriptor>) {
         self.set_handlers(handlers);
     }

--- a/crates/rig-effect-log/src/replay.rs
+++ b/crates/rig-effect-log/src/replay.rs
@@ -119,6 +119,7 @@ impl EffectLogReplayer {
         first: Option<EffectRecord>,
         records: Records,
     ) -> Result<Self, ErrorReport> {
+        Self::check_header(log)?;
         let (family, described) = match first {
             Some(first) => (first.kind.family(), describe(key, &first.kind, log)),
             // No record: the handler table is the header's first source —
@@ -175,6 +176,7 @@ impl EffectLogReplayer {
     /// key the required row names that no record does, each with its
     /// replayer.
     pub fn for_log(log: &EffectLog) -> Result<Vec<Self>, ErrorReport> {
+        Self::check_header(log)?;
         Self::keys_of(log)
             .iter()
             .map(|key| Self::for_key(log, key))
@@ -183,6 +185,7 @@ impl EffectLogReplayer {
 
     /// [`for_log`](Self::for_log) with every replayer answering by id.
     pub fn for_log_by_id(log: &EffectLog) -> Result<Vec<Self>, ErrorReport> {
+        Self::check_header(log)?;
         Self::keys_of(log)
             .iter()
             .map(|key| Self::for_key_by_id(log, key))
@@ -512,6 +515,22 @@ impl Serve for EffectLogReplayer {
                         ),
                     )),
                     None => {
+                        if let Some(output) = record.tool_output {
+                            let Some(published) = sink.scope::<rig_core::tool::PublishedContext>()
+                            else {
+                                sink.resolve(Err(ErrorReport::new(
+                                    ErrorKind::Divergence,
+                                    "replay requires a tool-result publication slot",
+                                )))
+                                .await;
+                                return;
+                            };
+                            let context = sink
+                                .scope::<rig_core::tool::ToolContext>()
+                                .map(|context| context.for_dispatch())
+                                .unwrap_or_default();
+                            published.publish(context.with_result_context(output));
+                        }
                         // A stream recorded verbatim replays verbatim: the
                         // consumer sees the original delta boundaries, not
                         // the fold re-emitted. A stream that ended in an

--- a/crates/rig-effect-log/src/replay.rs
+++ b/crates/rig-effect-log/src/replay.rs
@@ -16,7 +16,7 @@ use rig_core::{
 
 use rig_core::serve::{OutcomeSink, Serve};
 
-use super::{EFFECT_LOG_FORMAT, EffectLog, stable_hash};
+use super::{EffectLog, stable_hash};
 
 /// How a replayer compares an incoming request with the record's: by the
 /// whole payload as data (the divergence names the first differing JSON
@@ -207,19 +207,10 @@ impl EffectLogReplayer {
         keys
     }
 
-    /// The header checks a replay makes before any dispatch: the format is
-    /// this crate's, and every key the signature names is answered by
-    /// records of that family.
+    /// Check that each recorded key named by the signature has records of
+    /// that family. Logs have no global version gate: decoding validates
+    /// required data fields, while replay checks identity and requests.
     pub fn check_header(log: &EffectLog) -> Result<(), ErrorReport> {
-        if log.header.format != EFFECT_LOG_FORMAT {
-            return Err(ErrorReport::new(
-                ErrorKind::Internal,
-                format!(
-                    "replay refused: the log is format {}, this rig reads format {}",
-                    log.header.format, EFFECT_LOG_FORMAT
-                ),
-            ));
-        }
         for (key, family) in &log.header.signature {
             let recorded = log
                 .records

--- a/crates/rig-effect-log/src/tests.rs
+++ b/crates/rig-effect-log/src/tests.rs
@@ -69,15 +69,34 @@ fn effect_record_and_log_round_trip() {
 }
 
 #[test]
-fn format_five_cannot_claim_published_output_completeness() {
-    let mut log = EffectLog::from_records(vec![]);
-    log.header.format = 5;
-    let error = super::EffectLogReplayer::check_header(&log).expect_err("old recorder lost output");
-    assert!(error.message.contains("format 5"));
-    assert!(super::EffectLogReplayer::for_log(&log).is_err());
-    assert!(super::EffectLogReplayer::for_log_by_id(&log).is_err());
-    assert!(super::EffectLogReplayer::for_key(&log, &HandlerKey::from("tool")).is_err());
-    assert!(super::EffectLogReplayer::for_key_by_id(&log, &HandlerKey::from("tool")).is_err());
+fn headers_have_no_format_and_unknown_legacy_versions_do_not_gate_replay() {
+    let log = two_records();
+    let mut json = serde_json::to_value(&log).expect("serializes");
+    assert!(json["header"].get("format").is_none());
+    // Legacy headers may still carry the obsolete field; its value is ignored.
+    json["header"]["format"] = serde_json::json!(999);
+    let restored: EffectLog = serde_json::from_value(json).expect("structurally valid");
+    super::EffectLogReplayer::check_header(&restored).expect("no version gate");
+    super::EffectLogReplayer::for_log(&restored).expect("registers");
+    assert!(
+        serde_json::to_value(restored).unwrap()["header"]
+            .get("format")
+            .is_none()
+    );
+}
+
+#[test]
+fn missing_published_output_is_unknown_not_explicitly_absent() {
+    let mut json = serde_json::to_value(two_records()).unwrap();
+    assert!(json["records"][0].get("tool_output").is_some());
+    assert!(json["records"][0]["tool_output"].is_null());
+    serde_json::from_value::<EffectLog>(json.clone()).expect("explicit absence is valid");
+    json["records"][0]
+        .as_object_mut()
+        .unwrap()
+        .remove("tool_output");
+    let error = serde_json::from_value::<EffectLog>(json).expect_err("old recorder omitted output");
+    assert!(error.to_string().contains("tool_output"));
 }
 
 /// The recorder finds a slot from the back: the newest slot with an id is
@@ -195,7 +214,7 @@ fn two_records() -> EffectLog {
 fn a_checkpoint_names_the_position_the_next_id_and_the_state() {
     let log = two_records();
     let (checkpoint, tail) = log.checkpoint(1, serde_json::json!({"turn": 1}));
-    assert_eq!(checkpoint.format, super::EFFECT_LOG_FORMAT);
+    assert_eq!(checkpoint.format, super::CHECKPOINT_FORMAT);
     assert_eq!(checkpoint.at, 1);
     assert_eq!(checkpoint.next, Some(EffectId::from_raw(2)));
     assert_eq!(checkpoint.state, serde_json::json!({"turn": 1}));
@@ -243,20 +262,13 @@ fn a_continuation_that_does_not_follow_its_checkpoint_is_refused_by_name() {
         refused.message,
         "resume refused: the checkpoint at 2 ends the log, the tail begins at effect:2"
     );
-    // Another format, on either side.
+    // The checkpoint envelope retains its own version check.
     let mut old = checkpoint.clone();
     old.format = 3;
     let refused = EffectLog::from_checkpoint(&old, tail.clone()).expect_err("format 3");
     assert_eq!(
         refused.message,
         "resume refused: the checkpoint is format 3, this rig reads format 6"
-    );
-    let mut old_tail = tail;
-    old_tail.header.format = 3;
-    let refused = EffectLog::from_checkpoint(&checkpoint, old_tail).expect_err("format 3");
-    assert_eq!(
-        refused.message,
-        "resume refused: the tail is format 3, this rig reads format 6"
     );
 }
 

--- a/crates/rig-effect-log/src/tests.rs
+++ b/crates/rig-effect-log/src/tests.rs
@@ -25,6 +25,7 @@ fn request() -> CompletionRequest {
 fn effect_record_and_log_round_trip() {
     let log: EffectLog = EffectLog::from_records(vec![
         EffectRecord {
+            tool_output: None,
             parent: None,
             scope: None,
             id: EffectId::from_raw(1),
@@ -41,6 +42,7 @@ fn effect_record_and_log_round_trip() {
             events: None,
         },
         EffectRecord {
+            tool_output: None,
             parent: None,
             scope: None,
             id: EffectId::from_raw(2),
@@ -64,6 +66,18 @@ fn effect_record_and_log_round_trip() {
     assert_eq!(back[0].id, EffectId::from_raw(1));
     assert_eq!(back[1].key.as_str(), "tool:add");
     assert!(matches!(&back[1].outcome, Err(report) if report.kind == ErrorKind::Timeout));
+}
+
+#[test]
+fn format_five_cannot_claim_published_output_completeness() {
+    let mut log = EffectLog::from_records(vec![]);
+    log.header.format = 5;
+    let error = super::EffectLogReplayer::check_header(&log).expect_err("old recorder lost output");
+    assert!(error.message.contains("format 5"));
+    assert!(super::EffectLogReplayer::for_log(&log).is_err());
+    assert!(super::EffectLogReplayer::for_log_by_id(&log).is_err());
+    assert!(super::EffectLogReplayer::for_key(&log, &HandlerKey::from("tool")).is_err());
+    assert!(super::EffectLogReplayer::for_key_by_id(&log, &HandlerKey::from("tool")).is_err());
 }
 
 /// The recorder finds a slot from the back: the newest slot with an id is
@@ -151,6 +165,7 @@ fn custom_kind() -> EffectKind {
 fn two_records() -> EffectLog {
     EffectLog::from_records(vec![
         EffectRecord {
+            tool_output: None,
             parent: None,
             scope: None,
             id: EffectId::from_raw(1),
@@ -162,6 +177,7 @@ fn two_records() -> EffectLog {
             events: None,
         },
         EffectRecord {
+            tool_output: None,
             parent: None,
             scope: None,
             id: EffectId::from_raw(2),
@@ -233,14 +249,14 @@ fn a_continuation_that_does_not_follow_its_checkpoint_is_refused_by_name() {
     let refused = EffectLog::from_checkpoint(&old, tail.clone()).expect_err("format 3");
     assert_eq!(
         refused.message,
-        "resume refused: the checkpoint is format 3, this rig reads format 5"
+        "resume refused: the checkpoint is format 3, this rig reads format 6"
     );
     let mut old_tail = tail;
     old_tail.header.format = 3;
     let refused = EffectLog::from_checkpoint(&checkpoint, old_tail).expect_err("format 3");
     assert_eq!(
         refused.message,
-        "resume refused: the tail is format 3, this rig reads format 5"
+        "resume refused: the tail is format 3, this rig reads format 6"
     );
 }
 

--- a/crates/rig-verify/fixtures/anthropic_cancelled_stream.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_cancelled_stream.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_cancelled_stream.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_cancelled_stream.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_causal_completion_concurrent.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_causal_completion_concurrent.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {
@@ -50,6 +49,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -169,6 +169,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/tool:lookup#0",
       "kind": {
@@ -192,6 +193,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {
@@ -276,6 +278,7 @@
       "parent": 2
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_causal_completion_concurrent.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_causal_completion_concurrent.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_causal_completion_serial.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_causal_completion_serial.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {
@@ -50,6 +49,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -169,6 +169,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/tool:lookup#0",
       "kind": {
@@ -192,6 +193,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {
@@ -276,6 +278,7 @@
       "parent": 2
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_causal_completion_serial.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_causal_completion_serial.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_causal_completion_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_causal_completion_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {
@@ -50,6 +49,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -285,6 +285,7 @@
       ]
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/tool:lookup#0",
       "kind": {
@@ -308,6 +309,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {
@@ -392,6 +394,7 @@
       "parent": 2
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_causal_completion_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_causal_completion_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_completion_smoke.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_completion_smoke.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 171082663332529849,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_completion_smoke.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_completion_smoke.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 171082663332529849,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_concurrent_tools_serial.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_concurrent_tools_serial.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 18413898460084818763,
     "handlers": [
       {
@@ -59,6 +58,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -225,6 +225,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_concurrent_tools_serial.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_concurrent_tools_serial.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 18413898460084818763,
     "handlers": [
       {
@@ -177,6 +177,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:lookup_harbor_label#0",
       "kind": {
@@ -200,6 +201,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:lookup_orchard_label#1",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_endings_answer_outcome_cancelled.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_answer_outcome_cancelled.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -32,6 +31,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_endings_answer_outcome_cancelled.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_answer_outcome_cancelled.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_endings_answer_turn_stop.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_answer_turn_stop.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -181,6 +181,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_endings_answer_turn_stop.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_answer_turn_stop.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -59,6 +58,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -205,6 +205,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_endings_text_delta_stop.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_text_delta_stop.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -32,6 +31,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_endings_text_delta_stop.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_text_delta_stop.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_endings_tool_call_delta_stop.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_tool_call_delta_stop.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 1956647414268051610,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_endings_tool_call_delta_stop.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_tool_call_delta_stop.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 1956647414268051610,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_endings_tool_dispatch_cancelled.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_tool_dispatch_cancelled.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -58,6 +57,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_endings_tool_dispatch_cancelled.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_tool_dispatch_cancelled.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_endings_tool_dispatch_cancelled_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_tool_dispatch_cancelled_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -58,6 +57,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_endings_tool_dispatch_cancelled_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_tool_dispatch_cancelled_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_endings_tool_outcome_cancelled.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_tool_outcome_cancelled.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -181,6 +181,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_endings_tool_outcome_cancelled.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_tool_outcome_cancelled.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -59,6 +58,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_endings_tool_outcome_cancelled_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_tool_outcome_cancelled_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -273,6 +273,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_endings_tool_outcome_cancelled_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_tool_outcome_cancelled_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -59,6 +58,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_endings_turn_finished_stop.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_turn_finished_stop.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -58,6 +57,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_endings_turn_finished_stop.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_turn_finished_stop.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_endings_turn_finished_stop_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_turn_finished_stop_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -58,6 +57,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_endings_turn_finished_stop_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_endings_turn_finished_stop_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_hooks_demand_done.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_demand_done.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_hooks_demand_done.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_demand_done.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -31,6 +30,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -114,6 +114,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_hooks_deny_tool.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_deny_tool.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -57,6 +56,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -179,6 +179,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_hooks_deny_tool.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_deny_tool.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_hooks_deny_tool_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_deny_tool_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -57,6 +56,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -287,6 +287,7 @@
       ]
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_hooks_deny_tool_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_deny_tool_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_hooks_lookup_before_run.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_lookup_before_run.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -82,6 +81,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -228,6 +228,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_hooks_lookup_before_run.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_lookup_before_run.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -58,6 +58,7 @@
   },
   "records": [
     {
+      "tool_output": {},
       "id": 1,
       "key": "golden/tool:add#0",
       "kind": {
@@ -203,6 +204,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_hooks_observe_everything.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_observe_everything.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -66,6 +65,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/memory",
       "kind": {
@@ -84,6 +84,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -230,6 +231,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {
@@ -376,6 +378,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "golden/memory",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_hooks_observe_everything.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_observe_everything.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -206,6 +206,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_hooks_patch_tool_args.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_patch_tool_args.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -58,6 +57,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -204,6 +204,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_hooks_patch_tool_args.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_patch_tool_args.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -180,6 +180,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_hooks_patch_tool_args_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_patch_tool_args_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -58,6 +57,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -312,6 +312,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_hooks_patch_tool_args_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_patch_tool_args_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -288,6 +288,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_hooks_preamble_override.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_preamble_override.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_hooks_preamble_override.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_preamble_override.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -31,6 +30,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_hooks_replace_answer.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_replace_answer.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_hooks_replace_answer.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_replace_answer.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -31,6 +30,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_hooks_replace_tool_result.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_replace_tool_result.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -58,6 +57,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -204,6 +204,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_hooks_replace_tool_result.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_replace_tool_result.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -180,6 +180,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_hooks_two_hooks.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_two_hooks.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -181,6 +181,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_hooks_two_hooks.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_hooks_two_hooks.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -59,6 +58,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -205,6 +205,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_at_completion_call.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_at_completion_call.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -34,6 +33,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "host/note",
       "kind": {
@@ -52,6 +52,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_at_completion_call.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_at_completion_call.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_at_outcome.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_at_outcome.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -61,6 +60,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -207,6 +207,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "host/note",
       "kind": {
@@ -225,6 +226,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_at_outcome.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_at_outcome.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -183,6 +183,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_at_outcome_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_at_outcome_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -267,6 +267,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_at_outcome_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_at_outcome_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -61,6 +60,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -291,6 +291,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "host/note",
       "kind": {
@@ -309,6 +310,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_at_settled.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_at_settled.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_at_settled.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_at_settled.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -34,6 +33,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -117,6 +117,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "host/note",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_at_start.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_at_start.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -34,6 +33,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "host/note",
       "kind": {
@@ -52,6 +52,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_at_start.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_at_start.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_at_start_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_at_start_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -34,6 +33,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "host/note",
       "kind": {
@@ -52,6 +52,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_at_start_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_at_start_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_start_and_settled.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_start_and_settled.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_start_and_settled.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_start_and_settled.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -35,6 +34,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "host/note",
       "kind": {
@@ -53,6 +53,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -136,6 +137,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "host/note",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_twice_concurrent.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_twice_concurrent.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -34,6 +33,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "host/note",
       "kind": {
@@ -52,6 +52,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "host/note",
       "kind": {
@@ -70,6 +71,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_twice_concurrent.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_twice_concurrent.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_twice_serial.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_twice_serial.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -34,6 +33,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "host/note",
       "kind": {
@@ -52,6 +52,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "host/note",
       "kind": {
@@ -70,6 +71,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_twice_serial.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_twice_serial.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_unserved.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_unserved.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -26,6 +25,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_host_custom_unserved.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_host_custom_unserved.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_layers_deny_tool.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_layers_deny_tool.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -60,6 +59,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -182,6 +182,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_layers_deny_tool.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_layers_deny_tool.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_layers_host_deny_over_host_bus.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_layers_host_deny_over_host_bus.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -55,6 +54,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -177,6 +177,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_layers_host_deny_over_host_bus.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_layers_host_deny_over_host_bus.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_layers_memory_load_replaced.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_layers_memory_load_replaced.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -43,6 +42,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/memory",
       "kind": {
@@ -61,6 +61,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -163,6 +164,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/memory",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_layers_memory_load_replaced.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_layers_memory_load_replaced.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_layers_patch_beneath_hook_patch.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_layers_patch_beneath_hook_patch.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -62,6 +61,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -208,6 +208,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_layers_patch_beneath_hook_patch.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_layers_patch_beneath_hook_patch.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -184,6 +184,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_layers_patch_tool_args.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_layers_patch_tool_args.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -61,6 +60,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -207,6 +207,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_layers_patch_tool_args.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_layers_patch_tool_args.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -183,6 +183,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_layers_replace_tool_result.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_layers_replace_tool_result.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -61,6 +60,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -207,6 +207,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_layers_replace_tool_result.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_layers_replace_tool_result.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -183,6 +183,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_layers_two_layers.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_layers_two_layers.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -63,6 +62,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -209,6 +209,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_layers_two_layers.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_layers_two_layers.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -185,6 +185,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_memory_clear_at_settled.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_clear_at_settled.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_memory_clear_at_settled.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_clear_at_settled.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -39,6 +38,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/memory",
       "kind": {
@@ -57,6 +57,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -140,6 +141,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/memory",
       "kind": {
@@ -178,6 +180,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/memory",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_memory_clear_at_settled_two_runs.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_clear_at_settled_two_runs.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -39,6 +38,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/memory",
       "kind": {
@@ -57,6 +57,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -140,6 +141,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/memory",
       "kind": {
@@ -178,6 +180,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/memory",
       "kind": {
@@ -195,6 +198,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "golden/memory",
       "kind": {
@@ -213,6 +217,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 6,
       "key": "golden/model:default",
       "kind": {
@@ -296,6 +301,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 7,
       "key": "golden/memory",
       "kind": {
@@ -334,6 +340,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 8,
       "key": "golden/memory",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_memory_clear_at_settled_two_runs.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_clear_at_settled_two_runs.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_memory_clear_at_start.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_clear_at_start.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_memory_clear_at_start.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_clear_at_start.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -39,6 +38,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/memory",
       "kind": {
@@ -57,6 +57,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/memory",
       "kind": {
@@ -74,6 +75,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {
@@ -157,6 +159,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/memory",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_memory_clear_at_start_two_runs.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_clear_at_start_two_runs.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -39,6 +38,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/memory",
       "kind": {
@@ -57,6 +57,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/memory",
       "kind": {
@@ -74,6 +75,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {
@@ -157,6 +159,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/memory",
       "kind": {
@@ -195,6 +198,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "golden/memory",
       "kind": {
@@ -233,6 +237,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 6,
       "key": "golden/memory",
       "kind": {
@@ -250,6 +255,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 7,
       "key": "golden/model:default",
       "kind": {
@@ -352,6 +358,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 8,
       "key": "golden/memory",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_memory_clear_at_start_two_runs.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_clear_at_start_two_runs.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_memory_conversation.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_conversation.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 171082663332529849,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_memory_conversation.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_conversation.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 171082663332529849,
     "handlers": [
       {
@@ -37,6 +36,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/memory",
       "kind": {
@@ -55,6 +55,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -136,6 +137,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/memory",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_memory_failing_append.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_failing_append.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_memory_failing_append.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_failing_append.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -37,6 +36,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/memory",
       "kind": {
@@ -55,6 +55,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -138,6 +139,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/memory",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_memory_failing_append_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_failing_append_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -37,6 +36,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/memory",
       "kind": {
@@ -55,6 +55,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -179,6 +180,7 @@
       ]
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/memory",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_memory_failing_append_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_failing_append_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_memory_history_bypass.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_history_bypass.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -36,6 +35,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_memory_history_bypass.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_history_bypass.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_memory_host_bus.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_host_bus.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -32,6 +31,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/memory",
       "kind": {
@@ -50,6 +50,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -133,6 +134,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/memory",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_memory_host_bus.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_host_bus.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_memory_serial_two_tools.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_serial_two_tools.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 6972143684084239244,
     "handlers": [
       {
@@ -67,6 +66,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/memory",
       "kind": {
@@ -85,6 +85,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -398,6 +399,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "golden/model:default",
       "kind": {
@@ -650,6 +652,7 @@
       ]
     },
     {
+      "tool_output": null,
       "id": 6,
       "key": "golden/memory",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_memory_serial_two_tools.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_serial_two_tools.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 6972143684084239244,
     "handlers": [
       {
@@ -350,6 +350,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:lookup_harbor_label#0",
       "kind": {
@@ -373,6 +374,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 4,
       "key": "golden/tool:lookup_orchard_label#1",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_memory_two_runs.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_two_runs.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -37,6 +36,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/memory",
       "kind": {
@@ -55,6 +55,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -138,6 +139,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/memory",
       "kind": {
@@ -176,6 +178,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/memory",
       "kind": {
@@ -214,6 +217,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "golden/model:default",
       "kind": {
@@ -316,6 +320,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 6,
       "key": "golden/memory",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_memory_two_runs.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_two_runs.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_memory_two_runs_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_two_runs_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_memory_two_runs_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_memory_two_runs_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -37,6 +36,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/memory",
       "kind": {
@@ -55,6 +55,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -179,6 +180,7 @@
       ]
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/memory",
       "kind": {
@@ -217,6 +219,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/memory",
       "kind": {
@@ -255,6 +258,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "golden/model:default",
       "kind": {
@@ -398,6 +402,7 @@
       ]
     },
     {
+      "tool_output": null,
       "id": 6,
       "key": "golden/memory",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_oracle_concurrent_notes.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_oracle_concurrent_notes.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 6972143684084239244,
     "handlers": [
       {
@@ -204,6 +204,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:lookup_harbor_label#0",
       "kind": {
@@ -227,6 +228,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:lookup_orchard_label#1",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_oracle_concurrent_notes.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_oracle_concurrent_notes.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 6972143684084239244,
     "handlers": [
       {
@@ -64,6 +63,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -252,6 +252,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "host/note",
       "kind": {
@@ -270,6 +271,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "host/note",
       "kind": {
@@ -288,6 +290,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 6,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_oracle_stop_after_turn_two.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_oracle_stop_after_turn_two.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -58,6 +57,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -204,6 +204,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_oracle_stop_after_turn_two.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_oracle_stop_after_turn_two.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -180,6 +180,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_outcome_cancel_after_tool_call_delta.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_outcome_cancel_after_tool_call_delta.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 1956647414268051610,
     "handlers": [
       {
@@ -53,6 +52,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_outcome_cancel_after_tool_call_delta.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_outcome_cancel_after_tool_call_delta.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 1956647414268051610,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_outcome_default_max_turns.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_outcome_default_max_turns.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 13725602983091836856,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -202,6 +202,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_outcome_default_max_turns.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_outcome_default_max_turns.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 13725602983091836856,
     "handlers": [
       {
@@ -178,6 +178,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_outcome_max_turns_exhausted.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_outcome_max_turns_exhausted.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_outcome_max_turns_exhausted.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_outcome_max_turns_exhausted.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -178,6 +178,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_outcome_model_error.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_outcome_model_error.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_outcome_model_error.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_outcome_model_error.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_outcome_model_error_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_outcome_model_error_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_outcome_model_error_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_outcome_model_error_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_outcome_tool_error.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_outcome_tool_error.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -174,6 +174,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_outcome_tool_error.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_outcome_tool_error.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -54,6 +53,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -206,6 +206,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_outcome_tool_error_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_outcome_tool_error_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -274,6 +274,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_outcome_tool_error_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_outcome_tool_error_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -54,6 +53,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -306,6 +306,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_output_prompted_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_prompted_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 17759422913336850263,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_output_prompted_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_prompted_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 17759422913336850263,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_output_prompted_unary.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_prompted_unary.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 17759422913336850263,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_output_prompted_unary.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_prompted_unary.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 17759422913336850263,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_output_prompted_with_real_tool.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_prompted_with_real_tool.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 3927627128604115063,
     "handlers": [
       {
@@ -186,6 +186,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_output_prompted_with_real_tool.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_prompted_with_real_tool.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 3927627128604115063,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -210,6 +210,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_output_tool_choice_required.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_tool_choice_required.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 12938862389227305564,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_output_tool_choice_required.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_tool_choice_required.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 12938862389227305564,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_output_tool_choice_specific_output.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_tool_choice_specific_output.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 3815250667280501638,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_output_tool_choice_specific_output.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_tool_choice_specific_output.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 3815250667280501638,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_output_tool_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_tool_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 1030837007388641174,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_output_tool_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_tool_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 1030837007388641174,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_output_tool_thinking.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_tool_thinking.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 15855849518565157162,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_output_tool_thinking.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_tool_thinking.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 15855849518565157162,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_output_tool_unary.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_tool_unary.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 1030837007388641174,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_output_tool_unary.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_tool_unary.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 1030837007388641174,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_output_tool_under_none_degrades.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_tool_under_none_degrades.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 4057248294585460433,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_output_tool_under_none_degrades.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_tool_under_none_degrades.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 4057248294585460433,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_output_tool_with_real_tool.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_tool_with_real_tool.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 947379970989494918,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -233,6 +233,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_output_tool_with_real_tool.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_output_tool_with_real_tool.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 947379970989494918,
     "handlers": [
       {
@@ -209,6 +209,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_append_preamble.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_append_preamble.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 15370722154951577800,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_append_preamble.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_append_preamble.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 15370722154951577800,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_max_tokens.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_max_tokens.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 3219238563081221126,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_max_tokens.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_max_tokens.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 3219238563081221126,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_output_schema_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_output_schema_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14252285028098683575,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_output_schema_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_output_schema_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14252285028098683575,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_output_schema_unary.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_output_schema_unary.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14252285028098683575,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_output_schema_unary.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_output_schema_unary.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14252285028098683575,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_prior_history.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_prior_history.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_prior_history.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_prior_history.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_static_context.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_static_context.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 4023277009554223987,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_static_context.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_static_context.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 4023277009554223987,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_thinking_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_thinking_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 3769489103430885208,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_thinking_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_thinking_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 3769489103430885208,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_thinking_unary.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_thinking_unary.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 3769489103430885208,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_thinking_unary.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_thinking_unary.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 3769489103430885208,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_tool_choice_auto.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_tool_choice_auto.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 12507160732536575710,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -202,6 +202,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_tool_choice_auto.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_tool_choice_auto.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 12507160732536575710,
     "handlers": [
       {
@@ -178,6 +178,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_tool_choice_none.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_tool_choice_none.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 13526579486390297489,
     "handlers": [
       {
@@ -55,6 +54,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_tool_choice_none.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_tool_choice_none.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 13526579486390297489,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_tool_choice_required.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_tool_choice_required.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 4304616206682456876,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -202,6 +202,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_tool_choice_required.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_tool_choice_required.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 4304616206682456876,
     "handlers": [
       {
@@ -178,6 +178,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {
@@ -364,6 +365,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 4,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_tool_choice_specific.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_tool_choice_specific.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 8449702089946067695,
     "handlers": [
       {
@@ -184,6 +184,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {
@@ -376,6 +377,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 4,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_tool_choice_specific.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_tool_choice_specific.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 8449702089946067695,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -208,6 +208,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_without_preamble.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_without_preamble.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 28703887051136125,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_request_shape_without_preamble.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_request_shape_without_preamble.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 28703887051136125,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_serving_capacity_one.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_capacity_one.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 18413898460084818763,
     "handlers": [
       {
@@ -59,6 +58,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -225,6 +225,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_serving_capacity_one.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_capacity_one.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 18413898460084818763,
     "handlers": [
       {
@@ -177,6 +177,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:lookup_harbor_label#0",
       "kind": {
@@ -200,6 +201,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:lookup_orchard_label#1",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_serving_concurrent_concurrency_one.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_concurrent_concurrency_one.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 18413898460084818763,
     "handlers": [
       {
@@ -59,6 +58,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -225,6 +225,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_serving_concurrent_concurrency_one.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_concurrent_concurrency_one.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 18413898460084818763,
     "handlers": [
       {
@@ -177,6 +177,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:lookup_harbor_label#0",
       "kind": {
@@ -200,6 +201,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:lookup_orchard_label#1",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_serving_concurrent_concurrency_two.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_concurrent_concurrency_two.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 18413898460084818763,
     "handlers": [
       {
@@ -59,6 +58,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -225,6 +225,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_serving_concurrent_concurrency_two.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_concurrent_concurrency_two.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 18413898460084818763,
     "handlers": [
       {
@@ -177,6 +177,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:lookup_harbor_label#0",
       "kind": {
@@ -200,6 +201,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:lookup_orchard_label#1",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_serving_concurrent_concurrency_two_events.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_concurrent_concurrency_two_events.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 18413898460084818763,
     "handlers": [
       {
@@ -322,6 +322,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:lookup_harbor_label#0",
       "kind": {
@@ -345,6 +346,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:lookup_orchard_label#1",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_serving_concurrent_concurrency_two_events.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_concurrent_concurrency_two_events.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 18413898460084818763,
     "handlers": [
       {
@@ -59,6 +58,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -370,6 +370,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_serving_host_bus.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_host_bus.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -173,6 +173,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_serving_host_bus.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_host_bus.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -51,6 +50,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -197,6 +197,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_serving_host_bus_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_host_bus_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -273,6 +273,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_serving_host_bus_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_host_bus_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -51,6 +50,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -297,6 +297,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_serving_model_route.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_model_route.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -192,6 +192,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_serving_model_route.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_model_route.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -70,6 +69,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -216,6 +216,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:fast",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_serving_model_route_unselected.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_model_route_unselected.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -189,6 +189,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_serving_model_route_unselected.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_model_route_unselected.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -67,6 +66,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -213,6 +213,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_serving_serial_concurrency_one.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_serial_concurrency_one.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 18413898460084818763,
     "handlers": [
       {
@@ -59,6 +58,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -225,6 +225,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_serving_serial_concurrency_one.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_serial_concurrency_one.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 18413898460084818763,
     "handlers": [
       {
@@ -177,6 +177,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:lookup_harbor_label#0",
       "kind": {
@@ -200,6 +201,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:lookup_orchard_label#1",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_serving_serial_memory_tools.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_serial_memory_tools.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -204,6 +204,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_serving_serial_memory_tools.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_serving_serial_memory_tools.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -64,6 +63,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/memory",
       "kind": {
@@ -82,6 +82,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -228,6 +229,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {
@@ -374,6 +376,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "golden/memory",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_active_tools_none_second_turn.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_active_tools_none_second_turn.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -58,6 +57,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -204,6 +204,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_active_tools_none_second_turn.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_active_tools_none_second_turn.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -180,6 +180,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_extra_context.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_extra_context.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_shaping_extra_context.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_extra_context.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -31,6 +30,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_extra_context_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_extra_context_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_shaping_extra_context_streamed.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_extra_context_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -31,6 +30,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_history_first_turn.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_history_first_turn.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/anthropic_shaping_history_first_turn.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_history_first_turn.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -31,6 +30,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_late_route.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_late_route.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -68,6 +67,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:late",
       "kind": {
@@ -214,6 +214,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:late",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_late_route.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_late_route.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -190,6 +190,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_max_tokens_second_turn.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_max_tokens_second_turn.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -58,6 +57,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -204,6 +204,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_max_tokens_second_turn.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_max_tokens_second_turn.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -180,6 +180,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_merged_three.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_merged_three.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -187,6 +187,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_merged_three.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_merged_three.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -60,6 +59,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -211,6 +211,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_preamble_second_turn.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_preamble_second_turn.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -58,6 +57,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -204,6 +204,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_preamble_second_turn.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_preamble_second_turn.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -180,6 +180,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_route_on_first_turn.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_route_on_first_turn.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -192,6 +192,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_route_on_first_turn.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_route_on_first_turn.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -70,6 +69,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:fast",
       "kind": {
@@ -216,6 +216,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_thinking_second_turn.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_thinking_second_turn.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -58,6 +57,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -204,6 +204,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_thinking_second_turn.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_thinking_second_turn.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -180,6 +180,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_tool_choice_none_on_committed_output.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_tool_choice_none_on_committed_output.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 947379970989494918,
     "handlers": [
       {
@@ -211,6 +211,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_tool_choice_none_on_committed_output.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_tool_choice_none_on_committed_output.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 947379970989494918,
     "handlers": [
       {
@@ -58,6 +57,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -235,6 +235,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {
@@ -408,6 +409,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_tool_choice_required_first.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_tool_choice_required_first.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -58,6 +57,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -204,6 +204,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_shaping_tool_choice_required_first.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_shaping_tool_choice_required_first.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -180,6 +180,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_streaming_with_events.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_streaming_with_events.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9258363232016223254,
     "handlers": [
       {
@@ -342,6 +342,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:subtract#1",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_streaming_with_events.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_streaming_with_events.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9258363232016223254,
     "handlers": [
       {
@@ -82,6 +81,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -366,6 +366,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_tool_call_turn.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_tool_call_turn.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -202,6 +202,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/anthropic_tool_call_turn.effects.json
+++ b/crates/rig-verify/fixtures/anthropic_tool_call_turn.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -178,6 +178,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_breadth_custom_at_outcome.effects.json
+++ b/crates/rig-verify/fixtures/gemini_breadth_custom_at_outcome.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -61,6 +60,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -218,6 +218,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "host/note",
       "kind": {
@@ -236,6 +237,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_breadth_custom_at_outcome.effects.json
+++ b/crates/rig-verify/fixtures/gemini_breadth_custom_at_outcome.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -194,6 +194,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_breadth_embed_prompt.effects.json
+++ b/crates/rig-verify/fixtures/gemini_breadth_embed_prompt.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/gemini_breadth_embed_prompt.effects.json
+++ b/crates/rig-verify/fixtures/gemini_breadth_embed_prompt.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -37,6 +36,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "host/embed",
       "kind": {
@@ -6228,6 +6228,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_breadth_output_tool_streamed.effects.json
+++ b/crates/rig-verify/fixtures/gemini_breadth_output_tool_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 1030837007388641174,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/gemini_breadth_output_tool_streamed.effects.json
+++ b/crates/rig-verify/fixtures/gemini_breadth_output_tool_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 1030837007388641174,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_breadth_output_tool_unary.effects.json
+++ b/crates/rig-verify/fixtures/gemini_breadth_output_tool_unary.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 1030837007388641174,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/gemini_breadth_output_tool_unary.effects.json
+++ b/crates/rig-verify/fixtures/gemini_breadth_output_tool_unary.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 1030837007388641174,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_breadth_text_delta_stop.effects.json
+++ b/crates/rig-verify/fixtures/gemini_breadth_text_delta_stop.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/gemini_breadth_text_delta_stop.effects.json
+++ b/crates/rig-verify/fixtures/gemini_breadth_text_delta_stop.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -31,6 +30,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_breadth_tool_dispatch_cancelled.effects.json
+++ b/crates/rig-verify/fixtures/gemini_breadth_tool_dispatch_cancelled.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -57,6 +56,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_breadth_tool_dispatch_cancelled.effects.json
+++ b/crates/rig-verify/fixtures/gemini_breadth_tool_dispatch_cancelled.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/gemini_delta_interactions_baseline.effects.json
+++ b/crates/rig-verify/fixtures/gemini_delta_interactions_baseline.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -306,6 +306,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_delta_interactions_baseline.effects.json
+++ b/crates/rig-verify/fixtures/gemini_delta_interactions_baseline.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -330,6 +330,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_retrieval_context_and_tools.effects.json
+++ b/crates/rig-verify/fixtures/gemini_retrieval_context_and_tools.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 13216707040221315529,
     "handlers": [
       {
@@ -108,6 +107,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/retrieve:context#0",
       "kind": {
@@ -138,6 +138,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/retrieve:tools#0",
       "kind": {
@@ -167,6 +168,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {
@@ -327,6 +329,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "golden/retrieve:context#0",
       "kind": {
@@ -357,6 +360,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 6,
       "key": "golden/retrieve:tools#0",
       "kind": {
@@ -386,6 +390,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 7,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_retrieval_context_and_tools.effects.json
+++ b/crates/rig-verify/fixtures/gemini_retrieval_context_and_tools.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 13216707040221315529,
     "handlers": [
       {
@@ -303,6 +303,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 4,
       "key": "golden/tool:subtract#1",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_retrieval_dynamic_context_empty_index.effects.json
+++ b/crates/rig-verify/fixtures/gemini_retrieval_dynamic_context_empty_index.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -39,6 +38,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/retrieve:context#0",
       "kind": {
@@ -63,6 +63,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_retrieval_dynamic_context_empty_index.effects.json
+++ b/crates/rig-verify/fixtures/gemini_retrieval_dynamic_context_empty_index.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/gemini_retrieval_dynamic_context_one.effects.json
+++ b/crates/rig-verify/fixtures/gemini_retrieval_dynamic_context_one.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -39,6 +38,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/retrieve:context#0",
       "kind": {
@@ -69,6 +69,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_retrieval_dynamic_context_one.effects.json
+++ b/crates/rig-verify/fixtures/gemini_retrieval_dynamic_context_one.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/gemini_retrieval_dynamic_context_over_sampled.effects.json
+++ b/crates/rig-verify/fixtures/gemini_retrieval_dynamic_context_over_sampled.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -39,6 +38,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/retrieve:context#0",
       "kind": {
@@ -79,6 +79,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_retrieval_dynamic_context_over_sampled.effects.json
+++ b/crates/rig-verify/fixtures/gemini_retrieval_dynamic_context_over_sampled.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/gemini_retrieval_dynamic_context_two_streamed.effects.json
+++ b/crates/rig-verify/fixtures/gemini_retrieval_dynamic_context_two_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -39,6 +38,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/retrieve:context#0",
       "kind": {
@@ -74,6 +74,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_retrieval_dynamic_context_two_streamed.effects.json
+++ b/crates/rig-verify/fixtures/gemini_retrieval_dynamic_context_two_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/gemini_retrieval_retrieved_tools_one.effects.json
+++ b/crates/rig-verify/fixtures/gemini_retrieval_retrieved_tools_one.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 13216707040221315529,
     "handlers": [
       {
@@ -98,6 +97,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/retrieve:tools#0",
       "kind": {
@@ -127,6 +127,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -282,6 +283,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/retrieve:tools#0",
       "kind": {
@@ -311,6 +313,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_retrieval_retrieved_tools_one.effects.json
+++ b/crates/rig-verify/fixtures/gemini_retrieval_retrieved_tools_one.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 13216707040221315529,
     "handlers": [
       {
@@ -258,6 +258,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:subtract#1",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_retrieval_retrieved_tools_with_static.effects.json
+++ b/crates/rig-verify/fixtures/gemini_retrieval_retrieved_tools_with_static.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 13216707040221315529,
     "handlers": [
       {
@@ -276,6 +276,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:add#0",
       "kind": {
@@ -515,6 +516,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 6,
       "key": "golden/tool:subtract#1",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_retrieval_retrieved_tools_with_static.effects.json
+++ b/crates/rig-verify/fixtures/gemini_retrieval_retrieved_tools_with_static.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 13216707040221315529,
     "handlers": [
       {
@@ -95,6 +94,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/retrieve:tools#0",
       "kind": {
@@ -124,6 +124,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -300,6 +301,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/retrieve:tools#0",
       "kind": {
@@ -329,6 +331,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "golden/model:default",
       "kind": {
@@ -540,6 +543,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 7,
       "key": "golden/retrieve:tools#0",
       "kind": {
@@ -569,6 +573,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 8,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_serving_two_turns_serial.effects.json
+++ b/crates/rig-verify/fixtures/gemini_serving_two_turns_serial.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 13512054446980575785,
     "handlers": [
       {
@@ -211,6 +211,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "stress-agent/tool:add#0",
       "kind": {
@@ -397,6 +398,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 4,
       "key": "stress-agent/tool:subtract#1",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_serving_two_turns_serial.effects.json
+++ b/crates/rig-verify/fixtures/gemini_serving_two_turns_serial.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 13512054446980575785,
     "handlers": [
       {
@@ -83,6 +82,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "stress-agent/model:default",
       "kind": {
@@ -235,6 +235,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "stress-agent/model:default",
       "kind": {
@@ -422,6 +423,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "stress-agent/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_tool_call_turns.effects.json
+++ b/crates/rig-verify/fixtures/gemini_tool_call_turns.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 13512054446980575785,
     "handlers": [
       {
@@ -211,6 +211,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "stress-agent/tool:add#0",
       "kind": {
@@ -397,6 +398,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 4,
       "key": "stress-agent/tool:subtract#1",
       "kind": {

--- a/crates/rig-verify/fixtures/gemini_tool_call_turns.effects.json
+++ b/crates/rig-verify/fixtures/gemini_tool_call_turns.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 13512054446980575785,
     "handlers": [
       {
@@ -83,6 +82,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "stress-agent/model:default",
       "kind": {
@@ -235,6 +235,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "stress-agent/model:default",
       "kind": {
@@ -422,6 +423,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "stress-agent/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_causal_depth_two.effects.json
+++ b/crates/rig-verify/fixtures/mock_causal_depth_two.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {
@@ -73,6 +72,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -163,6 +163,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/tool:lookup#0",
       "kind": {
@@ -186,6 +187,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "host/relay",
       "kind": {
@@ -205,6 +207,7 @@
       "parent": 2
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "host/note",
       "kind": {
@@ -224,6 +227,7 @@
       "parent": 3
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_causal_depth_two.effects.json
+++ b/crates/rig-verify/fixtures/mock_causal_depth_two.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_causal_detached_resolver.effects.json
+++ b/crates/rig-verify/fixtures/mock_causal_detached_resolver.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {
@@ -72,6 +71,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -162,6 +162,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/tool:lookup#0",
       "kind": {
@@ -185,6 +186,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "host/note",
       "kind": {
@@ -204,6 +206,7 @@
       "parent": 2
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_causal_detached_resolver.effects.json
+++ b/crates/rig-verify/fixtures/mock_causal_detached_resolver.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_causal_note_concurrent.effects.json
+++ b/crates/rig-verify/fixtures/mock_causal_note_concurrent.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {
@@ -72,6 +71,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -162,6 +162,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/tool:lookup#0",
       "kind": {
@@ -185,6 +186,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "host/note",
       "kind": {
@@ -204,6 +206,7 @@
       "parent": 2
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_causal_note_concurrent.effects.json
+++ b/crates/rig-verify/fixtures/mock_causal_note_concurrent.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_causal_note_serial.effects.json
+++ b/crates/rig-verify/fixtures/mock_causal_note_serial.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {
@@ -72,6 +71,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -162,6 +162,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/tool:lookup#0",
       "kind": {
@@ -185,6 +186,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "host/note",
       "kind": {
@@ -204,6 +206,7 @@
       "parent": 2
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_causal_note_serial.effects.json
+++ b/crates/rig-verify/fixtures/mock_causal_note_serial.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_causal_parent_cancelled_child_in_flight.effects.json
+++ b/crates/rig-verify/fixtures/mock_causal_parent_cancelled_child_in_flight.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {
@@ -72,6 +71,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -162,6 +162,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/tool:lookup#0",
       "kind": {
@@ -182,6 +183,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "host/never",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_causal_parent_cancelled_child_in_flight.effects.json
+++ b/crates/rig-verify/fixtures/mock_causal_parent_cancelled_child_in_flight.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_causal_parent_cancelled_child_queued.effects.json
+++ b/crates/rig-verify/fixtures/mock_causal_parent_cancelled_child_queued.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {
@@ -72,6 +71,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -162,6 +162,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/tool:lookup#0",
       "kind": {
@@ -182,6 +183,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "host/never",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_causal_parent_cancelled_child_queued.effects.json
+++ b/crates/rig-verify/fixtures/mock_causal_parent_cancelled_child_queued.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_causal_same_key_concurrent_served.effects.json
+++ b/crates/rig-verify/fixtures/mock_causal_same_key_concurrent_served.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {
@@ -71,6 +70,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -161,6 +161,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/tool:lookup#0",
       "kind": {
@@ -184,6 +185,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/tool:lookup#0",
       "kind": {
@@ -208,6 +210,7 @@
       "parent": 2
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_causal_same_key_concurrent_served.effects.json
+++ b/crates/rig-verify/fixtures/mock_causal_same_key_concurrent_served.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_causal_same_key_from_thread_refused.effects.json
+++ b/crates/rig-verify/fixtures/mock_causal_same_key_from_thread_refused.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {
@@ -71,6 +70,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -161,6 +161,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/tool:lookup#0",
       "kind": {
@@ -184,6 +185,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_causal_same_key_from_thread_refused.effects.json
+++ b/crates/rig-verify/fixtures/mock_causal_same_key_from_thread_refused.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_causal_same_key_serial_refused.effects.json
+++ b/crates/rig-verify/fixtures/mock_causal_same_key_serial_refused.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {
@@ -71,6 +70,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -161,6 +161,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/tool:lookup#0",
       "kind": {
@@ -184,6 +185,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_causal_same_key_serial_refused.effects.json
+++ b/crates/rig-verify/fixtures/mock_causal_same_key_serial_refused.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 16853303954472180534,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_delta_baseline.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_baseline.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -250,6 +250,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_delta_baseline.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_baseline.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -54,6 +53,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -274,6 +274,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_delta_fail.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_fail.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_delta_fail.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_fail.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -53,6 +52,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_delta_ignore.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_ignore.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_delta_ignore.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_ignore.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -53,6 +52,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_delta_ignore_beside_valid.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_ignore_beside_valid.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -54,6 +53,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -345,6 +345,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_delta_ignore_beside_valid.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_ignore_beside_valid.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -321,6 +321,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_delta_output_tool.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_output_tool.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 17063702180001451641,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_delta_output_tool.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_output_tool.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 17063702180001451641,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_delta_repair.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_repair.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -252,6 +252,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_delta_repair.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_repair.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -276,6 +276,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_delta_retry.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_retry.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -480,6 +480,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_delta_retry.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_retry.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -252,6 +252,7 @@
       ]
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -504,6 +505,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_delta_retry_arguments_first.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_retry_arguments_first.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -483,6 +483,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_delta_retry_arguments_first.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_retry_arguments_first.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -252,6 +252,7 @@
       ]
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -507,6 +508,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_delta_skip.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_skip.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_delta_skip.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_skip.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -55,6 +54,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -251,6 +251,7 @@
       ]
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_delta_stop_on_arguments.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_stop_on_arguments.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_delta_stop_on_arguments.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_stop_on_arguments.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -55,6 +54,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_delta_stop_on_name.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_stop_on_name.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_delta_stop_on_name.effects.json
+++ b/crates/rig-verify/fixtures/mock_delta_stop_on_name.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -55,6 +54,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_endings_stop_at_completion_call.effects.json
+++ b/crates/rig-verify/fixtures/mock_endings_stop_at_completion_call.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_endings_stop_at_completion_call.effects.json
+++ b/crates/rig-verify/fixtures/mock_endings_stop_at_completion_call.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_endings_stop_at_model_select.effects.json
+++ b/crates/rig-verify/fixtures/mock_endings_stop_at_model_select.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_endings_stop_at_model_select.effects.json
+++ b/crates/rig-verify/fixtures/mock_endings_stop_at_model_select.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_endings_stop_at_start.effects.json
+++ b/crates/rig-verify/fixtures/mock_endings_stop_at_start.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_endings_stop_at_start.effects.json
+++ b/crates/rig-verify/fixtures/mock_endings_stop_at_start.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_hooks_retry_twice.effects.json
+++ b/crates/rig-verify/fixtures/mock_hooks_retry_twice.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -146,6 +146,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -277,6 +278,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {
@@ -473,6 +475,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_hooks_retry_twice.effects.json
+++ b/crates/rig-verify/fixtures/mock_hooks_retry_twice.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -449,6 +449,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 4,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_ignore_streamed.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_ignore_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_invalid_ignore_streamed.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_ignore_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -53,6 +52,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_ignore_unary.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_ignore_unary.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_invalid_ignore_unary.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_ignore_unary.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -53,6 +52,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_mixed_fail.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_mixed_fail.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_invalid_mixed_fail.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_mixed_fail.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -53,6 +52,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_mixed_ignore.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_mixed_ignore.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -54,6 +53,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -184,6 +184,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_mixed_ignore.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_mixed_ignore.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -160,6 +160,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_mixed_ignore_streamed.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_mixed_ignore_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -285,6 +285,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_mixed_ignore_streamed.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_mixed_ignore_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -54,6 +53,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -309,6 +309,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_repair_to_add.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_repair_to_add.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -146,6 +146,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_repair_to_add.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_repair_to_add.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -170,6 +170,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_retry_under_required.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_retry_under_required.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 1438132051453786004,
     "handlers": [
       {
@@ -277,6 +277,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_retry_under_required.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_retry_under_required.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 1438132051453786004,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -146,6 +146,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_skip_under_auto.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_skip_under_auto.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_invalid_skip_under_auto.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_skip_under_auto.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -55,6 +54,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -145,6 +145,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_skip_under_none.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_skip_under_none.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 13947441209079244713,
     "handlers": [
       {
@@ -55,6 +54,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_skip_under_none.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_skip_under_none.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 13947441209079244713,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_invalid_streamed_repair.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_streamed_repair.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -258,6 +258,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_streamed_repair.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_streamed_repair.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -234,6 +234,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_streamed_retry_once.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_streamed_retry_once.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -234,6 +234,7 @@
       ]
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -477,6 +478,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_streamed_retry_once.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_streamed_retry_once.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -453,6 +453,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_streamed_retry_twice.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_streamed_retry_twice.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -234,6 +234,7 @@
       ]
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -453,6 +454,7 @@
       ]
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {
@@ -737,6 +739,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_streamed_retry_twice.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_streamed_retry_twice.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -713,6 +713,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 4,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_streamed_skip.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_streamed_skip.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_invalid_streamed_skip.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_streamed_skip.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -55,6 +54,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -233,6 +233,7 @@
       ]
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_tool_call_recovery.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_tool_call_recovery.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -146,6 +146,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -301,6 +302,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_invalid_tool_call_recovery.effects.json
+++ b/crates/rig-verify/fixtures/mock_invalid_tool_call_recovery.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -277,6 +277,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_layers_replace_streamed_cancelled.effects.json
+++ b/crates/rig-verify/fixtures/mock_layers_replace_streamed_cancelled.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_layers_replace_streamed_cancelled.effects.json
+++ b/crates/rig-verify/fixtures/mock_layers_replace_streamed_cancelled.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_layers_suspend_approve.effects.json
+++ b/crates/rig-verify/fixtures/mock_layers_suspend_approve.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -61,6 +60,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -177,6 +177,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_layers_suspend_approve.effects.json
+++ b/crates/rig-verify/fixtures/mock_layers_suspend_approve.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -153,6 +153,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_layers_suspend_cancelled.effects.json
+++ b/crates/rig-verify/fixtures/mock_layers_suspend_cancelled.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -61,6 +60,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -153,6 +153,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_layers_suspend_cancelled.effects.json
+++ b/crates/rig-verify/fixtures/mock_layers_suspend_cancelled.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_layers_suspend_deny.effects.json
+++ b/crates/rig-verify/fixtures/mock_layers_suspend_deny.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -60,6 +59,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -152,6 +152,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_layers_suspend_deny.effects.json
+++ b/crates/rig-verify/fixtures/mock_layers_suspend_deny.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_layers_wrong_family_patch.effects.json
+++ b/crates/rig-verify/fixtures/mock_layers_wrong_family_patch.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -60,6 +59,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -152,6 +152,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_layers_wrong_family_patch.effects.json
+++ b/crates/rig-verify/fixtures/mock_layers_wrong_family_patch.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_leftovers_denied_completion.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_denied_completion.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_leftovers_denied_completion.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_denied_completion.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_leftovers_denied_custom_from_hook.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_denied_custom_from_hook.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -37,6 +36,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_leftovers_denied_custom_from_hook.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_denied_custom_from_hook.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_leftovers_denied_custom_from_hook_streamed.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_denied_custom_from_hook_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -37,6 +36,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_leftovers_denied_custom_from_hook_streamed.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_denied_custom_from_hook_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_leftovers_denied_memory_load.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_denied_memory_load.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_leftovers_denied_memory_load.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_denied_memory_load.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_leftovers_denied_tool.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_denied_tool.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -60,6 +59,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -152,6 +152,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_leftovers_denied_tool.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_denied_tool.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_leftovers_denied_tool_streamed.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_denied_tool_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_leftovers_denied_tool_streamed.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_denied_tool_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -55,6 +54,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -235,6 +235,7 @@
       ]
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_leftovers_five_thousand_events.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_five_thousand_events.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -34,6 +33,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "host/note",
       "kind": {
@@ -52,6 +52,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "host/note",
       "kind": {
@@ -70,6 +71,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "host/note",
       "kind": {
@@ -88,6 +90,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "host/note",
       "kind": {
@@ -106,6 +109,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "host/note",
       "kind": {
@@ -124,6 +128,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 6,
       "key": "host/note",
       "kind": {
@@ -142,6 +147,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 7,
       "key": "host/note",
       "kind": {
@@ -160,6 +166,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 8,
       "key": "host/note",
       "kind": {
@@ -178,6 +185,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 9,
       "key": "host/note",
       "kind": {
@@ -196,6 +204,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 10,
       "key": "host/note",
       "kind": {
@@ -214,6 +223,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 11,
       "key": "host/note",
       "kind": {
@@ -232,6 +242,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 12,
       "key": "host/note",
       "kind": {
@@ -250,6 +261,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 13,
       "key": "host/note",
       "kind": {
@@ -268,6 +280,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 14,
       "key": "host/note",
       "kind": {
@@ -286,6 +299,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 15,
       "key": "host/note",
       "kind": {
@@ -304,6 +318,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 16,
       "key": "host/note",
       "kind": {
@@ -322,6 +337,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 17,
       "key": "host/note",
       "kind": {
@@ -340,6 +356,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 18,
       "key": "host/note",
       "kind": {
@@ -358,6 +375,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 19,
       "key": "host/note",
       "kind": {
@@ -376,6 +394,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 20,
       "key": "host/note",
       "kind": {
@@ -394,6 +413,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 21,
       "key": "host/note",
       "kind": {
@@ -412,6 +432,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 22,
       "key": "host/note",
       "kind": {
@@ -430,6 +451,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 23,
       "key": "host/note",
       "kind": {
@@ -448,6 +470,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 24,
       "key": "host/note",
       "kind": {
@@ -466,6 +489,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 25,
       "key": "host/note",
       "kind": {
@@ -484,6 +508,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 26,
       "key": "host/note",
       "kind": {
@@ -502,6 +527,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 27,
       "key": "host/note",
       "kind": {
@@ -520,6 +546,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 28,
       "key": "host/note",
       "kind": {
@@ -538,6 +565,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 29,
       "key": "host/note",
       "kind": {
@@ -556,6 +584,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 30,
       "key": "host/note",
       "kind": {
@@ -574,6 +603,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 31,
       "key": "host/note",
       "kind": {
@@ -592,6 +622,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 32,
       "key": "host/note",
       "kind": {
@@ -610,6 +641,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 33,
       "key": "host/note",
       "kind": {
@@ -628,6 +660,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 34,
       "key": "host/note",
       "kind": {
@@ -646,6 +679,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 35,
       "key": "host/note",
       "kind": {
@@ -664,6 +698,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 36,
       "key": "host/note",
       "kind": {
@@ -682,6 +717,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 37,
       "key": "host/note",
       "kind": {
@@ -700,6 +736,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 38,
       "key": "host/note",
       "kind": {
@@ -718,6 +755,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 39,
       "key": "host/note",
       "kind": {
@@ -736,6 +774,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 40,
       "key": "host/note",
       "kind": {
@@ -754,6 +793,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 41,
       "key": "host/note",
       "kind": {
@@ -772,6 +812,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 42,
       "key": "host/note",
       "kind": {
@@ -790,6 +831,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 43,
       "key": "host/note",
       "kind": {
@@ -808,6 +850,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 44,
       "key": "host/note",
       "kind": {
@@ -826,6 +869,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 45,
       "key": "host/note",
       "kind": {
@@ -844,6 +888,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 46,
       "key": "host/note",
       "kind": {
@@ -862,6 +907,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 47,
       "key": "host/note",
       "kind": {
@@ -880,6 +926,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 48,
       "key": "host/note",
       "kind": {
@@ -898,6 +945,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 49,
       "key": "host/note",
       "kind": {
@@ -916,6 +964,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 50,
       "key": "host/note",
       "kind": {
@@ -934,6 +983,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 51,
       "key": "host/note",
       "kind": {
@@ -952,6 +1002,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 52,
       "key": "host/note",
       "kind": {
@@ -970,6 +1021,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 53,
       "key": "host/note",
       "kind": {
@@ -988,6 +1040,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 54,
       "key": "host/note",
       "kind": {
@@ -1006,6 +1059,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 55,
       "key": "host/note",
       "kind": {
@@ -1024,6 +1078,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 56,
       "key": "host/note",
       "kind": {
@@ -1042,6 +1097,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 57,
       "key": "host/note",
       "kind": {
@@ -1060,6 +1116,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 58,
       "key": "host/note",
       "kind": {
@@ -1078,6 +1135,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 59,
       "key": "host/note",
       "kind": {
@@ -1096,6 +1154,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 60,
       "key": "host/note",
       "kind": {
@@ -1114,6 +1173,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 61,
       "key": "host/note",
       "kind": {
@@ -1132,6 +1192,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 62,
       "key": "host/note",
       "kind": {
@@ -1150,6 +1211,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 63,
       "key": "host/note",
       "kind": {
@@ -1168,6 +1230,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 64,
       "key": "host/note",
       "kind": {
@@ -1186,6 +1249,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 65,
       "key": "host/note",
       "kind": {
@@ -1204,6 +1268,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 66,
       "key": "host/note",
       "kind": {
@@ -1222,6 +1287,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 67,
       "key": "host/note",
       "kind": {
@@ -1240,6 +1306,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 68,
       "key": "host/note",
       "kind": {
@@ -1258,6 +1325,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 69,
       "key": "host/note",
       "kind": {
@@ -1276,6 +1344,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 70,
       "key": "host/note",
       "kind": {
@@ -1294,6 +1363,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 71,
       "key": "host/note",
       "kind": {
@@ -1312,6 +1382,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 72,
       "key": "host/note",
       "kind": {
@@ -1330,6 +1401,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 73,
       "key": "host/note",
       "kind": {
@@ -1348,6 +1420,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 74,
       "key": "host/note",
       "kind": {
@@ -1366,6 +1439,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 75,
       "key": "host/note",
       "kind": {
@@ -1384,6 +1458,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 76,
       "key": "host/note",
       "kind": {
@@ -1402,6 +1477,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 77,
       "key": "host/note",
       "kind": {
@@ -1420,6 +1496,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 78,
       "key": "host/note",
       "kind": {
@@ -1438,6 +1515,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 79,
       "key": "host/note",
       "kind": {
@@ -1456,6 +1534,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 80,
       "key": "host/note",
       "kind": {
@@ -1474,6 +1553,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 81,
       "key": "host/note",
       "kind": {
@@ -1492,6 +1572,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 82,
       "key": "host/note",
       "kind": {
@@ -1510,6 +1591,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 83,
       "key": "host/note",
       "kind": {
@@ -1528,6 +1610,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 84,
       "key": "host/note",
       "kind": {
@@ -1546,6 +1629,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 85,
       "key": "host/note",
       "kind": {
@@ -1564,6 +1648,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 86,
       "key": "host/note",
       "kind": {
@@ -1582,6 +1667,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 87,
       "key": "host/note",
       "kind": {
@@ -1600,6 +1686,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 88,
       "key": "host/note",
       "kind": {
@@ -1618,6 +1705,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 89,
       "key": "host/note",
       "kind": {
@@ -1636,6 +1724,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 90,
       "key": "host/note",
       "kind": {
@@ -1654,6 +1743,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 91,
       "key": "host/note",
       "kind": {
@@ -1672,6 +1762,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 92,
       "key": "host/note",
       "kind": {
@@ -1690,6 +1781,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 93,
       "key": "host/note",
       "kind": {
@@ -1708,6 +1800,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 94,
       "key": "host/note",
       "kind": {
@@ -1726,6 +1819,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 95,
       "key": "host/note",
       "kind": {
@@ -1744,6 +1838,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 96,
       "key": "host/note",
       "kind": {
@@ -1762,6 +1857,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 97,
       "key": "host/note",
       "kind": {
@@ -1780,6 +1876,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 98,
       "key": "host/note",
       "kind": {
@@ -1798,6 +1895,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 99,
       "key": "host/note",
       "kind": {
@@ -1816,6 +1914,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 100,
       "key": "host/note",
       "kind": {
@@ -1834,6 +1933,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 101,
       "key": "host/note",
       "kind": {
@@ -1852,6 +1952,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 102,
       "key": "host/note",
       "kind": {
@@ -1870,6 +1971,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 103,
       "key": "host/note",
       "kind": {
@@ -1888,6 +1990,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 104,
       "key": "host/note",
       "kind": {
@@ -1906,6 +2009,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 105,
       "key": "host/note",
       "kind": {
@@ -1924,6 +2028,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 106,
       "key": "host/note",
       "kind": {
@@ -1942,6 +2047,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 107,
       "key": "host/note",
       "kind": {
@@ -1960,6 +2066,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 108,
       "key": "host/note",
       "kind": {
@@ -1978,6 +2085,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 109,
       "key": "host/note",
       "kind": {
@@ -1996,6 +2104,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 110,
       "key": "host/note",
       "kind": {
@@ -2014,6 +2123,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 111,
       "key": "host/note",
       "kind": {
@@ -2032,6 +2142,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 112,
       "key": "host/note",
       "kind": {
@@ -2050,6 +2161,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 113,
       "key": "host/note",
       "kind": {
@@ -2068,6 +2180,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 114,
       "key": "host/note",
       "kind": {
@@ -2086,6 +2199,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 115,
       "key": "host/note",
       "kind": {
@@ -2104,6 +2218,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 116,
       "key": "host/note",
       "kind": {
@@ -2122,6 +2237,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 117,
       "key": "host/note",
       "kind": {
@@ -2140,6 +2256,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 118,
       "key": "host/note",
       "kind": {
@@ -2158,6 +2275,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 119,
       "key": "host/note",
       "kind": {
@@ -2176,6 +2294,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 120,
       "key": "host/note",
       "kind": {
@@ -2194,6 +2313,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 121,
       "key": "host/note",
       "kind": {
@@ -2212,6 +2332,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 122,
       "key": "host/note",
       "kind": {
@@ -2230,6 +2351,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 123,
       "key": "host/note",
       "kind": {
@@ -2248,6 +2370,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 124,
       "key": "host/note",
       "kind": {
@@ -2266,6 +2389,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 125,
       "key": "host/note",
       "kind": {
@@ -2284,6 +2408,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 126,
       "key": "host/note",
       "kind": {
@@ -2302,6 +2427,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 127,
       "key": "host/note",
       "kind": {
@@ -2320,6 +2446,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 128,
       "key": "host/note",
       "kind": {
@@ -2338,6 +2465,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 129,
       "key": "host/note",
       "kind": {
@@ -2356,6 +2484,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 130,
       "key": "host/note",
       "kind": {
@@ -2374,6 +2503,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 131,
       "key": "host/note",
       "kind": {
@@ -2392,6 +2522,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 132,
       "key": "host/note",
       "kind": {
@@ -2410,6 +2541,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 133,
       "key": "host/note",
       "kind": {
@@ -2428,6 +2560,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 134,
       "key": "host/note",
       "kind": {
@@ -2446,6 +2579,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 135,
       "key": "host/note",
       "kind": {
@@ -2464,6 +2598,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 136,
       "key": "host/note",
       "kind": {
@@ -2482,6 +2617,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 137,
       "key": "host/note",
       "kind": {
@@ -2500,6 +2636,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 138,
       "key": "host/note",
       "kind": {
@@ -2518,6 +2655,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 139,
       "key": "host/note",
       "kind": {
@@ -2536,6 +2674,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 140,
       "key": "host/note",
       "kind": {
@@ -2554,6 +2693,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 141,
       "key": "host/note",
       "kind": {
@@ -2572,6 +2712,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 142,
       "key": "host/note",
       "kind": {
@@ -2590,6 +2731,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 143,
       "key": "host/note",
       "kind": {
@@ -2608,6 +2750,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 144,
       "key": "host/note",
       "kind": {
@@ -2626,6 +2769,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 145,
       "key": "host/note",
       "kind": {
@@ -2644,6 +2788,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 146,
       "key": "host/note",
       "kind": {
@@ -2662,6 +2807,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 147,
       "key": "host/note",
       "kind": {
@@ -2680,6 +2826,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 148,
       "key": "host/note",
       "kind": {
@@ -2698,6 +2845,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 149,
       "key": "host/note",
       "kind": {
@@ -2716,6 +2864,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 150,
       "key": "host/note",
       "kind": {
@@ -2734,6 +2883,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 151,
       "key": "host/note",
       "kind": {
@@ -2752,6 +2902,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 152,
       "key": "host/note",
       "kind": {
@@ -2770,6 +2921,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 153,
       "key": "host/note",
       "kind": {
@@ -2788,6 +2940,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 154,
       "key": "host/note",
       "kind": {
@@ -2806,6 +2959,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 155,
       "key": "host/note",
       "kind": {
@@ -2824,6 +2978,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 156,
       "key": "host/note",
       "kind": {
@@ -2842,6 +2997,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 157,
       "key": "host/note",
       "kind": {
@@ -2860,6 +3016,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 158,
       "key": "host/note",
       "kind": {
@@ -2878,6 +3035,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 159,
       "key": "host/note",
       "kind": {
@@ -2896,6 +3054,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 160,
       "key": "host/note",
       "kind": {
@@ -2914,6 +3073,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 161,
       "key": "host/note",
       "kind": {
@@ -2932,6 +3092,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 162,
       "key": "host/note",
       "kind": {
@@ -2950,6 +3111,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 163,
       "key": "host/note",
       "kind": {
@@ -2968,6 +3130,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 164,
       "key": "host/note",
       "kind": {
@@ -2986,6 +3149,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 165,
       "key": "host/note",
       "kind": {
@@ -3004,6 +3168,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 166,
       "key": "host/note",
       "kind": {
@@ -3022,6 +3187,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 167,
       "key": "host/note",
       "kind": {
@@ -3040,6 +3206,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 168,
       "key": "host/note",
       "kind": {
@@ -3058,6 +3225,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 169,
       "key": "host/note",
       "kind": {
@@ -3076,6 +3244,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 170,
       "key": "host/note",
       "kind": {
@@ -3094,6 +3263,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 171,
       "key": "host/note",
       "kind": {
@@ -3112,6 +3282,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 172,
       "key": "host/note",
       "kind": {
@@ -3130,6 +3301,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 173,
       "key": "host/note",
       "kind": {
@@ -3148,6 +3320,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 174,
       "key": "host/note",
       "kind": {
@@ -3166,6 +3339,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 175,
       "key": "host/note",
       "kind": {
@@ -3184,6 +3358,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 176,
       "key": "host/note",
       "kind": {
@@ -3202,6 +3377,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 177,
       "key": "host/note",
       "kind": {
@@ -3220,6 +3396,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 178,
       "key": "host/note",
       "kind": {
@@ -3238,6 +3415,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 179,
       "key": "host/note",
       "kind": {
@@ -3256,6 +3434,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 180,
       "key": "host/note",
       "kind": {
@@ -3274,6 +3453,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 181,
       "key": "host/note",
       "kind": {
@@ -3292,6 +3472,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 182,
       "key": "host/note",
       "kind": {
@@ -3310,6 +3491,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 183,
       "key": "host/note",
       "kind": {
@@ -3328,6 +3510,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 184,
       "key": "host/note",
       "kind": {
@@ -3346,6 +3529,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 185,
       "key": "host/note",
       "kind": {
@@ -3364,6 +3548,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 186,
       "key": "host/note",
       "kind": {
@@ -3382,6 +3567,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 187,
       "key": "host/note",
       "kind": {
@@ -3400,6 +3586,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 188,
       "key": "host/note",
       "kind": {
@@ -3418,6 +3605,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 189,
       "key": "host/note",
       "kind": {
@@ -3436,6 +3624,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 190,
       "key": "host/note",
       "kind": {
@@ -3454,6 +3643,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 191,
       "key": "host/note",
       "kind": {
@@ -3472,6 +3662,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 192,
       "key": "host/note",
       "kind": {
@@ -3490,6 +3681,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 193,
       "key": "host/note",
       "kind": {
@@ -3508,6 +3700,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 194,
       "key": "host/note",
       "kind": {
@@ -3526,6 +3719,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 195,
       "key": "host/note",
       "kind": {
@@ -3544,6 +3738,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 196,
       "key": "host/note",
       "kind": {
@@ -3562,6 +3757,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 197,
       "key": "host/note",
       "kind": {
@@ -3580,6 +3776,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 198,
       "key": "host/note",
       "kind": {
@@ -3598,6 +3795,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 199,
       "key": "host/note",
       "kind": {
@@ -3616,6 +3814,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 200,
       "key": "host/note",
       "kind": {
@@ -3634,6 +3833,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 201,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_leftovers_five_thousand_events.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_five_thousand_events.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_leftovers_required_custom.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_required_custom.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_leftovers_required_custom.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_required_custom.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -31,6 +30,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_leftovers_required_embed.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_required_embed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -34,6 +33,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_leftovers_required_embed.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_required_embed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_leftovers_required_rerank.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_required_rerank.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -32,6 +31,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_leftovers_required_rerank.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_required_rerank.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_leftovers_unserializable_from_hook.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_unserializable_from_hook.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -33,6 +32,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_leftovers_unserializable_from_hook.effects.json
+++ b/crates/rig-verify/fixtures/mock_leftovers_unserializable_from_hook.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_memory_failing_load.effects.json
+++ b/crates/rig-verify/fixtures/mock_memory_failing_load.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 171082663332529849,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_memory_failing_load.effects.json
+++ b/crates/rig-verify/fixtures/mock_memory_failing_load.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 171082663332529849,
     "handlers": [
       {
@@ -36,6 +35,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/memory",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_oracle_prompted_unvalidated.effects.json
+++ b/crates/rig-verify/fixtures/mock_oracle_prompted_unvalidated.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 2992322369403042042,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_oracle_prompted_unvalidated.effects.json
+++ b/crates/rig-verify/fixtures/mock_oracle_prompted_unvalidated.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 2992322369403042042,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_oracle_rerank.effects.json
+++ b/crates/rig-verify/fixtures/mock_oracle_rerank.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 171082663332529849,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_oracle_rerank.effects.json
+++ b/crates/rig-verify/fixtures/mock_oracle_rerank.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 171082663332529849,
     "handlers": [
       {
@@ -35,6 +34,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "host/rerank",
       "kind": {
@@ -77,6 +77,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_outcome_invalid_call_unhandled.effects.json
+++ b/crates/rig-verify/fixtures/mock_outcome_invalid_call_unhandled.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_outcome_invalid_call_unhandled.effects.json
+++ b/crates/rig-verify/fixtures/mock_outcome_invalid_call_unhandled.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 14178699323467550126,
     "handlers": [
       {
@@ -53,6 +52,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_output_tool_missing_field_reprompt.effects.json
+++ b/crates/rig-verify/fixtures/mock_output_tool_missing_field_reprompt.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 17063702180001451641,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -123,6 +123,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/mock_output_tool_missing_field_reprompt.effects.json
+++ b/crates/rig-verify/fixtures/mock_output_tool_missing_field_reprompt.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 17063702180001451641,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_output_tool_text_reprompt.effects.json
+++ b/crates/rig-verify/fixtures/mock_output_tool_text_reprompt.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 17063702180001451641,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/mock_output_tool_text_reprompt.effects.json
+++ b/crates/rig-verify/fixtures/mock_output_tool_text_reprompt.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 17063702180001451641,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -111,6 +111,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_breadth_custom_at_outcome.effects.json
+++ b/crates/rig-verify/fixtures/openai_breadth_custom_at_outcome.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -61,6 +60,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -255,6 +255,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "host/note",
       "kind": {
@@ -273,6 +274,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_breadth_custom_at_outcome.effects.json
+++ b/crates/rig-verify/fixtures/openai_breadth_custom_at_outcome.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -231,6 +231,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_breadth_memory_two_runs.effects.json
+++ b/crates/rig-verify/fixtures/openai_breadth_memory_two_runs.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -37,6 +36,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/memory",
       "kind": {
@@ -55,6 +55,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -170,6 +171,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/memory",
       "kind": {
@@ -208,6 +210,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/memory",
       "kind": {
@@ -246,6 +249,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "golden/model:default",
       "kind": {
@@ -380,6 +384,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 6,
       "key": "golden/memory",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_breadth_memory_two_runs.effects.json
+++ b/crates/rig-verify/fixtures/openai_breadth_memory_two_runs.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/openai_breadth_output_tool_streamed.effects.json
+++ b/crates/rig-verify/fixtures/openai_breadth_output_tool_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 1030837007388641174,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/openai_breadth_output_tool_streamed.effects.json
+++ b/crates/rig-verify/fixtures/openai_breadth_output_tool_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 1030837007388641174,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_breadth_prompted_streamed.effects.json
+++ b/crates/rig-verify/fixtures/openai_breadth_prompted_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 17759422913336850263,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_breadth_prompted_streamed.effects.json
+++ b/crates/rig-verify/fixtures/openai_breadth_prompted_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 17759422913336850263,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/openai_breadth_text_delta_stop.effects.json
+++ b/crates/rig-verify/fixtures/openai_breadth_text_delta_stop.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/openai_breadth_text_delta_stop.effects.json
+++ b/crates/rig-verify/fixtures/openai_breadth_text_delta_stop.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -31,6 +30,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_breadth_tool_dispatch_cancelled.effects.json
+++ b/crates/rig-verify/fixtures/openai_breadth_tool_dispatch_cancelled.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -57,6 +56,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_breadth_tool_dispatch_cancelled.effects.json
+++ b/crates/rig-verify/fixtures/openai_breadth_tool_dispatch_cancelled.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/openai_delta_chat_baseline.effects.json
+++ b/crates/rig-verify/fixtures/openai_delta_chat_baseline.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -320,6 +320,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_delta_chat_baseline.effects.json
+++ b/crates/rig-verify/fixtures/openai_delta_chat_baseline.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 9072754608376111302,
     "handlers": [
       {
@@ -56,6 +55,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -344,6 +344,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_host_embed_prompt.effects.json
+++ b/crates/rig-verify/fixtures/openai_host_embed_prompt.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/openai_host_embed_prompt.effects.json
+++ b/crates/rig-verify/fixtures/openai_host_embed_prompt.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -37,6 +36,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "host/embed",
       "kind": {
@@ -3165,6 +3165,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_host_embed_prompt_streamed.effects.json
+++ b/crates/rig-verify/fixtures/openai_host_embed_prompt_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/openai_host_embed_prompt_streamed.effects.json
+++ b/crates/rig-verify/fixtures/openai_host_embed_prompt_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -37,6 +36,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "host/embed",
       "kind": {
@@ -3165,6 +3165,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_output_prompted_unary.effects.json
+++ b/crates/rig-verify/fixtures/openai_output_prompted_unary.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 17759422913336850263,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_output_prompted_unary.effects.json
+++ b/crates/rig-verify/fixtures/openai_output_prompted_unary.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 17759422913336850263,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/openai_output_tool_unary.effects.json
+++ b/crates/rig-verify/fixtures/openai_output_tool_unary.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 1030837007388641174,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/openai_output_tool_unary.effects.json
+++ b/crates/rig-verify/fixtures/openai_output_tool_unary.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 1030837007388641174,
     "handlers": [
       {
@@ -29,6 +28,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_retrieval_context_and_tools.effects.json
+++ b/crates/rig-verify/fixtures/openai_retrieval_context_and_tools.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 13216707040221315529,
     "handlers": [
       {
@@ -338,6 +338,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 4,
       "key": "golden/tool:subtract#1",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_retrieval_context_and_tools.effects.json
+++ b/crates/rig-verify/fixtures/openai_retrieval_context_and_tools.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 13216707040221315529,
     "handlers": [
       {
@@ -108,6 +107,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/retrieve:context#0",
       "kind": {
@@ -138,6 +138,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/retrieve:tools#0",
       "kind": {
@@ -167,6 +168,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {
@@ -362,6 +364,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "golden/retrieve:context#0",
       "kind": {
@@ -392,6 +395,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 6,
       "key": "golden/retrieve:tools#0",
       "kind": {
@@ -421,6 +425,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 7,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_retrieval_dynamic_context_one.effects.json
+++ b/crates/rig-verify/fixtures/openai_retrieval_dynamic_context_one.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -39,6 +38,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/retrieve:context#0",
       "kind": {
@@ -69,6 +69,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_retrieval_dynamic_context_one.effects.json
+++ b/crates/rig-verify/fixtures/openai_retrieval_dynamic_context_one.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/openai_retrieval_dynamic_context_one_streamed.effects.json
+++ b/crates/rig-verify/fixtures/openai_retrieval_dynamic_context_one_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {
@@ -39,6 +38,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/retrieve:context#0",
       "kind": {
@@ -69,6 +69,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_retrieval_dynamic_context_one_streamed.effects.json
+++ b/crates/rig-verify/fixtures/openai_retrieval_dynamic_context_one_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 10072942899351225430,
     "handlers": [
       {

--- a/crates/rig-verify/fixtures/openai_retrieval_retrieved_tools_one.effects.json
+++ b/crates/rig-verify/fixtures/openai_retrieval_retrieved_tools_one.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 13216707040221315529,
     "handlers": [
       {
@@ -293,6 +293,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:subtract#1",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_retrieval_retrieved_tools_one.effects.json
+++ b/crates/rig-verify/fixtures/openai_retrieval_retrieved_tools_one.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 13216707040221315529,
     "handlers": [
       {
@@ -98,6 +97,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/retrieve:tools#0",
       "kind": {
@@ -127,6 +127,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -317,6 +318,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/retrieve:tools#0",
       "kind": {
@@ -346,6 +348,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_retrieval_retrieved_tools_one_streamed.effects.json
+++ b/crates/rig-verify/fixtures/openai_retrieval_retrieved_tools_one_streamed.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 13216707040221315529,
     "handlers": [
       {
@@ -98,6 +97,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/retrieve:tools#0",
       "kind": {
@@ -127,6 +127,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 2,
       "key": "golden/model:default",
       "kind": {
@@ -424,6 +425,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 4,
       "key": "golden/retrieve:tools#0",
       "kind": {
@@ -453,6 +455,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_retrieval_retrieved_tools_one_streamed.effects.json
+++ b/crates/rig-verify/fixtures/openai_retrieval_retrieved_tools_one_streamed.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 13216707040221315529,
     "handlers": [
       {
@@ -400,6 +400,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 3,
       "key": "golden/tool:subtract#1",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_serving_two_turns_concurrency_two.effects.json
+++ b/crates/rig-verify/fixtures/openai_serving_two_turns_concurrency_two.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 13512054446980575785,
     "handlers": [
       {
@@ -83,6 +82,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -323,6 +323,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {
@@ -606,6 +607,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_serving_two_turns_concurrency_two.effects.json
+++ b/crates/rig-verify/fixtures/openai_serving_two_turns_concurrency_two.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 13512054446980575785,
     "handlers": [
       {
@@ -299,6 +299,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {
@@ -581,6 +582,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 4,
       "key": "golden/tool:subtract#1",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_streaming_with_events.effects.json
+++ b/crates/rig-verify/fixtures/openai_streaming_with_events.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 11694127286234811568,
     "handlers": [
       {
@@ -82,6 +81,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -402,6 +402,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_streaming_with_events.effects.json
+++ b/crates/rig-verify/fixtures/openai_streaming_with_events.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 11694127286234811568,
     "handlers": [
       {
@@ -378,6 +378,7 @@
       ]
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:subtract#1",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_tool_call_turns.effects.json
+++ b/crates/rig-verify/fixtures/openai_tool_call_turns.effects.json
@@ -1,6 +1,5 @@
 {
   "header": {
-    "format": 6,
     "run_spec": 13512054446980575785,
     "handlers": [
       {
@@ -83,6 +82,7 @@
   },
   "records": [
     {
+      "tool_output": null,
       "id": 1,
       "key": "golden/model:default",
       "kind": {
@@ -323,6 +323,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 3,
       "key": "golden/model:default",
       "kind": {
@@ -606,6 +607,7 @@
       }
     },
     {
+      "tool_output": null,
       "id": 5,
       "key": "golden/model:default",
       "kind": {

--- a/crates/rig-verify/fixtures/openai_tool_call_turns.effects.json
+++ b/crates/rig-verify/fixtures/openai_tool_call_turns.effects.json
@@ -1,6 +1,6 @@
 {
   "header": {
-    "format": 5,
+    "format": 6,
     "run_spec": 13512054446980575785,
     "handlers": [
       {
@@ -299,6 +299,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 2,
       "key": "golden/tool:add#0",
       "kind": {
@@ -581,6 +582,7 @@
       }
     },
     {
+      "tool_output": {},
       "id": 4,
       "key": "golden/tool:subtract#1",
       "kind": {

--- a/crates/rig-verify/tests/corpus/mod.rs
+++ b/crates/rig-verify/tests/corpus/mod.rs
@@ -2151,12 +2151,13 @@ pub fn golden(fixture: &str) -> EffectLog {
     serde_json::from_str(&text).expect("the golden fixture loads")
 }
 
-/// A record as data: its kind, its outcome and its events, if any.
+/// A record as data: its kind, outcome, published tool output and events.
 pub fn as_data(record: &EffectRecord) -> serde_json::Value {
     serde_json::json!({
         "key": record.key,
         "kind": record.kind,
         "outcome": record.outcome,
+        "tool_output": record.tool_output,
         "events": record.events,
     })
 }

--- a/crates/rig-verify/tests/corpus_checkpoint.rs
+++ b/crates/rig-verify/tests/corpus_checkpoint.rs
@@ -433,16 +433,16 @@ async fn a_one_byte_change_is_refused_by_hash_or_by_pointer() {
 fn a_checkpoint_of_another_format_is_refused_by_name() {
     let log = corpus::golden(PATCH_TOOL_ARGS.fixture);
     let (mut checkpoint, tail) = log.checkpoint(2, serde_json::json!({"run": "state"}));
-    checkpoint.format = 6;
-    let refused = EffectLog::from_checkpoint(&checkpoint, tail).expect_err("format 6");
+    checkpoint.format = 7;
+    let refused = EffectLog::from_checkpoint(&checkpoint, tail).expect_err("format 7");
     assert_eq!(
         refused.message,
-        "resume refused: the checkpoint is format 6, this rig reads format 5"
+        "resume refused: the checkpoint is format 7, this rig reads format 6"
     );
     let json = serde_json::to_string(&checkpoint).expect("serializes");
     let restored: Checkpoint<serde_json::Value> =
         serde_json::from_str(&json).expect("restores: the number is data");
-    assert_eq!(restored.format, 6);
+    assert_eq!(restored.format, 7);
 }
 
 #[test]

--- a/crates/rig-verify/tests/corpus_header.rs
+++ b/crates/rig-verify/tests/corpus_header.rs
@@ -282,25 +282,16 @@ async fn a_policy_absent_on_one_side_is_accepted() {
 }
 
 #[tokio::test]
-async fn a_log_of_another_format_is_refused_by_number() {
-    let mut log = corpus::golden(TOOLS.fixture);
-    log.header.format = 3;
-    let by_the_replayer = EffectLogReplayer::check_header(&log)
-        .expect_err("format 3")
-        .to_string();
-    assert_eq!(
-        by_the_replayer,
-        "replay refused: the log is format 3, this rig reads format 6"
-    );
-    // The agent's check reads the header first, before its own fields.
-    let by_the_agent = refusal(&TOOLS, |log| log.header.format = 3).await;
-    assert_eq!(by_the_agent, by_the_replayer);
-    // And the replayer's registration refuses before any key.
+async fn a_log_header_needs_no_global_format_number() {
+    let log = corpus::golden(TOOLS.fixture);
+    let mut json = serde_json::to_value(&log).expect("serializes");
+    assert!(json["header"].get("format").is_none());
+    json["header"]["format"] = serde_json::json!(999);
+    let log = serde_json::from_value(json).expect("legacy header field is ignored");
+    EffectLogReplayer::check_header(&log).expect("compatible structure");
     let (_dispatcher, _registrar, mut driver) = rig_agent::bus::Bus::channel();
-    let by_registration = rig_agent::bus::replay::register_all(&log, &mut driver)
-        .expect_err("format 3")
-        .to_string();
-    assert_eq!(by_registration, by_the_replayer);
+    rig_agent::bus::replay::register_all(&log, &mut driver)
+        .expect("registers without a version gate");
 }
 
 #[tokio::test]

--- a/crates/rig-verify/tests/corpus_header.rs
+++ b/crates/rig-verify/tests/corpus_header.rs
@@ -290,7 +290,7 @@ async fn a_log_of_another_format_is_refused_by_number() {
         .to_string();
     assert_eq!(
         by_the_replayer,
-        "replay refused: the log is format 3, this rig reads format 5"
+        "replay refused: the log is format 3, this rig reads format 6"
     );
     // The agent's check reads the header first, before its own fields.
     let by_the_agent = refusal(&TOOLS, |log| log.header.format = 3).await;


### PR DESCRIPTION
## Description

Corrective PR into `feat/effect-bus`, following review of #2443 at `9d129c48ae5c94d58129c7be2df63900328cb72b`. This does not target `main`, expand the ECS migration, refactor shared policy, or decide whether `rig-agent` should be replaced.

All four original findings were confirmed:

1. **Memory finalization:** restoring `Settled` could schedule a second append. Persist `MemoryAppendScheduled` with the original child operation; restore completed operations without appending again and reissue unresolved operations under their saved identity.
2. **Published tool output:** logs omitted the result context observable by subsequent policy. Record result-only metadata and restore it before replay resolves, including failures and cancellation. Preserve inbound context from the current dispatch; do not log inbound credentials or live scopes. Cover async/raw calls, ECS tasks, world-native handlers, and layered verdicts. `tool_output` is required on the wire: `null` explicitly records no publication, while an object records published values.
3. **Replay identity:** hash supported effective run settings, including invalid-call policy and overrides, and select the exact run scope. Require an explicit nonempty `PolicyVersion` declaration for custom policy; missing scoped identity/version is unverified rather than accepted through a builder-header fallback.
4. **Extension persistence:** `WorldScene` did not capture arbitrary application state. Add a small, explicit `SceneExtensions` registry for serde components on saved graph entities. Reject unknown saved registrations and invalid payloads; preserve existing graph relationships through index remapping.

Documentation changes describe only these concrete contracts beside the code and in maintained crate documentation. External design documents and broader architectural claims are not part of this PR.

At the user's request, remove `LogHeader.format` entirely: there is no global log version gate or routine header-version bump. Legacy header version fields are ignored; required data fields, identities, effect signatures and requests establish compatibility. The separate checkpoint envelope retains its existing format field, with its constant now named `CHECKPOINT_FORMAT`.

## Changelog

- *(ecs)* Fix duplicate memory finalization after scene restoration.
- *(effect-log)* **Breaking:** record and replay explicitly published tool-result metadata, requiring an explicit nullable `tool_output` field; remove the global log-header format field and version gate.
- *(ecs)* **Breaking:** check effective run policy and exact scope, with explicit custom-policy version declarations.
- *(ecs)* Add registered persistence for application components on saved run-graph entities.

## Migration

- Re-record or regenerate logs that omit `tool_output` from their producers; do not blindly insert `null`. Omission cannot establish whether published metadata was lost. The 207 committed golden logs were regenerated by their existing producers.
- Remove uses of `LogHeader.format`. `EFFECT_LOG_FORMAT` is removed; checkpoint-specific callers use `CHECKPOINT_FORMAT` instead. Header version fields in old JSON are ignored and are not written back.
- Implement the new `Recorder::tool_output` callback in custom recorders, persisting it before the dispatch's terminal outcome.
- Use `stamp_run(world, run, recorder)` and `check_replayable(world, run, log)` for effective compatibility; declare `PolicyVersion("your-policy/v1".into())` on the agent or run. `stamp_header` remains a legacy builder/corpus header.
- Install identical `SceneExtensions` registrations in both worlds, using application-owned versioned names such as `registry.register_component::<RetryBudget>("app/retry-budget/v1")?`. Bind handlers before loading and install application insertion observers afterward.

## Verification

Passed locally (with a dedicated `CARGO_TARGET_DIR`):

```sh
cargo fmt --all -- --check
git diff --check
RIG_PROVIDER_TEST_MODE=replay cargo test --locked --quiet
cargo test -p rig-ecs -p rig-effect-log -p rig-agent -p rig-core -p rig-verify --all-features --locked --quiet
cargo clippy -p rig -p rig-agent -p rig-core -p rig-ecs -p rig-effect-log -p rig-verify --all-targets --all-features --locked --quiet -- -D warnings
cargo check -p rig-core -p rig-agent -p rig-ecs -p rig-effect-log --all-features --target wasm32-unknown-unknown --locked --quiet
RUSTFLAGS='--cfg rig_loom' cargo test --locked -p rig-agent --lib --release loom_ --quiet
cargo doc --workspace --no-deps --locked --quiet
cargo xtask check-test-layout
# With wasm-bindgen-test-runner 0.2.118 and Node 24 configured as the target runner:
cargo test -p rig-agent -p rig-ecs --target wasm32-unknown-unknown --test bus_wasm --locked
cargo test -p rig-ecs --target wasm32-unknown-unknown --test run_wasm --locked
RIG_REGENERATE_GOLDEN=1 RIG_PROVIDER_TEST_MODE=replay cargo test -p rig --test core --test anthropic --test openai --test gemini --locked --quiet
```

All 7 executed WASM tests, all 10 model-checker tests, and the test-layout check passed. The documentation build passed with existing feature-gated link warnings in unchanged files (`rig-ecs/src/lib.rs`, `rig-core/src/client/mod.rs`, `rig-core/src/providers/venice/mod.rs`); the model-checker configuration also reports the existing unused `parked_senders` helper. Strict all-feature linting passed without warnings.

No provider traffic was recorded: golden regeneration used committed provider cassettes in replay mode. The five published-output regressions include success/error, task cancellation, world-native cancellation, world-native success/request mismatch, and layered replacement. Live-service tests remain ignored under the repository defaults.

## CI and GitHub review state

All 23 jobs passed for `dff74d56fba6198ada6b936beb91f3158c78e0c2` in [Lint & Test run 33926449950, attempt 2](https://github.com/0xPlaygrounds/rig/actions/runs/33926449950/attempts/2). The first attempt's only failure was a crates.io timeout downloading the `surrealdb` dependency index before the ECS WASM suite compiled; a targeted retry passed without code changes. No unresolved GitHub review threads or submitted reviews were present at final inspection. The PR remains non-draft and open against `feat/effect-bus`; neither PR has been merged.

## Independent review results

An independent reviewer inspected the full merge-base diff, all untracked regression tests, and fixture semantics. The review found one P2: world-native cancellation omitted already-inserted `ToolOutputs`. Fixed the omission and added a dedicated regression. Added nonempty layered-output coverage as recommended. Final independent review reported no remaining confirmed findings or architectural scope violations.

A separate extension-contract review identified a documentation edge around repeated deserialization. Documented pure deterministic serde requirements and the possibility of partial load on extension insertion failure.

The same independent reviewer re-reviewed the complete header-removal revision and combined diff with no confirmed findings. Fixture comparison verified exactly 207 removed header fields and 634 added explicit nulls relative to the initial corrective revision, with the 95 existing empty published-output maps retained and no unrelated changes.

## Remaining boundaries

- Stable append identity does not make external writes exactly once. A crash after an external write and before persisting its outcome still requires backend idempotency (properly namespaced) or reconciliation. `Settled` is not proof that memory committed.
- Published result metadata is durable application data. Handlers must publish before resolving and must not place secrets/live capabilities in result values. Explicit scenes may contain inbound context and must be protected by the host.
- A policy version is an application declaration, not an automatic code fingerprint or verification of ambient inputs/external state.
- Extension registration covers components on the saved graph, not arbitrary entities, resources, custom effect components, embedded entity references, system-local state or live tasks. Loading is not transactional across graph/extension insertion failures or application observers.
- Runtime replacement, unrestricted forking, and broader continuation architecture remain separate decisions. Neither this PR nor #2443 is to be merged by this task.
