### PR TITLE
docs: point "Who is using Rig?" to awesome-rig

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,26 +88,9 @@ The root `rig` facade re-exports both at their familiar paths, so most code
 depends only on `rig`.
 
 ## Who is using Rig?
-Below is a non-exhaustive list of companies and people who are using Rig:
-- [St Jude](https://www.stjude.org/) - Using Rig for a chatbot utility as part of [`proteinpaint`](https://github.com/stjude/proteinpaint), a genomics visualisation tool.
-- [Coral Protocol](https://www.coralprotocol.org/) - Using Rig extensively, both internally as well as part of the [Coral Rust SDK.](https://github.com/Coral-Protocol/coral-rs)
-- [VT Code](https://github.com/vinhnx/vtcode) - VT Code is a Rust-based terminal coding agent with semantic code intelligence via Tree-sitter and ast-grep. VT Code uses `rig` for simplifying LLM calls and implementing the model picker.
-- [Con](https://github.com/nowledge-co/con) - Con is a GPU-accelerated terminal emulator with a built-in AI agent harness. It uses Rig as the provider abstraction layer for its integrated coding agents.
-- [Dria](https://dria.co/) - a decentralised AI network. Currently using Rig as part of their [compute node.](https://github.com/firstbatchxyz/dkn-compute-node)
-- [Nethermind](https://www.nethermind.io/) - Using Rig as part of their [Neural Interconnected Nodes Engine](https://github.com/NethermindEth/nine) framework.
-- [Neon](https://neon.com) - Using Rig for their [app.build](https://github.com/neondatabase/appdotbuild-agent) V2 reboot in Rust.
-- [Listen](https://github.com/piotrostr/listen) - A framework aiming to become the go-to framework for AI portfolio management agents. Powers [the Listen app.](https://app.listen-rs.com/)
-- [Cairnify](https://cairnify.com/) - helps users find documents, links, and information instantly through an intelligent search bar. Rig provides the agentic foundation behind Cairnify’s AI search experience, enabling tool-calling, reasoning, and retrieval workflows.
-- [Ryzome](https://ryzome.ai) - Ryzome is a visual AI workspace that lets you build interconnected canvases of thoughts, research, and AI agents to orchestrate complex knowledge work.
-- [deepwiki-rs](https://github.com/sopaco/deepwiki-rs) - Turn code into clarity. Generate accurate technical docs and AI-ready context in minutes—perfectly structured for human teams and intelligent agents.
-- [Cortex Memory](https://github.com/sopaco/cortex-mem) - The production-ready memory system for intelligent agents. A complete solution for memory management, from extraction and vector search to automated optimization, with a REST API, MCP, CLI, and insights dashboard out-of-the-box.
-- [Ironclaw](https://github.com/nearai/ironclaw) - A secure personal AI assistant
-- [ilert](https://www.ilert.com/) - Incident management & alerting platform. Uses Rig as the multi-provider abstraction in its agentic LLM proxy powering ilert AI.
-- [Archestra](https://github.com/archestra-ai/archestra) - MCP-native secure AI platform. Uses Rig in its agentic benchmark.
+Rig powers coding agents and developer tools, desktop and terminal AI assistants, retrieval-augmented generation and semantic search, agent memory systems, multi-agent and workflow orchestration frameworks, and production services ranging from genomics research and incident management to decentralised compute networks.
 
-For a curated list of Rig projects, libraries, tools, articles, and production users, check out [awesome-rig](https://github.com/0xPlaygrounds/awesome-rig).
-
-Are you also using Rig? [Open an issue](https://www.github.com/0xPlaygrounds/rig/issues) to have your name added!
+The full list of companies, applications, libraries, and articles lives in [awesome-rig](https://github.com/0xPlaygrounds/awesome-rig), a community-maintained list. Using Rig? Open a pull request there to add your project.
 
 ## Get Started
 Use the root `rig` facade when you want feature-gated access to companion crates,

--- a/crates/rig-core/README.md
+++ b/crates/rig-core/README.md
@@ -120,15 +120,6 @@ The following providers are available as separate companion-crates:
 - Google Vertex: [`rig-vertexai`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-vertexai)
 
 ## Who is using Rig?
-Below is a non-exhaustive list of companies and people who are using Rig:
-- [St Jude](https://www.stjude.org/) - Using Rig for a chatbot utility as part of [`proteinpaint`](https://github.com/stjude/proteinpaint), a genomics visualisation tool.
-- [Coral Protocol](https://www.coralprotocol.org/) - Using Rig extensively, both internally as well as part of the [Coral Rust SDK.](https://github.com/Coral-Protocol/coral-rs)
-- [VT Code](https://github.com/vinhnx/vtcode) - VT Code is a Rust-based terminal coding agent with semantic code intelligence via Tree-sitter and ast-grep. VT Code uses `rig` for simplifying LLM calls and implement model picker.
-- [Dria](https://dria.co/) - a decentralised AI network. Currently using Rig as part of their [compute node.](https://github.com/firstbatchxyz/dkn-compute-node)
-- [Nethermind](https://www.nethermind.io/) - Using Rig as part of their [Neural Interconnected Nodes Engine](https://github.com/NethermindEth/nine) framework.
-- [Neon](https://neon.com) - Using Rig for their [app.build](https://github.com/neondatabase/appdotbuild-agent) V2 reboot in Rust.
-- [Listen](https://github.com/piotrostr/listen) - A framework aiming to become the go-to framework for AI portfolio management agents. Powers [the Listen app.](https://app.listen-rs.com/)
-- [Cairnify](https://cairnify.com/) - helps users find documents, links, and information instantly through an intelligent search bar. Rig provides the agentic foundation behind Cairnify’s AI search experience, enabling tool-calling, reasoning, and retrieval workflows.
-- [Ironclaw](https://github.com/nearai/ironclaw) - A secure personal AI assistant
+Rig powers coding agents and developer tools, desktop and terminal AI assistants, retrieval-augmented generation and semantic search, agent memory systems, multi-agent and workflow orchestration frameworks, and production services ranging from genomics research and incident management to decentralised compute networks.
 
-Are you also using Rig in production? [Open an issue](https://www.github.com/0xPlaygrounds/rig/issues) to have your name added!
+The full list of companies, applications, libraries, and articles lives in [awesome-rig](https://github.com/0xPlaygrounds/awesome-rig), a community-maintained list. Using Rig? Open a pull request there to add your project.


### PR DESCRIPTION
## Description

The "Who is using Rig?" section in the root README and in `crates/rig-core/README.md` had grown into a per-project list that duplicated [awesome-rig](https://github.com/0xPlaygrounds/awesome-rig). This replaces it with a two-paragraph section: one sentence summarising the kinds of things people build with Rig, and a single link to awesome-rig as the place to explore and add projects.

The heading and its `#who-is-using-rig` anchor are unchanged, so the table of contents and the CHANGELOG reference still resolve. No images belonged to the section, so no assets were removed.

**Before** (root README, abbreviated):

> Below is a non-exhaustive list of companies and people who are using Rig:
> - [St Jude](https://www.stjude.org/) - Using Rig for a chatbot utility …
> - … 14 more entries …
>
> For a curated list of Rig projects … check out awesome-rig.
>
> Are you also using Rig? Open an issue to have your name added!

**After**:

> Rig powers coding agents and developer tools, desktop and terminal AI assistants, retrieval-augmented generation and semantic search, agent memory systems, multi-agent and workflow orchestration frameworks, and production services ranging from genomics research and incident management to decentralised compute networks.
>
> The full list of companies, applications, libraries, and articles lives in [awesome-rig](https://github.com/0xPlaygrounds/awesome-rig), a community-maintained list. Using Rig? Open a pull request there to add your project.

The categories in the summary are drawn from the projects actually listed in the old section and in awesome-rig (coding agents such as VT Code, assistants such as Ironclaw and Con, RAG and search such as Cairnify and deepwiki-rs, memory such as Cortex Memory, orchestration frameworks such as graph-flow and coral-rs, and production users St. Jude, ilert, and Dria).

## Changelog

None

## Migration

None

## Testing

- All 15 entries from the old section are present in awesome-rig (Applications, Libraries, or Production Users), so nothing is lost. One URL differs: the README linked Con at `nowledge-co/con`, awesome-rig lists `nowledge-co/con-terminal`.
- `https://github.com/0xPlaygrounds/awesome-rig` returns 200.
- Searched the repository for the anchor and the removed project names; the only remaining references are the TOC entry (still valid) and a historical CHANGELOG line.
- No `lychee` or markdown-lint job exists in CI, so no link-check workflow to run.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have updated READMEs and Rust docs affected by this change
- [x] My changes generate no new warnings
- [x] I did not edit `CHANGELOG.md` or `MIGRATING.md` (they are generated at release)

## Notes

Docs-only. The rig-core README is the crates.io readme for `rig-core`, so the shorter section will show there on the next release.
