### PR TITLE
fix(rig-reqwest): default-transport constructors return an error instead of panicking when the client cannot be built

### DIFF
--- a/crates/rig-reqwest/src/client.rs
+++ b/crates/rig-reqwest/src/client.rs
@@ -19,11 +19,48 @@
 //! or `.http_client(ReqwestClient::default()).build()`.
 
 use rig_core::client::{Client, ClientBuilder, Provider, ProviderClientError};
-use rig_core::http_client::BoxedHttpClient;
+use rig_core::http_client::{self, BoxedHttpClient};
 use rig_core::markers::Missing;
 
-fn bundled() -> BoxedHttpClient {
-    BoxedHttpClient::from(crate::ReqwestClient::default())
+/// The bundled transport, built fallibly. `reqwest::Client::new()` (and so
+/// `ReqwestClient::default()`) panics when the client cannot be built — on a
+/// host with no CA store, for one — while every constructor below promises
+/// a `Result`. Build through the builder and hand the failure back as the
+/// `Http` variant the rest of the client-construction path already uses.
+fn bundled() -> Result<BoxedHttpClient, ProviderClientError> {
+    let client = reqwest::Client::builder()
+        .build()
+        .map_err(|error| http_client::Error::Instance(Box::new(TransportBuildError(error))))?;
+    Ok(BoxedHttpClient::from(crate::ReqwestClient::new(client)))
+}
+
+/// The bundled reqwest transport could not be built. `reqwest::Error`
+/// displays as just "builder error" and keeps the reason (no CA store, a
+/// bad proxy, ..) in its source chain, so this flattens the chain into the
+/// message a caller prints, while `source()` still exposes the original.
+#[derive(Debug)]
+struct TransportBuildError(reqwest::Error);
+
+impl std::fmt::Display for TransportBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "could not build the bundled reqwest transport: {}",
+            self.0
+        )?;
+        let mut source = std::error::Error::source(&self.0);
+        while let Some(cause) = source {
+            write!(f, ": {cause}")?;
+            source = cause.source();
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for TransportBuildError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
 }
 
 /// One-argument construction of a provider client over the erased default
@@ -59,15 +96,15 @@ where
     type Input = P::EnvInput;
 
     fn new(api_key: impl Into<Self::ApiKey>) -> Result<Self, ProviderClientError> {
-        Client::new_with(api_key, bundled())
+        Client::new_with(api_key, bundled()?)
     }
 
     fn from_env() -> Result<Self, ProviderClientError> {
-        P::from_env(bundled())
+        P::from_env(bundled()?)
     }
 
     fn from_val(input: Self::Input) -> Result<Self, ProviderClientError> {
-        P::from_val(input, bundled())
+        P::from_val(input, bundled()?)
     }
 }
 
@@ -93,7 +130,7 @@ where
     type Client = Client<P, BoxedHttpClient>;
 
     fn build(self) -> Result<Self::Client, ProviderClientError> {
-        self.http_client(bundled()).build()
+        self.http_client(bundled()?).build()
     }
 }
 

--- a/crates/rig-reqwest/tests/default_transport_no_ca_store.rs
+++ b/crates/rig-reqwest/tests/default_transport_no_ca_store.rs
@@ -10,9 +10,13 @@
 //! The store is emptied through the `SSL_CERT_FILE` / `SSL_CERT_DIR`
 //! overrides rustls-native-certs honours, which is why this test is its own
 //! binary (the variables are process-wide) and Linux-only (the macOS and
-//! Windows verifiers read their keychains instead).
+//! Windows verifiers read their keychains instead). It also needs the
+//! rustls backend to be the one reqwest builds with: with `native-tls`
+//! enabled as well (CI's `--all-features`), reqwest defaults to OpenSSL,
+//! which does not read the store at build time, so there is no failure to
+//! observe and the test compiles to nothing.
 
-#![cfg(target_os = "linux")]
+#![cfg(all(target_os = "linux", feature = "rustls", not(feature = "native-tls")))]
 
 use rig_core::client::ProviderClientError;
 use rig_core::providers::openai;
@@ -41,16 +45,14 @@ fn every_default_transport_constructor_reports_a_missing_ca_store() {
         ("new", new.map(drop)),
         ("build", built.map(drop)),
     ] {
-        match result {
-            Err(ProviderClientError::Http(error)) => {
-                let text = error.to_string();
-                assert!(
-                    text.contains("CA certificates"),
-                    "{name}: expected the CA-store failure, got {text}"
-                );
-            }
-            Err(other) => panic!("{name}: expected ProviderClientError::Http, got {other}"),
-            Ok(()) => panic!("{name}: built a client with no CA store"),
-        }
+        let outcome = match result {
+            Err(ProviderClientError::Http(error)) => error.to_string(),
+            Err(other) => format!("wrong variant: {other}"),
+            Ok(()) => "built a client with no CA store".to_owned(),
+        };
+        assert!(
+            outcome.contains("CA certificates"),
+            "{name}: expected the Http error naming the CA store, got: {outcome}"
+        );
     }
 }

