### PR TITLE
Reduce provider build dependencies and unify verification

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,8 @@
+# Preserve CI retries for ordinary tests while running drift tripwires once.
+# Do not pass --retries to the guards run: it overrides per-test settings.
+[profile.guards]
+retries = 2
+
+[[profile.guards.overrides]]
+filter = 'test(telemetry::) + test(span_safety_net::)'
+retries = 0

--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -34,10 +34,11 @@ inputs:
     default: "true"
   cache-save-if:
     description: >-
-      Additional rust-cache save gate. Cache writes are always restricted to
-      the default branch so pull-request merge refs can restore but cannot
-      evict the reusable caches they consume.
+      Additional rust-cache save gate. Only trusted upstream pushes can save.
     default: "true"
+  cache-development:
+    description: Allow the bounded development-base warming job to save caches
+    default: "false"
   sccache:
     description: >-
       Enable sccache with the GitHub Actions cache backend. Reserved for the
@@ -91,7 +92,7 @@ runs:
         components: ${{ inputs.components }}
         target: ${{ inputs.target }}
         cache: ${{ inputs.cache }}
-        cache-save-if: ${{ inputs.cache-save-if == 'true' && github.ref == 'refs/heads/main' }}
+        cache-save-if: ${{ inputs.cache-save-if == 'true' && github.repository == '0xPlaygrounds/rig' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || (inputs.cache-development == 'true' && github.ref == 'refs/heads/feat/effect-bus')) }}
 
     # rust-cache (inside setup-rust-toolchain above) persists *dependency*
     # artifacts but always recompiles the workspace's own crates; sccache
@@ -133,6 +134,8 @@ runs:
     - name: Enable sccache as the rustc wrapper
       if: inputs.sccache == 'true'
       shell: bash
+      env:
+        CACHE_WRITE_ALLOWED: ${{ github.repository == '0xPlaygrounds/rig' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || (inputs.cache-development == 'true' && github.ref == 'refs/heads/feat/effect-bus')) }}
       run: |
         if [ "${{ steps.sccache.outcome }}" != "success" ]; then
           echo "::warning::sccache install failed; building without it"
