### PR TITLE
refactor(rig-ecs): depend on bevy_ecs and bevy_tasks only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10574,12 +10574,11 @@ dependencies = [
  "bevy_reflect",
  "bevy_tasks",
  "futures",
+ "log",
  "rig-core",
  "rig-effect-log",
- "schemars 1.2.1",
  "serde",
  "serde_json",
- "tracing",
  "wasm-bindgen-test",
 ]
 

--- a/crates/rig-ecs/CONTRACT.md
+++ b/crates/rig-ecs/CONTRACT.md
@@ -310,7 +310,7 @@ and held requests can await another update or host input. A refusal installs
 through to ordinary collection and exposing unpaced successful answers.
 Hosts driving `RigSchedule` directly must reset `Progress` before each pass
 and call `bus::delivery::diagnose_idle_replay` after a complete pass reports no
-progress; the standard `Update` runner does this automatically.
+progress; `run_to_quiescence`, which the host calls once per tick, does this.
 
 Policy observers may use `On<Add, EffectOutcome>` or systems ordered after
 all of `BusSet::Collect`, preserving their relevant live/replay ordering.

--- a/crates/rig-ecs/Cargo.toml
+++ b/crates/rig-ecs/Cargo.toml
@@ -8,10 +8,6 @@ repository = "https://github.com/0xPlaygrounds/rig"
 # Not published yet; rig-verify is the precedent.
 publish = false
 
-[package.metadata.docs.rs]
-all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-
 [lints]
 workspace = true
 
@@ -29,7 +25,7 @@ reflect = ["dep:bevy_reflect", "bevy_ecs/bevy_reflect"]
 # with `bevy_asset` loaders, and the systems that turn them into a
 # `Preamble` and `Grant`s. The one feature that needs `bevy_app`:
 # `bevy_asset` is built on it.
-assets = ["dep:bevy_asset", "dep:bevy_app", "reflect"]
+assets = ["dep:bevy_asset", "dep:bevy_app", "dep:bevy_reflect"]
 
 [dependencies]
 rig-core = { path = "../rig-core", version = "0.42.0", default-features = false }
@@ -47,10 +43,9 @@ bevy_app = { workspace = true, optional = true }
 # The channel types rig-core's `OutcomeSink` names; rig-core already
 # depends on the crate.
 futures = { workspace = true }
-schemars = { workspace = true }
+log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tracing = { workspace = true }
 
 [dev-dependencies]
 rig-core = { path = "../rig-core", version = "0.42.0", features = ["test-utils"] }

--- a/crates/rig-ecs/Cargo.toml
+++ b/crates/rig-ecs/Cargo.toml
@@ -24,24 +24,28 @@ replay = ["dep:rig-effect-log"]
 # the rig-core types they hold), `reflect::ReflectPlugin` registering
 # them, `reflect::ReflectedScene` — the graph as reflected data beside the
 # serde scene. rig-core takes no Bevy dependency: the wrappers live here.
-reflect = ["dep:bevy_reflect", "bevy_ecs/bevy_reflect", "bevy_app/bevy_reflect"]
+reflect = ["dep:bevy_reflect", "bevy_ecs/bevy_reflect"]
 # Prompts and tool definitions as assets: `assets::{Prompt, ToolDefinitions}`
 # with `bevy_asset` loaders, and the systems that turn them into a
-# `Preamble` and `Grant`s.
-assets = ["dep:bevy_asset", "reflect"]
+# `Preamble` and `Grant`s. The one feature that needs `bevy_app`:
+# `bevy_asset` is built on it.
+assets = ["dep:bevy_asset", "dep:bevy_app", "reflect"]
 
 [dependencies]
 rig-core = { path = "../rig-core", version = "0.42.0", default-features = false }
 rig-effect-log = { path = "../rig-effect-log", version = "0.42.0", optional = true }
-# Each Bevy crate with default features off and exactly what the module
-# needs: `std` for the executor-backed task pools and `bevy_app`'s
-# `ScheduleRunnerPlugin`; `multi_threaded` so handler futures run on pool
-# threads natively (the single-threaded pool takes over on wasm).
+# The crate is bevy_ecs and bevy_tasks: the bus installs into a `World`,
+# the host owns the loop. Each Bevy crate with default features off and
+# exactly what the module needs: `std` for the executor-backed task pools;
+# `multi_threaded` so handler futures run on pool threads natively (the
+# single-threaded pool takes over on wasm).
 bevy_ecs = { workspace = true }
 bevy_tasks = { workspace = true }
-bevy_app = { workspace = true }
 bevy_reflect = { workspace = true, optional = true }
 bevy_asset = { workspace = true, optional = true }
+bevy_app = { workspace = true, optional = true }
+# The channel types rig-core's `OutcomeSink` names; rig-core already
+# depends on the crate.
 futures = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
@@ -50,6 +54,9 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 rig-core = { path = "../rig-core", version = "0.42.0", features = ["test-utils"] }
+# Tests and examples drive the bus from an `App`'s `Update`; the library
+# does not.
+bevy_app = { workspace = true }
 
 # The module executed on `wasm32-unknown-unknown` (`tests/bus_wasm.rs`),
 # under `wasm-bindgen-test-runner`, as rig-agent's `tests/bus_wasm.rs` is.

--- a/crates/rig-ecs/README.md
+++ b/crates/rig-ecs/README.md
@@ -6,7 +6,7 @@ see the [ECS consumer harness](../../tests/consumer/README.md). Its owning
 producer runs through this runtime; the existing cross-runtime corpus remains
 separate evidence with its own applicability limits.
 
-rig inside a Bevy `World`. Two layers: `rig_ecs::bus`, the effect bus as a plugin in the native shape — effects are entities, handlers are entities, the driver is a system, an outcome is a component, causality is `ChildOf`, a scene is a checkpoint — and the agent runtime over it (`agent`, `policy`, `systems`, `replay`): the run as a graph, the request as its fold. Nothing awaits, nothing blocks, nothing is probed; rig-agent is not in the graph; nothing is copied from rig-agent.
+rig inside a Bevy `World`. Two layers: `rig_ecs::bus`, the effect bus in the native shape — effects are entities, handlers are entities, the driver is a system, an outcome is a component, causality is `ChildOf`, a scene is a checkpoint — and the agent runtime over it (`agent`, `policy`, `systems`, `replay`): the run as a graph, the request as its fold. Nothing awaits, nothing blocks, nothing is probed; rig-agent is not in the graph; nothing is copied from rig-agent.
 
 ## The run as a graph
 
@@ -145,7 +145,7 @@ Every hook cell of the corpus is written against the public sets and components 
 
 ## The schedule
 
-`BusPlugin` adds `RigSchedule` with four sets in order and runs it to quiescence from one exclusive system in `Update` (`run_to_quiescence`: while a plugin system marks `Progress`, at most `QUIESCENCE_CAP` passes). Users add their systems to `RigSchedule`, ordered against the sets, never to `Update`.
+`Bus::install` (or `install_bus`) adds `RigSchedule` with four sets in order to a `World`; the host runs it to quiescence by calling `run_to_quiescence` once per tick from the schedule or loop it owns (while a bus system marks `Progress`, at most `QUIESCENCE_CAP` passes). The crate depends on `bevy_ecs` and `bevy_tasks` only: no `App`, no `bevy_app`. Users add their systems to `RigSchedule`, ordered against the sets, never beside the runner.
 
 | set | true before | written during |
 |---|---|---|
@@ -296,9 +296,9 @@ them during restoration.
 
 `rig_ecs::prelude` names what a user's systems need and nothing else: the sets (`RigSet`, `BusSet`), the components a user writes (`Cancelled`, `RequestPatch`, `Retry`, `Resolution`, `Held`, `UsesModel`, `Grant`, `Context`, `Remembers`, `Retrieves`) and the components a user reads (`Streamed`, `Outputs`, `EffectOutcome`, `RunResult`, `Settled`, `Failed`, `Usage`).
 