--- a/crates/rig-reqwest/tests/default_transport_no_ca_store.rs
+++ b/crates/rig-reqwest/tests/default_transport_no_ca_store.rs
@@ -1,0 +1,56 @@
+//! The default-transport constructors return an error, not a panic, when the
+//! bundled reqwest client cannot be built.
+//!
+//! reqwest's rustls backend loads the platform CA store while building the
+//! client; on a host with none (a bare `ubuntu` container, say) `Client::new()`
+//! panics with "No CA certificates were loaded from the system". `from_env`,
+//! `new`, `from_val` and `build` all promise a `Result`, so that failure must
+//! come back as `ProviderClientError::Http`.
+//!
+//! The store is emptied through the `SSL_CERT_FILE` / `SSL_CERT_DIR`
+//! overrides rustls-native-certs honours, which is why this test is its own
+//! binary (the variables are process-wide) and Linux-only (the macOS and
+//! Windows verifiers read their keychains instead).
+
+#![cfg(target_os = "linux")]
+
+use rig_core::client::ProviderClientError;
+use rig_core::providers::openai;
+use rig_reqwest::prelude::*;
+
+fn empty_the_ca_store() {
+    // SAFETY: this test binary has one test and no other threads read the
+    // environment before it runs.
+    unsafe {
+        std::env::set_var("SSL_CERT_FILE", "/nonexistent/rig-no-ca.pem");
+        std::env::set_var("SSL_CERT_DIR", "/nonexistent/rig-no-ca");
+        std::env::set_var("OPENAI_API_KEY", "test-key");
+    }
+}
+
+#[test]
+fn every_default_transport_constructor_reports_a_missing_ca_store() {
+    empty_the_ca_store();
+
+    let from_env = openai::Client::from_env();
+    let new = openai::Client::new("test-key");
+    let built = openai::Client::builder().api_key("test-key").build();
+
+    for (name, result) in [
+        ("from_env", from_env.map(drop)),
+        ("new", new.map(drop)),
+        ("build", built.map(drop)),
+    ] {
+        match result {
+            Err(ProviderClientError::Http(error)) => {
+                let text = error.to_string();
+                assert!(
+                    text.contains("CA certificates"),
+                    "{name}: expected the CA-store failure, got {text}"
+                );
+            }
+            Err(other) => panic!("{name}: expected ProviderClientError::Http, got {other}"),
+            Ok(()) => panic!("{name}: built a client with no CA store"),
+        }
+    }
+}


### PR DESCRIPTION
## The defect

`rig_reqwest`'s default-transport constructors all promise a `Result<_, ProviderClientError>`:

- `DefaultTransportClient::{new, from_env, from_val}` (e.g. `openai::Client::from_env()`)
- `DefaultTransportBuilder::build` (e.g. `anthropic::Client::builder().api_key(..).build()`)

But they obtain the bundled transport through `ReqwestClient::default()`, which derives `Default` over `reqwest::Client` — and `reqwest::Client::new()` **panics** when the client cannot be built. The common way to hit that is a host with no CA store: reqwest's rustls backend loads the platform roots at build time and aborts with

```
thread 'main' panicked at reqwest-0.13.4/src/async_impl/client.rs:2507:38:
Client::new(): reqwest::Error { kind: Builder, source: General("No CA certificates were loaded from the system") }
```

So a `from_env()` that the caller wrapped in `?` (or matched on to report a configuration problem) tears the process down instead. The `Result` is a promise the code did not keep.

## How it was found

Running a rig-ecs consumer (a coding agent) inside Terminal-Bench task containers through Harbor. Tasks built from `python:3.13-slim-bookworm` worked; the one built from bare `ubuntu:24.04` — which ships no `ca-certificates` — died at startup with the panic above, before any error-handling path in the consumer could run or report it. The consumer's `Handlers::register` error path, which would have surfaced "could not register the model: …", never executed.

## The fix

`bundled()` builds the transport through `reqwest::Client::builder().build()` and returns `Result<BoxedHttpClient, ProviderClientError>`, mapping the builder error into `ProviderClientError::Http(http_client::Error::Instance(..))` — the variant the client-construction path already uses for transport failures. The four constructors thread it with `?`. `ReqwestClient`'s `Default` impl is untouched: it wraps reqwest's own documented panicking constructor and is used by tests and examples that want exactly that spelling; the change is confined to the paths that already claim fallibility.

## The test

`crates/rig-reqwest/tests/default_transport_no_ca_store.rs` empties the CA store through the `SSL_CERT_FILE` / `SSL_CERT_DIR` overrides that rustls-native-certs honours, then asserts that `from_env`, `new` and `build` each return `ProviderClientError::Http` whose message names the CA-store failure. It is its own test binary because the variables are process-wide; `cfg(target_os = "linux")` because the macOS and Windows verifiers read their keychains rather than those variables; and `cfg(feature = "rustls", not(feature = "native-tls"))` because reqwest only defaults to rustls when native-tls is absent (`TlsBackend::default`), and OpenSSL does not read the store at build time, so under `--all-features` (CI's test-guards job) there is no failure to observe. The default feature set, which the `test` job exercises, runs it.

Run in a `rust:1.95.0-bookworm` container against this branch:

```
running 1 test
test every_default_transport_constructor_reports_a_missing_ca_store ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

The same test with `client.rs` reverted to the base commit:

```
thread 'every_default_transport_constructor_reports_a_missing_ca_store' panicked at reqwest-0.13.4/src/async_impl/client.rs:2507:38:
Client::new(): reqwest::Error { kind: Builder, source: General("No CA certificates were loaded from the system") }

test result: FAILED. 0 passed; 1 failed
```

(That is the panic escaping `from_env()`; the test never reaches its assertions.)

With the fix, the error a caller prints reads `could not build the bundled reqwest transport: builder error: No CA certificates were loaded from the system`, because `TransportBuildError` flattens reqwest's source chain into its message (reqwest's own `Display` is just "builder error") while keeping `source()` for callers that walk the chain.

Under `--all-features` in the same container the binary compiles to zero tests, as intended. Locally on macOS: `cargo clippy -p rig-reqwest --all-features --tests -- -D clippy::panic` and `cargo fmt --check` clean.