@@ -141,7 +144,7 @@ runs:
         {
           echo "SCCACHE_GHA_ENABLED=true"
           echo "RUSTC_WRAPPER=sccache"
-          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+          if [ "$CACHE_WRITE_ALLOWED" != "true" ]; then
             # PR caches are scoped to their merge ref and cannot warm other
             # branches. Read the default branch's entries without creating
             # thousands of short-lived, quota-consuming PR entries.
@@ -164,4 +167,3 @@ runs:
       if: inputs.protoc == 'true'
       shell: bash
       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-

--- a/.github/workflows/cache-warm.yaml
+++ b/.github/workflows/cache-warm.yaml
@@ -1,0 +1,31 @@
+name: Development cache warm
+
+on:
+  push:
+    branches: [feat/effect-bus]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cache-warm-effect-bus
+  cancel-in-progress: true
+
+jobs:
+  # One configuration and one base branch, not every matrix leg. PR merge
+  # refs can restore their base's cache but cannot warm other PRs themselves.
+  # Match ci.yaml's test job ID and setup so rust-cache keys stay compatible.
+  test:
+    if: github.repository == '0xPlaygrounds/rig' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - run: bash .github/scripts/setup-consumer-sandbox.sh
+      - uses: ./.github/actions/rust-setup
+        with:
+          nextest: "true"
+          protoc: "true"
+          components: rustfmt
+          sccache: "true"
+          cache-development: "true"
+      - run: cargo xtask verify --check default-tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,19 +143,7 @@ jobs:
           target: wasm32-unknown-unknown
 
       - name: Run cargo check wasm target
-        run: cargo check --package ${{ matrix.package }} --target wasm32-unknown-unknown
-
-      - name: Check ECS without replay
-        if: matrix.package == 'rig-ecs'
-        run: |
-          cargo check -p rig-ecs --no-default-features --lib
-          cargo check -p rig-ecs --no-default-features --lib --target wasm32-unknown-unknown
-
-      # rig-core's features and rig-ecs's `reflect` and `assets` are off by
-      # default; the wasm build of each is proven here, not only natively.
-      - name: Run all-features wasm check
-        if: matrix.package == 'rig-core' || matrix.package == 'rig-ecs'
-        run: cargo check --package ${{ matrix.package }} --all-features --target wasm32-unknown-unknown
+        run: cargo xtask verify --check wasm-${{ matrix.package }}
 
   # The *executed* wasm tests in the tree: rig-agent's `tests/bus_wasm.rs`
   # and rig-ecs's `tests/{bus_wasm,run_wasm}.rs`, run under
@@ -203,7 +191,7 @@ jobs:
       - name: Run the wasm suite
         env:
           CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner
-        run: cargo test --locked --package ${{ matrix.package }} --target wasm32-unknown-unknown --test ${{ matrix.test }}
+        run: cargo xtask verify --check wasm-${{ matrix.package }}-${{ matrix.test }}
 
   # `rig-rmcp` is native-only: rmcp's `ClientHandler` requires `Send + Sync`
   # unconditionally, which rig's wasm tool registry cannot satisfy. Building it
@@ -334,10 +322,8 @@ jobs:
           components: clippy
           protoc: "true"
 
-      - name: Run clippy action
-        uses: clechasseur/rs-clippy-check@v3
-        with:
-          args: --all-features --all-targets
+      - name: Run Clippy
+        run: cargo xtask verify --check clippy
 
   # The PR gate's test sweep. The full `--all-features` run (companion vector
   # stores, Docker-backed integration tests, the nested-`cargo check` facade
@@ -364,8 +350,8 @@ jobs:
       - name: Prepare repository-repair process isolation
         run: bash .github/scripts/setup-consumer-sandbox.sh
 
-      # The raw lancedb dependency used by the facade's integration tests is
-      # feature-gated with those tests. Neither graph below enables it, so a
+      # The raw database drivers live in the service-test runner, gated with
+      # their suites. Neither graph below enables those features, so a
       # cold PR run avoids the Lance/Arrow/DataFusion graph and needs no
       # system protoc. The all-features jobs retain both.
       - name: Install Rust stable
@@ -393,7 +379,7 @@ jobs:
       # `cfg(not(feature = …))` in test code, so a break that appears only
       # with features *removed* has no known mechanism.
       - name: Check default-feature root test targets
-        run: cargo check --locked -p rig --tests
+        run: cargo xtask verify --check default-check
 
       # The workspace sweep over the default members' default features, plus
       # the facade's `bedrock` feature. `bedrock` rides along because the
@@ -421,14 +407,10 @@ jobs:
       # cold test execution spend minutes recompiling a scratch project after
       # the other ~3,600 tests had nearly finished.
       - name: Test with latest nextest release
-        run: >-
-          cargo nextest run --locked --features bedrock --retries 2
-          -E 'not binary(macro_hygiene)'
+        run: cargo xtask verify --check default-tests
 
       - name: Check ECS scenario registrations
-        run: |
-          cargo nextest list --locked -p rig --features bedrock --message-format json > "$RUNNER_TEMP/ecs-tests.json"
-          cargo xtask check-ecs-scenarios "$RUNNER_TEMP/ecs-tests.json"
+        run: cargo xtask verify --check scenario-registrations
 
       - name: Show sccache statistics
         if: always() && env.RUSTC_WRAPPER == 'sccache'
@@ -459,7 +441,7 @@ jobs:
         uses: ./.github/actions/rust-setup
 
       - name: Run the loom models
-        run: cargo test --locked -p rig-agent --lib --release loom_
+        run: cargo xtask verify --check loom
 
   test-guards:
     name: stable / test guards
@@ -483,12 +465,8 @@ jobs:
       # ran these on every PR; that sweep now lives in nightly.yaml, and this
       # step keeps the feature-gated tests (the rmcp tool registry, the
       # pdf/epub loaders, audio generation, …) from silently demoting to
-      # nightly-only coverage. It reuses the compile artifacts of the
-      # telemetry step below (same packages, same `--all-features`), so the
-      # cost is execution time only. The telemetry:: tests also run here with
-      # retries — harmless duplication: their no-retries discipline is
-      # enforced by the dedicated step below, exactly as it was when the
-      # workspace sweep ran them with `--retries 2` alongside it.
+      # nightly-only coverage. The guards profile applies zero retries to
+      # telemetry and span-safety contracts within this same execution.
       #
       # All test targets except macro_hygiene, NOT `--lib`: `--lib` here
       # would demote the non-lib targets — rig-agent's
@@ -498,9 +476,7 @@ jobs:
       # macro_hygiene also shells out to Cargo, but its dedicated step below
       # is the authoritative plain-`cargo test` execution.
       - name: Test rig-core and rig-agent with all features
-        run: >-
-          cargo nextest run --locked -p rig-core -p rig-reqwest -p rig-tungstenite -p rig-agent -p rig-rmcp --all-features
-          --retries 2 -E 'not binary(macro_hygiene)'
+        run: cargo xtask verify --check core-all
 
       # The bus's behavioural verification suite (`crates/rig-verify`,
       # unpublished): properties over the public API — record and replay,
@@ -508,38 +484,16 @@ jobs:
       # runs under `--all-features` and without retries; it is also in the
       # workspace's default members for the default-feature sweep.
       - name: Test the bus's verification suite
-        run: cargo nextest run --locked -p rig-verify --all-features
+        run: cargo xtask verify --check bus-verification
 
-      # `cargo nextest run` (in the `test` job) selects the workspace's
-      # *default members* — historically just the `rig` facade, which is why a
-      # `crates/*` unit test executed in CI only when its package was named
-      # explicitly; `default-members` now lists the core crates, but that
-      # sweep compiles them with *default* features and `--retries 2`. This
-      # step re-runs the `telemetry::` and `span_safety_net::` tests under
-      # `--all-features` and without retries. They are the drift tripwires
-      # for the marker and the required `gen_ai.*` field set: unrun, the
-      # three forms of the contract can silently desync, which is the exact
-      # failure the `completion_parent_span!` macro exists to prevent.
-      #
-      # The sweep above already *executes* these tests (same packages, same
-      # `--all-features`, so this step reuses its compile artifacts and costs
-      # execution time only) — but it runs them with `--retries 2`, and a
-      # drift tripwire that passes on the second attempt conceals exactly the
-      # nondeterminism it exists to catch. The dedicated no-retries run is
-      # the point of this step, not redundancy.
-      #
-      # No `--retries`, deliberately: these are static-metadata assertions
-      # (set equality against a `const`, field counts, callsite dedup), so a
-      # pass on the second attempt would be concealing nondeterminism rather
-      # than tolerating a flaky network.
-      - name: Test telemetry completion-parent contract
-        run: cargo nextest run --locked -p rig-core -p rig-agent --all-features -E 'test(telemetry::) + test(span_safety_net::)'
+      # The guards profile applies zero retries to telemetry/span contracts
+      # within core-all, so no second execution is needed.
 
       # This compiles a standalone downstream consumer that renames rig-core
       # and has no direct tracing dependency. Keep it outside the workspace so
       # release tooling cannot discover it as a publishable package.
       - name: Test telemetry macro hygiene
-        run: cargo test --locked -p rig-core --test macro_hygiene
+        run: cargo xtask verify --check macro-hygiene
 
       # Same default-members problem as the telemetry step above, with two
       # distinct casualties:
@@ -571,7 +525,7 @@ jobs:
       # the second attempt would conceal nondeterminism rather than tolerate a
       # flaky network.
       - name: Test out-of-facade streaming conformance and structural guards
-        run: cargo nextest run --locked -p rig-core -p rig-tungstenite -p rig-candle -p rig-gemini-grpc --all-features -E 'binary(streaming_conformance) + binary(streaming_conformance_websocket) + binary(driver_adoption)'
+        run: cargo xtask verify --check conformance
 
       - name: Show sccache statistics
         if: always() && env.RUSTC_WRAPPER == 'sccache'
@@ -613,7 +567,7 @@ jobs:
         uses: ./.github/actions/rust-setup
 
       - name: Test rig-derive
-        run: cargo test --locked -p rig-derive
+        run: cargo xtask verify --check derive
 
   # `cargo nextest` (used by the `test` job) does NOT run doctests, and the
   # `doc` job only builds documentation — so without this job nothing executes
@@ -638,7 +592,7 @@ jobs:
       # provider examples are all `no_run`/compile-only), so this job stays
       # hermetic and non-flaky.
       - name: Run doctests
-        run: cargo test --locked --doc --workspace --all-features
+        run: cargo xtask verify --check doctests
 
   doc:
     name: stable / doc
@@ -656,6 +610,6 @@ jobs:
           protoc: "true"
 
       - name: Run cargo doc
-        run: cargo doc --locked --no-deps --all-features
+        run: cargo xtask verify --check docs
         env:
           RUSTDOCFLAGS: -D warnings

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -56,6 +56,9 @@ on:
       - "crates/rig-sqlite/**"
       - "crates/rig-vectorize/**"
       - "tests/integrations/**"
+      - "test-support/**"
+      - "xtask/**"
+      - ".config/**"
       - "tests/integrations.rs"
       # The facade feature-forwarding guard is the one test whose failure
       # class (a facade feature forgetting a sub-feature, invisible to any
@@ -162,7 +165,7 @@ jobs:
       # A plain `run:` rather than `actions-rs/cargo@v1`: that action was
       # archived in 2023 and pins Node 20.
       - name: Test with all features
-        run: cargo nextest run --locked --all-features --retries 2
+        run: cargo xtask verify --check full-tests
 
   # The declared dependency requirements are floors, not pins (`tokio = "1"`
   # is `^1`), and a downstream resolves anywhere inside them — usually to
@@ -192,4 +195,4 @@ jobs:
           protoc: "true"
 
       - name: Build against the declared dependency floors
-        run: python3 scripts/check-dependency-floors.py
+        run: cargo xtask verify --check dependency-floors

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ agents must follow while reading, editing, testing, and documenting code.
 - Provider test modules: `tests/providers/<provider>/`
 - Provider cassette fixtures: `tests/cassettes/<provider>/`
 - External-service integration tests: `tests/integrations/`
+- Unpublished vector-store test runner: `test-support/service-tests`
 
 The root `rig` crate re-exports `rig-core` and exposes companion crates behind
 feature flags. Check `Cargo.toml` and `src/lib.rs` before documenting or changing
@@ -250,22 +251,6 @@ presenting changes.
 
 ## Verification
 
-Run the smallest useful checks first, then broaden as needed. For tests, prefer
-the targeted commands in `tests/README.md` before running broad workspace checks.
+Use `cargo xtask verify --changed` for the edit/check loop and `--dry-run` to inspect selection. Do not repeat broad workspace checks after every small edit when targeted checks suffice. For a complete intended PR diff, run `cargo xtask verify --pr --base <intended-base-ref>`; never silently assume main. `cargo xtask verify --full` runs exhaustive supported verification. See [DEVELOPING.md](DEVELOPING.md) for prerequisites, invalidation, and the complete PR gate.
 
-Before considering code complete, run when feasible:
-
-```bash
-cargo fmt
-cargo clippy --all-targets --all-features
-cargo test
-```
-
-For documentation changes, also consider:
-
-```bash
-cargo doc --workspace --no-deps
-```
-
-If a command cannot be run, say why and tell the user exactly what remains
-unverified.
+Before publishing, inspect the full diff including working changes, complete required verification, and obtain independent review. Validate findings, fix confirmed P0/P1 and in-scope issues, then rerun affected checks and review. After publishing, inspect committed-head required CI and actionable review threads. Do not declare completion while checks are pending/failing or required work remains. Report exact unrelated failures or missing prerequisites without broadening scope. These requirements do not independently authorize commits, pushes, or PR creation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to Rig
 
+For the fast edit/check loop, run `cargo xtask verify --changed`. Before publishing, run `cargo xtask verify --pr --base <intended-base-ref>` and complete independent review and committed-head CI. See [development verification](DEVELOPING.md) for modes, prerequisites, result invalidation, and measurements.
+
 Thank you for considering contributing to Rig! Here are some guidelines to help you get started.
 
 General guidelines and requested contributions can be found in the [How to Contribute](https://docs.rig.rs/docs/how_to_contribute) section of the documentation.
@@ -111,7 +113,8 @@ Rig is split up into multiple crates in a monorepo structure:
 - `crates/rig-derive`: derive macros.
 - `crates/rig-*`: first-party provider, vector-store, memory, and companion integration crates.
 - `examples/*`: workspace example packages.
-- `xtask/`: workspace maintenance tasks, run as `cargo xtask <task>`. This is where source-tree checks that need a real parser rather than a grep live. Today: `cargo xtask check-test-layout`, which fails on any inline `#[cfg(test)] mod x { }` (test modules are sibling files). Not a default workspace member, so it is not built by `cargo test`.
+- `xtask/`: authoritative verification planning and source-tree checks. Run `cargo xtask verify --changed`; see `DEVELOPING.md` for the complete workflow. Its own tests run explicitly in CI.
+- `test-support/service-tests`: unpublished runner for vector-store integrations, separated from provider build dependencies.
 - `tests/*.rs`: root integration test targets.
 - `tests/providers/<provider>/`: provider-specific test modules.
 - `tests/cassettes/<provider>/`: committed HTTP cassette fixtures for replayable provider tests.
@@ -163,8 +166,8 @@ cargo test -p rig --test core
 External-service integration tests are collected under the `integrations` target and may require feature flags, Docker, credentials, or pre-provisioned services. For example:
 
 ```bash
-cargo test -p rig --features qdrant --test integrations qdrant -- --nocapture
-cargo test -p rig --all-features --test integrations
+cargo test -p rig-service-tests --features qdrant --test integrations qdrant -- --nocapture
+cargo test -p rig-service-tests --all-features --test integrations
 ```
 
 ### Cassette regression tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10361,7 +10361,6 @@ name = "rig"
 version = "0.42.0"
 dependencies = [
  "anyhow",
- "arrow-array",
  "assert_fs",
  "async-stream",
  "aws-config",
@@ -10377,14 +10376,9 @@ dependencies = [
  "futures",
  "httpmock",
  "hyper-util",
- "lancedb",
- "mongodb",
- "neo4rs",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "qdrant-client",
- "redis",
  "reqwest 0.13.4",
  "reqwest-middleware",
  "reqwest-retry",
@@ -10415,20 +10409,15 @@ dependencies = [
  "rig-vectorize",
  "rig-vertexai",
  "rmcp",
- "rusqlite",
  "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_path_to_error",
  "serde_yaml",
  "sha2 0.10.9",
- "sqlite-vec",
- "sqlx",
  "syn 2.0.117",
- "testcontainers",
  "thiserror 2.0.18",
  "tokio",
- "tokio-rusqlite",
  "tokio-test",
  "tracing",
  "tracing-opentelemetry",
@@ -10850,6 +10839,29 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "rig-service-tests"
+version = "0.42.0"
+dependencies = [
+ "arrow-array",
+ "assert_fs",
+ "futures",
+ "httpmock",
+ "lancedb",
+ "mongodb",
+ "neo4rs",
+ "qdrant-client",
+ "rig",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sqlite-vec",
+ "sqlx",
+ "testcontainers",
+ "tokio",
+ "tokio-rusqlite",
 ]
 
 [[package]]
@@ -15027,6 +15039,7 @@ version = "0.42.0"
 dependencies = [
  "proc-macro2",
  "serde_json",
+ "sha2 0.10.9",
  "syn 2.0.117",
  "thiserror 2.0.18",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "crates/*",
     "examples/*",
     "xtask",
+    "test-support/service-tests",
 ]
 # The root manifest is itself the `rig` facade package, so without an
 # explicit `default-members` a bare `cargo nextest run` resolved to the
@@ -68,6 +69,7 @@ default-members = [
     "crates/rig-candle",
     "crates/rig-gemini-grpc",
     "crates/rig-verify",
+    "test-support/service-tests",
 ]
 exclude = [
     "archived",
@@ -276,7 +278,6 @@ rig-fastembed = { path = "crates/rig-fastembed", version = "0.42.0", optional = 
 rig-gemini-grpc = { path = "crates/rig-gemini-grpc", version = "0.42.0", optional = true, default-features = false }
 rig-helixdb = { path = "crates/rig-helixdb", version = "0.42.0", optional = true, default-features = false }
 rig-lancedb = { path = "crates/rig-lancedb", version = "0.42.0", optional = true, default-features = false }
-lancedb = { workspace = true, optional = true }
 rig-memory = { path = "crates/rig-memory", version = "0.42.0", optional = true, default-features = false }
 rig-derive = { path = "crates/rig-derive", version = "0.42.0", optional = true }
 rig-milvus = { path = "crates/rig-milvus", version = "0.42.0", optional = true, default-features = false }
@@ -313,7 +314,6 @@ rig-ecs = { path = "crates/rig-ecs" }
 bevy_app = { workspace = true }
 bevy_ecs = { workspace = true }
 anyhow = { workspace = true }
-arrow-array = { workspace = true }
 assert_fs = { workspace = true }
 async-stream = { workspace = true }
 aws-config = { workspace = true }
@@ -330,15 +330,11 @@ rig-agent = { path = "crates/rig-agent", version = "0.42.0", default-features = 
 tokio = { workspace = true, features = ["full"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tokio-test = { workspace = true }
-redis = { workspace = true, features = ["tokio-comp", "aio", "vector-sets"] }
 serde_path_to_error = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 httpmock = { workspace = true, features = ["record", "proxy"] }
-mongodb = { workspace = true }
-neo4rs = { workspace = true }
-qdrant-client = { workspace = true }
 reqwest-retry = { workspace = true }
 reqwest = { workspace = true, features = ["json", "stream"] }
 reqwest-middleware = { workspace = true, features = [
@@ -354,15 +350,12 @@ sha2 = { workspace = true }
 # float_roundtrip keeps cassette scrubbing idempotent on float-heavy bodies
 # (e.g. embedding vectors): without it, parse→print can oscillate between two
 # representations of the same decimal and the recorded YAML never stabilizes.
-serde_json = { workspace = true, features = ["float_roundtrip"] }
+# Golden logs preserve JSON object insertion order. Declare that requirement
+# directly instead of inheriting it from a database driver's feature graph.
+serde_json = { workspace = true, features = ["float_roundtrip", "preserve_order"] }
 serde_yaml = { workspace = true }
 syn = { workspace = true, features = ["full", "visit"] }
-rusqlite = { workspace = true, features = ["bundled"] }
-sqlite-vec = { workspace = true }
-sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "uuid", "json"] }
-testcontainers = { workspace = true }
 thiserror = { workspace = true }
-tokio-rusqlite = { workspace = true, features = ["bundled"] }
 hyper-util = { workspace = true, features = ["service", "server"] }
 rmcp = { workspace = true, features = [
   "client",
@@ -381,7 +374,6 @@ opentelemetry-otlp = { workspace = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 url = { workspace = true }
-
 [features]
 default = ["rig-core/default", "reqwest", "agent", "derive", "rustls"]
 agent = ["dep:rig-agent"]
@@ -401,7 +393,7 @@ fastembed-hf-hub = ["dep:rig-fastembed", "rig-fastembed/hf-hub"]
 fastembed-ort-download-binaries = ["dep:rig-fastembed", "rig-fastembed/ort-download-binaries"]
 gemini-grpc = ["dep:rig-gemini-grpc"]
 helixdb = ["dep:rig-helixdb"]
-lancedb = ["dep:rig-lancedb", "dep:lancedb"]
+lancedb = ["dep:rig-lancedb"]
 memory = ["dep:rig-memory"]
 milvus = ["dep:rig-milvus"]
 mongodb = ["dep:rig-mongodb"]

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -126,14 +126,16 @@ profile with normal local debuginfo/incremental settings and default features:
 | --- | ---: | ---: | --- |
 | Cold narrow provider type-check | 44.13s | 27.05s | `cargo check --locked -p rig --test anthropic --timings` |
 | Warm no-op check | 0.435s | 0.355s | `cargo check --locked -p rig --test anthropic` |
-| Warm ECS source edit | 0.856s | 0.836s | `cargo check --locked -p rig-ecs --all-features --lib` |
+| Warm ECS implementation edit | 0.933s | 0.950s | `cargo check --locked -p rig-ecs --all-features --lib` |
 | Warm single cassette replay | 1.012s | 0.922s | Command below |
 | Warm fixture-only edit | 0.984s | 0.900s | Same replay command |
-| Warm example source edit | 0.397s | 0.398s | `cargo check --locked -p agent_no_tokio` |
+| Warm example implementation edit | 0.382s | 0.381s | `cargo check --locked -p agent_no_tokio` |
 | Warm Rust documentation edit | 2.279s | 2.217s | `cargo doc --locked -p rig-ecs --all-features --no-deps` |
 
-The baseline is the tree merged as `de065e9be`; its source checkout is
-`45216c03e`. The candidate includes the service-test dependency split. Both
+The baseline is `de065e9be`, the same source tree as `45216c03e`. Body-edit
+and planner measurements use candidate `6aafd32ef`. The cold and other warm
+measurements used the preceding working candidate with the same narrow-provider
+dependency split, before temporary-store and Git-fixture cleanup. Both cold
 measurements used initially empty dedicated target directories, serially, on
 the same machine with the registry already available. This measures compilation,
 not registry downloads, provider latency, or CI cache restoration. It is one
@@ -142,12 +144,34 @@ sample (about 39% lower wall time), not a universal speedup guarantee.
 Warm values are medians of three runs on an Apple M2 Max with 64 GiB RAM,
 nextest 0.9.67. Each checkout started with an empty target directory and ran
 the same configuration warmups before measurement. No measured run reported
-a Cargo lock wait. Source edits added a comment; the documentation edit added
-a crate-doc line; the fixture edit added a harmless response header to the
-consumed cassette. Each edit was restored afterward. The example difference
-is a small regression within normal timing noise; the ECS/docs differences
-do not establish a meaningful speedup. These direct Cargo measurements isolate
+a Cargo lock wait. The ECS implementation edit changed `WorldOutcome::order`
+to a saturating increment; the example changed its frame duration from 16 to
+17 milliseconds. These were compile-only edits, restored byte-for-byte after
+each trial. The documentation edit added a crate-doc line; the fixture edit
+added a harmless response header to the consumed cassette. The ECS result is
+a small regression in this sample; the example/docs differences do not establish
+a meaningful speedup. These direct Cargo measurements isolate
 the dependency boundary and are not timings of the complete planner checks.
+
+The actual planner, using the existing local validation target at `6aafd32ef`,
+took a median **0.274s** for a clean `cargo xtask verify --changed` (three runs).
+The example implementation edit selected formatting, the example test harness,
+and consumer compilation: its first execution took **32.301s**, then three
+identical invocations reused all three checks in a median **1.843s**. The first
+execution included compilation with the existing cache; it is not a comparable
+cold-build sample or evidence that a changed input may reuse stale success.
+The tests separately exercise fixture/configuration/command invalidation.
+
+Local validation passed formatting, source guards, 38 tooling tests and strict
+Clippy, 7,941 default tests (203 skipped), 8,306 all-feature workspace tests
+(213 skipped), core/bus/conformance/derive/macro-hygiene checks, documentation,
+loom, all-target workspace compilation, eight WASM compilation configurations,
+all three executed WASM suites, and both expected native-only diagnostics.
+The final full suite ran in 653.588s with no failures or retries. Dependency-floor
+validation passed with 52 downgrades, 24 already at floor, and 44 floors constrained
+by transitives and checked at the lowest admitted versions. Node was v24.10.0;
+the executed WASM suites used an isolated wasm-bindgen runner 0.2.118 matching
+the lockfile. Required committed-head CI remains a separate PR gate.
 
 The single-test replay command (native default features plus bedrock) was:
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,170 @@
+# Development verification
+
+Use the Rust planner in `xtask` for the ordinary edit/check loop:
+
+```sh
+cargo xtask verify --changed
+cargo xtask verify --changed --dry-run
+cargo xtask verify --pr --base origin/feat/effect-bus
+cargo xtask verify --full
+```
+
+`--changed` selects checks for staged, unstaged and untracked working changes.
+With `--base REF`, it additionally includes the complete diff from that ref's
+merge base. Without it, the comparison is explicitly to `HEAD`, not to `main`.
+Provider edits and cassette-only edits run the complete provider target,
+with all facade features, including audio/image/websocket tests and safety
+assertions. This uses the existing all-feature configuration rather than
+maintaining a second list of provider feature gates. Package edits run package tests and compile
+Cargo's reverse dependencies, including examples; dependent tests and the
+complete feature/platform matrix belong to PR/full validation. Shared support,
+manifests, dependencies, verification tooling, and unknown inputs broaden the
+plan conservatively. Read the printed selection and skip reasons.
+
+`--pr` requires an explicit intended base and includes every existing fast CI
+check. Changes affecting the full lane also select full verification. It is the
+local execution part of preparing a PR, not the independent review or remote CI
+gate. `--full` executes supported workspace tests, all example/consumer targets,
+feature combinations, documentation, dependency-floor checks, concurrency
+models, and the native/WASM matrix. Ignored tests, including live-provider,
+model, and service tests, remain opt-in; neither mode records cassettes or
+regenerates goldens.
+
+Full validation needs the repository toolchain, nextest, Clippy, rustfmt,
+protoc, Docker for service integrations, Node, and wasm-bindgen-test-runner
+matching the lockfile. The existing dependency-floor script also needs Python.
+CI installs its required tools through `.github/actions/rust-setup`. A missing
+prerequisite is a failed/incomplete check, never successful verification.
+
+## Narrow manual checks
+
+```sh
+cargo nextest run --locked -p rig --features bedrock --test anthropic --retries 0
+cargo test --locked -p rig-ecs --all-features
+cargo test --locked -p rig-service-tests --features sqlite --test integrations
+cargo xtask verify --check core-all
+```
+
+The eight vector-store suites still live under `tests/integrations/`, but their
+unpublished runner is `rig-service-tests`. This removes their database/container
+dev-dependencies from `-p rig` provider builds. Their identities change from
+`rig::integrations::<service>::<test>` to
+`rig-service-tests::integrations::<service>::<test>`; test functions and assertions
+are retained. Bedrock integration tests remain in the root `rig` package.
+The two LanceDB tests use separate temporary stores, cleaned up automatically,
+so running the new package does not create database files in the repository.
+The current agent/ECS scenario catalog contains no service-integration mappings.
+The service runner is a default workspace member and full CI enables all its
+features. `cargo test -p rig --all-features` alone no longer runs these services.
+
+## Build and result reuse
+
+Use a stable target directory and a few configurations: native default/bedrock,
+native all-features, and browser WASM. Local debug/incremental settings remain
+unchanged. The planner starts Cargo children serially and uses an OS lock to
+avoid two planners competing in the same target directory. It never stops an
+unrelated Cargo process; Cargo may still wait for another process's build lock.
+Do not run independent verification planners against the same build artifacts.
+
+On macOS, a heavily accumulated `target/debug/deps` directory can also slow
+test execution: system proxy discovery calls CoreFoundation bundle discovery,
+which enumerates the executable directory. Profiling the old local cache found
+this path dominating cassette startup with 384,122 directory entries. A fresh
+or smaller target can help in that situation; use one deliberately for the
+verification session, rather than a new directory for every check. This is an
+observed platform/cache limitation, not a change to Rig's proxy support.
+
+Changed mode can reuse successful local checks; `--no-reuse` forces execution.
+PR mode executes by default (`--reuse` is an explicit local opt-in); full mode
+and CI always execute. `full-tests` and `dependency-floors` always execute even
+with `--reuse`, because external services and dependency resolution can change.
+Result files under `target/verify/` are disposable and
+contain only the latest success fingerprint and elapsed time for each check.
+There is no evidence archive, download step, historical review log, or parity
+verdict. Deleting the files simply causes fresh verification.
+
+Fingerprints include commands, repository source/fixture/lock/configuration
+bytes, test selection, environment, tool versions, ancestor/user Cargo
+configuration, and user nextest configuration. A changed input invalidates reuse; a failed rerun removes prior
+success. Inputs changing during a check prevent recording a reusable result.
+Unsupported inputs such as symlinks execute fresh without a reusable receipt.
+This guide is reporting-only and is not a compilation or test input.
+
+CI uses the same check definitions in `xtask/src/verify/checks.rs`, while retaining
+separate jobs for parallelism and platform setup. The guards nextest profile
+runs telemetry and span-safety tests without retries in the existing all-feature
+run. Other tests retain their prior retry policy. Command-line retry settings
+would override these per-test rules, so that run deliberately does not pass
+`--retries`. See [nextest retry precedence](https://nexte.st/docs/features/retries/).
+
+Only trusted upstream pushes may write shared caches. One warming job targets
+`feat/effect-bus` and the default/bedrock test configuration; fork PRs and PR merge
+refs remain read-only. PRs can restore their base branch's caches under
+[GitHub's cache visibility rules](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching).
+Other matrix configurations are not multiplied into development-base caches.
+Cache warming still consumes runner time and quota; its benefit can only be
+measured after the workflow lands and trusted pushes populate that base cache.
+
+## PR completion
+
+Inspect the complete intended diff against its merge base, including staged,
+unstaged and relevant untracked files. Run targeted checks first, then the full
+required PR plan. Obtain a fresh independent review of the complete diff;
+validate findings, fix confirmed P0/P1 issues and in-scope lower-severity issues,
+and rerun affected checks and review after fixes. Publish a normal PR only after
+initial verification and review. Inspect committed-head required CI and
+unresolved actionable review threads afterward. Pending/failed checks and
+unresolved required work mean the PR is incomplete. Report unrelated blockers
+without broadening the change to fix them.
+
+## Measurements
+
+Initial comparable cold check, Rust 1.95.0, aarch64-apple-darwin, native dev
+profile with normal local debuginfo/incremental settings and default features:
+
+| Workflow | Before | After | Configuration |
+| --- | ---: | ---: | --- |
+| Cold narrow provider type-check | 44.13s | 27.05s | `cargo check --locked -p rig --test anthropic --timings` |
+| Warm no-op check | 0.435s | 0.355s | `cargo check --locked -p rig --test anthropic` |
+| Warm ECS source edit | 0.856s | 0.836s | `cargo check --locked -p rig-ecs --all-features --lib` |
+| Warm single cassette replay | 1.012s | 0.922s | Command below |
+| Warm fixture-only edit | 0.984s | 0.900s | Same replay command |
+| Warm example source edit | 0.397s | 0.398s | `cargo check --locked -p agent_no_tokio` |
+| Warm Rust documentation edit | 2.279s | 2.217s | `cargo doc --locked -p rig-ecs --all-features --no-deps` |
+
+The baseline is the tree merged as `de065e9be`; its source checkout is
+`45216c03e`. The candidate includes the service-test dependency split. Both
+measurements used initially empty dedicated target directories, serially, on
+the same machine with the registry already available. This measures compilation,
+not registry downloads, provider latency, or CI cache restoration. It is one
+sample (about 39% lower wall time), not a universal speedup guarantee.
+
+Warm values are medians of three runs on an Apple M2 Max with 64 GiB RAM,
+nextest 0.9.67. Each checkout started with an empty target directory and ran
+the same configuration warmups before measurement. No measured run reported
+a Cargo lock wait. Source edits added a comment; the documentation edit added
+a crate-doc line; the fixture edit added a harmless response header to the
+consumed cassette. Each edit was restored afterward. The example difference
+is a small regression within normal timing noise; the ECS/docs differences
+do not establish a meaningful speedup. These direct Cargo measurements isolate
+the dependency boundary and are not timings of the complete planner checks.
+
+The single-test replay command (native default features plus bedrock) was:
+
+```sh
+cargo nextest run --locked -p rig --features bedrock --test anthropic --retries 0 \
+  -E 'test(ecs_endings::tool_call_delta_stop_effect_log_is_the_golden_fixture)'
+```
+
+The baseline committed-head GitHub runs were
+[Lint & Test](https://github.com/0xPlaygrounds/rig/actions/runs/34055590165)
+and [Nightly Full Test](https://github.com/0xPlaygrounds/rig/actions/runs/34055590122),
+on Ubuntu x64 with Rust 1.95.0, incremental compilation disabled and
+`line-tables-only` dev/test debuginfo. Neither test job restored a Rust cache;
+lookup took about 0.17s in the default job and 0.05s in the all-feature job.
+The default job reported zero sccache hits. Default test compilation took
+7m00s and execution 289.043s (7,942 passed); all-feature compilation took
+10m58s and execution 575.039s (8,025 passed). The complete all-feature job
+took 21m24s, including setup and post steps. These are CI measurements,
+not comparable to local Mac compilation or claims about the unpopulated
+development-base cache.

--- a/test-support/service-tests/Cargo.toml
+++ b/test-support/service-tests/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "rig-service-tests"
+version.workspace = true
+edition.workspace = true
+publish = false
+license = "MIT"
+description = "Internal vector-store integration suites; kept out of provider test builds"
+autotests = false
+
+[lints]
+workspace = true
+
+[[test]]
+name = "integrations"
+path = "integrations.rs"
+
+[dependencies]
+rig = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+futures = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+httpmock = { workspace = true }
+arrow-array = { workspace = true, optional = true }
+assert_fs = { workspace = true, optional = true }
+lancedb = { workspace = true, optional = true }
+mongodb = { workspace = true, optional = true }
+neo4rs = { workspace = true, optional = true }
+qdrant-client = { workspace = true, optional = true }
+rusqlite = { workspace = true, features = ["bundled"], optional = true }
+sqlite-vec = { workspace = true, optional = true }
+sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "uuid", "json"], optional = true }
+testcontainers = { workspace = true, optional = true }
+tokio-rusqlite = { workspace = true, features = ["bundled"], optional = true }
+
+[features]
+default = []
+lancedb = ["rig/lancedb", "dep:lancedb", "dep:arrow-array", "dep:assert_fs"]
+mongodb = ["rig/mongodb", "dep:mongodb", "dep:testcontainers"]
+neo4j = ["rig/neo4j", "dep:neo4rs", "dep:testcontainers"]
+postgres = ["rig/postgres", "dep:sqlx", "dep:testcontainers"]
+qdrant = ["rig/qdrant", "dep:qdrant-client", "dep:testcontainers"]
+scylladb = ["rig/scylladb", "dep:testcontainers"]
+sqlite = ["rig/sqlite", "dep:rusqlite", "dep:sqlite-vec", "dep:tokio-rusqlite"]
+vectorize = ["rig/vectorize"]

--- a/test-support/service-tests/integrations.rs
+++ b/test-support/service-tests/integrations.rs
@@ -1,0 +1,32 @@
+#![allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::unreachable
+)]
+
+#[cfg(feature = "lancedb")]
+#[path = "../../tests/integrations/lancedb/mod.rs"]
+mod lancedb;
+#[cfg(feature = "mongodb")]
+#[path = "../../tests/integrations/mongodb.rs"]
+mod mongodb;
+#[cfg(feature = "neo4j")]
+#[path = "../../tests/integrations/neo4j.rs"]
+mod neo4j;
+#[cfg(feature = "postgres")]
+#[path = "../../tests/integrations/postgres.rs"]
+mod postgres;
+#[cfg(feature = "qdrant")]
+#[path = "../../tests/integrations/qdrant.rs"]
+mod qdrant;
+#[cfg(feature = "scylladb")]
+#[path = "../../tests/integrations/scylladb.rs"]
+mod scylladb;
+#[cfg(feature = "sqlite")]
+#[path = "../../tests/integrations/sqlite.rs"]
+mod sqlite;
+#[cfg(feature = "vectorize")]
+#[path = "../../tests/integrations/vectorize.rs"]
+mod vectorize;

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,11 +1,13 @@
 # Test Suites
 
+For the fast edit/check loop, run `cargo xtask verify --changed`. Before publishing, run `cargo xtask verify --pr --base <intended-base-ref>` and complete independent review and committed-head CI. See [development verification](../DEVELOPING.md) for modes, prerequisites, result invalidation, and measurements.
+
 Rig's root crate uses integration test targets under `tests/`.
 
 - `tests/<provider>.rs` are provider-specific test targets.
 - `tests/providers/<provider>/cassette/` contains provider tests backed by committed HTTP cassettes.
 - `tests/providers/<provider>/live/` contains provider tests that still require a real service.
-- `tests/integrations.rs` is the vector-store and external-service integration target.
+- `test-support/service-tests/integrations.rs` runs the vector-store suites from `tests/integrations/` as the unpublished `rig-service-tests` package. `tests/integrations.rs` retains the root Bedrock integrations.
 - `tests/core.rs` contains provider-agnostic core behavior tests.
 - `tests/ecs_consumer.rs` exercises the real headless ECS maintenance consumer;
   its [recording, golden and repair workflow](consumer/README.md) is also runnable
@@ -372,15 +374,15 @@ feature flags.
 Run all enabled non-ignored integration tests with:
 
 ```bash
-cargo test -p rig --all-features --test integrations
+cargo test -p rig-service-tests --all-features --test integrations
 ```
 
 Run one feature-gated integration group with:
 
 ```bash
-cargo test -p rig --features qdrant --test integrations qdrant -- --nocapture
-cargo test -p rig --features mongodb --test integrations mongodb -- --nocapture
-cargo test -p rig --features sqlite --test integrations sqlite -- --nocapture
+cargo test -p rig-service-tests --features qdrant --test integrations qdrant -- --nocapture
+cargo test -p rig-service-tests --features mongodb --test integrations mongodb -- --nocapture
+cargo test -p rig-service-tests --features sqlite --test integrations sqlite -- --nocapture
 ```
 
 Some integration tests start Docker containers through `testcontainers`; Docker must be running.
@@ -389,7 +391,7 @@ Run ignored integration tests explicitly:
 
 ```bash
 cargo test -p rig --features bedrock --test integrations bedrock -- --ignored --nocapture --test-threads=1
-cargo test -p rig --features vectorize --test integrations vectorize -- --ignored --nocapture --test-threads=1
+cargo test -p rig-service-tests --features vectorize --test integrations vectorize -- --ignored --nocapture --test-threads=1
 ```
 
 Check each integration module for required environment variables. For example, Vectorize requires

--- a/tests/core/nightly_paths_registry.rs
+++ b/tests/core/nightly_paths_registry.rs
@@ -30,6 +30,9 @@ const REQUIRED_PATHS: &[&str] = &[
     // The suites' own sources.
     "tests/integrations/**",
     "tests/integrations.rs",
+    "test-support/**",
+    "xtask/**",
+    ".config/**",
     // Companion-crate dependency versions are `workspace = true` references
     // resolved in the root manifest and lockfile; without these, dependency
     // bumps merge with zero integration coverage.

--- a/tests/core/streaming_conformance_registry.rs
+++ b/tests/core/streaming_conformance_registry.rs
@@ -217,6 +217,21 @@ fn out_of_binary_families_name_a_live_ci_step() {
                 workflow.display(),
             )
         });
+        let run = if let Some(id) = run.trim().strip_prefix("cargo xtask verify --check ") {
+            let checks = verification_checks::all();
+            let check = checks
+                .iter()
+                .find(|check| check.id == id)
+                .expect("CI must name an existing authoritative verification check");
+            check
+                .steps
+                .iter()
+                .map(|step| format!("{} {}", step.program, step.args.join(" ")))
+                .collect::<Vec<_>>()
+                .join("\n")
+        } else {
+            run
+        };
         if let Some(selector) = entry.ci_selector {
             // A `--features X` selector asserts an *outcome* — the feature is
             // enabled in that step — not a spelling: `--all-features` enables
@@ -242,3 +257,9 @@ fn out_of_binary_families_name_a_live_ci_step() {
         }
     }
 }
+
+// Compile the same definitions used by xtask; comments or stale command copies
+// cannot satisfy the live CI selector assertions above.
+#[allow(dead_code)]
+#[path = "../../xtask/src/verify/checks.rs"]
+mod verification_checks;

--- a/tests/integrations.rs
+++ b/tests/integrations.rs
@@ -9,27 +9,3 @@
 #[cfg(feature = "bedrock")]
 #[path = "integrations/bedrock/mod.rs"]
 mod bedrock;
-#[cfg(feature = "lancedb")]
-#[path = "integrations/lancedb/mod.rs"]
-mod lancedb;
-#[cfg(feature = "mongodb")]
-#[path = "integrations/mongodb.rs"]
-mod mongodb;
-#[cfg(feature = "neo4j")]
-#[path = "integrations/neo4j.rs"]
-mod neo4j;
-#[cfg(feature = "postgres")]
-#[path = "integrations/postgres.rs"]
-mod postgres;
-#[cfg(feature = "qdrant")]
-#[path = "integrations/qdrant.rs"]
-mod qdrant;
-#[cfg(feature = "scylladb")]
-#[path = "integrations/scylladb.rs"]
-mod scylladb;
-#[cfg(feature = "sqlite")]
-#[path = "integrations/sqlite.rs"]
-mod sqlite;
-#[cfg(feature = "vectorize")]
-#[path = "integrations/vectorize.rs"]
-mod vectorize;

--- a/tests/integrations/lancedb/mod.rs
+++ b/tests/integrations/lancedb/mod.rs
@@ -123,7 +123,8 @@ async fn vector_search_test() {
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
 
     // Initialize LanceDB locally.
-    let db = lancedb::connect("data/lancedb-store")
+    let store = assert_fs::TempDir::new().unwrap();
+    let db = lancedb::connect(store.path().to_str().unwrap())
         .execute()
         .await
         .unwrap();
@@ -335,7 +336,8 @@ async fn agent_with_dynamic_context_test() {
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
 
     // Initialize LanceDB locally.
-    let db = lancedb::connect("data/lancedb-store")
+    let store = assert_fs::TempDir::new().unwrap();
+    let db = lancedb::connect(store.path().to_str().unwrap())
         .execute()
         .await
         .unwrap();

--- a/tests/integrations/postgres.rs
+++ b/tests/integrations/postgres.rs
@@ -65,7 +65,7 @@ async fn vector_search_test() {
     let pg_pool = connect_to_postgres(host, port).await;
 
     // run migrations on Postgres
-    sqlx::migrate!("./tests/migrations")
+    sqlx::migrate!("../../tests/migrations")
         .run(&pg_pool)
         .await
         .expect("Failed to run migrations");

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,3 +14,4 @@ syn = { workspace = true, features = ["full"] }
 proc-macro2 = { workspace = true, features = ["span-locations"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+sha2 = { workspace = true }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -19,6 +19,7 @@
 
 mod scenarios;
 mod test_layout;
+mod verify;
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -28,6 +29,7 @@ fn main() -> ExitCode {
     let task = args.next();
 
     let result = match task.as_deref() {
+        Some("verify") => verify::run(&workspace_root(), args.collect()).map_err(|e| e.to_string()),
         Some("check-test-layout") => test_layout::check(&workspace_root()),
         Some("check-ecs-scenarios") => {
             scenarios::run(&workspace_root(), args.collect()).map_err(|e| e.to_string())
@@ -49,6 +51,7 @@ const USAGE: &str = "\
 usage: cargo xtask <task>
 
 tasks:
+  verify --changed|--pr|--full [--base REF] [--dry-run]  plan and run verification
   check-ecs-scenarios [nextest.json]  validate current scenario files and compiled mappings
   check-test-layout           fail if any crates/*/src file has an inline
                               test-gated `mod x { }` instead of `mod x;`

--- a/xtask/src/verify.rs
+++ b/xtask/src/verify.rs
@@ -1,0 +1,147 @@
+//! Conservative verification planning with disposable, local successful-result reuse.
+//! This is not a historical evidence archive or a substitute for independent review.
+mod checks;
+mod execute;
+mod selection;
+#[cfg(test)]
+mod tests;
+use serde_json::Value;
+use std::{collections::BTreeMap, path::Path, process::Command};
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Error {
+    #[error("{0}")]
+    Invalid(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}
+type Result<T> = std::result::Result<T, Error>;
+fn invalid(message: impl Into<String>) -> Error {
+    Error::Invalid(message.into())
+}
+use checks::{Check, Step};
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Mode {
+    Changed,
+    Pr,
+    Full,
+    Check,
+}
+#[derive(Debug)]
+struct Options {
+    mode: Mode,
+    base: Option<String>,
+    dry_run: bool,
+    reuse: bool,
+    check: Option<String>,
+}
+impl Options {
+    fn parse(args: Vec<String>) -> Result<Self> {
+        let mut mode = None;
+        let mut base = None;
+        let mut dry_run = false;
+        let mut reuse = None;
+        let mut check = None;
+        let mut args = args.into_iter();
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--changed" | "--pr" | "--full" | "--check" => {
+                    if mode.is_some() {
+                        return Err(invalid(
+                            "select exactly one of --changed, --pr, --full, --check ID",
+                        ));
+                    }
+                    mode = Some(match arg.as_str() {
+                        "--changed" => Mode::Changed,
+                        "--pr" => Mode::Pr,
+                        "--full" => Mode::Full,
+                        _ => Mode::Check,
+                    });
+                    if arg == "--check" {
+                        check = Some(
+                            args.next()
+                                .ok_or_else(|| invalid("--check requires an ID"))?,
+                        );
+                    }
+                }
+                "--base" => {
+                    base = Some(
+                        args.next()
+                            .ok_or_else(|| invalid("--base requires a revision"))?,
+                    )
+                }
+                "--dry-run" => dry_run = true,
+                "--reuse" => reuse = Some(true),
+                "--no-reuse" => reuse = Some(false),
+                _ => return Err(invalid(format!("unknown verify option {arg}"))),
+            }
+        }
+        let mode=mode.ok_or_else(||invalid("verify requires --changed, --pr --base REF, --full, or --check ID; optional --dry-run and --no-reuse"))?;
+        if mode == Mode::Pr && base.is_none() {
+            return Err(invalid(
+                "--pr requires --base REF (for example origin/feat/effect-bus); no implicit main",
+            ));
+        }
+        if mode == Mode::Full && reuse == Some(true) {
+            return Err(invalid("--full always executes; omit --reuse"));
+        }
+        Ok(Self {
+            mode,
+            base,
+            dry_run,
+            reuse: reuse.unwrap_or(mode == Mode::Changed),
+            check,
+        })
+    }
+}
+fn output(root: &Path, program: &str, args: &[&str]) -> Result<String> {
+    let result = Command::new(program)
+        .args(args)
+        .current_dir(root)
+        .output()?;
+    if !result.status.success() {
+        return Err(invalid(format!(
+            "{program} {args:?} failed: {}",
+            String::from_utf8_lossy(&result.stderr)
+        )));
+    }
+    String::from_utf8(result.stdout)
+        .map_err(|_| invalid("non-UTF-8 command output; cannot safely plan"))
+}
+pub(crate) fn run(root: &Path, args: Vec<String>) -> Result<()> {
+    let opts = Options::parse(args)?;
+    let metadata: Value = serde_json::from_str(&output(
+        root,
+        "cargo",
+        &["metadata", "--locked", "--no-deps", "--format-version", "1"],
+    )?)?;
+    let changes = selection::changes(root, &opts)?;
+    let all = checks::all();
+    let plan = selection::plan(root, &metadata, &opts, &changes, &all)?;
+    println!(
+        "Verification {:?}: {} changed paths; {} checks. No live recording or recapture.",
+        opts.mode,
+        changes.len(),
+        plan.len()
+    );
+    for check in &plan {
+        println!("SELECT {}: {}", check.id, check.reason);
+        for step in &check.steps {
+            println!("  {} {} {:?}", step.program, step.args.join(" "), step.env);
+        }
+    }
+    for check in &all {
+        if !plan.iter().any(|c| c.id == check.id) {
+            println!(
+                "SKIP {}: outside {:?} selection; not certified or reused",
+                check.id, opts.mode
+            );
+        }
+    }
+    if opts.dry_run {
+        return Ok(());
+    }
+    execute::run(root, &metadata, &opts, &plan)
+}

--- a/xtask/src/verify/checks.rs
+++ b/xtask/src/verify/checks.rs
@@ -1,0 +1,386 @@
+//! Check definitions shared by local plans and CI's independently scheduled jobs.
+use std::collections::BTreeMap;
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Step {
+    pub(crate) program: String,
+    pub(crate) args: Vec<String>,
+    pub(crate) env: BTreeMap<String, String>,
+}
+impl Step {
+    pub(crate) fn new(program: &str, args: &[&str]) -> Self {
+        Self {
+            program: program.into(),
+            args: args.iter().map(|s| (*s).into()).collect(),
+            env: BTreeMap::new(),
+        }
+    }
+    pub(crate) fn env(mut self, k: &str, v: &str) -> Self {
+        self.env.insert(k.into(), v.into());
+        self
+    }
+}
+#[derive(Clone, Debug)]
+pub(crate) struct Check {
+    pub(crate) id: String,
+    pub(crate) steps: Vec<Step>,
+    pub(crate) reason: String,
+}
+
+fn cargo(args: &[&str]) -> Step {
+    Step::new("cargo", args)
+}
+fn check(id: &str, steps: Vec<Step>) -> Check {
+    Check {
+        id: id.into(),
+        steps,
+        reason: String::new(),
+    }
+}
+pub(super) fn all() -> Vec<Check> {
+    let mut checks = vec![
+        check("fmt", vec![cargo(&["fmt", "--all", "--", "--check"])]),
+        check(
+            "source-guards",
+            vec![
+                Step::new(
+                    "bash",
+                    &[".github/scripts/check-migrating-guide-preamble.sh"],
+                ),
+                Step::new("bash", &[".github/scripts/check-toolchain-pin.sh"]),
+                Step::new("@fixture-paths", &[]),
+                Step::new(
+                    "node",
+                    &[
+                        "--test",
+                        "examples/candle_wasm_chat/www/worker-runtime.test.mjs",
+                    ],
+                ),
+            ],
+        ),
+        check(
+            "tooling",
+            vec![
+                Step::new("@layout", &[]),
+                Step::new("@scenarios", &[]),
+                cargo(&["test", "--locked", "-p", "xtask"]),
+                cargo(&[
+                    "clippy",
+                    "--locked",
+                    "-p",
+                    "xtask",
+                    "--all-targets",
+                    "--",
+                    "-D",
+                    "warnings",
+                ]),
+            ],
+        ),
+        check(
+            "clippy",
+            vec![cargo(&[
+                "clippy",
+                "--locked",
+                "--all-features",
+                "--all-targets",
+                "--",
+                "-D",
+                "warnings",
+            ])],
+        ),
+        check(
+            "default-check",
+            vec![cargo(&["check", "--locked", "-p", "rig", "--tests"])],
+        ),
+        check(
+            "default-tests",
+            vec![cargo(&[
+                "nextest",
+                "run",
+                "--locked",
+                "--features",
+                "bedrock",
+                "--retries",
+                "2",
+                "-E",
+                "not binary(macro_hygiene)",
+            ])],
+        ),
+        check(
+            "scenario-registrations",
+            // Match default-tests' package/feature graph; narrowing to -p rig
+            // recompiles root binaries after the default-member sweep.
+            vec![Step::new(
+                "@registrations",
+                &[
+                    "nextest",
+                    "list",
+                    "--locked",
+                    "--features",
+                    "bedrock",
+                    "--message-format",
+                    "json",
+                ],
+            )],
+        ),
+        check(
+            "core-all",
+            vec![cargo(&[
+                "nextest",
+                "run",
+                "--locked",
+                "-p",
+                "rig-core",
+                "-p",
+                "rig-reqwest",
+                "-p",
+                "rig-tungstenite",
+                "-p",
+                "rig-agent",
+                "-p",
+                "rig-rmcp",
+                "--all-features",
+                "--profile",
+                "guards",
+                "-E",
+                "not binary(macro_hygiene)",
+            ])],
+        ),
+        check(
+            "bus-verification",
+            vec![cargo(&[
+                "nextest",
+                "run",
+                "--locked",
+                "-p",
+                "rig-verify",
+                "--all-features",
+                "--retries",
+                "0",
+            ])],
+        ),
+        check(
+            "macro-hygiene",
+            vec![cargo(&[
+                "test",
+                "--locked",
+                "-p",
+                "rig-core",
+                "--test",
+                "macro_hygiene",
+            ])],
+        ),
+        check(
+            "conformance",
+            vec![cargo(&[
+                "nextest",
+                "run",
+                "--locked",
+                "-p",
+                "rig-core",
+                "-p",
+                "rig-tungstenite",
+                "-p",
+                "rig-candle",
+                "-p",
+                "rig-gemini-grpc",
+                "--all-features",
+                "--retries",
+                "0",
+                "-E",
+                "binary(streaming_conformance) + binary(streaming_conformance_websocket) + binary(driver_adoption)",
+            ])],
+        ),
+        check(
+            "derive",
+            vec![cargo(&["test", "--locked", "-p", "rig-derive"])],
+        ),
+        check(
+            "doctests",
+            vec![cargo(&[
+                "test",
+                "--locked",
+                "--doc",
+                "--workspace",
+                "--all-features",
+            ])],
+        ),
+        check(
+            "docs",
+            vec![
+                cargo(&[
+                    "doc",
+                    "--locked",
+                    "--workspace",
+                    "--no-deps",
+                    "--all-features",
+                ])
+                .env("RUSTDOCFLAGS", "-D warnings"),
+            ],
+        ),
+        check(
+            "loom",
+            vec![
+                cargo(&[
+                    "test",
+                    "--locked",
+                    "-p",
+                    "rig-agent",
+                    "--lib",
+                    "--release",
+                    "loom_",
+                ])
+                .env("RUSTFLAGS", "--cfg rig_loom")
+                .env("LOOM_MAX_PREEMPTIONS", "3"),
+            ],
+        ),
+        check(
+            "full-tests",
+            vec![cargo(&[
+                "nextest",
+                "run",
+                "--locked",
+                "--workspace",
+                "--all-features",
+                "--retries",
+                "2",
+                "-E",
+                "not package(rig-derive)",
+            ])],
+        ),
+        check(
+            "workspace-check",
+            vec![cargo(&[
+                "check",
+                "--locked",
+                "--workspace",
+                "--all-features",
+                "--all-targets",
+            ])],
+        ),
+        // Existing repository floor checker; new verification tooling is Rust.
+        check(
+            "dependency-floors",
+            vec![Step::new(
+                "python3",
+                &["scripts/check-dependency-floors.py"],
+            )],
+        ),
+    ];
+    for package in [
+        "rig-core",
+        "rig-effect-log",
+        "rig-ecs",
+        "rig-reqwest",
+        "rig-agent",
+        "rig",
+        "rig-candle",
+        "candle_wasm_chat",
+    ] {
+        let mut steps = vec![cargo(&[
+            "check",
+            "--locked",
+            "--package",
+            package,
+            "--target",
+            "wasm32-unknown-unknown",
+        ])];
+        if package == "rig-ecs" {
+            steps.push(cargo(&[
+                "check",
+                "--locked",
+                "-p",
+                package,
+                "--no-default-features",
+                "--lib",
+            ]));
+            steps.push(cargo(&[
+                "check",
+                "--locked",
+                "-p",
+                package,
+                "--no-default-features",
+                "--lib",
+                "--target",
+                "wasm32-unknown-unknown",
+            ]));
+        }
+        if ["rig-core", "rig-ecs"].contains(&package) {
+            steps.push(cargo(&[
+                "check",
+                "--locked",
+                "--package",
+                package,
+                "--all-features",
+                "--target",
+                "wasm32-unknown-unknown",
+            ]));
+        }
+        checks.push(check(&format!("wasm-{package}"), steps));
+    }
+    for (package, test) in [
+        ("rig-agent", "bus_wasm"),
+        ("rig-ecs", "bus_wasm"),
+        ("rig-ecs", "run_wasm"),
+    ] {
+        checks.push(check(
+            &format!("wasm-{package}-{test}"),
+            vec![
+                cargo(&[
+                    "test",
+                    "--locked",
+                    "--package",
+                    package,
+                    "--target",
+                    "wasm32-unknown-unknown",
+                    "--test",
+                    test,
+                ])
+                .env(
+                    "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER",
+                    "wasm-bindgen-test-runner",
+                ),
+            ],
+        ));
+    }
+    for (package, message) in [
+        ("rig-rmcp", "the `rmcp` feature is native-only"),
+        (
+            "rig-tungstenite",
+            "rig-tungstenite is a native websocket backend",
+        ),
+    ] {
+        checks.push(check(
+            &format!("native-only-{package}"),
+            vec![Step::new("@native-only", &[package, message])],
+        ));
+    }
+    checks
+}
+pub(super) fn full_lane(path: &str) -> bool {
+    [
+        "Cargo.toml",
+        "Cargo.lock",
+        ".github/workflows/nightly.yaml",
+        "scripts/check-dependency-floors.py",
+        "tests/tool_facade_features.rs",
+        "tests/integrations.rs",
+    ]
+    .contains(&path)
+        || path.starts_with("tests/integrations/")
+        || path.starts_with("test-support/")
+        || (path.starts_with("crates/") && path.ends_with("/Cargo.toml"))
+        || [
+            "rig-lancedb",
+            "rig-mongodb",
+            "rig-neo4j",
+            "rig-postgres",
+            "rig-qdrant",
+            "rig-scylladb",
+            "rig-sqlite",
+            "rig-vectorize",
+        ]
+        .iter()
+        .any(|p| path.starts_with(&format!("crates/{p}/")))
+        || path.starts_with("xtask/")
+        || path.starts_with(".config/")
+}

--- a/xtask/src/verify/execute.rs
+++ b/xtask/src/verify/execute.rs
@@ -1,0 +1,353 @@
+use super::*;
+use sha2::{Digest, Sha256};
+use std::{
+    fs::{self, File, OpenOptions},
+    io::Write,
+    path::PathBuf,
+    time::Instant,
+};
+
+struct PlannerLock(File);
+impl Drop for PlannerLock {
+    fn drop(&mut self) {
+        // A concurrent fork can briefly inherit the open file description.
+        // Closing our descriptor alone need not release its flock immediately.
+        // Explicitly unlock on every return, including a failed check.
+        let _ = self.0.unlock();
+    }
+}
+
+fn tracked_inputs(root: &Path) -> Result<Vec<String>> {
+    let mut files = std::collections::BTreeSet::new();
+    for args in [
+        vec!["ls-files", "-z"],
+        vec!["ls-files", "--others", "--exclude-standard", "-z"],
+    ] {
+        files.extend(
+            output(root, "git", &args)?
+                .split('\0')
+                .filter(|s| !s.is_empty())
+                .map(str::to_owned),
+        );
+    }
+    Ok(files.into_iter().collect())
+}
+pub(super) fn digest(root: &Path, files: &[String], config: &[u8]) -> Result<String> {
+    let mut hash = Sha256::new();
+    hash.update(b"rig-verify-local-v2\0");
+    hash.update(config);
+    let mut existing = Vec::new();
+    for name in files {
+        // The timing report describes measurements; no executable consumes it.
+        // All other source, fixture, lock, config and documentation bytes count.
+        if name == "DEVELOPING.md" {
+            continue;
+        }
+        hash.update(name.len().to_le_bytes());
+        hash.update(name.as_bytes());
+        let path = root.join(name);
+        match fs::symlink_metadata(&path) {
+            Ok(meta) => {
+                if meta.file_type().is_symlink() {
+                    return Err(invalid(format!(
+                        "cannot reuse verification across symlink input {name}; use --no-reuse"
+                    )));
+                }
+                if !meta.is_file() {
+                    return Err(invalid(format!("unsupported verification input {name}")));
+                }
+                existing.push(name.as_str());
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    hash.update(meta.permissions().mode().to_le_bytes());
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => hash.update(b"<deleted>"),
+            Err(e) => return Err(e.into()),
+        }
+    }
+    // Git hashes the actual working bytes in optimized native code. Reading
+    // every cassette through unoptimized sha2 added seconds to cheap checks.
+    // --no-filters preserves byte-sensitive fixtures regardless of attributes;
+    // the index/status cache is deliberately not trusted for content identity.
+    for paths in existing.chunks(256) {
+        let mut args = vec!["hash-object", "--no-filters", "--"];
+        args.extend_from_slice(paths);
+        hash.update(output(root, "git", &args)?);
+    }
+    Ok(format!("{:x}", hash.finalize()))
+}
+pub(super) fn config(root: &Path, check: &Check) -> Result<Vec<u8>> {
+    let mut s = format!("{} {:?}\nroot={}\n", check.id, check.steps, root.display());
+    // Hash, never print, environment values: test switches and toolchain flags
+    // must invalidate reuse, and credentials must not enter a result file.
+    for (key, value) in std::env::vars_os().collect::<BTreeMap<_, _>>() {
+        s.push_str(&format!("{key:?}={value:?}\n"));
+    }
+    // Cargo searches ancestor configuration and CARGO_HOME, not just Git.
+    let mut config_dirs: Vec<PathBuf> = root.ancestors().map(|p| p.join(".cargo")).collect();
+    if let Some(home) = std::env::var_os("CARGO_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|p| PathBuf::from(p).join(".cargo")))
+    {
+        config_dirs.push(home);
+    }
+    for directory in config_dirs {
+        for name in ["config", "config.toml"] {
+            let path = directory.join(name);
+            match fs::read(&path) {
+                Ok(bytes) => {
+                    s.push_str(&format!("{}:{:x}\n", path.display(), Sha256::digest(bytes)))
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e.into()),
+            }
+        }
+    }
+    let mut nextest_configs = Vec::new();
+    if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
+        nextest_configs.push(home.join(".config/nextest/config.toml"));
+        nextest_configs.push(home.join("Library/Application Support/nextest/config.toml"));
+    }
+    if let Some(home) = std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from) {
+        nextest_configs.push(home.join("nextest/config.toml"));
+    }
+    for path in nextest_configs {
+        match fs::read(&path) {
+            Ok(bytes) => s.push_str(&format!("{}:{:x}\n", path.display(), Sha256::digest(bytes))),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+    for (program, args) in [
+        ("rustc", vec!["-Vv"]),
+        ("cargo", vec!["-V"]),
+        ("git", vec!["--version"]),
+        ("cargo", vec!["nextest", "--version"]),
+        ("node", vec!["--version"]),
+        ("wasm-bindgen-test-runner", vec!["--version"]),
+    ] {
+        let value = Command::new(program).args(&args).current_dir(root).output();
+        s.push_str(&format!("{program} {args:?}: {value:?}\n"));
+    }
+    Ok(s.into_bytes())
+}
+pub(super) fn command(root: &Path, step: &Step) -> Command {
+    let mut cmd = Command::new(&step.program);
+    cmd.args(&step.args).current_dir(root).envs(&step.env);
+    // Verification is always replay. CLI/environment retry overrides must not
+    // defeat the no-retry telemetry contract in the guards profile.
+    cmd.env("RIG_PROVIDER_TEST_MODE", "replay")
+        .env_remove("RIG_REGENERATE_GOLDEN")
+        .env_remove("NEXTEST_RETRIES");
+    cmd
+}
+fn internal(root: &Path, directory: &Path, step: &Step) -> Result<()> {
+    match step.program.as_str() {
+        "@layout" => crate::test_layout::check(root).map_err(invalid),
+        "@scenarios" => crate::scenarios::run(root, Vec::new()).map_err(|e| invalid(e.to_string())),
+        "@registrations" => {
+            let json = output(
+                root,
+                "cargo",
+                &step.args.iter().map(String::as_str).collect::<Vec<_>>(),
+            )?;
+            let file = directory.join("registrations.json");
+            fs::write(&file, json)?;
+            crate::scenarios::run(root, vec![file.to_string_lossy().into_owned()])
+                .map_err(|e| invalid(e.to_string()))
+        }
+        "@fixture-paths" => {
+            for path in tracked_inputs(root)?.into_iter().filter(|p| {
+                p.starts_with("crates/")
+                    && p.ends_with(".rs")
+                    && (p.contains("/src/") || p.contains("/tests/"))
+            }) {
+                let text = match fs::read_to_string(root.join(&path)) {
+                    Ok(text) => text,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                    Err(e) => return Err(e.into()),
+                };
+                for line in text.lines().filter(|l| {
+                    !l.trim_start().starts_with("///") && !l.trim_start().starts_with("//!")
+                }) {
+                    if line.contains("\"tests/data") || line.contains("\"./tests/data") {
+                        return Err(invalid(format!(
+                            "CWD-relative fixture path in {path}; anchor it to CARGO_MANIFEST_DIR"
+                        )));
+                    }
+                }
+            }
+            Ok(())
+        }
+        "@native-only" => {
+            let package = step
+                .args
+                .first()
+                .ok_or_else(|| invalid("native-only package missing"))?;
+            let expected = step
+                .args
+                .get(1)
+                .ok_or_else(|| invalid("native-only diagnostic missing"))?;
+            let result = Command::new("cargo")
+                .args([
+                    "check",
+                    "--locked",
+                    "--package",
+                    package,
+                    "--target",
+                    "wasm32-unknown-unknown",
+                ])
+                .env("CARGO_TERM_COLOR", "never")
+                .current_dir(root)
+                .output()?;
+            let stderr = String::from_utf8_lossy(&result.stderr);
+            print!("{stderr}");
+            let count = stderr
+                .lines()
+                .filter(|l| {
+                    (l.starts_with("error:") || l.starts_with("error["))
+                        && !l.contains("could not compile")
+                })
+                .count();
+            if result.status.success() || !stderr.contains(expected) || count != 1 {
+                return Err(invalid(format!(
+                    "{package}: expected exactly one native-only diagnostic, got {count}"
+                )));
+            }
+            Ok(())
+        }
+        _ => Err(invalid(format!(
+            "unknown internal command {}",
+            step.program
+        ))),
+    }
+}
+pub(super) fn run(root: &Path, metadata: &Value, opts: &Options, plan: &[Check]) -> Result<()> {
+    if plan.is_empty() {
+        println!("No working changes; no verification result claimed.");
+        return Ok(());
+    }
+    let target = metadata["target_directory"]
+        .as_str()
+        .ok_or_else(|| invalid("Cargo metadata missing target directory"))?;
+    let directory = PathBuf::from(target).join("verify");
+    fs::create_dir_all(&directory)?;
+    // An OS lock, not a stale pid/marker. Only our planner participates; we
+    // neither kill nor wait on unrelated builds. Our Cargo children are serial.
+    let lock = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(directory.join("planner.lock"))?;
+    lock.try_lock().map_err(|e| {
+        invalid(format!(
+            "another verification planner owns {}: {e}; retry after it finishes",
+            directory.display()
+        ))
+    })?;
+    let _lock = PlannerLock(lock);
+    for check in plan {
+        let start = Instant::now();
+        let receipt = directory.join(format!("{}.json", check.id));
+        let inputs = tracked_inputs(root)?;
+        let configuration = config(root, check)?;
+        let external_path_dependency = metadata["packages"].as_array().is_some_and(|packages| {
+            packages.iter().any(|p| {
+                p["dependencies"].as_array().is_some_and(|deps| {
+                    deps.iter().any(|d| {
+                        d["path"]
+                            .as_str()
+                            .is_some_and(|p| !Path::new(p).starts_with(root))
+                    })
+                })
+            })
+        });
+        let before = match if external_path_dependency {
+            Err(invalid(
+                "external path dependency: local source fingerprint cannot certify its inputs",
+            ))
+        } else {
+            digest(root, &inputs, &configuration)
+        } {
+            Ok(digest) => Some(digest),
+            Err(error) => {
+                println!(
+                    "NO REUSE {}: {error}; execute fresh without a receipt",
+                    check.id
+                );
+                None
+            }
+        };
+        let prior = fs::read(&receipt)
+            .ok()
+            .and_then(|s| serde_json::from_slice::<Value>(&s).ok());
+        if opts.reuse
+            && !["full-tests", "dependency-floors"].contains(&check.id.as_str())
+            && std::env::var_os("CI").is_none()
+            && prior.as_ref().is_some_and(|p| {
+                before
+                    .as_ref()
+                    .is_some_and(|hash| p["fingerprint"] == *hash)
+                    && p["success"] == true
+            })
+        {
+            println!(
+                "REUSE {}: all current inputs, commands, environment and tool versions match ({:.3}s)",
+                check.id,
+                start.elapsed().as_secs_f64()
+            );
+            continue;
+        }
+        println!(
+            "RUN {}: {}",
+            check.id,
+            if !opts.reuse {
+                "fresh execution requested"
+            } else {
+                "no matching successful local result"
+            }
+        );
+        // Invalidate before running, so a failed rerun cannot expose old success.
+        if receipt.exists() {
+            fs::remove_file(&receipt)?;
+        }
+        for step in &check.steps {
+            if step.program.starts_with('@') {
+                internal(root, &directory, step)?;
+            } else {
+                let status = command(root, step).status()?;
+                if !status.success() {
+                    return Err(invalid(format!(
+                        "required check {} failed: {} {:?} ({status})",
+                        check.id, step.program, step.args
+                    )));
+                }
+            }
+        }
+        if before.is_some()
+            && before != Some(digest(root, &tracked_inputs(root)?, &config(root, check)?)?)
+        {
+            return Err(invalid(format!(
+                "inputs changed during {}; result not reusable; rerun",
+                check.id
+            )));
+        }
+        let elapsed = start.elapsed().as_secs_f64();
+        if before.is_none() {
+            println!("PASS {}: {elapsed:.3}s; no reusable result", check.id);
+            continue;
+        }
+        let value =
+            serde_json::json!({"schema":1,"success":true,"fingerprint":before,"seconds":elapsed});
+        let tmp = receipt.with_extension("tmp");
+        let mut f = File::create(&tmp)?;
+        f.write_all(&serde_json::to_vec_pretty(&value)?)?;
+        f.sync_all()?;
+        fs::rename(tmp, receipt)?;
+        println!("PASS {}: {elapsed:.3}s", check.id);
+    }
+    println!("All selected checks passed. This does not certify independent review or remote CI.");
+    Ok(())
+}

--- a/xtask/src/verify/selection.rs
+++ b/xtask/src/verify/selection.rs
@@ -1,0 +1,335 @@
+use super::*;
+use std::{
+    collections::{BTreeSet, VecDeque},
+    path::PathBuf,
+};
+
+pub(super) fn changes(root: &Path, opts: &Options) -> Result<BTreeSet<String>> {
+    let revision = if let Some(base) = &opts.base {
+        let merge = output(root, "git", &["merge-base", base, "HEAD"])?;
+        println!("Base: {base}; merge base: {}", merge.trim());
+        merge.trim().to_string()
+    } else {
+        "HEAD".into()
+    };
+    let mut paths = BTreeSet::new();
+    // Union the index and working-tree deltas: a staged edit undone only in
+    // the working tree still belongs in the plan. Include both sides of moves.
+    for args in [
+        vec!["diff", "--name-only", "--no-renames", "-z", &revision],
+        vec![
+            "diff",
+            "--cached",
+            "--name-only",
+            "--no-renames",
+            "-z",
+            &revision,
+        ],
+        vec!["ls-files", "--others", "--exclude-standard", "-z"],
+    ] {
+        for p in output(root, "git", &args)?
+            .split('\0')
+            .filter(|s| !s.is_empty())
+        {
+            paths.insert(p.into());
+        }
+    }
+    Ok(paths)
+}
+fn broad(all: &[Check], reason: &str, full: bool) -> Vec<Check> {
+    all.iter()
+        .filter(|c| {
+            full || !["full-tests", "dependency-floors", "workspace-check"].contains(&c.id.as_str())
+        })
+        .cloned()
+        .map(|mut c| {
+            c.reason = reason.into();
+            c
+        })
+        .collect()
+}
+fn add(out: &mut Vec<Check>, all: &[Check], id: &str, reason: &str) -> Result<()> {
+    if out.iter().any(|c| c.id == id) {
+        return Ok(());
+    }
+    let mut c = all
+        .iter()
+        .find(|c| c.id == id)
+        .cloned()
+        .ok_or_else(|| invalid(format!("missing required check {id}")))?;
+    c.reason = reason.into();
+    out.push(c);
+    Ok(())
+}
+fn provider(path: &str) -> Option<&str> {
+    for prefix in ["tests/cassettes/", "tests/providers/"] {
+        if let Some(rest) = path.strip_prefix(prefix) {
+            return rest.split('/').next();
+        }
+    }
+    path.strip_prefix("tests/")
+        .filter(|s| !s.contains('/'))
+        .and_then(|s| s.strip_suffix(".rs"))
+}
+fn package<'a>(root: &Path, packages: &'a [Value], path: &str) -> Option<&'a Value> {
+    let absolute = root.join(path);
+    packages
+        .iter()
+        .filter_map(|p| {
+            let dir = Path::new(p["manifest_path"].as_str()?).parent()?;
+            absolute
+                .starts_with(dir)
+                .then_some((dir.components().count(), p))
+        })
+        .max_by_key(|(depth, _)| *depth)
+        .map(|(_, p)| p)
+}
+fn consumers(packages: &[Value], name: &str) -> BTreeSet<String> {
+    let mut result = BTreeSet::from([name.into()]);
+    let mut queue = VecDeque::from([name.to_string()]);
+    while let Some(next) = queue.pop_front() {
+        for p in packages {
+            let Some(name) = p["name"].as_str() else {
+                continue;
+            };
+            if p["dependencies"]
+                .as_array()
+                .is_some_and(|deps| deps.iter().any(|d| d["name"] == next))
+                && result.insert(name.into())
+            {
+                queue.push_back(name.into());
+            }
+        }
+    }
+    result
+}
+fn dynamic(id: String, args: Vec<String>, reason: &str) -> Check {
+    Check {
+        id,
+        steps: vec![Step {
+            program: "cargo".into(),
+            args,
+            env: BTreeMap::new(),
+        }],
+        reason: reason.into(),
+    }
+}
+pub(super) fn plan(
+    root: &Path,
+    metadata: &Value,
+    opts: &Options,
+    paths: &BTreeSet<String>,
+    all: &[Check],
+) -> Result<Vec<Check>> {
+    if opts.mode == Mode::Check {
+        let id = opts
+            .check
+            .as_deref()
+            .ok_or_else(|| invalid("missing check ID"))?;
+        let mut out = Vec::new();
+        add(&mut out, all, id, "explicit check; always selected")?;
+        return Ok(out);
+    }
+    if opts.mode == Mode::Full {
+        return Ok(broad(
+            all,
+            "exhaustive supported repository verification",
+            true,
+        ));
+    }
+    if opts.mode == Mode::Pr {
+        if paths.iter().any(|p| {
+            p == "CHANGELOG.md"
+                || p == "MIGRATING.md"
+                || p.starts_with("docs/migrations/")
+                || (p.starts_with("crates/") && p.ends_with("/CHANGELOG.md"))
+        }) {
+            return Err(invalid(
+                "ordinary PR changes frozen release documents; put release notes in the PR description",
+            ));
+        }
+        // The PR plan must never be narrower than a conservative local
+        // fallback (for example an unknown generator or CI configuration).
+        let changed = Options {
+            mode: Mode::Changed,
+            base: opts.base.clone(),
+            dry_run: opts.dry_run,
+            reuse: false,
+            check: None,
+        };
+        let needs_full = paths.iter().any(|p| checks::full_lane(p))
+            || plan(root, metadata, &changed, paths, all)?
+                .iter()
+                .any(|check| check.id == "full-tests");
+        return Ok(broad(
+            all,
+            "complete intended PR diff; preserves existing required lanes",
+            needs_full,
+        ));
+    }
+    let packages = metadata["packages"]
+        .as_array()
+        .ok_or_else(|| invalid("Cargo metadata missing packages"))?;
+    let mut out = Vec::new();
+    let mut affected = BTreeSet::new();
+    for path in paths {
+        if path == "Cargo.lock"
+            || path.ends_with("Cargo.toml")
+            || path == "rust-toolchain.toml"
+            || [
+                ".cargo/",
+                ".config/",
+                ".github/",
+                "xtask/",
+                "scripts/",
+                "test-support/",
+                "src/",
+                "tests/common/",
+                "tests/consumer/",
+                "tests/integrations/",
+            ]
+            .iter()
+            .any(|p| path.starts_with(p))
+        {
+            return Ok(broad(
+                all,
+                &format!("conservative fallback: shared/build/verification input {path}"),
+                true,
+            ));
+        }
+        if path.starts_with("tests/ecs_parity/") {
+            add(
+                &mut out,
+                all,
+                "tooling",
+                "scenario catalog or semantic contract changed",
+            )?;
+            continue;
+        }
+        if path.starts_with("examples/candle_wasm_chat/www/") {
+            add(
+                &mut out,
+                all,
+                "source-guards",
+                "browser worker runtime changed",
+            )?;
+            add(
+                &mut out,
+                all,
+                "wasm-candle_wasm_chat",
+                "browser example Rust/JavaScript boundary",
+            )?;
+            continue;
+        }
+        if path.starts_with("crates/rig-verify/fixtures/") {
+            add(&mut out, all, "bus-verification", "consumed golden changed")?;
+            add(
+                &mut out,
+                all,
+                "default-tests",
+                "goldens may be consumed by any original/native provider target",
+            )?;
+            continue;
+        }
+        if let Some(name) = provider(path) {
+            let root_package = packages
+                .iter()
+                .find(|p| p["name"] == "rig")
+                .ok_or_else(|| invalid("missing rig package"))?;
+            let target = root_package["targets"].as_array().and_then(|ts| {
+                ts.iter().find(|t| {
+                    t["name"] == name
+                        && t["kind"]
+                            .as_array()
+                            .is_some_and(|k| k.iter().any(|x| x == "test"))
+                })
+            });
+            if target.is_none() {
+                return Ok(broad(
+                    all,
+                    &format!("unknown provider/target for {path}"),
+                    true,
+                ));
+            }
+            let id = format!("provider-{name}");
+            if !out.iter().any(|c| c.id == id) {
+                out.push(dynamic(
+                    id,
+                    ["nextest", "run", "--locked", "-p", "rig", "--all-features", "--test", name, "--retries", "0"]
+                        .iter().map(|s| (*s).into()).collect(),
+                    "provider source or cassette: execute complete target with all capabilities, including feature-gated tests and shared safety assertions",
+                ));
+            }
+            continue;
+        }
+        if ["README.md", "CONTRIBUTING.md", "AGENTS.md", "DEVELOPING.md"].contains(&path.as_str())
+            || path.starts_with("docs/")
+        {
+            add(&mut out, all, "docs", "documentation edit")?;
+            add(
+                &mut out,
+                all,
+                "doctests",
+                "documentation edit; preserve executable documentation",
+            )?;
+            continue;
+        }
+        let owner = package(root, packages, path).and_then(|p| p["name"].as_str());
+        if let Some(name) = owner.filter(|n| *n != "rig") {
+            if !path.ends_with(".rs") && !path.ends_with(".md") {
+                return Ok(broad(
+                    all,
+                    &format!("unmodeled package asset or generator {path}"),
+                    true,
+                ));
+            }
+            affected.insert(name.to_string());
+            continue;
+        }
+        return Ok(broad(
+            all,
+            &format!("unknown input {path}; cannot safely narrow"),
+            true,
+        ));
+    }
+    if !paths.is_empty() {
+        add(&mut out, all, "fmt", "changed files must remain formatted")?;
+    }
+    let mut downstream = BTreeSet::new();
+    for name in affected {
+        downstream.extend(consumers(packages, &name));
+        let package = packages
+            .iter()
+            .find(|p| p["name"] == name)
+            .ok_or_else(|| invalid("package vanished"))?;
+        let manifest = PathBuf::from(
+            package["manifest_path"]
+                .as_str()
+                .ok_or_else(|| invalid("missing manifest"))?,
+        );
+        if manifest.starts_with(root.join("examples")) {
+            out.push(dynamic(
+                format!("example-{name}"),
+                ["test", "--locked", "-p", &name, "--all-targets"]
+                    .iter()
+                    .map(|s| (*s).into())
+                    .collect(),
+                "example edit: compile declared features and run test harnesses, not application entry points",
+            ));
+        } else {
+            out.push(dynamic(format!("package-{name}"),["test","--locked","-p",&name,"--all-features"].iter().map(|s|(*s).into()).collect(),"package edit: unit, integration and documentation tests under all package features"));
+        }
+    }
+    if !downstream.is_empty() {
+        let mut args = vec!["check".into(), "--locked".into(), "--all-targets".into()];
+        for name in downstream {
+            args.extend(["-p".into(), name]);
+        }
+        out.push(dynamic(
+            "consumers".into(),
+            args,
+            "Cargo metadata reverse dependencies, including examples and public API consumers",
+        ));
+    }
+    Ok(out)
+}

--- a/xtask/src/verify/tests.rs
+++ b/xtask/src/verify/tests.rs
@@ -1,0 +1,432 @@
+use super::*;
+use std::collections::BTreeSet;
+fn opts(mode: &str) -> Options {
+    Options::parse(vec![mode.into(), "--base".into(), "HEAD".into()]).unwrap()
+}
+fn metadata() -> Value {
+    serde_json::json!({"packages":[{"name":"rig","manifest_path":"/repo/Cargo.toml","targets":[{"name":"anthropic","kind":["test"]}]},{"name":"rig-ecs","manifest_path":"/repo/crates/rig-ecs/Cargo.toml","dependencies":[]},{"name":"example","manifest_path":"/repo/examples/example/Cargo.toml","dependencies":[{"name":"rig-ecs"}]}]})
+}
+fn ids(mode: &str, paths: &[&str]) -> BTreeSet<String> {
+    selection::plan(
+        Path::new("/repo"),
+        &metadata(),
+        &opts(mode),
+        &paths.iter().map(|s| (*s).into()).collect(),
+        &checks::all(),
+    )
+    .unwrap()
+    .into_iter()
+    .map(|c| c.id)
+    .collect()
+}
+#[test]
+fn pr_requires_explicit_base() {
+    assert!(Options::parse(vec!["--pr".into()]).is_err());
+}
+#[test]
+fn conflicting_modes_fail() {
+    assert!(Options::parse(vec!["--changed".into(), "--full".into()]).is_err());
+}
+#[test]
+fn unknown_changes_select_full_coverage() {
+    assert_eq!(ids("--changed", &["unknown.xyz"]), ids("--full", &[]));
+    assert_eq!(ids("--pr", &["unknown.xyz"]), ids("--full", &[]));
+}
+
+#[test]
+fn gated_provider_changes_enable_every_capability() {
+    let mut metadata = metadata();
+    metadata["packages"][0]["targets"] = serde_json::json!([{"name":"openai","kind":["test"]}]);
+    for path in [
+        "tests/providers/openai/cassette/audio_params_matrix.rs",
+        "tests/providers/openai/cassette/image_params_matrix.rs",
+        "tests/cassettes/openai/websocket/example.yaml",
+    ] {
+        let plan = selection::plan(
+            Path::new("/repo"),
+            &metadata,
+            &opts("--changed"),
+            &BTreeSet::from([path.into()]),
+            &checks::all(),
+        )
+        .unwrap();
+        let provider = plan.iter().find(|c| c.id == "provider-openai").unwrap();
+        assert!(provider.steps[0].args.contains(&"--all-features".into()));
+        assert!(!provider.steps[0].args.contains(&"--features".into()));
+        assert!(!plan.iter().any(|c| c.id == "full-tests"));
+    }
+}
+#[test]
+fn planner_and_dependency_edits_cannot_skip_checks() {
+    for p in [
+        "xtask/src/main.rs",
+        "Cargo.lock",
+        "crates/rig-ecs/Cargo.toml",
+        ".config/nextest.toml",
+    ] {
+        assert_eq!(ids("--changed", &[p]), ids("--full", &[]));
+    }
+}
+#[test]
+fn fixture_selects_complete_provider_target() {
+    let plan = ids("--changed", &["tests/cassettes/anthropic/a.yaml"]);
+    assert!(plan.contains("provider-anthropic"));
+    assert!(!plan.contains("full-tests"));
+}
+#[test]
+fn unknown_fixture_provider_falls_back() {
+    assert!(ids("--changed", &["tests/cassettes/unknown/a.yaml"]).contains("full-tests"));
+}
+#[test]
+fn ecs_changes_include_reverse_consumers() {
+    let p = ids("--changed", &["crates/rig-ecs/src/lib.rs"]);
+    assert!(p.contains("package-rig-ecs"));
+    assert!(p.contains("consumers"));
+}
+#[test]
+fn pr_preserves_required_platform_and_default_guarantees() {
+    let p = ids("--pr", &["README.md"]);
+    for c in [
+        "default-check",
+        "default-tests",
+        "wasm-rig-ecs",
+        "wasm-rig-ecs-run_wasm",
+        "native-only-rig-rmcp",
+        "loom",
+        "doctests",
+        "conformance",
+        "derive",
+    ] {
+        assert!(p.contains(c), "missing {c}");
+    }
+    assert!(!p.contains("full-tests"));
+    assert!(ids("--pr", &["Cargo.lock"]).contains("full-tests"));
+}
+#[test]
+fn unknown_check_cannot_succeed() {
+    let o = Options::parse(vec!["--check".into(), "typo".into()]).unwrap();
+    assert!(
+        selection::plan(
+            Path::new("/repo"),
+            &metadata(),
+            &o,
+            &BTreeSet::new(),
+            &checks::all()
+        )
+        .is_err()
+    );
+}
+#[test]
+fn check_ids_are_unique() {
+    let all = checks::all();
+    assert_eq!(
+        all.len(),
+        all.iter().map(|c| &c.id).collect::<BTreeSet<_>>().len()
+    );
+}
+#[test]
+fn telemetry_retry_policy_is_not_overridden() {
+    let all = checks::all();
+    let c = all.iter().find(|c| c.id == "core-all").unwrap();
+    assert!(c.steps[0].args.contains(&"guards".into()));
+    assert!(!c.steps[0].args.contains(&"--retries".into()));
+}
+
+#[test]
+fn registration_discovery_reuses_default_test_graph_without_filtering() {
+    let all = checks::all();
+    for id in ["default-tests", "scenario-registrations"] {
+        let args = &all.iter().find(|c| c.id == id).unwrap().steps[0].args;
+        for flag in [
+            "-p",
+            "--package",
+            "--workspace",
+            "--all-features",
+            "--no-default-features",
+        ] {
+            assert!(
+                !args.iter().any(|arg| arg == flag),
+                "{id}: different graph via {flag}"
+            );
+        }
+        assert!(
+            args.windows(2)
+                .any(|args| args == ["--features", "bedrock"])
+        );
+        if id == "scenario-registrations" {
+            for flag in ["-E", "--filter-expr", "--test", "--lib"] {
+                assert!(
+                    !args.iter().any(|arg| arg == flag),
+                    "filtered listing via {flag}"
+                );
+            }
+        }
+    }
+}
+#[test]
+fn fingerprints_include_content_configuration_and_deletions() {
+    let root = std::env::temp_dir().join(format!("rig-verify-test-{}", std::process::id()));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("fixture.json"), "a").unwrap();
+    let files = vec!["fixture.json".into()];
+    let a = execute::digest(&root, &files, b"rustc-1;features-a;target-native").unwrap();
+    assert_ne!(
+        a,
+        execute::digest(&root, &files, b"rustc-2;features-b;target-wasm").unwrap()
+    );
+    std::fs::write(root.join("fixture.json"), "b").unwrap();
+    assert_ne!(
+        a,
+        execute::digest(&root, &files, b"rustc-1;features-a;target-native").unwrap()
+    );
+    std::fs::remove_file(root.join("fixture.json")).unwrap();
+    assert_ne!(
+        a,
+        execute::digest(&root, &files, b"rustc-1;features-a;target-native").unwrap()
+    );
+    std::fs::remove_dir(root).unwrap();
+}
+
+struct Repo(std::path::PathBuf);
+impl Repo {
+    fn new() -> Self {
+        static SEQUENCE: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "rig-planner-repo-{}-{}",
+            std::process::id(),
+            SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        std::fs::create_dir(&path).unwrap();
+        output(&path, "git", &["init", "--quiet"]).unwrap();
+        let hooks = path.join(".git/empty-hooks");
+        std::fs::create_dir(&hooks).unwrap();
+        output(&path, "git", &["config", "commit.gpgsign", "false"]).unwrap();
+        output(
+            &path,
+            "git",
+            &["config", "core.hooksPath", hooks.to_str().unwrap()],
+        )
+        .unwrap();
+        std::fs::write(path.join(".gitignore"), "target/\n").unwrap();
+        std::fs::write(path.join("file.rs"), "original").unwrap();
+        output(&path, "git", &["add", "."]).unwrap();
+        output(
+            &path,
+            "git",
+            &[
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=test@example.invalid",
+                "commit",
+                "--quiet",
+                "-m",
+                "fixture",
+            ],
+        )
+        .unwrap();
+        Self(path)
+    }
+}
+impl Drop for Repo {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.0).unwrap();
+    }
+}
+#[test]
+fn staged_then_undone_and_untracked_inputs_are_not_lost() {
+    let repo = Repo::new();
+    std::fs::write(repo.0.join("file.rs"), "staged").unwrap();
+    output(&repo.0, "git", &["add", "file.rs"]).unwrap();
+    std::fs::write(repo.0.join("file.rs"), "original").unwrap();
+    std::fs::write(repo.0.join("new.rs"), "new").unwrap();
+    let paths = selection::changes(&repo.0, &opts("--changed")).unwrap();
+    assert!(paths.contains("file.rs"));
+    assert!(paths.contains("new.rs"));
+}
+#[test]
+fn failed_required_command_removes_success_and_stops_later_checks() {
+    let repo = Repo::new();
+    let metadata = serde_json::json!({"target_directory":repo.0.join("target")});
+    let mut opts = opts("--changed");
+    opts.reuse = false;
+    let ok = Check {
+        id: "first".into(),
+        reason: "test".into(),
+        steps: vec![Step::new("git", &["status", "--porcelain"])],
+    };
+    execute::run(&repo.0, &metadata, &opts, &[ok]).unwrap();
+    let receipt = repo.0.join("target/verify/first.json");
+    assert!(receipt.exists());
+    let bad = Check {
+        id: "first".into(),
+        reason: "test".into(),
+        steps: vec![Step::new("git", &["not-a-command"])],
+    };
+    let later = Check {
+        id: "later".into(),
+        reason: "test".into(),
+        steps: vec![Step::new("git", &["status", "--porcelain"])],
+    };
+    let error = execute::run(&repo.0, &metadata, &opts, &[bad, later]).unwrap_err();
+    assert!(
+        error.to_string().contains("required check first failed"),
+        "{error}"
+    );
+    assert!(!receipt.exists());
+    assert!(!repo.0.join("target/verify/later.json").exists());
+}
+#[test]
+#[cfg(unix)]
+fn symlink_inputs_can_still_run_fresh_without_cache() {
+    let repo = Repo::new();
+    std::os::unix::fs::symlink("file.rs", repo.0.join("link")).unwrap();
+    let metadata = serde_json::json!({"target_directory":repo.0.join("target")});
+    let check = Check {
+        id: "fresh".into(),
+        reason: "test".into(),
+        steps: vec![Step::new("git", &["status", "--porcelain"])],
+    };
+    let mut opts = opts("--changed");
+    opts.reuse = false;
+    execute::run(&repo.0, &metadata, &opts, &[check]).unwrap();
+    assert!(!repo.0.join("target/verify/fresh.json").exists());
+}
+#[test]
+fn full_covers_workspace_and_example_targets() {
+    let all = checks::all();
+    let c = all.iter().find(|c| c.id == "full-tests").unwrap();
+    assert!(c.steps[0].args.contains(&"--workspace".into()));
+    let c = all.iter().find(|c| c.id == "workspace-check").unwrap();
+    for flag in ["--workspace", "--all-features", "--all-targets"] {
+        assert!(c.steps[0].args.contains(&flag.into()));
+    }
+}
+
+#[test]
+fn reporting_only_edits_do_not_invalidate_executable_results() {
+    let repo = Repo::new();
+    let files = vec!["file.rs".into(), "DEVELOPING.md".into()];
+    let before = execute::digest(&repo.0, &files, b"configuration").unwrap();
+    std::fs::write(repo.0.join("DEVELOPING.md"), "updated timing report").unwrap();
+    assert_eq!(
+        before,
+        execute::digest(&repo.0, &files, b"configuration").unwrap()
+    );
+}
+#[test]
+fn frozen_release_edits_include_untracked_and_working_changes() {
+    assert!(
+        selection::plan(
+            Path::new("/repo"),
+            &metadata(),
+            &opts("--pr"),
+            &BTreeSet::from(["docs/migrations/new.md".into()]),
+            &checks::all()
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn browser_worker_changes_run_javascript_and_wasm_checks() {
+    let p = ids(
+        "--changed",
+        &["examples/candle_wasm_chat/www/worker-runtime.mjs"],
+    );
+    assert!(p.contains("source-guards"));
+    assert!(p.contains("wasm-candle_wasm_chat"));
+}
+#[test]
+fn unmodeled_package_assets_broaden_instead_of_skipping() {
+    assert_eq!(
+        ids("--changed", &["crates/rig-ecs/generator.sh"]),
+        ids("--full", &[])
+    );
+}
+
+#[test]
+fn successful_execution_is_reused_until_fixture_or_command_changes() {
+    let repo = Repo::new();
+    let metadata = serde_json::json!({"target_directory":repo.0.join("target")});
+    let mut check = Check {
+        id: "count-executions".into(),
+        reason: "test".into(),
+        // An empty commit changes only .git, which is not an execution input.
+        // Its count tells us whether the runner actually invoked the command.
+        steps: vec![Step::new(
+            "git",
+            &[
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=test@example.invalid",
+                "commit",
+                "--quiet",
+                "--allow-empty",
+                "-m",
+                "executed",
+            ],
+        )],
+    };
+    let opts = opts("--changed");
+    execute::run(&repo.0, &metadata, &opts, &[check.clone()]).unwrap();
+    execute::run(&repo.0, &metadata, &opts, &[check.clone()]).unwrap();
+    // CI deliberately executes even when a matching local result exists.
+    let first_count = if std::env::var_os("CI").is_some() {
+        3
+    } else {
+        2
+    };
+    let count = || {
+        output(&repo.0, "git", &["rev-list", "--count", "HEAD"])
+            .unwrap()
+            .trim()
+            .parse::<usize>()
+            .unwrap()
+    };
+    assert_eq!(count(), first_count);
+    std::fs::write(repo.0.join("fixture.yaml"), "changed fixture").unwrap();
+    execute::run(&repo.0, &metadata, &opts, &[check.clone()]).unwrap();
+    assert_eq!(count(), first_count + 1);
+    check.steps[0]
+        .env
+        .insert("RIG_VERIFY_TEST_CONFIG".into(), "different".into());
+    execute::run(&repo.0, &metadata, &opts, &[check.clone()]).unwrap();
+    assert_eq!(count(), first_count + 2);
+    check.id = "different-test-identity".into();
+    execute::run(&repo.0, &metadata, &opts, &[check]).unwrap();
+    assert_eq!(count(), first_count + 3);
+}
+
+#[test]
+fn ancestor_cargo_configuration_invalidates_results() {
+    let repo = Repo::new();
+    let child = repo.0.join("child");
+    std::fs::create_dir(&child).unwrap();
+    std::fs::create_dir(repo.0.join(".cargo")).unwrap();
+    let check = Check {
+        id: "config".into(),
+        reason: "test".into(),
+        steps: vec![],
+    };
+    let before = execute::config(&child, &check).unwrap();
+    std::fs::write(repo.0.join(".cargo/config.toml"), "[build]\njobs = 2\n").unwrap();
+    assert_ne!(before, execute::config(&child, &check).unwrap());
+}
+
+#[test]
+fn verification_commands_force_replay_and_preserve_retry_contracts() {
+    let step = Step::new("cargo", &["test"])
+        .env("RIG_PROVIDER_TEST_MODE", "record")
+        .env("RIG_REGENERATE_GOLDEN", "1")
+        .env("NEXTEST_RETRIES", "5");
+    let command = execute::command(Path::new("/repo"), &step);
+    let env: BTreeMap<_, _> = command.get_envs().collect();
+    assert_eq!(
+        env[std::ffi::OsStr::new("RIG_PROVIDER_TEST_MODE")],
+        Some(std::ffi::OsStr::new("replay"))
+    );
+    assert_eq!(env[std::ffi::OsStr::new("RIG_REGENERATE_GOLDEN")], None);
+    assert_eq!(env[std::ffi::OsStr::new("NEXTEST_RETRIES")], None);
+}


### PR DESCRIPTION
## Description

Narrow provider builds currently compile unrelated database/container test dependencies, contributor commands duplicate CI definitions, and development-base pushes cannot warm shared Rust caches. This change separates the service-test runner and adds one Rust `xtask` verification planner shared by local workflows and CI.

The planner uses Cargo metadata and explicit fixture/configuration rules, includes staged/unstaged/untracked changes, broadens unknown inputs, and explains selection and reuse. Its latest local results are disposable; no evidence archive is required. Full/service and dependency-floor checks always execute.

The everyday commands are:

```sh
cargo xtask verify --changed
cargo xtask verify --changed --dry-run
cargo xtask verify --pr --base origin/feat/effect-bus
cargo xtask verify --full
```

Maintainability takes priority over line-count reduction: one command table, one unpublished service-test package, existing test sources and assertions, and conservative selection rules. No runtime redesign or provider recapture is included.

## Measurements

On the same Apple M2 Max / 64 GiB machine with Rust 1.95.0, an initially empty target and an available registry, `cargo check --locked -p rig --test anthropic --timings` took **44.13s before and 27.05s after**. This is one cold compilation sample, about 39% lower wall time, not a universal speedup claim.

Warm medians of three matched direct Cargo runs: no-op 0.435s → 0.355s; single Anthropic cassette replay 1.012s → 0.922s; consumed fixture edit 0.984s → 0.900s; actual ECS implementation edit 0.933s → 0.950s; example implementation edit 0.382s → 0.381s. The ECS result is a small regression in this sample; example/documentation checks show little difference. These are dependency-boundary measurements, not timings of complete planner validation. Commands, feature/profile/target details, and limitations are in `DEVELOPING.md`.

Actual planner measurements at `6aafd32ef`: clean changed-mode no-op **0.274s** median; first example-edit verification **32.301s** using the existing validation cache; three identical invocations reuse formatting, example tests and consumer compilation in **1.843s** median. Changed-input invalidation is tested separately. All benchmark edits were restored and no measured Cargo lock waits occurred.

Registration validation now lists the same default-member/bedrock graph already built by the preceding test sweep. All **4,347 root registrations** exactly match the prior listing. The previous Linux CI registration step spent another three minutes compiling; the local candidate check took 3.120s. Those different environments do not establish a cross-machine speedup ratio.

Development-base cache warming is bounded to one trusted branch and one default/bedrock configuration. PRs/forks cannot write shared caches. Its actual benefit cannot be measured until the workflow lands and a trusted base push populates the cache; existing cache quota pressure can cause eviction.

## Coverage and review

The eight service suites retain their original source files and assertions under the `rig-service-tests` runner. Bedrock integration tests remain in `rig`. The service runner is a default workspace member and required full CI enables its features. LanceDB tests now own temporary stores rather than writing databases into the repository. No cassette/golden bytes or assertions were removed or recaptured.

Default, all-feature, no-default-feature, downstream consumer, documentation, loom, WASM and native-only guarantees remain required. Telemetry/span tests keep zero retries through nextest overrides in their existing run, removing the separate duplicate rerun. Live/ignored tests remain opt-in.

Independent reviewers inspected the complete intended diff against `feat/effect-bus`, including new files. Confirmed findings were fixed: feature-gated provider selection, unknown-change PR fallback, explicit planner-lock release, temporary Git fixture signing/hook isolation, and LanceDB output isolation. No outstanding actionable review findings remain from that review.

## Testing

Completed the full local check set through `cargo xtask verify --pr --base origin/feat/effect-bus`, followed by affected and remaining `--check ID` invocations after fixes:

- Formatting, source guards, strict workspace/tooling Clippy, and 38 tooling tests.
- Default tests: 7,941 passed, 203 skipped. Final all-feature workspace tests: **8,306 passed, 213 skipped, no retries**, execution 653.588s.
- Core, bus verification, conformance, derive, macro hygiene, all workspace doctests/documentation, loom, and workspace all-feature/all-target compilation.
- Dependency floors: passed with 52 downgrades, 24 already at floor, and 44 transitive-constrained floors verified at the lowest admitted versions.
- Eight WASM compilation configurations, all three executed WASM suites (seven tests), and both expected native-only diagnostics. The executed suites used Node v24.10.0 and an isolated wasm-bindgen runner 0.2.118 matching the lockfile.

The first full run detected generated LanceDB store files through its input fingerprint; temporary stores fixed that issue and the final full run was accepted with unchanged inputs. A local WASM runner mismatch was resolved with the matching tool, without changing dependency versions. Colima was restored to its original stopped state and CPU/memory settings after service validation.

## CI measurements

All **25 checks are green** at `d0637e310`: [Lint & Test](https://github.com/0xPlaygrounds/rig/actions/runs/34065213889) and [Nightly Full Test](https://github.com/0xPlaygrounds/rig/actions/runs/34065213857). GitHub reports a clean merge state and no unresolved review threads. Baseline runs: [Lint & Test](https://github.com/0xPlaygrounds/rig/actions/runs/34055590165), [Nightly Full Test](https://github.com/0xPlaygrounds/rig/actions/runs/34055590122).

The baseline is committed head `45216c03e` (the tree merged as `de065e9be`); the candidate is `d0637e310`. Both use Ubuntu x64 runners, Rust 1.95.0, incremental compilation disabled, and `line-tables-only` dev/test debuginfo. These are single CI observations on the same runner class, not a guarantee of identical physical machines.

| Default test job | Before | After |
| --- | ---: | ---: |
| Complete job | 18m37s | 13m42s |
| Default-feature test-target check step | 3m04s | 2m04s |
| Test compilation | 7m00s | 6m08s |
| Test execution, 7,942 passed / 203 skipped | 289.043s | 294.494s |
| Scenario registration step | 3m08s | 5s |

The default job is 26% shorter. Test execution itself is a small regression in this sample; the savings come from compilation and eliminating the separate registration feature graph. Neither default job restored a Rust cache; lookup took approximately 0.17s before and 0.09s after, and both reported zero sccache hits. This does not measure the future development-base warming job.

The complete CI run is **slower** in this sample, despite faster ordinary/default checks:

| Full verification | Before | After |
| --- | ---: | ---: |
| All checks, first job start to last completion | 21m42s | 23m22s |
| All-feature test job | 21m24s | 23m21s |
| All-feature compilation | 10m58s | 12m42s |
| All-feature test execution | 575.039s | 588.041s |
| All-feature tests passed / skipped | 8,025 / 213 | 8,307 / 213 |
| Documentation job | 5m45s | 7m34s |
| Doctest job | 9m55s | 10m26s |
| Guard job | 8m40s | 7m36s |
| Clippy job | 6m40s | 6m24s |
| Dependency-floor job | 10m18s | 10m15s |

Full verification now enables all features throughout the workspace and executes 282 additional tests. That broader coverage is intentional, and its increased full-run cost is reported here. Neither all-feature job restored a Rust cache (approximately 0.05s lookup before and 0.04s after). The longer full/documentation jobs are observed costs, not speedup claims.

MongoDB service readiness remains a limitation: one unchanged vector-search integration test could not connect to MongoDB's Search Index Management service on its first attempt and passed on the next attempt under the existing retry policy. Its source, assertions, image version, and retry policy are retained; separate service-readiness changes are outside this dependency/verification PR's scope.

## Changelog

- *(development)* Add `cargo xtask verify` for conservative changed-file, PR, full, and individual-check verification shared with CI.
- *(tests)* Move vector-store integration execution to the unpublished `rig-service-tests` workspace package, reducing unrelated provider build dependencies.
- *(ci)* Warm one development-base Rust cache configuration on trusted upstream pushes and remove duplicate registration compilation and telemetry execution.

## Migration

Root-only `cargo test -p rig --all-features` no longer runs the eight service suites. Use `cargo test -p rig-service-tests --all-features --test integrations`, or the complete `cargo xtask verify --full` command. Individual service features remain available, for example `cargo test -p rig-service-tests --features sqlite --test integrations`.

Service test identities move from `rig::integrations::<service>::<test>` to `rig-service-tests::integrations::<service>::<test>`. The agent/ECS scenario catalog has no service-integration mappings to migrate. Ordinary regression execution needs the checkout and prerequisites, not an evidence archive.
