### PR TITLE
fix(gemini): surface an in-band error frame as the provider's verdict instead of a truncated stream

### DIFF
--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -88,6 +88,13 @@ pub struct StreamGenerateContentResponse {
     pub prompt_feedback: Option<PromptFeedback>,
     pub model_version: Option<String>,
     pub usage_metadata: Option<PartialUsage>,
+    /// Gemini's error envelope, sent as a frame of its own when the
+    /// service aborts a stream in-band (`{"error":{"code":500,"message":
+    /// …,"status":"INTERNAL"}}`). The provider's verdict, not an unknown
+    /// frame to skip: the stream closes after it, and without this the
+    /// turn ended as a truncation with the error lost. Kept raw so every
+    /// field (code, status, message, details) survives into the report.
+    pub error: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -123,9 +130,11 @@ fn tool_protocol_finish_reason_error(choice: &ContentCandidate) -> Option<Comple
 /// The recognizability markers of a `streamGenerateContent` chunk: every
 /// genuine frame carries `candidates`, `usageMetadata` and/or
 /// `promptFeedback` (a blocked prompt's only chunk may carry nothing but
-/// the feedback). A frame with any of them must fully decode (else
-/// `Corrupt`); other JSON is `Unknown`.
-const RECOGNIZABLE_CHUNK_KEYS: &[&str] = &["candidates", "usageMetadata", "promptFeedback"];
+/// the feedback), and the service's in-band abort carries only `error`. A
+/// frame with any of them must fully decode (else `Corrupt`); other JSON
+/// is `Unknown`.
+const RECOGNIZABLE_CHUNK_KEYS: &[&str] =
+    &["candidates", "usageMetadata", "promptFeedback", "error"];
 
 /// The Gemini REST (`streamGenerateContent`) SSE wire as a [`WireAdapter`].
 ///
@@ -208,6 +217,20 @@ impl WireAdapter for GeminiRestAdapter {
         if let Some(usage) = data.usage_metadata.as_ref() {
             span.record_token_usage(&crate::completion::Usage::from(usage));
             self.final_usage = Some(usage.clone());
+        }
+
+        if let Some(error) = data.error {
+            // The service aborted the turn in-band: the envelope is the
+            // whole answer and the stream closes after it. Surface it as
+            // the provider error it is, with the envelope as the body (as
+            // the unary wire and the other families' streams do), rather
+            // than skipping an unknown frame and reporting a truncation.
+            self.failed = true;
+            let body = serde_json::json!({ "error": error }).to_string();
+            out.push(Err(crate::provider_response::completion_error_from_body(
+                body,
+            )));
+            return;
         }
 
         if let Some(blocked) = data.prompt_feedback.as_ref().and_then(blocked_prompt_error) {

--- a/tests/providers/gemini/cassette/stream_terminal_matrix.rs
+++ b/tests/providers/gemini/cassette/stream_terminal_matrix.rs
@@ -764,6 +764,8 @@ mod unit {
         unknowns: usize,
         terminals: Vec<rig::streaming::StreamFinal>,
         errors: usize,
+        /// The error items' messages, in order.
+        error_messages: Vec<String>,
         last_was_terminal: bool,
         response: Option<rig::streaming::StreamFinal>,
     }
@@ -797,6 +799,7 @@ mod unit {
             unknowns: 0,
             terminals: Vec::new(),
             errors: 0,
+            error_messages: Vec::new(),
             last_was_terminal: false,
             response: None,
         };
@@ -824,9 +827,10 @@ mod unit {
                         _ => {}
                     }
                 }
-                Err(_) => {
+                Err(error) => {
                     run.last_was_terminal = false;
                     run.errors += 1;
+                    run.error_messages.push(error.to_string());
                 }
             }
         }
@@ -894,6 +898,54 @@ mod unit {
         assert!(run.terminals.is_empty(), "truncation is still truncation");
         assert!(run.response.is_none());
         assert_eq!(run.text, "The answer is 42.");
+    }
+
+    /// Gemini's in-band abort: a frame carrying only its error envelope.
+    const ERROR_FRAME: &str =
+        r#"{"error":{"code":500,"message":"An internal error has occurred.","status":"INTERNAL"}}"#;
+
+    #[tokio::test]
+    async fn an_error_frame_after_text_is_the_providers_verdict_not_a_truncation() {
+        let run = run(&[ANSWER, ERROR_FRAME]).await;
+        assert_eq!(run.text, "The answer is 42.");
+        assert_eq!(
+            run.unknowns, 0,
+            "the envelope is a modeled frame, never skipped"
+        );
+        assert_eq!(run.errors, 1, "one error item: the provider's");
+        assert!(
+            run.terminals.is_empty(),
+            "no terminal record after an abort"
+        );
+        let message = &run.error_messages[0];
+        assert!(
+            message.contains("INTERNAL"),
+            "the envelope's status survives: {message}"
+        );
+        assert!(
+            message.contains("An internal error has occurred."),
+            "the envelope's message survives: {message}"
+        );
+        assert!(
+            !message.contains("terminal record"),
+            "not reported as a cut stream: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_error_frame_alone_is_the_providers_verdict() {
+        let run = run(&[ERROR_FRAME]).await;
+        assert!(run.text.is_empty());
+        assert_eq!(run.errors, 1);
+        assert!(run.terminals.is_empty());
+        assert!(run.error_messages[0].contains("INTERNAL"));
+    }
+
+    #[tokio::test]
+    async fn frames_after_an_error_frame_are_not_read() {
+        let run = run(&[ERROR_FRAME, ANSWER]).await;
+        assert_eq!(run.errors, 1);
+        assert!(run.text.is_empty(), "the abort is the wire's terminal");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Stacked on `feat/effect-bus` (#2443). Found by running rigcoder's Gemini cassette matrix for the observation witness (#2476) against the real product session; the derived cell `observe_failures/stream_error_frame_stream` (rigcoder PR to follow) is the downstream reproduction.

## The defect

A `streamGenerateContent` stream the service aborts sends one last SSE frame carrying only Gemini's error envelope and closes:

```
data: {"error":{"code":500,"message":"An internal error has occurred.","status":"INTERNAL"}}
```

`RECOGNIZABLE_CHUNK_KEYS` (`candidates`, `usageMetadata`, `promptFeedback`) did not include `error`, so the frame classified as `Unknown`, was passed through as an unknown event, and the close was then reported as `the stream ended before its terminal record` (`ErrorKind::Response`, `retryable: false`). The provider's code, status and message never reached the report, and any host that treats a cut stream as transient (rigcoder does) retried a verdict.

What the witness saw before the fix, on the product session (the envelope inside the truncation's tail, `errors` empty):

```
{"action":"stream_truncated","delivered":3,"tail":[{"event":"block_start",…},{"event":"block_delta","delta":{"delta":"text","text":"pong"}},{"event":"unknown","error":{"code":500,"message":"An internal error has occurred.","status":"INTERNAL"}}],"errors":[]}
Ended { provider, "response: the stream ended before its terminal record" }
```

## The fix

`StreamGenerateContentResponse` gains `error: Option<serde_json::Value>`, `error` joins the recognizable keys, and `interpret` ends the stream with the envelope as the body of a provider error through `completion_error_from_body` — the same path the other families' in-band envelopes take (anthropic's `{"type":"error",…}`, the interactions wire). Frames after it are not read (`is_finished`).

What that report is: `ErrorKind::ProviderResponse` with the envelope as its body and no HTTP status (`ProviderResponseError::without_status`), so `is_retryable()` is false. The same envelope on the unary wire arrives as a non-2xx response and is `ErrorKind::Http { status: 500 }`, retryable. That difference is shared with every streaming family today (none consults the envelope's `code` for a status); it is noted here, not changed here — a host that keys retries on `is_retryable` will not retry an in-band `INTERNAL`, which is the pre-existing behaviour for the other providers too. Consulting the envelope's `code`/`status` for retryability is a follow-up for `completion_error_from_body`.

## Regression cells (`tests/providers/gemini/cassette/stream_terminal_matrix.rs`, `unit`)

| cell | pins |
|---|---|
| `an_error_frame_after_text_is_the_providers_verdict_not_a_truncation` | text delivered, one error item carrying `INTERNAL` and the message, no unknown event, no terminal, not worded as a cut |
| `an_error_frame_alone_is_the_providers_verdict` | the envelope as the only frame |
| `frames_after_an_error_frame_are_not_read` | the abort is the wire's terminal |

Pre-fix failure (this branch's tests over `origin/feat/effect-bus`'s `streaming.rs`):

```
test …unit::an_error_frame_after_text_is_the_providers_verdict_not_a_truncation ... FAILED
test …unit::an_error_frame_alone_is_the_providers_verdict ... FAILED
```

## Verification

- `cargo fmt`; `RUSTFLAGS="-D warnings" cargo clippy -p rig-core --all-targets --all-features`; `cargo check -p rig-core --target wasm32-unknown-unknown`
- key-free replay of the whole Gemini cassette suite: `cargo test -p rig --all-features --test gemini gemini::cassette -- --test-threads=1` → 382 passed, 1 ignored (no recorded fixture changes: the envelope frame is not something the live API produced on demand, so the cells are unit cells over the documented shape)

Not covered here, recorded for a follow-up: a body cut in the middle of a frame is dropped by the SSE decoder and reports exactly like a clean truncation (`observe_failures/transport_cut_stream`); distinguishing the two needs a "partial frame at EOF" fact from the decoder.