-`reflect` (off by default): every component of the bus and the graph derives `Reflect`, the rig-core values they hold reflect through opaque remote wrappers (`bus::reflect`, `agent::reflect` — serialized as their wire form, so an inspector shows an effect entity's payload as the log would), `reflect::ReflectPlugin` registers them all, and `reflect::ReflectedScene` is the world as reflected data beside the serde scene: canonical (entities ordered by content, an `Entity` in a component as its index in the scene, a relationship target's indexes sorted), so a world and the world its `WorldScene` loads into export the same JSON (`tests/reflect_scene.rs`); every component round-trips through `ReflectSerializer` / `ReflectDeserializer` / `FromReflect` by value (`tests/reflect_roundtrip.rs`). The runtime-only components (`Serving`, `Streaming`, `Publishing`, `Observed`, `Asked`, `Answer`, `Typed`, and the asset handles) reflect nothing. rig-core takes no Bevy dependency.
+`reflect` (off by default): every component of the bus and the graph derives `Reflect`, the rig-core values they hold reflect through opaque remote wrappers (`bus::reflect`, `agent::reflect` — serialized as their wire form, so an inspector shows an effect entity's payload as the log would), `reflect::install_reflect` registers them all, and `reflect::ReflectedScene` is the world as reflected data beside the serde scene: canonical (entities ordered by content, an `Entity` in a component as its index in the scene, a relationship target's indexes sorted), so a world and the world its `WorldScene` loads into export the same JSON (`tests/reflect_scene.rs`); every component round-trips through `ReflectSerializer` / `ReflectDeserializer` / `FromReflect` by value (`tests/reflect_roundtrip.rs`). The runtime-only components (`Serving`, `Streaming`, `Publishing`, `Observed`, `Asked`, `Answer`, `Typed`, and the asset handles) reflect nothing. rig-core takes no Bevy dependency.
 
-`assets` (off by default, implies `reflect`): `assets::Prompt` (a `.md` / `.txt` file) and `assets::ToolDefinitions` (a `.json` array of `{ name, description, parameters }`) are `bevy_asset` assets with loaders; `PromptHandle` / `ToolsHandle` on an agent become its `Preamble` and its `Grant`s — one per definition, in file order, to the bound handler whose descriptor is the tool of that name; a definition nothing serves is not granted — the tick the asset loads, once (`Applied<A>`). `assets::AssetsPlugin` after `bevy_asset::AssetPlugin`. `tests/assets_prompt.rs`, `examples/prompt_from_assets.rs` (an in-memory source; a directory with the default one).
+`assets` (off by default; the one feature that takes `bevy_app`, because `bevy_asset` is built on it): `assets::Prompt` (a `.md` / `.txt` file) and `assets::ToolDefinitions` (a `.json` array of `{ name, description, parameters }`) are `bevy_asset` assets with loaders; `PromptHandle` / `ToolsHandle` on an agent become its `Preamble` and its `Grant`s — one per definition, in file order, to the bound handler whose descriptor is the tool of that name; a definition nothing serves is not granted — the tick the asset loads, once (`Applied<A>`). `assets::AssetsPlugin` after `bevy_asset::AssetPlugin`, and the host orders `run_to_quiescence` after `assets::AssetsSet`. `tests/assets_prompt.rs`, `examples/prompt_from_assets.rs` (an in-memory source; a directory with the default one).
 
 ## The examples, side by side
 

--- a/crates/rig-ecs/examples/hello_model.rs
+++ b/crates/rig-ecs/examples/hello_model.rs
@@ -13,7 +13,7 @@
     reason = "an example: user code, thirty lines, a mock behind it"
 )]
 
-use bevy_app::{App, AppExit, ScheduleRunnerPlugin, Startup};
+use bevy_app::{App, AppExit, ScheduleRunnerPlugin, Startup, Update};
 use bevy_ecs::prelude::*;
 use rig_core::{
     completion::{
@@ -21,15 +21,17 @@ use rig_core::{
     },
     effect::{EffectKind, FamilyDescriptor, HandlerDescriptor, HandlerKey, Outcome},
     message::AssistantContent,
-    serve::{OutcomeSink, Serve},
+    serve::{OutcomeSink, Serve, ServingPolicy},
 };
-use rig_ecs::bus::{BusPlugin, EffectOutcome, Handlers, PendingEffect};
+use rig_ecs::bus::{EffectOutcome, Handlers, PendingEffect, install_bus, run_to_quiescence};
 
 // ---- the user's program: the next thirty lines ----
 
 fn main() {
-    App::new()
-        .add_plugins((ScheduleRunnerPlugin::default(), BusPlugin::default()))
+    let mut app = App::new();
+    install_bus(app.world_mut(), ServingPolicy::default());
+    app.add_plugins(ScheduleRunnerPlugin::default())
+        .add_systems(Update, run_to_quiescence)
         .add_systems(Startup, (register_the_model, ask).chain())
         .add_observer(print_the_answer)
         .run();

--- a/crates/rig-ecs/examples/prompt_from_assets.rs
+++ b/crates/rig-ecs/examples/prompt_from_assets.rs
@@ -27,8 +27,10 @@ use bevy_ecs::prelude::*;
 use rig_core::message::AssistantContent;
 use rig_ecs::{
     agent::{Grant, Run},
-    assets::{Applied, AssetsPlugin, Prompt, PromptHandle, ToolDefinitions, ToolsHandle},
-    bus::Handlers,
+    assets::{
+        Applied, AssetsPlugin, AssetsSet, Prompt, PromptHandle, ToolDefinitions, ToolsHandle,
+    },
+    bus::{Handlers, run_to_quiescence},
     systems::spawn_run,
 };
 
@@ -57,6 +59,7 @@ fn main() {
     ))
     .add_systems(Startup, ask)
     .add_systems(Update, start_when_applied)
+    .configure_sets(Update, AssetsSet.before(run_to_quiescence))
     .add_observer(support::print_the_answer_and_exit)
     .run();
 }

--- a/crates/rig-ecs/examples/support/mod.rs
+++ b/crates/rig-ecs/examples/support/mod.rs
@@ -12,14 +12,14 @@
 
 use std::sync::Mutex;
 
-use bevy_app::{App, AppExit, ScheduleRunnerPlugin};
+use bevy_app::{App, AppExit, ScheduleRunnerPlugin, Update};
 use bevy_ecs::prelude::*;
 use rig_core::{
     completion::{CompletionResponse, ModelRef, ProviderCapabilities, Usage},
     effect::{EffectKind, FamilyDescriptor, HandlerDescriptor, HandlerKey, Outcome},
     error::{ErrorKind, ErrorReport},
     message::AssistantContent,
-    serve::{OutcomeSink, Serve},
+    serve::{OutcomeSink, Serve, ServingPolicy},
     streaming::StreamFinal,
     tool::{ToolOutput, ToolResult},
 };
@@ -28,8 +28,8 @@ use rig_ecs::{
         AdditionalParams, DefaultMaxTurns, Failed, InvalidCalls, MaxTokens, MaxTurns, Output,
         Owner, Preamble, RunResult, Settled, Temperature, ToolChoiceSpec, UsesModel,
     },
-    bus::{BusPlugin, Handlers},
-    systems::AgentPlugin,
+    bus::{Handlers, install_bus, run_to_quiescence},
+    systems::install_agent,
 };
 
 pub const MODEL: &str = "demo/model:default";
@@ -217,14 +217,14 @@ pub fn send_email() -> Tool {
     }
 }
 
-/// An app with both plugins; an example adds its own exit.
+/// An app with the bus and the agent installed and the runner in
+/// `Update`; an example adds its own exit.
 pub fn app() -> App {
     let mut app = App::new();
-    app.add_plugins((
-        ScheduleRunnerPlugin::default(),
-        BusPlugin::default(),
-        AgentPlugin::default(),
-    ));
+    app.add_plugins(ScheduleRunnerPlugin::default());
+    install_bus(app.world_mut(), ServingPolicy::default());
+    install_agent(app.world_mut());
+    app.add_systems(Update, run_to_quiescence);
     app.add_observer(exit_when_failed);
     app
 }

--- a/crates/rig-ecs/src/assets.rs
+++ b/crates/rig-ecs/src/assets.rs
@@ -159,9 +159,9 @@ pub fn grant_tools(
                 Some(tool) => {
                     commands.spawn((Grant(tool), next_order_in(&mut orders), ChildOf(agent)));
                 }
-                None => tracing::warn!(
-                    tool = definition.name,
-                    "a tool definition no handler serves: not granted"
+                None => log::warn!(
+                    "a tool definition no handler serves: not granted: {}",
+                    definition.name
                 ),
             }
         }

