### PR TITLE
fix(moonshot): update Kimi model to k2.6

### DIFF
--- a/crates/rig-core/src/providers/moonshot.rs
+++ b/crates/rig-core/src/providers/moonshot.rs
@@ -7,7 +7,7 @@
 //!
 //! let client = moonshot::Client::new("YOUR_API_KEY").expect("Failed to build client");
 //!
-//! let kimi_model = client.completion_model(moonshot::KIMI_K2_5);
+//! let kimi_model = client.completion_model(moonshot::KIMI_K2_6);
 //! ```
 //!
 //! # Custom base URL
@@ -122,11 +122,16 @@ const ANTHROPIC_BASE_URLS: AnthropicBaseUrl = AnthropicBaseUrl::new(
 /// Moonshot v1 128K context model (legacy)
 pub const MOONSHOT_CHAT: &str = "moonshot-v1-128k";
 
-/// Kimi K2 — Mixture-of-Experts model (1T total params, 32B active)
+/// Kimi K2 — Mixture-of-Experts model (1T total params, 32B active).
+/// Discontinued 2026-05-25; the Moonshot API answers 404 for the K2 series.
 pub const KIMI_K2: &str = "kimi-k2";
 
-/// Kimi K2.5 — Native multimodal agentic model with 256K context
+/// Kimi K2.5 — Native multimodal agentic model with 256K context.
+/// Discontinued 2026-08-31; use [`KIMI_K2_6`] instead.
 pub const KIMI_K2_5: &str = "kimi-k2.5";
+
+/// Kimi K2.6 — Multimodal thinking/non-thinking agentic model with 256K context
+pub const KIMI_K2_6: &str = "kimi-k2.6";
 
 /// Moonshot completion model, driven by the shared OpenAI Chat Completions path.
 pub type CompletionModel<H = crate::http_client::BoxedHttpClient> =

--- a/tests/providers/moonshot/anthropic.rs
+++ b/tests/providers/moonshot/anthropic.rs
@@ -10,7 +10,7 @@ use crate::support::{BASIC_PREAMBLE, BASIC_PROMPT, assert_nonempty_response};
 async fn anthropic_compatible_completion_smoke() {
     let response = moonshot::AnthropicClient::from_env()
         .expect("moonshot anthropic client should build")
-        .agent(moonshot::KIMI_K2_5)
+        .agent(moonshot::KIMI_K2_6)
         .preamble(BASIC_PREAMBLE)
         .build()
         .prompt(BASIC_PROMPT)

--- a/tests/providers/moonshot/reasoning_history.rs
+++ b/tests/providers/moonshot/reasoning_history.rs
@@ -21,7 +21,7 @@ fn response_text(choice: &[AssistantContent]) -> String {
 async fn assistant_reasoning_content_roundtrips_in_history() {
     let model = moonshot::Client::from_env()
         .expect("moonshot client should build")
-        .completion_model(moonshot::KIMI_K2_5);
+        .completion_model(moonshot::KIMI_K2_6);
     let assistant = Message::Assistant {
         id: None,
         content: vec![

--- a/tests/providers/moonshot/tools.rs
+++ b/tests/providers/moonshot/tools.rs
@@ -13,7 +13,7 @@ use crate::support::{
 async fn required_tool_choice_agent_roundtrip() {
     let agent = moonshot::Client::from_env()
         .expect("moonshot client should build")
-        .agent(moonshot::KIMI_K2_5)
+        .agent(moonshot::KIMI_K2_6)
         .preamble(TOOLS_PREAMBLE)
         .tool_choice(ToolChoice::Required)
         .tool(Adder)


### PR DESCRIPTION
## Summary

Updates the Moonshot provider to use the current Kimi K2.6 model instead of Kimi K2.5 in examples and provider smoke tests.

The existing `KIMI_K2` and `KIMI_K2_5` constants remain exported to avoid breaking downstream users.

## Changes

- add `KIMI_K2_6` with model ID `kimi-k2.6`;
- update the Moonshot module example to use `KIMI_K2_6`;
- update Moonshot smoke tests to use `KIMI_K2_6`;
- document that the older K2 and K2.5 model IDs are discontinued.

Results:

- Moonshot unit tests pass;
- Moonshot integration tests compile successfully and remain ignored because they require `MOONSHOT_API_KEY`;
- clippy passes;
- formatting check passes.

## Notes

I could not run the credential-gated Moonshot integration tests because I do not have a `MOONSHOT_API_KEY`.

The change therefore updates the model ID based on Moonshot's current model documentation while preserving the existing provider API.

Related - #2465 