### PR TITLE
fix(gemini): surface a blocked prompt as a provider error instead of a truncated stream

### DIFF
--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -580,6 +580,58 @@ impl TryFrom<Vec<completion::ToolDefinition>> for Tool {
     }
 }
 
+/// The wire spelling of a serde enum (`SCREAMING_SNAKE_CASE`, or the raw
+/// string of an `Unknown` variant), for messages that quote the provider.
+mod erased_wire {
+    pub(super) trait Wire {
+        fn wire_name(&self) -> String;
+    }
+    impl<T: serde::Serialize> Wire for T {
+        fn wire_name(&self) -> String {
+            match serde_json::to_value(self) {
+                Ok(serde_json::Value::String(name)) => name,
+                Ok(other) => other.to_string(),
+                Err(_) => "<unserializable>".to_owned(),
+            }
+        }
+    }
+}
+
+/// A prompt Gemini refused to answer: `promptFeedback.blockReason` is set and
+/// no candidate is returned. Both wires (`generateContent` and
+/// `streamGenerateContent`) spell it the same way, so both surface the same
+/// error, naming the reason and the safety ratings that explain it, instead
+/// of a generic missing-candidate failure (unary) or a stream that ends
+/// before its terminal record (streaming).
+pub(crate) fn blocked_prompt_error(
+    feedback: &gemini_api_types::PromptFeedback,
+) -> Option<CompletionError> {
+    let reason = match feedback.block_reason.as_ref()? {
+        // Documented as unused: the zero value is never sent, and it names
+        // no block if it ever were.
+        gemini_api_types::BlockReason::BlockReasonUnspecified => return None,
+        reason => reason,
+    };
+    let wire = |value: &dyn erased_wire::Wire| value.wire_name();
+    let ratings = feedback
+        .safety_ratings
+        .as_ref()
+        .filter(|ratings| !ratings.is_empty())
+        .map(|ratings| {
+            ratings
+                .iter()
+                .map(|rating| format!("{}={}", wire(&rating.category), wire(&rating.probability)))
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .map(|ratings| format!(", safety_ratings=[{ratings}]"))
+        .unwrap_or_default();
+    Some(CompletionError::ProviderError(format!(
+        "Gemini blocked the prompt: block_reason={}{ratings}",
+        reason.as_wire_str()
+    )))
+}
+
 pub(crate) fn function_call_finish_reason_error(
     reason: &FinishReason,
     finish_message: Option<&str>,
@@ -752,6 +804,13 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse {
     type Error = CompletionError;
 
     fn try_from(response: GenerateContentResponse) -> Result<Self, Self::Error> {
+        if let Some(blocked) = response
+            .prompt_feedback
+            .as_ref()
+            .and_then(blocked_prompt_error)
+        {
+            return Err(blocked);
+        }
         let candidate = response.candidates.first().ok_or_else(|| {
             CompletionError::ResponseError("No response candidates in response".into())
         })?;
@@ -1560,6 +1619,10 @@ pub mod gemini_api_types {
         Low,
         Medium,
         High,
+        /// A probability this crate does not know yet, carried verbatim so
+        /// a rating (and the chunk that carries it) stays deserializable.
+        #[serde(untagged)]
+        Unknown(String),
     }
 
     #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
@@ -1577,6 +1640,12 @@ pub mod gemini_api_types {
         HarmCategorySexuallyExplicit,
         HarmCategoryDangerousContent,
         HarmCategoryCivicIntegrity,
+        /// A category this crate does not know yet (Google adds them without
+        /// notice: `HARM_CATEGORY_JAILBREAK`, the `HARM_CATEGORY_IMAGE_*`
+        /// family), carried verbatim so a rating — and a blocked prompt's
+        /// only chunk, which carries the ratings — stays deserializable.
+        #[serde(untagged)]
+        Unknown(String),
     }
 
     #[derive(Debug, Deserialize, Clone, Default, Serialize)]
@@ -1699,6 +1768,21 @@ pub mod gemini_api_types {
         /// whole payload deserializable instead of failing on the new value.
         #[serde(untagged)]
         Unknown(String),
+    }
+
+    impl BlockReason {
+        /// The exact spelling Gemini uses for this reason on the wire (see
+        /// [`FinishReason::as_wire_str`] for why it is spelled out).
+        pub fn as_wire_str(&self) -> &str {
+            match self {
+                Self::BlockReasonUnspecified => "BLOCK_REASON_UNSPECIFIED",
+                Self::Safety => "SAFETY",
+                Self::Other => "OTHER",
+                Self::Blocklist => "BLOCKLIST",
+                Self::ProhibitedContent => "PROHIBITED_CONTENT",
+                Self::Unknown(raw) => raw.as_str(),
+            }
+        }
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/rig-core/src/providers/gemini/completion/tests.rs
+++ b/crates/rig-core/src/providers/gemini/completion/tests.rs
@@ -34,6 +34,69 @@ fn test_generate_content_response_deserializes_without_candidates_or_response_id
     assert!(response.response_id.is_empty());
     assert!(response.candidates.is_empty());
 
+    // A set `blockReason` is the provider's verdict on the prompt: the
+    // error names it instead of reporting a generic missing-candidate parse
+    // failure.
+    let error = completion::CompletionResponse::try_from(response)
+        .expect_err("a blocked prompt is an error");
+    assert!(
+        matches!(&error, CompletionError::ProviderError(message) if message.contains("blocked the prompt") && message.contains("SAFETY")),
+        "{error}"
+    );
+}
+
+#[test]
+fn test_blocked_prompt_error_carries_the_safety_ratings() {
+    let response: GenerateContentResponse = serde_json::from_value(json!({
+        "promptFeedback": {
+            "blockReason": "PROHIBITED_CONTENT",
+            "safetyRatings": [
+                {"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "probability": "HIGH"}
+            ]
+        },
+        "usageMetadata": {"promptTokenCount": 12, "totalTokenCount": 12}
+    }))
+    .expect("blocked prompt response should deserialize");
+    let error = completion::CompletionResponse::try_from(response).expect_err("blocked");
+    let message = error.to_string();
+    assert!(message.contains("PROHIBITED_CONTENT"), "{message}");
+    assert!(
+        message.contains("HARM_CATEGORY_DANGEROUS_CONTENT"),
+        "{message}"
+    );
+    assert!(message.contains("HIGH"), "{message}");
+}
+
+#[test]
+fn test_unknown_block_reason_reaches_the_error_verbatim() {
+    let response: GenerateContentResponse = serde_json::from_value(json!({
+        "promptFeedback": {"blockReason": "SOMETHING_NEW"}
+    }))
+    .unwrap();
+    let error = completion::CompletionResponse::try_from(response).expect_err("blocked");
+    assert!(
+        error.to_string().contains("block_reason=SOMETHING_NEW"),
+        "{error}"
+    );
+}
+
+#[test]
+fn test_unspecified_block_reason_is_not_a_block() {
+    let response: GenerateContentResponse = serde_json::from_value(json!({
+        "promptFeedback": {"blockReason": "BLOCK_REASON_UNSPECIFIED"}
+    }))
+    .unwrap();
+    let error = completion::CompletionResponse::try_from(response).expect_err("no candidates");
+    assert!(
+        error.to_string().contains("No response candidates"),
+        "{error}"
+    );
+}
+
+#[test]
+fn test_no_candidates_without_prompt_feedback_is_still_a_response_error() {
+    let response: GenerateContentResponse =
+        serde_json::from_value(json!({})).expect("empty response should deserialize");
     let error = completion::CompletionResponse::try_from(response)
         .expect_err("empty candidates should become a response error");
     assert!(error.to_string().contains("No response candidates"));

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -1,11 +1,12 @@
 use serde::{Deserialize, Serialize};
 
 use super::completion::gemini_api_types::{
-    ContentCandidate, FinishReason, Part, PartKind, UsageMetadata, map_finish_reason,
+    ContentCandidate, FinishReason, Part, PartKind, PromptFeedback, UsageMetadata,
+    map_finish_reason,
 };
 use super::completion::{
-    CompletionModel, PROVIDER_NAME, create_request_body, function_call_finish_reason_error,
-    resolve_request_model, streaming_endpoint,
+    CompletionModel, PROVIDER_NAME, blocked_prompt_error, create_request_body,
+    function_call_finish_reason_error, resolve_request_model, streaming_endpoint,
 };
 use crate::completion::{CompletionError, CompletionRequest};
 use crate::http_client::HttpClientExt;
@@ -81,6 +82,10 @@ pub struct StreamGenerateContentResponse {
     /// Candidate responses from the model.
     #[serde(default)]
     pub candidates: Vec<ContentCandidate>,
+    /// The prompt's content-filter verdict. A set `blockReason` means the
+    /// prompt was refused and no candidate follows: the chunk that carries
+    /// it is the whole answer.
+    pub prompt_feedback: Option<PromptFeedback>,
     pub model_version: Option<String>,
     pub usage_metadata: Option<PartialUsage>,
 }
@@ -116,9 +121,11 @@ fn tool_protocol_finish_reason_error(choice: &ContentCandidate) -> Option<Comple
 }
 
 /// The recognizability markers of a `streamGenerateContent` chunk: every
-/// genuine frame carries `candidates` and/or `usageMetadata`. A frame with
-/// either must fully decode (else `Corrupt`); other JSON is `Unknown`.
-const RECOGNIZABLE_CHUNK_KEYS: &[&str] = &["candidates", "usageMetadata"];
+/// genuine frame carries `candidates`, `usageMetadata` and/or
+/// `promptFeedback` (a blocked prompt's only chunk may carry nothing but
+/// the feedback). A frame with any of them must fully decode (else
+/// `Corrupt`); other JSON is `Unknown`.
+const RECOGNIZABLE_CHUNK_KEYS: &[&str] = &["candidates", "usageMetadata", "promptFeedback"];
 
 /// The Gemini REST (`streamGenerateContent`) SSE wire as a [`WireAdapter`].
 ///
@@ -152,7 +159,7 @@ struct GeminiRestAdapter {
     /// and silently drop the model's whole answer while still reporting a
     /// successful `STOP`.
     saw_finish_reason: bool,
-    /// A tool-protocol finish reason ended the turn; later frames are dead —
+    /// A tool-protocol finish reason or a blocked prompt ended the turn; later frames are dead —
     /// the provider aborted, and interpreting more output (or a terminal)
     /// would dress the failure up as a completed turn.
     failed: bool,
@@ -201,6 +208,16 @@ impl WireAdapter for GeminiRestAdapter {
         if let Some(usage) = data.usage_metadata.as_ref() {
             span.record_token_usage(&crate::completion::Usage::from(usage));
             self.final_usage = Some(usage.clone());
+        }
+
+        if let Some(blocked) = data.prompt_feedback.as_ref().and_then(blocked_prompt_error) {
+            // The provider refused the prompt: this chunk is its whole
+            // answer and the stream closes after it. Without this the turn
+            // would end with no terminal record and be reported as a
+            // truncated stream, the block reason lost.
+            self.failed = true;
+            out.push(Err(blocked));
+            return;
         }
 
         let Some(choice) = data.candidates.into_iter().next() else {
@@ -278,8 +295,8 @@ impl WireAdapter for GeminiRestAdapter {
     }
 
     fn is_finished(&self) -> bool {
-        // A tool-protocol terminal failure is the wire's own in-band
-        // terminal: `interpret` already pushed the `Err` and gates itself on
+        // A tool-protocol terminal failure or a blocked prompt is the wire's
+        // own in-band terminal: `interpret` already pushed the `Err` and gates itself on
         // `failed`, so the driver must stop reading rather than drain the
         // rest of the transport (and pass through post-error unknown frames).
         self.failed

--- a/crates/rig-core/src/providers/gemini/streaming/tests.rs
+++ b/crates/rig-core/src/providers/gemini/streaming/tests.rs
@@ -790,3 +790,136 @@ mod terminal_emission {
         assert_eq!(terminal.response_id.as_deref(), Some("resp-1"));
     }
 }
+
+/// Open a `streamGenerateContent` stream over the given SSE frames and
+/// collect every item the consumer sees.
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+async fn collect_stream(
+    frames: &[&str],
+) -> (
+    Vec<Result<crate::streaming::StreamEvent, crate::error::ErrorReport>>,
+    bool,
+) {
+    use crate::client::CompletionClient;
+    use crate::completion::CompletionModel as _;
+    use crate::providers::gemini::Client;
+    use crate::test_utils::MockStreamingClient;
+    use futures::StreamExt;
+
+    let sse_bytes = bytes::Bytes::from(
+        frames
+            .iter()
+            .map(|frame| format!("data: {frame}\n\n"))
+            .collect::<String>(),
+    );
+    let client = Client::builder()
+        .api_key("test-key")
+        .http_client(MockStreamingClient { sse_bytes })
+        .build()
+        .expect("build client");
+    let model = client.completion_model("gemini-2.5-flash");
+    let request = model.completion_request("hello").build();
+    let mut stream = crate::completion::CompletionModel::stream(&model, request)
+        .await
+        .expect("stream should open");
+    let mut items = Vec::new();
+    while let Some(item) = stream.next().await {
+        items.push(item);
+    }
+    let finished = stream.response.is_some();
+    (items, finished)
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+#[tokio::test]
+async fn blocked_prompt_is_a_provider_error_naming_the_block_reason() {
+    // Gemini answers a blocked prompt on the streaming wire with one chunk
+    // that carries `promptFeedback.blockReason` and no candidates, then
+    // closes the stream. That is the provider's definitive verdict, not a
+    // truncation: the consumer must get an error naming the reason (and the
+    // safety ratings that explain it), never a stream that simply ends
+    // before its terminal record.
+    let frames = [
+        r#"{"promptFeedback":{"blockReason":"PROHIBITED_CONTENT","safetyRatings":[{"category":"HARM_CATEGORY_DANGEROUS_CONTENT","probability":"HIGH"}]},"usageMetadata":{"promptTokenCount":12,"totalTokenCount":12},"modelVersion":"gemini-2.5-flash","responseId":"abc123"}"#,
+    ];
+    let (items, finished) = collect_stream(&frames).await;
+    assert_eq!(items.len(), 1, "exactly the refusal: {items:?}");
+    let Err(report) = &items[0] else {
+        panic!("expected a provider error, got {:?}", items[0]);
+    };
+    assert_eq!(report.kind, crate::error::ErrorKind::Provider, "{report:?}");
+    assert!(!report.retryable, "a refusal is not retryable: {report:?}");
+    let message = &report.message;
+    assert!(message.contains("blocked the prompt"), "{message}");
+    assert!(message.contains("PROHIBITED_CONTENT"), "{message}");
+    assert!(
+        message.contains("HARM_CATEGORY_DANGEROUS_CONTENT"),
+        "{message}"
+    );
+    assert!(message.contains("HIGH"), "{message}");
+    assert!(!finished, "a blocked prompt has no terminal record");
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+#[tokio::test]
+async fn blocked_prompt_without_usage_is_still_recognised_and_ends_the_stream() {
+    // The block chunk may carry no `usageMetadata` at all (proto3 JSON omits
+    // default-valued fields). It must still decode as the wire's chunk shape
+    // rather than pass through as an unknown frame, and it ends the turn:
+    // nothing after it is interpreted.
+    let frames = [
+        r#"{"promptFeedback":{"blockReason":"SAFETY"}}"#,
+        r#"{"candidates":[{"content":{"parts":[{"text":"dead"}],"role":"model"},"finishReason":"STOP","index":0}]}"#,
+    ];
+    let (items, finished) = collect_stream(&frames).await;
+    assert_eq!(items.len(), 1, "exactly the refusal: {items:?}");
+    assert!(
+        matches!(&items[0], Err(report) if report.kind == crate::error::ErrorKind::Provider && report.message.contains("SAFETY")),
+        "{:?}",
+        items[0]
+    );
+    assert!(!finished);
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+#[tokio::test]
+async fn prompt_feedback_without_a_block_reason_is_not_an_error() {
+    // Gemini also attaches `promptFeedback` (safety ratings only, no
+    // `blockReason`) to ordinary answers. Only a set `blockReason` is a
+    // refusal; the ratings alone must not fail a completed turn.
+    let frames = [
+        r#"{"promptFeedback":{"safetyRatings":[{"category":"HARM_CATEGORY_HARASSMENT","probability":"NEGLIGIBLE"}]},"candidates":[{"content":{"parts":[{"text":"hi"}],"role":"model"},"index":0}]}"#,
+        r#"{"candidates":[{"content":{"parts":[],"role":"model"},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}"#,
+    ];
+    let (items, finished) = collect_stream(&frames).await;
+    assert!(items.iter().all(Result::is_ok), "{items:?}");
+    assert!(finished, "the turn completed normally");
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+#[tokio::test]
+async fn blocked_prompt_with_an_unrecognised_safety_category_still_names_the_block() {
+    // Google adds harm categories without notice. The block chunk carries
+    // the ratings, so an unknown category must not turn the provider's
+    // verdict into a corrupt-frame decode error.
+    let frames = [
+        r#"{"promptFeedback":{"blockReason":"OTHER","safetyRatings":[{"category":"HARM_CATEGORY_JAILBREAK","probability":"SOMEDAY"}]}}"#,
+    ];
+    let (items, finished) = collect_stream(&frames).await;
+    assert_eq!(items.len(), 1, "{items:?}");
+    let Err(report) = &items[0] else {
+        panic!("{:?}", items[0]);
+    };
+    assert_eq!(report.kind, crate::error::ErrorKind::Provider, "{report:?}");
+    assert!(
+        report.message.contains("block_reason=OTHER"),
+        "{}",
+        report.message
+    );
+    assert!(
+        report.message.contains("HARM_CATEGORY_JAILBREAK=SOMEDAY"),
+        "{}",
+        report.message
+    );
+    assert!(!finished);
+}


### PR DESCRIPTION
## Description

**Application trigger.** [rigcoder](https://github.com/gold-silver-copper/rigcoder) (a coding agent on `rig-ecs`, pinned to this branch) ran a Terminal-Bench task with `gemini/gemini-3.8-flash`, streaming. The very first completion of the run ended after 7.5 s with

```
Provider(ErrorReport { kind: Response, retryable: false,
  message: "the stream ended before its terminal record", .. })
```

zero output, zero usage, and the effect log holding one completion record with that `Err` outcome (`rigcoder-e/harness/runs/gen-000-1788767011/fix-code-vulnerability__1`, Rig `8a2ecce`; the same task passed in other generations). The application treated "stream ended" as a transient fault and grew a whole-prompt retry for it.

**Root cause.** When Gemini refuses a prompt it answers `streamGenerateContent?alt=sse` with a single chunk carrying `promptFeedback.blockReason` (optionally `safetyRatings` and `usageMetadata`) and **no `candidates`**, then closes the stream — the documented "prompt was blocked and no candidates are returned" shape. In `crates/rig-core/src/providers/gemini/streaming.rs`:

- `StreamGenerateContentResponse` had no `prompt_feedback` field, so the verdict was discarded at decode.
- `interpret` returned silently for a candidate-less chunk; `finish` emitted nothing because no `finishReason` was ever seen (correctly, for a real truncation).
- `run_wire_stream` therefore ended the stream with no `Final`, and the bus's fold (`serve/handler.rs` `stream_truncated`) reported a **definitive provider refusal as a truncated stream**, with the block reason and safety ratings lost, as a `Response`-kind error a consumer reasonably retries.
- A block chunk without `usageMetadata` was not even a recognisable chunk (`RECOGNIZABLE_CHUNK_KEYS`): it passed through as an `Unknown` frame and any later frames were interpreted.
- The unary path (`completion.rs`, `TryFrom<GenerateContentResponse>`) dropped the reason too: "No response candidates in response".

**Expected.** The provider's verdict is meaningful, terminal error information: the consumer must get one error naming the block reason (and the ratings that explain it), non-retryable, with no terminal record and nothing interpreted after it.

**Fix.** One shared helper, `blocked_prompt_error(&PromptFeedback) -> Option<CompletionError>`, produces `ProviderError("Gemini blocked the prompt: block_reason=<WIRE_SPELLING>, safety_ratings=[…]")` for both wires:

- streaming: `StreamGenerateContentResponse.prompt_feedback`; `promptFeedback` added to `RECOGNIZABLE_CHUNK_KEYS`; `interpret` pushes the error and sets `failed`, so `is_finished` stops the driver and later frames are dead, exactly as the existing tool-protocol finish-reason failures already do;
- unary: `TryFrom` checks `prompt_feedback` before the candidate lookup;
- `BlockReason::as_wire_str` (same rationale as `FinishReason::as_wire_str`); `BLOCK_REASON_UNSPECIFIED` (documented as unused) is not a block.
- `HarmCategory`/`HarmProbability` gain an `#[serde(untagged)] Unknown(String)` variant, as `BlockReason`/`FinishReason` already have: the block chunk carries the ratings, so a category Google added since (`HARM_CATEGORY_JAILBREAK`, `HARM_CATEGORY_IMAGE_*`) must not turn the verdict into a corrupt-frame decode error.

`promptFeedback` carrying only `safetyRatings` (which Gemini attaches to ordinary answers) is unchanged: only a set `blockReason` is a refusal.

Fixes no filed issue; found while running rigcoder against this branch.

## Changelog

- *(gemini)* A prompt Gemini blocks (`promptFeedback.blockReason`) is now reported as a non-retryable `ProviderError` naming the block reason and safety ratings, on both `generateContent` and `streamGenerateContent`, instead of "the stream ended before its terminal record" (streaming) or "No response candidates in response" (unary).

## Migration

Silent behaviour change on the error path only.

- Streaming, old: the stream ends with no terminal record; through the effect bus that is `ErrorReport { kind: Response, message: "the stream ended before its terminal record" }`. New: one `Err` item, `ErrorReport { kind: Provider, retryable: false, message: "ProviderError: Gemini blocked the prompt: block_reason=PROHIBITED_CONTENT, safety_ratings=[HARM_CATEGORY_DANGEROUS_CONTENT=HIGH]" }`, and the stream ends.
- Unary, old: `CompletionError::ResponseError("No response candidates in response")`. New: `CompletionError::ProviderError("Gemini blocked the prompt: block_reason=SAFETY")`. A response with neither candidates nor a block reason still reports "No response candidates in response".

If you matched on the old message to detect a blocked prompt, match on `ErrorKind::Provider` / the `Gemini blocked the prompt` message instead. If you retry on stream-truncation errors, blocked prompts no longer reach that retry.

## Type of change

- [x] Bug fix

## Testing

**Regression tests (red on `f5ab79d5e`, green with the fix)** — `crates/rig-core/src/providers/gemini/streaming/tests.rs` drives the real `streamGenerateContent` path over `MockStreamingClient` SSE bytes:

- `blocked_prompt_is_a_provider_error_naming_the_block_reason` — before: the stream yielded **zero** items.
- `blocked_prompt_without_usage_is_still_recognised_and_ends_the_stream` — before: the chunk passed through as `Unknown` and the dead frames after it were interpreted up to a `Final`.
- `prompt_feedback_without_a_block_reason_is_not_an_error` — guards the ratings-only shape.
- `blocked_prompt_with_an_unrecognised_safety_category_still_names_the_block` — an unknown category/probability in the ratings still yields the provider error.

`crates/rig-core/src/providers/gemini/completion/tests.rs`: `test_generate_content_response_deserializes_without_candidates_or_response_id` now asserts the reason is named (the deserialisation assertions it carried are kept); `test_blocked_prompt_error_carries_the_safety_ratings`; `test_unknown_block_reason_reaches_the_error_verbatim`; `test_unspecified_block_reason_is_not_a_block`; `test_no_candidates_without_prompt_feedback_is_still_a_response_error`.

```sh
cargo test -p rig-core --lib -- gemini::streaming::tests gemini::completion::tests
```

**Downstream validation (real consumer, before/after under identical input and assertions).** rigcoder's product session (`RigcoderPlugin::live`, real Gemini adapter through a host `ModelConnection`, streaming, its default three provider retries) against a local server that answers every request with the blocked chunk:

| Rig source | provider requests | transcript |
| --- | --- | --- |
| `de83e9f` (rigcoder's pin, unmodified) | 4 | 3 × `Retrying`, then `Failed(… "the stream ended before its terminal record")` — byte-identical to the live incident |
| this branch via a local `[patch]` path override (all Rig git crates) | 1 | `Failed(… "Gemini blocked the prompt: block_reason=PROHIBITED_CONTENT, safety_ratings=[…]")`, `kind: Provider`, `retryable: false` |

The reproducer is `crates/rigcoder/tests/gemini_blocked_prompt.rs` in rigcoder (kept downstream; it needs the product's retry loop, which is not Rig's to reproduce). The override was local to that run and is not committed anywhere.

**Verification.** `cargo xtask verify --pr --base origin/feat/effect-bus --no-reuse` passes: 26 selected lanes (fmt, source-guards, tooling, clippy, default-check, default-tests, scenario-registrations, core-all, bus-verification, macro-hygiene, conformance, derive, doctests, docs, loom, the wasm32 check lanes, the three `wasm-bindgen` test lanes under the lockfile's runner 0.2.118, native-only guards) — "All selected checks passed". `full-tests`, `workspace-check` and `dependency-floors` are outside the PR selection. Also `cargo fmt --all -- --check` and `cargo clippy -p rig-core --all-targets --all-features -- -D warnings` clean.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated READMEs and Rust docs affected by this change (none reference the old messages)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did not edit `CHANGELOG.md` or `MIGRATING.md` (they are generated at release)

## Notes

- **Base.** Stacked on `feat/effect-bus` (#2443) because that is the runtime the consumer runs and where the before/after comparison was made. `main` carries the same defect in the pre-`StreamEvent` shape of this adapter (no `prompt_feedback` on the streaming chunk either); the fix is a small, mechanical port there if wanted separately.
- **Honest limit of the field evidence.** The live incident's log did not keep stream frames (rigcoder's recorder does not keep events), so the incident is *consistent with* a blocked prompt (first request of the run, 7.5 s, zero output, a vulnerability-hunting instruction that lists CWE categories, nondeterministic across generations) but a network truncation cannot be excluded from that log alone. The defect and the fix are established offline by the tests above independently of that.
- `ErrorReport.refusal` stays `false`: `CompletionError` has no refusal-carrying variant and widening that mapping is a separate decision. Consumers can rely on `ErrorKind::Provider` + `retryable: false`.
- Not changed: a *candidate-level* block on the streaming wire (`finishReason: SAFETY` with no content) still yields a `Final` with `finish_reason: ContentFilter` and empty content, consistent with how other providers report content filtering, while the unary Gemini path errors on it ("Gemini candidate missing content"). That asymmetry predates this PR and is out of its scope.
- The Interactions API wire, `rig-gemini-grpc` and `rig-vertexai` are separate adapters with no `promptFeedback` handling either; they are untouched here and worth a follow-up.
- Prompt-token usage reported on the block chunk is recorded on the telemetry span but has no slot on `ErrorReport`, so it is not surfaced to the consumer.