--- a/crates/rig-ecs/src/assets.rs
+++ b/crates/rig-ecs/src/assets.rs
@@ -5,9 +5,11 @@
 //! [`Preamble`] and its [`Grant`]s — to the bound handlers the definitions
 //! name, in file order — the tick the asset is loaded, once (the marker
 //! [`Applied`] says so — a later change to the asset is not re-applied).
-//! The systems run in `Update` before the bus's quiescence loop, so a run
-//! spawned the tick an asset loads folds with it. The host adds
-//! `bevy_asset::AssetPlugin` first, then [`AssetsPlugin`].
+//! The systems run in `Update` in [`AssetsSet`]; the host orders its
+//! `run_to_quiescence` after that set so a run spawned the tick an asset
+//! loads folds with it. This is the one module that needs `bevy_app`
+//! (`bevy_asset` is built on it): the host adds `bevy_asset::AssetPlugin`
+//! first, then [`AssetsPlugin`].
 
 use std::marker::PhantomData;
 
@@ -169,8 +171,13 @@ pub fn grant_tools(
     }
 }
 
+/// The set the applying systems run in, in `Update`: the host runs
+/// `run_to_quiescence` after it.
+#[derive(SystemSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AssetsSet;
+
 /// Registers the two assets and their loaders, and the systems that apply
-/// them. After `bevy_asset::AssetPlugin`.
+/// them, in [`AssetsSet`]. After `bevy_asset::AssetPlugin`.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct AssetsPlugin;
 
@@ -180,9 +187,6 @@ impl Plugin for AssetsPlugin {
             .register_asset_loader(PromptLoader)
             .init_asset::<ToolDefinitions>()
             .register_asset_loader(ToolDefinitionsLoader)
-            .add_systems(
-                Update,
-                (apply_prompts, grant_tools).before(crate::bus::run_to_quiescence),
-            );
+            .add_systems(Update, (apply_prompts, grant_tools).in_set(AssetsSet));
     }
 }

--- a/crates/rig-ecs/src/bus/mod.rs
+++ b/crates/rig-ecs/src/bus/mod.rs
@@ -64,15 +64,16 @@
 //!
 //! # The schedule
 //!
-//! [`BusPlugin`] adds a [`RigSchedule`] with four sets in order —
+//! [`Bus::install`] adds a [`RigSchedule`] with four sets in order —
 //! [`BusSet::Gate`], [`BusSet::Dispatch`], [`BusSet::Collect`],
-//! [`BusSet::Judge`] — and runs it **to quiescence** from one exclusive
-//! system in `Update`: as long as a plugin system reports [`Progress`], the
-//! schedule runs again (capped at [`QUIESCENCE_CAP`] passes, a `warn!`
-//! when reached). Users add their systems to `RigSchedule`, ordered
-//! against the sets, never to `Update`: a system in `Update` sees one pass,
-//! a system in `RigSchedule` sees every pass. Intake bounds can defer a
-//! dispatch to the next Update; async readiness can require later updates.
+//! [`BusSet::Judge`]. The host runs it **to quiescence** by calling
+//! [`run_to_quiescence`] once per tick from the schedule or loop it owns:
+//! as long as a bus system reports [`Progress`], the schedule runs again
+//! (capped at [`QUIESCENCE_CAP`] passes, a `warn!` when reached). Users add
+//! their systems to `RigSchedule`, ordered against the sets, never beside
+//! the runner: a system beside the runner sees one pass, a system in
+//! `RigSchedule` sees every pass. Intake bounds can defer a dispatch to the
+//! next tick; async readiness can require later ticks.
 //!
 //! # What it deliberately does not have
 //!
@@ -110,7 +111,8 @@ pub use handlers::{
     Bound, HandlerTable, Handlers, Served, WorldHandler, WorldServe, answered, unbound,
 };
 pub use plugin::{
-    BusPlugin, BusSet, Intake, Policy, Progress, QUIESCENCE_CAP, RigSchedule, run_to_quiescence,
+    Bus, BusSet, Intake, Policy, Progress, QUIESCENCE_CAP, RigSchedule, install_bus,
+    run_to_quiescence,
 };
 pub use record::{
     Observed, ObservedState, Recording, WorldObserver, record_bound, record_cancelled,

--- a/crates/rig-ecs/src/bus/plugin.rs
+++ b/crates/rig-ecs/src/bus/plugin.rs
@@ -1,6 +1,6 @@
-//! The plugin, the schedule and its sets, and the run to quiescence.
+//! The bus's installation into a world, the schedule and its sets, and the
+//! run to quiescence.
 
-use bevy_app::{App, Plugin, Update};
 use bevy_ecs::{
     prelude::*,
     schedule::{LogLevel, ScheduleBuildSettings, ScheduleLabel},
@@ -16,7 +16,7 @@ use super::{
     record::{DeliveryBatch, begin_delivery_pass, record_bound, record_cancelled, record_outcome},
 };
 
-/// The schedule the bus runs in, to quiescence, once per `Update`. Users add
+/// The schedule the bus runs in, to quiescence, once per host tick. Users add
 /// their systems here, ordered against [`BusSet`]s.
 #[derive(ScheduleLabel, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RigSchedule;
@@ -67,16 +67,17 @@ pub struct Intake(pub usize);
 /// warns: a diagnostic, never a hang.
 pub const QUIESCENCE_CAP: usize = 64;
 
-/// The bus in a world. Adds [`RigSchedule`] with its sets and systems, the
-/// counters, the handler table and the cancel observer, and the exclusive
-/// runner in `Update`.
+/// The bus's configuration: [`install`](Self::install) adds [`RigSchedule`]
+/// with its sets and systems, the counters, the handler table and the
+/// observers to a world. It does not schedule the runner: the host calls
+/// [`run_to_quiescence`] once per tick from the schedule or loop it owns.
 ///
-/// The task pool: `build` calls `IoTaskPool::get_or_init`, so the plugin
-/// works with or without `bevy_app`'s `TaskPoolPlugin` (when that plugin
-/// is added first its pool wins; when this one is first, a default pool
-/// is made and `TaskPoolPlugin` finds it initialised).
+/// The task pool: `install` calls `IoTaskPool::get_or_init`, so the bus
+/// works with or without a host that initialises the pools itself (a pool
+/// initialised first wins; otherwise a default pool is made and a later
+/// initialiser finds it in place).
 #[derive(Debug, Clone)]
-pub struct BusPlugin {
+pub struct Bus {
     /// The serving policy: intake per tick, stream buffer, serial keys.
     pub policy: ServingPolicy,
     /// Ambiguity detection on the schedule: `Warn` by default; the crate's
@@ -84,7 +85,7 @@ pub struct BusPlugin {
     pub ambiguity: LogLevel,
 }
 
-impl Default for BusPlugin {
+impl Default for Bus {
     fn default() -> Self {
         Self {
             policy: ServingPolicy::default(),
@@ -93,8 +94,8 @@ impl Default for BusPlugin {
     }
 }
 
-impl BusPlugin {
-    /// The plugin under `policy`.
+impl Bus {
+    /// The bus under `policy`.
     pub fn with_policy(policy: ServingPolicy) -> Self {
         Self {
             policy,
@@ -107,23 +108,27 @@ impl BusPlugin {
         self.ambiguity = level;
         self
     }
-}
 
-impl Plugin for BusPlugin {
-    fn build(&self, app: &mut App) {
+    /// Install the bus into `world`. Installing twice panics: the schedule
+    /// and its resources exist once per world.
+    pub fn install(&self, world: &mut World) {
+        assert!(
+            !world.contains_resource::<Policy>(),
+            "the bus is already installed in this world"
+        );
         IoTaskPool::get_or_init(TaskPool::default);
-        app.insert_resource(Policy(self.policy))
-            .init_resource::<SeqCounter>()
-            .init_resource::<IdCounter>()
-            .init_resource::<Progress>()
-            .init_resource::<Intake>()
-            .init_resource::<DeliveryBatch>()
-            .init_resource::<WorldOutcomeCounter>()
-            .init_non_send::<HandlerTable>();
-        app.add_observer(unbound)
-            .add_observer(record_outcome)
-            .add_observer(record_cancelled)
-            .add_observer(record_bound);
+        world.insert_resource(Policy(self.policy));
+        world.init_resource::<SeqCounter>();
+        world.init_resource::<IdCounter>();
+        world.init_resource::<Progress>();
+        world.init_resource::<Intake>();
+        world.init_resource::<DeliveryBatch>();
+        world.init_resource::<WorldOutcomeCounter>();
+        world.init_non_send::<HandlerTable>();
+        world.add_observer(unbound);
+        world.add_observer(record_outcome);
+        world.add_observer(record_cancelled);
+        world.add_observer(record_bound);
         let mut schedule = Schedule::new(RigSchedule);
         schedule.set_build_settings(ScheduleBuildSettings {
             ambiguity_detection: self.ambiguity,
@@ -156,9 +161,15 @@ impl Plugin for BusPlugin {
                 .chain()
                 .in_set(BusSet::Collect),
         );
-        app.add_schedule(schedule);
-        app.add_systems(Update, run_to_quiescence);
+        world.init_resource::<Schedules>();
+        world.resource_mut::<Schedules>().insert(schedule);
     }
+}
+
+/// Install the bus under `policy` with default ambiguity detection: the
+/// one-call form of [`Bus::install`].
+pub fn install_bus(world: &mut World, policy: ServingPolicy) {
+    Bus::with_policy(policy).install(world);
 }
 
 /// The runner: reset the tick's intake, then run [`RigSchedule`] while a

--- a/crates/rig-ecs/src/bus/plugin.rs
+++ b/crates/rig-ecs/src/bus/plugin.rs
@@ -185,10 +185,9 @@ pub fn run_to_quiescence(world: &mut World) {
             return;
         }
         if pass + 1 == QUIESCENCE_CAP {
-            tracing::warn!(
+            log::warn!(
                 target: "rig_ecs::bus",
-                cap = QUIESCENCE_CAP,
-                "RigSchedule reached the quiescence cap in one tick; the rest waits for the next"
+                "RigSchedule reached the quiescence cap ({QUIESCENCE_CAP}) in one tick; the rest waits for the next"
             );
         }
     }

--- a/crates/rig-ecs/src/lib.rs
+++ b/crates/rig-ecs/src/lib.rs
@@ -32,7 +32,7 @@
 //!
 //! [`prelude`] names the sets and the components a user's systems write
 //! and read, and nothing else. Behind features: `reflect` — every
-//! component derives `Reflect`, `reflect::ReflectPlugin` registers them,
+//! component derives `Reflect`, `reflect::install_reflect` registers them,
 //! `reflect::ReflectedScene` is the world as reflected data beside the
 //! serde scene.
 //!

--- a/crates/rig-ecs/src/policy/mod.rs
+++ b/crates/rig-ecs/src/policy/mod.rs
@@ -225,7 +225,9 @@ pub fn fold_request(graph: &RequestGraph<'_>) -> CompletionRequest {
     }
 
     let output_schema = match (graph.output, graph.schema) {
-        (OutputKind::Native, Some(schema)) => schemars::Schema::try_from(schema.clone()).ok(),
+        (OutputKind::Native, Some(schema)) => {
+            rig_core::schemars::Schema::try_from(schema.clone()).ok()
+        }
         (OutputKind::Native, None)
         | (OutputKind::Auto | OutputKind::Tool | OutputKind::Prompted, _) => None,
     };

--- a/crates/rig-ecs/src/reflect.rs
+++ b/crates/rig-ecs/src/reflect.rs
@@ -1,7 +1,7 @@
 //! The inspector's view (the `reflect` feature): every component of the
 //! graph and the bus derives `Reflect`, the rig-core values they hold
 //! reflect through opaque remote wrappers ([`crate::bus::reflect`],
-//! [`crate::agent::reflect`]), [`ReflectPlugin`] registers them all, and
+//! [`crate::agent::reflect`]), [`install_reflect`] registers them all, and
 //! [`ReflectedScene`] is the world as reflected data — what an inspector
 //! walks, and a second export beside the serde scene
 //! ([`crate::agent::scene::WorldScene`], which stays the format).
@@ -15,7 +15,6 @@
 
 use std::{any::TypeId, collections::HashMap};
 
-use bevy_app::{App, Plugin};
 use bevy_ecs::{
     prelude::*,
     reflect::{AppTypeRegistry, ReflectComponent},
@@ -27,28 +26,21 @@ use bevy_reflect::{
 
 pub use crate::{agent::reflect::*, bus::reflect::*};
 
-/// Registers every component of the bus and the graph, and every remote
-/// wrapper, with the app's type registry.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct ReflectPlugin;
-
-impl Plugin for ReflectPlugin {
-    fn build(&self, app: &mut App) {
-        register(app);
-    }
-}
-
 macro_rules! register_all {
-    ($app:expr, [$($ty:ty),* $(,)?]) => {
-        $( $app.register_type::<$ty>(); )*
+    ($registry:expr, [$($ty:ty),* $(,)?]) => {
+        $( $registry.register::<$ty>(); )*
     };
 }
 
-/// Register every reflected type of this crate with `app`.
-pub fn register(app: &mut App) {
+/// Register every component of the bus and the graph, and every remote
+/// wrapper, with the world's [`AppTypeRegistry`] (created if absent).
+pub fn install_reflect(world: &mut World) {
     use crate::{agent, bus, systems};
+    world.init_resource::<AppTypeRegistry>();
+    let registry = world.resource::<AppTypeRegistry>().clone();
+    let mut registry = registry.write();
     register_all!(
-        app,
+        registry,
         [
             bevy_ecs::hierarchy::ChildOf,
             bevy_ecs::hierarchy::Children,

--- a/crates/rig-ecs/src/systems/mod.rs
+++ b/crates/rig-ecs/src/systems/mod.rs
@@ -17,8 +17,7 @@
 //! The first steering slot is any system before `Assemble`: it edits the
 //! graph (utterances, documents, grants, settings).
 
-use bevy_app::{App, Plugin};
-use bevy_ecs::{prelude::*, schedule::LogLevel};
+use bevy_ecs::prelude::*;
 use rig_core::{
     completion::message::{AssistantContent, ToolChoice, ToolResultContent, UserContent},
     effect::{EffectKind, FamilyDescriptor, Outcome},
@@ -38,8 +37,8 @@ use crate::{
         ToolContextSpec, ToolPolicy, Turn, Unhandled, Usage, UsesModel, Utterance,
     },
     bus::{
-        Bound, BusPlugin, BusSet, EffectOutcome, Held, Issued, PendingEffect, Progress,
-        RigSchedule, Scope, Streamed as BusStreamed, ToolInputs,
+        Bound, BusSet, EffectOutcome, Held, Issued, PendingEffect, Progress, RigSchedule, Scope,
+        Streamed as BusStreamed, ToolInputs,
     },
     policy::{self, RequestGraph},
 };
@@ -161,71 +160,64 @@ pub struct Folded(pub OutputKind);
 #[cfg_attr(feature = "reflect", derive(bevy_reflect::Reflect), reflect(Component))]
 pub struct Materialised;
 
-/// The agent runtime: [`BusPlugin`] must be added first (it owns the
-/// schedule); this adds the sets, the counters and the systems.
-#[derive(Debug, Clone, Default)]
-pub struct AgentPlugin {
-    /// Ambiguity detection for the agent's systems' ordering.
-    pub ambiguity: Option<LogLevel>,
-}
-
-impl Plugin for AgentPlugin {
-    fn build(&self, app: &mut App) {
-        assert!(
-            app.is_plugin_added::<BusPlugin>(),
-            "AgentPlugin needs BusPlugin added first: it runs in the bus's RigSchedule"
-        );
-        app.init_resource::<OrderCounter>()
-            .init_resource::<RunCounter>();
-        app.add_observer(effect_cancelled);
-        app.add_observer(run_cancelled);
-        let mut schedules = app.world_mut().resource_mut::<Schedules>();
-        let Some(schedule) = schedules.get_mut(RigSchedule) else {
-            return;
-        };
-        schedule.configure_sets(
-            (
-                RigSet::Advance,
-                RigSet::Select,
-                RigSet::Assemble,
-                RigSet::Patch,
-                RigSet::Release,
-            )
-                .chain()
-                .before(BusSet::Gate),
-        );
-        schedule.configure_sets(
-            (
-                RigSet::Fold,
-                RigSet::Judge,
-                RigSet::Materialise,
-                RigSet::Settle,
-            )
-                .chain()
-                .after(BusSet::Judge),
-        );
-        schedule.add_systems((
-            advance.in_set(RigSet::Advance),
-            attach_retrieved
-                .after(RigSet::Advance)
-                .before(RigSet::Select),
-            select.in_set(RigSet::Select),
-            assemble.in_set(RigSet::Assemble),
-            release_batch.in_set(RigSet::Release),
-            (fold, discover_streamed_invalid_calls)
-                .chain()
-                .in_set(RigSet::Fold),
-            (
-                land_memory,
-                resolve_invalid_defaults,
-                land_batch,
-                materialise,
-            )
-                .chain()
-                .in_set(RigSet::Materialise),
-            append_memory.in_set(RigSet::Settle),
-        ));
-    }
+/// Install the agent runtime into `world`: the bus must be installed first
+/// (it owns the schedule); this adds the sets, the counters, the observers
+/// and the systems.
+pub fn install_agent(world: &mut World) {
+    assert!(
+        world.contains_resource::<crate::bus::Policy>(),
+        "install_agent needs the bus installed first: it runs in the bus's RigSchedule"
+    );
+    world.init_resource::<OrderCounter>();
+    world.init_resource::<RunCounter>();
+    world.add_observer(effect_cancelled);
+    world.add_observer(run_cancelled);
+    let mut schedules = world.resource_mut::<Schedules>();
+    let Some(schedule) = schedules.get_mut(RigSchedule) else {
+        return;
+    };
+    schedule.configure_sets(
+        (
+            RigSet::Advance,
+            RigSet::Select,
+            RigSet::Assemble,
+            RigSet::Patch,
+            RigSet::Release,
+        )
+            .chain()
+            .before(BusSet::Gate),
+    );
+    schedule.configure_sets(
+        (
+            RigSet::Fold,
+            RigSet::Judge,
+            RigSet::Materialise,
+            RigSet::Settle,
+        )
+            .chain()
+            .after(BusSet::Judge),
+    );
+    schedule.add_systems((
+        advance.in_set(RigSet::Advance),
+        attach_retrieved
+            .after(RigSet::Advance)
+            .before(RigSet::Select),
+        select.in_set(RigSet::Select),
+        assemble.in_set(RigSet::Assemble),
+        release_batch.in_set(RigSet::Release),
+        (fold, discover_streamed_invalid_calls)
+            .chain()
+            .in_set(RigSet::Fold),
+        (
+            land_memory,
+            resolve_invalid_defaults,
+            land_batch,
+            materialise,
+        )
+            .chain()
+            .in_set(RigSet::Materialise),
+        append_memory.in_set(RigSet::Settle),
+    ));
 }
 
 /// Spawn a run of `agent` with `prompt` as its first utterance, after

--- a/crates/rig-ecs/tests/assets_prompt.rs
+++ b/crates/rig-ecs/tests/assets_prompt.rs
@@ -15,7 +15,7 @@
 
 mod run_support;
 
-use bevy_app::App;
+use bevy_app::{App, Update};
 use bevy_asset::{
     AssetApp, AssetPlugin, AssetServer,
     io::{
@@ -27,9 +27,11 @@ use bevy_ecs::{prelude::*, schedule::LogLevel};
 use rig_core::serve::ServingPolicy;
 use rig_ecs::{
     agent::{Grant, Grants, Order, Preamble, Settled},
-    assets::{Applied, AssetsPlugin, Prompt, PromptHandle, ToolDefinitions, ToolsHandle},
-    bus::BusPlugin,
-    systems::{AgentPlugin, spawn_run},
+    assets::{
+        Applied, AssetsPlugin, AssetsSet, Prompt, PromptHandle, ToolDefinitions, ToolsHandle,
+    },
+    bus::{Bus, run_to_quiescence},
+    systems::{install_agent, spawn_run},
 };
 use run_support::*;
 
@@ -45,13 +47,16 @@ fn a_prompt_and_tool_definitions_become_the_preamble_and_the_grants() {
         ]"#,
     );
     let mut app = App::new();
+    Bus::with_policy(ServingPolicy::default())
+        .ambiguity_detection(LogLevel::Error)
+        .install(app.world_mut());
+    install_agent(app.world_mut());
+    app.add_systems(Update, run_to_quiescence.after(AssetsSet));
     app.register_asset_source(
         AssetSourceId::Default,
         AssetSourceBuilder::new(move || Box::new(MemoryAssetReader { root: dir.clone() })),
     )
     .add_plugins((
-        BusPlugin::with_policy(ServingPolicy::default()).ambiguity_detection(LogLevel::Error),
-        AgentPlugin::default(),
         AssetPlugin {
             watch_for_changes_override: Some(false),
             use_asset_processor_override: Some(false),

--- a/crates/rig-ecs/tests/bus_support/mod.rs
+++ b/crates/rig-ecs/tests/bus_support/mod.rs
@@ -11,7 +11,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use bevy_app::App;
+use bevy_app::{App, Update};
 use bevy_ecs::{prelude::*, schedule::LogLevel};
 use rig_core::{
     completion::{
@@ -23,7 +23,7 @@ use rig_core::{
     serve::{OutcomeSink, Serve, ServingPolicy},
     streaming::StreamFinal,
 };
-use rig_ecs::bus::{BusPlugin, Handlers};
+use rig_ecs::bus::{Bus, Handlers, run_to_quiescence};
 
 /// A hang is a failure, never a wait.
 pub const GUARD: Duration = Duration::from_secs(10);
@@ -210,11 +210,14 @@ pub fn streaming() -> EffectKind {
     }
 }
 
-/// An app with the plugin under `policy`, ambiguity detection at error
-/// level, plugins finished.
+/// An app with the bus installed under `policy`, ambiguity detection at
+/// error level, the runner in `Update`.
 pub fn app_with(policy: ServingPolicy) -> App {
     let mut app = App::new();
-    app.add_plugins(BusPlugin::with_policy(policy).ambiguity_detection(LogLevel::Error));
+    Bus::with_policy(policy)
+        .ambiguity_detection(LogLevel::Error)
+        .install(app.world_mut());
+    app.add_systems(Update, run_to_quiescence);
     app.finish();
     app.cleanup();
     app

--- a/crates/rig-ecs/tests/bus_wasm.rs
+++ b/crates/rig-ecs/tests/bus_wasm.rs
@@ -42,7 +42,7 @@ use rig_core::{
     streaming::StreamFinal,
 };
 use rig_ecs::bus::{
-    BusPlugin, EffectOutcome, Handlers, InFlight, PendingEffect, Streamed, run_to_quiescence,
+    Bus, EffectOutcome, Handlers, InFlight, PendingEffect, Streamed, run_to_quiescence,
 };
 use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -120,15 +120,15 @@ fn request() -> CompletionRequest {
 }
 
 fn app() -> App {
-    // The plugin initialises the IO pool it spawns on; the test ticks the
+    // The bus initialises the IO pool it spawns on; the test ticks the
     // pools the way `bevy_app`'s `TaskPoolPlugin` would, which needs the
     // other two initialised as well.
     bevy_tasks::ComputeTaskPool::get_or_init(bevy_tasks::TaskPool::default);
     bevy_tasks::AsyncComputeTaskPool::get_or_init(bevy_tasks::TaskPool::default);
     let mut app = App::new();
-    app.add_plugins(
-        BusPlugin::with_policy(ServingPolicy::default()).ambiguity_detection(LogLevel::Error),
-    );
+    Bus::with_policy(ServingPolicy::default())
+        .ambiguity_detection(LogLevel::Error)
+        .install(app.world_mut());
     app.finish();
     app.cleanup();
     app

--- a/crates/rig-ecs/tests/reflect_roundtrip.rs
+++ b/crates/rig-ecs/tests/reflect_roundtrip.rs
@@ -50,7 +50,7 @@ const ADD: &str = "t/tool:add#0";
 /// plus one entity carrying the components that run did not produce.
 fn populated() -> bevy_app::App {
     let mut app = app();
-    rig_ecs::reflect::register(&mut app);
+    rig_ecs::reflect::install_reflect(app.world_mut());
     app.world_mut().resource_mut::<IdCounter>().0 = 1;
     let (model, _) = Scripted::new(
         MODEL,

--- a/crates/rig-ecs/tests/reflect_scene.rs
+++ b/crates/rig-ecs/tests/reflect_scene.rs
@@ -36,7 +36,7 @@ const ADD: &str = "t/tool:add#0";
 
 fn ran() -> bevy_app::App {
     let mut app = app();
-    rig_ecs::reflect::register(&mut app);
+    rig_ecs::reflect::install_reflect(app.world_mut());
     app.world_mut().resource_mut::<IdCounter>().0 = 1;
     let (model, _) = Scripted::new(
         MODEL,
@@ -77,7 +77,7 @@ fn a_world_and_its_loaded_scene_reflect_alike() {
     drop(first);
 
     let mut second = app();
-    rig_ecs::reflect::register(&mut second);
+    rig_ecs::reflect::install_reflect(second.world_mut());
     let (model, _) = Scripted::new(MODEL, Vec::new());
     register(&mut second, MODEL, model);
     register(&mut second, ADD, Adder::new(ADD));
@@ -127,7 +127,7 @@ struct OrderedNumbers(Vec<u64>);
 fn user_numeric_arrays_preserve_order_and_duplicates() {
     use bevy_reflect::TypePath;
     let mut app = app();
-    rig_ecs::reflect::register(&mut app);
+    rig_ecs::reflect::install_reflect(app.world_mut());
     app.register_type::<OrderedNumbers>();
     app.world_mut().spawn(OrderedNumbers(vec![3, 1, 2, 1]));
     let scene = json(&mut app);

--- a/crates/rig-ecs/tests/run_scene.rs
+++ b/crates/rig-ecs/tests/run_scene.rs
@@ -18,7 +18,7 @@ mod run_support;
 
 use std::time::Instant;
 
-use bevy_app::App;
+use bevy_app::{App, Update};
 use bevy_ecs::{prelude::*, schedule::LogLevel};
 use rig_core::{effect::HandlerKey, serve::ServingPolicy};
 use rig_ecs::{
@@ -29,10 +29,10 @@ use rig_ecs::{
         scene::{RunScene, WorldScene, load_world, save_world},
     },
     bus::{
-        BusPlugin, EffectLogResource, Handlers, IdCounter, InFlight, Issued, PendingEffect, Replay,
-        RigSchedule,
+        Bus, EffectLogResource, Handlers, IdCounter, InFlight, Issued, PendingEffect, Replay,
+        RigSchedule, run_to_quiescence,
     },
-    systems::{AgentPlugin, spawn_run},
+    systems::{install_agent, spawn_run},
 };
 use rig_effect_log::{EffectLog, EffectLogRecorder, EffectLogReplayer};
 use run_support::{GUARD, NeverAnswers};
@@ -48,10 +48,11 @@ fn golden(name: &str) -> EffectLog {
 
 fn world_with(log: &EffectLog) -> (App, Entity) {
     let mut app = App::new();
-    app.add_plugins((
-        BusPlugin::with_policy(ServingPolicy::default()).ambiguity_detection(LogLevel::Error),
-        AgentPlugin::default(),
-    ));
+    Bus::with_policy(ServingPolicy::default())
+        .ambiguity_detection(LogLevel::Error)
+        .install(app.world_mut());
+    install_agent(app.world_mut());
+    app.add_systems(Update, run_to_quiescence);
     app.finish();
     app.cleanup();
     let key = HandlerKey::from("golden/model:default");

--- a/crates/rig-ecs/tests/run_support/mod.rs
+++ b/crates/rig-ecs/tests/run_support/mod.rs
@@ -8,7 +8,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use bevy_app::App;
+use bevy_app::{App, Update};
 use bevy_ecs::{prelude::*, schedule::LogLevel};
 use rig_core::{
     completion::{CompletionRequest, CompletionResponse, ModelRef, ProviderCapabilities, Usage},
@@ -22,8 +22,8 @@ use rig_ecs::{
         AdditionalParams, DefaultMaxTurns, InvalidCalls, MaxTokens, MaxTurns, Output, Owner,
         Preamble, Temperature, ToolChoiceSpec, UsesModel,
     },
-    bus::{BusPlugin, Handlers},
-    systems::AgentPlugin,
+    bus::{Bus, Handlers, run_to_quiescence},
+    systems::install_agent,
 };
 
 pub const GUARD: Duration = Duration::from_secs(10);
@@ -115,13 +115,15 @@ impl Serve for NeverCalled {
     }
 }
 
-/// An app with both plugins, ambiguity detection at error level.
+/// An app with the bus and the agent installed, ambiguity detection at
+/// error level, the runner in `Update`.
 pub fn app() -> App {
     let mut app = App::new();
-    app.add_plugins((
-        BusPlugin::with_policy(ServingPolicy::default()).ambiguity_detection(LogLevel::Error),
-        AgentPlugin::default(),
-    ));
+    Bus::with_policy(ServingPolicy::default())
+        .ambiguity_detection(LogLevel::Error)
+        .install(app.world_mut());
+    install_agent(app.world_mut());
+    app.add_systems(Update, run_to_quiescence);
     app.finish();
     app.cleanup();
     app

--- a/crates/rig-ecs/tests/run_wasm.rs
+++ b/crates/rig-ecs/tests/run_wasm.rs
@@ -20,8 +20,8 @@ use rig_ecs::{
         AdditionalParams, DefaultMaxTurns, Failed, InvalidCalls, MaxTokens, MaxTurns, Output,
         OutputKind, Owner, Preamble, RunResult, Settled, Temperature, ToolChoiceSpec, UsesModel,
     },
-    bus::{BusPlugin, EffectLogResource, Handlers, IdCounter, run_to_quiescence},
-    systems::{AgentPlugin, spawn_run},
+    bus::{Bus, EffectLogResource, Handlers, IdCounter, run_to_quiescence},
+    systems::{install_agent, spawn_run},
 };
 use rig_effect_log::{EffectLog, EffectLogRecorder, EffectLogReplayer};
 use wasm_bindgen_test::wasm_bindgen_test;
@@ -35,10 +35,10 @@ fn app(log: &EffectLog) -> (App, Entity) {
     bevy_tasks::ComputeTaskPool::get_or_init(bevy_tasks::TaskPool::default);
     bevy_tasks::AsyncComputeTaskPool::get_or_init(bevy_tasks::TaskPool::default);
     let mut app = App::new();
-    app.add_plugins((
-        BusPlugin::with_policy(ServingPolicy::default()).ambiguity_detection(LogLevel::Error),
-        AgentPlugin::default(),
-    ));
+    Bus::with_policy(ServingPolicy::default())
+        .ambiguity_detection(LogLevel::Error)
+        .install(app.world_mut());
+    install_agent(app.world_mut());
     app.finish();
     app.cleanup();
     app.world_mut().resource_mut::<IdCounter>().0 = 1;

--- a/crates/rig-verify/tests/corpus/world.rs
+++ b/crates/rig-verify/tests/corpus/world.rs
@@ -12,7 +12,7 @@
 
 use std::time::{Duration, Instant};
 
-use bevy_app::App;
+use bevy_app::{App, Update};
 use bevy_ecs::{prelude::*, schedule::LogLevel};
 use rig_core::{
     effect::{EffectFamily, HandlerKey},
@@ -26,9 +26,12 @@ use rig_ecs::{
         Owner, Preamble, Remembers, Retrievable, Retrieval, RetrievalKind, Retrieves, RunResult,
         Settled, Temperature, ToolChoiceSpec, ToolPolicy, Unhandled as WorldUnhandled, UsesModel,
     },
-    bus::{BusPlugin, EffectLogResource, EffectOutcome, Handlers, IdCounter, PendingEffect},
+    bus::{
+        Bus, EffectLogResource, EffectOutcome, Handlers, IdCounter, PendingEffect,
+        run_to_quiescence,
+    },
     replay::stamp_header,
-    systems::{AgentPlugin, spawn_run},
+    systems::{install_agent, spawn_run},
 };
 use rig_effect_log::{EffectLogRecorder, EffectLogReplayer, RequestCheck};
 
@@ -74,14 +77,14 @@ pub(super) fn open(
             .build()
     });
     let mut app = App::new();
-    app.add_plugins((
-        BusPlugin::with_policy(ServingPolicy {
-            command_capacity: 1_000,
-            ..policy
-        })
-        .ambiguity_detection(LogLevel::Error),
-        AgentPlugin::default(),
-    ));
+    Bus::with_policy(ServingPolicy {
+        command_capacity: 1_000,
+        ..policy
+    })
+    .ambiguity_detection(LogLevel::Error)
+    .install(app.world_mut());
+    install_agent(app.world_mut());
+    app.add_systems(Update, run_to_quiescence);
     app.finish();
     app.cleanup();
     let world = app.world_mut();

--- a/crates/rig-verify/tests/world_replay.rs
+++ b/crates/rig-verify/tests/world_replay.rs
@@ -28,11 +28,11 @@
 
 use std::time::{Duration, Instant};
 
-use bevy_app::App;
+use bevy_app::{App, Update};
 use bevy_ecs::schedule::LogLevel;
 use rig_core::serve::ServingPolicy;
 use rig_ecs::bus::{
-    BusPlugin, EffectLogResource, EffectOutcome, Handlers, Issued, Replay, Streamed,
+    Bus, EffectLogResource, EffectOutcome, Handlers, Issued, Replay, Streamed, run_to_quiescence,
 };
 use rig_effect_log::{EffectLog, EffectLogRecorder};
 
@@ -72,7 +72,10 @@ fn world(log: &EffectLog) -> App {
         command_capacity: 10_000,
         ..log.header.bus.unwrap_or_default()
     };
-    app.add_plugins(BusPlugin::with_policy(policy).ambiguity_detection(LogLevel::Error));
+    Bus::with_policy(policy)
+        .ambiguity_detection(LogLevel::Error)
+        .install(app.world_mut());
+    app.add_systems(Update, run_to_quiescence);
     app.finish();
     app.cleanup();
     app

--- a/tests/common/ecs_agent.rs
+++ b/tests/common/ecs_agent.rs
@@ -8,13 +8,13 @@ mod tests;
 
 use std::{sync::Arc, time::Duration};
 
-use bevy_app::App;
+use bevy_app::{App, Update};
 use bevy_ecs::prelude::*;
 use rig_core::{
     completion::CompletionModel,
     effect::{EffectKind, HandlerDescriptor},
     serve::{
-        OutcomeSink, Serve,
+        OutcomeSink, Serve, ServingPolicy,
         adapters::{CompletionAdapter, ToolAdapter},
     },
     tool::Tool,
@@ -24,8 +24,8 @@ use rig_ecs::{
         DefaultMaxTurns, Failed, Failure, Grant, MaxTurns, Order, Owner, Preamble, RunResult,
         Settled, UsesModel,
     },
-    bus::{BusPlugin, Handlers, Recording},
-    systems::{AgentPlugin, spawn_run},
+    bus::{Handlers, Recording, install_bus, run_to_quiescence},
+    systems::{install_agent, spawn_run},
 };
 use rig_effect_log::EffectLogRecorder;
 
@@ -100,7 +100,9 @@ impl EcsAgent {
         setup: impl FnOnce(&mut World),
     ) -> Self {
         let mut app = App::new();
-        app.add_plugins((BusPlugin::default(), AgentPlugin::default()));
+        install_bus(app.world_mut(), ServingPolicy::default());
+        install_agent(app.world_mut());
+        app.add_systems(Update, run_to_quiescence);
         app.finish();
         app.cleanup();
         let recorder = if keep_events {

--- a/tests/consumer/mod.rs
+++ b/tests/consumer/mod.rs
@@ -24,7 +24,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use bevy_app::App;
+use bevy_app::{App, Update};
 use bevy_ecs::{prelude::*, schedule::LogLevel};
 use rig_core::{
     completion::{CompletionResponse, ModelRef, ProviderCapabilities, Usage},
@@ -37,10 +37,10 @@ use rig_core::{
 use rig_ecs::{
     agent::*,
     bus::{
-        self, Bound, BusPlugin, BusSet, EffectLogResource, EffectOutcome, Handlers, InFlight,
-        Issued, PendingEffect, Replay, RigSchedule, WorldOutcome,
+        self, Bound, Bus, BusSet, EffectLogResource, EffectOutcome, Handlers, InFlight, Issued,
+        PendingEffect, Replay, RigSchedule, WorldOutcome,
     },
-    systems::{AgentPlugin, spawn_run},
+    systems::{install_agent, spawn_run},
 };
 use rig_effect_log::{EffectLog, EffectLogRecorder};
 use serde::{Deserialize, Serialize};
@@ -252,10 +252,11 @@ fn build_with_replay(case: &Case, replay: Option<&EffectLog>, mode: Replay) -> R
         serial_per_handler: case.serial_keys,
         stream_capacity: 4096,
     };
-    app.add_plugins((
-        BusPlugin::with_policy(serving).ambiguity_detection(LogLevel::Error),
-        AgentPlugin::default(),
-    ));
+    Bus::with_policy(serving)
+        .ambiguity_detection(LogLevel::Error)
+        .install(app.world_mut());
+    install_agent(app.world_mut());
+    app.add_systems(Update, bus::run_to_quiescence);
     app.finish();
     app.cleanup();
     app.init_resource::<scheduled::DeliveryControl>();

--- a/tests/core/dependency_graph.rs
+++ b/tests/core/dependency_graph.rs
@@ -91,31 +91,29 @@ fn rig_effect_log_depends_on_rig_core_only() {
 /// and rig-effect-log (the `replay` feature), never rig-agent — its driver
 /// is a system, not a client of rig-agent's bus, and the agent half is a
 /// rewrite held to rig-agent's bytes by the corpus alone — never the `bevy` facade, no
-/// runtime, no transport, no MCP. Reflection and assets are features:
+/// runtime, no transport, no MCP. On the Bevy side exactly `bevy_ecs` and
+/// `bevy_tasks`: the bus installs into a `World` and the host owns the
+/// loop, so `bevy_app` is absent by default and joins only with `assets`
+/// (`bevy_asset` is built on it). Reflection and assets are features:
 /// `bevy_reflect` and `bevy_asset` are absent by default and present with
 /// every feature on (programme stage 6), and nothing else joins either way.
 #[test]
 fn rig_ecs_is_rig_core_and_bevy_only() {
     let forbidden = ["rig-agent", "rig-rmcp", "rmcp", "bevy", "tokio", "reqwest"];
     assert_absent("rig-ecs", &[], &forbidden);
-    assert_absent("rig-ecs", &[], &["bevy_reflect", "bevy_asset"]);
+    assert_absent("rig-ecs", &[], &["bevy_app", "bevy_reflect", "bevy_asset"]);
     assert_absent("rig-ecs", &["--all-features"], &forbidden);
+    assert_absent("rig-ecs", &["--features", "reflect"], &["bevy_app"]);
     assert_absent("rig-ecs", &["--no-default-features"], &["rig-effect-log"]);
     let names = normal_dependency_names("rig-ecs", &[]);
-    for required in [
-        "rig-core",
-        "rig-effect-log",
-        "bevy_ecs",
-        "bevy_tasks",
-        "bevy_app",
-    ] {
+    for required in ["rig-core", "rig-effect-log", "bevy_ecs", "bevy_tasks"] {
         assert!(
             names.iter().any(|name| name == required),
             "`rig-ecs` must depend on `{required}`"
         );
     }
     let with_features = normal_dependency_names("rig-ecs", &["--all-features"]);
-    for feature_dependency in ["bevy_reflect", "bevy_asset"] {
+    for feature_dependency in ["bevy_reflect", "bevy_asset", "bevy_app"] {
         assert!(
             with_features.iter().any(|name| name == feature_dependency),
             "`rig-ecs` (--all-features) must depend on `{feature_dependency}`"

--- a/tests/core/dependency_graph.rs
+++ b/tests/core/dependency_graph.rs
@@ -102,6 +102,21 @@ fn rig_ecs_is_rig_core_and_bevy_only() {
     let forbidden = ["rig-agent", "rig-rmcp", "rmcp", "bevy", "tokio", "reqwest"];
     assert_absent("rig-ecs", &[], &forbidden);
     assert_absent("rig-ecs", &[], &["bevy_app", "bevy_reflect", "bevy_asset"]);
+    // `tracing` and `schemars` reach the crate through rig-core; the manifest
+    // names neither, reaching `schemars` through rig-core's re-export.
+    let manifest = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/crates/rig-ecs/Cargo.toml"
+    ))
+    .expect("the rig-ecs manifest");
+    for direct in ["tracing", "schemars", "async-channel"] {
+        assert!(
+            !manifest
+                .lines()
+                .any(|line| line.starts_with(&format!("{direct} "))),
+            "`rig-ecs` must not name `{direct}` directly"
+        );
+    }
     assert_absent("rig-ecs", &["--all-features"], &forbidden);
     assert_absent("rig-ecs", &["--features", "reflect"], &["bevy_app"]);
     assert_absent("rig-ecs", &["--no-default-features"], &["rig-effect-log"]);

--- a/tests/ecs_parity/agent-goldens-contract.md
+++ b/tests/ecs_parity/agent-goldens-contract.md
@@ -15,7 +15,7 @@ unset. The memory case uses a fresh InMemoryConversationMemory and the original
 `golden-conversation` key. Its memory handler is registered before the model,
 matching the original recorder header's handler order.
 
-Native EcsAgent installs Recording and drives ordinary BusPlugin/AgentPlugin
+Native EcsAgent installs Recording and drives ordinary `install_bus`/`install_agent`
 systems. RuntimeHandler keeps provider and memory futures within native effect
 ownership. Memory is attached with Remembers and Conversation. No legacy agent
 runner, policy, builder, or recorded answer drives execution. Success requires

--- a/tests/ecs_parity/layers-contract.md
+++ b/tests/ecs_parity/layers-contract.md
@@ -2,7 +2,7 @@
 
 Scope: the seven corpus_layers scenarios on the native host.
 
-The native producer uses App, BusPlugin, AgentPlugin, native handler registration,
+The native producer uses App, `install_bus`, `install_agent`, native handler registration,
 Grant and real provider/ToolAdapter/MemoryAdapter handlers. Shared rig-core
 Intercept layers are host middleware, not the legacy agent runner or hooks.
 RuntimeHandler wraps each leaf before ErasedHandler layering; this preserves the

--- a/tests/ecs_parity/provider-completions-contract.md
+++ b/tests/ecs_parity/provider-completions-contract.md
@@ -8,7 +8,7 @@ provider and ignored live tests are outside this family.
 
 ## Independent execution and settings
 
-Each native producer uses `EcsAgent` with ordinary `BusPlugin` and `AgentPlugin`
+Each native producer uses `EcsAgent` with ordinary `install_bus` and `install_agent`
 configuration. The real provider's `CompletionAdapter` is polled through the
 existing `RuntimeHandler`, which enters Tokio on every poll while ECS owns the
 future. Bedrock tools use real `ToolAdapter`s through the same bridge. No legacy

--- a/tests/ecs_parity/request-shape-contract.md
+++ b/tests/ecs_parity/request-shape-contract.md
@@ -5,7 +5,7 @@ case stays in its original module and does not receive an agent mapping.
 
 ## Execution and configuration
 
-Each native case owns a fresh App using ordinary native BusPlugin/AgentPlugin,
+Each native case owns a fresh App using ordinary native `install_bus`/`install_agent`,
 CompletionAdapter and ToolAdapter. Existing provider wrappers perform request
 matching and exhaustion against the original fixtures. Original constants and
 reasoning/text helpers are imported, with visibility-only changes to the original

--- a/tests/providers/gemini/cassette/ecs_stress/main_golden.rs
+++ b/tests/providers/gemini/cassette/ecs_stress/main_golden.rs
@@ -1,10 +1,13 @@
 //! Exact named producer setup for the Gemini effect golden; real provider IO.
 use crate::ecs_agent::RuntimeHandler;
-use bevy_app::App;
+use bevy_app::{App, Update};
 use bevy_ecs::prelude::*;
 use rig::{
     completion::CompletionModel,
-    serve::adapters::{CompletionAdapter, ToolAdapter},
+    serve::{
+        ServingPolicy,
+        adapters::{CompletionAdapter, ToolAdapter},
+    },
     tool::Tool,
 };
 use rig_ecs::{
@@ -12,8 +15,8 @@ use rig_ecs::{
         DefaultMaxTurns, Failed, Grant, MaxTurns, Order, Owner, Preamble, RunResult, Settled,
         Temperature, UsesModel,
     },
-    bus::{BusPlugin, Handlers, Recording},
-    systems::{AgentPlugin, spawn_run},
+    bus::{Handlers, Recording, install_bus, run_to_quiescence},
+    systems::{install_agent, spawn_run},
 };
 use rig_effect_log::{EffectLog, EffectLogRecorder};
 use std::{sync::Arc, time::Duration};
@@ -41,7 +44,9 @@ pub(super) async fn run(
     subtract: impl Tool + 'static,
 ) -> (bool, EffectLog) {
     let mut app = App::new();
-    app.add_plugins((BusPlugin::default(), AgentPlugin::default()));
+    install_bus(app.world_mut(), ServingPolicy::default());
+    install_agent(app.world_mut());
+    app.add_systems(Update, run_to_quiescence);
     app.finish();
     app.cleanup();
     // Original record_effects() does not retain stream events.


### PR DESCRIPTION
Depends on #2443.

Stacked on `feat/effect-bus` at 8a2ecce11 (rebased on main after #2471). Cuts `crates/rig-ecs/Cargo.toml` to what the crate's contract needs. The contract is its own description: effects as entities, handlers as entities, the driver as a system. A `bevy_app::App` was never part of it. No observable bus behaviour changes and no golden changed.

## What changed

**Commit 1: install into a `World`, no `bevy_app`.**
- `BusPlugin` becomes `Bus` with `Bus::install(&self, world)` and the one-call `install_bus(world, policy)`.
- `AgentPlugin` becomes `install_agent(world)`; it probes the bus's `Policy` resource rather than `is_plugin_added`.
- `ReflectPlugin` / `register(app)` becomes `install_reflect(world)`, registering through `AppTypeRegistry`.
- The crate no longer schedules `run_to_quiescence`. The host calls it once per tick from the schedule or loop it owns. `assets::AssetsSet` names the asset systems' set so a host orders the runner after it.
- `bevy_app` is a dev-dependency, and an optional dependency only under `assets`, because `bevy_asset` is built on it.
- Every test, example and root harness migrates to `install_bus` / `install_agent` on `app.world_mut()` plus `add_systems(Update, run_to_quiescence)` in the support modules.

**Commit 2: the small ones.**
- `tracing::warn!` becomes `log::warn!`; the direct `tracing` line goes.
- `schemars::Schema` is reached through rig-core's re-export; the direct line goes.
- `assets` no longer implies `reflect`. `assets.rs` needs only `bevy_reflect::TypePath`.
- The `docs.rs` metadata block goes; the crate is `publish = false`.
- `tests/core/dependency_graph.rs` pins the new shape.

## What stays, and why

`futures` stays. rig-core's `OutcomeSink::{unary,stream}` take `futures::channel::{oneshot,mpsc}` senders, so the channel types are rig-core's choice, and rig-core already depends on the crate. `bevy_tasks` exports no channel. Removing the line would change the direct-dependency list and nothing in the tree.

## Dependency tree

`cargo tree -p rig-ecs -e normal --depth 1`, before:

```
bevy_app, bevy_ecs, bevy_tasks, futures, rig-core, rig-effect-log, schemars, serde, serde_json, tracing
```

after:

```
bevy_ecs, bevy_tasks, futures, log, rig-core, rig-effect-log, serde, serde_json
```

| | crates in `cargo tree -p rig-ecs -e normal` |
|---|---|
| before | 316 |
| after | 290 |

Under `--features assets`, `bevy_app` returns, because `bevy_asset` depends on it.

## Gates

`cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo nextest run -p rig-ecs --all-features` (186 passed), `-p rig-verify` (815 passed), `-p rig --features bedrock` (4148 passed, 199 skipped).

## Note for rig-bevy

When rig-bevy is written, a `bevy_app::Plugin` wrapper over `install_bus` / `install_agent` that also adds `run_to_quiescence` to `Update` belongs there, in one file. This crate stays `bevy_ecs` and `bevy_tasks`.

