### PR TITLE
fix(agent): own the tool context and the memory append across every ending

### DIFF
--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -745,18 +745,23 @@ impl Agent {
 
     /// Run one turn against caller-owned history, appending only the messages
     /// the run committed. Returns the same [`PromptResponse`] as
-    /// [`prompt`](Self::prompt).
+    /// [`prompt`](Self::prompt), its `messages` included.
+    ///
+    /// The caller's history is the run's input history, so conversation
+    /// memory is bypassed (no load, no append) and the caller owns
+    /// persistence. A run that fails appends nothing: the error carries the
+    /// history the run had, the caller's vector is unchanged.
     #[tracing::instrument(skip(self, prompt, chat_history), fields(agent_name = self.name_or_default()))]
     pub async fn chat(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
         chat_history: &mut Vec<Message>,
     ) -> Result<PromptResponse, PromptError> {
-        let mut response = AgentRunner::from_agent(self, prompt)
+        let response = AgentRunner::from_agent(self, prompt)
             .history(chat_history.clone())
             .await?;
-        if let Some(messages) = response.messages.take() {
-            chat_history.extend(messages);
+        if let Some(messages) = &response.messages {
+            chat_history.extend(messages.iter().cloned());
         }
         Ok(response)
     }

--- a/crates/rig-agent/src/agent/engine.rs
+++ b/crates/rig-agent/src/agent/engine.rs
@@ -52,7 +52,7 @@ use super::{
         streamed::{StreamedResolution, StreamedTurnAssembler, StreamedTurnEvent},
     },
     run::{
-        response::PromptResponse,
+        response::{MemoryAppend, PromptResponse},
         transcript::{assistant_text_from_choice, is_empty_assistant_turn, tool_result_output},
     },
     runner::AgentRunner,
@@ -505,13 +505,18 @@ where
                         "Agent run finished"
                     );
                     source.record_run_level_telemetry(&agent_span, &response, created_agent_span);
-                    append_run_messages(
+                    // The answer stands whatever the append says; how the
+                    // append settled rides on the response so a caller can
+                    // tell a persisted transcript from one the backend
+                    // refused without a hook or the effect log.
+                    let memory_append = append_run_messages(
                         &runner,
                         &hook_ctx,
                         memory_handle.as_ref(),
                         response.messages.as_deref().unwrap_or_default(),
                     )
                     .await;
+                    let response = response.with_memory_append(memory_append);
                     // The run has settled successfully: nothing follows this
                     // response — the error endings settle after the loop.
                     if runner.config.hooks.observes(StepEventKind::RunSettled) {
@@ -1467,12 +1472,15 @@ impl TurnSource for StreamingTurnSource {
         // caller supplied input history.
         let final_messages: Option<Vec<Message>> =
             Some(response.messages.clone().unwrap_or_default());
-        Some(MultiTurnStreamItem::final_response_with_completion_calls(
-            final_choice,
-            response.usage,
-            response.completion_calls.clone(),
-            final_messages,
-        ))
+        Some(
+            MultiTurnStreamItem::final_response_with_completion_calls(
+                final_choice,
+                response.usage,
+                response.completion_calls.clone(),
+                final_messages,
+            )
+            .with_memory_append(response.memory_append.clone()),
+        )
     }
 }
 
@@ -1641,18 +1649,17 @@ pub(crate) async fn resolve_completion_call(
 /// Append a finished run's messages to conversation memory, logging and
 /// proceeding on failure. Shared `Done`-arm behavior for both drivers. The
 /// append is a `Memory` dispatch at the boundary: observe-only for hooks
-/// unless one opts into `MemoryDispatch`.
+/// unless one opts into `MemoryDispatch`. Returns how the append settled
+/// for the response, `None` when the run has no memory to append to.
 pub(crate) async fn append_run_messages(
     runner: &AgentRunner,
     ctx: &HookContext,
     memory_handle: Option<&(MemoryHandle, rig_core::id::ConversationId)>,
     messages: &[Message],
-) {
+) -> Option<MemoryAppend> {
     // Clone into an owned vec only when there is a backend to append to — the
     // common no-memory path pays nothing.
-    let Some((memory, id)) = memory_handle else {
-        return;
-    };
+    let (memory, id) = memory_handle?;
     let appended = dispatch_effect(
         &runner.config.hooks,
         ctx,
@@ -1670,13 +1677,17 @@ pub(crate) async fn append_run_messages(
         Outcome::Memory(rig_core::effect::MemoryOutcome::Appended) => Ok(()),
         other => Err(wrong_outcome("appended memory", &other)),
     });
-    if let Err(err) = appended {
-        tracing::warn!(
-            error = %err,
-            conversation_id = %id,
-            "conversation memory append failed; surfacing final response anyway"
-        );
-    }
+    Some(match appended {
+        Ok(()) => MemoryAppend::Acknowledged,
+        Err(report) => {
+            tracing::warn!(
+                error = %report,
+                conversation_id = %id,
+                "conversation memory append failed; surfacing final response anyway"
+            );
+            MemoryAppend::Failed { report }
+        }
+    })
 }
 
 /// Dispatch any effect through the agent's bus at the dispatch boundary:

--- a/crates/rig-agent/src/agent/mod.rs
+++ b/crates/rig-agent/src/agent/mod.rs
@@ -118,7 +118,7 @@ mod typed;
 pub(crate) const UNKNOWN_AGENT_NAME: &str = "Unnamed Agent";
 
 pub use crate::bus::ModelHandle;
-pub use crate::run::response::{CompletionCall, PromptResponse};
+pub use crate::run::response::{CompletionCall, MemoryAppend, PromptResponse};
 pub use crate::run::spec::RunSpec;
 pub use builder::{AgentBuilder, NoToolConfig, WithBuilderTools, WithToolServerHandle};
 pub use completion::{Agent, AgentParts};

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -108,11 +108,17 @@ impl AgentRunner {
     /// the state a driver serialized between steps (see [`AgentRun`]) is
     /// picked up where it stopped — its pending tool calls execute, its
     /// next model turn is asked for — under this agent's hooks, tools,
-    /// bus and settings. The runner's prompt and history are ignored (the
-    /// run carries its own), as is conversation memory (its history is
-    /// already in the run; nothing is loaded, and the run's messages are
-    /// not appended a second time). The run must have been suspended by
-    /// the same rig version.
+    /// bus, settings and [`tool_context`](Self::tool_context) (inbound tool
+    /// context is driver state, never part of the persisted run). The
+    /// runner's prompt and history are ignored (the run carries its own),
+    /// and conversation memory is neither loaded nor appended: the history
+    /// is already in the run, and the driver that persisted the run owns
+    /// its memory — it appends the finished run's `messages` itself, since
+    /// a suspended run never reached the `Done` append. The response's
+    /// `memory_append` is therefore `None`. Pending tool calls re-execute
+    /// on resume: a tool that ran before the suspension and answered
+    /// nothing runs again. The run must have been suspended by the same
+    /// rig version.
     pub fn resume(mut self, run: AgentRun) -> Self {
         self.resume = Some(Box::new(run));
         self
@@ -341,6 +347,15 @@ impl AgentRunner {
     }
 
     /// Set the conversation id used to load and persist memory for this run.
+    ///
+    /// With a memory backend configured, the run loads the conversation
+    /// before its first model call (a load failure fails the run with
+    /// [`PromptError::MemoryError`] before any completion) and appends its
+    /// `messages` once it finishes. The append is acknowledged on the
+    /// response's [`memory_append`](PromptResponse::memory_append): a
+    /// refused append does not fail the run, the answer stands and the
+    /// response says the transcript was not persisted. Explicit
+    /// [`history`](Self::history) bypasses both.
     pub fn conversation(mut self, id: impl Into<rig_core::id::ConversationId>) -> Self {
         self.config.conversation_id = Some(id.into());
         self
@@ -513,7 +528,8 @@ impl AgentRunner {
         // A resumed run brought its history with it: nothing is loaded and
         // nothing is saved — no `Memory` dispatch, no memory hook event, no
         // record in the log — so its continuation is exactly the reference
-        // log's tail and a memory backend that is down cannot fail it.
+        // log's tail and a memory backend that is down cannot fail it. The
+        // driver that persisted the run owns its append (see `resume`).
         let resumed = self.resume.take();
         let (history_override, memory_handle) = match &resumed {
             Some(_) => (None, None),

--- a/crates/rig-agent/src/agent/runner/prompt_tests.rs
+++ b/crates/rig-agent/src/agent/runner/prompt_tests.rs
@@ -1,6 +1,6 @@
 use crate::agent::ResponseIdentity;
 use crate::agent::typed::{TypedPromptResponse, deserialize_structured_output};
-use crate::run::response::{CompletionCall, PromptResponse};
+use crate::run::response::{CompletionCall, MemoryAppend, PromptResponse};
 use crate::run::transcript::{TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER, turn_delivered_no_answer};
 use crate::run::transcript::{assistant_text_from_choice, is_empty_assistant_turn};
 use crate::{
@@ -1916,7 +1916,7 @@ async fn memory_appends_full_turn_after_success() {
     let model = MockCompletionModel::text("ack");
     let agent = AgentBuilder::new(model).memory(memory.clone()).build();
 
-    let _ = agent
+    let response = agent
         .prompt("hello")
         .conversation("t1")
         .await
@@ -1924,6 +1924,16 @@ async fn memory_appends_full_turn_after_success() {
 
     let stored = memory.load(&"t1".into()).await.unwrap();
     assert_eq!(stored.len(), 2, "user prompt + assistant response saved");
+    assert_eq!(
+        response.memory_append,
+        Some(MemoryAppend::Acknowledged),
+        "the response acknowledges the append"
+    );
+    assert_eq!(
+        response.messages.as_deref(),
+        Some(stored.as_slice()),
+        "what was appended is the response's transcript"
+    );
 }
 
 #[tokio::test]
@@ -1939,7 +1949,7 @@ async fn explicit_with_history_overrides_memory() {
     let recorded = model.clone();
 
     let agent = AgentBuilder::new(model).memory(memory.clone()).build();
-    let _ = agent
+    let response = agent
         .prompt("hello")
         .conversation("t1")
         .history(vec![Message::user("from-caller")])
@@ -1949,6 +1959,10 @@ async fn explicit_with_history_overrides_memory() {
     assert_eq!(memory.load_count(), 0, "load skipped");
     let appends = memory.append_count();
     assert_eq!(appends, 0, "append skipped");
+    assert_eq!(
+        response.memory_append, None,
+        "explicit history bypasses memory: nothing to acknowledge"
+    );
 
     let received = recorded.requests()[0].chat_history.clone();
     assert_eq!(received.len(), 2, "caller history (1) + current prompt");
@@ -2220,7 +2234,7 @@ async fn without_memory_disables_for_request() {
         .conversation("t1")
         .build();
 
-    let _ = agent
+    let response = agent
         .prompt("hello")
         .without_memory()
         .await
@@ -2228,6 +2242,7 @@ async fn without_memory_disables_for_request() {
 
     assert_eq!(memory.load_count(), 0);
     assert_eq!(memory.append_count(), 0);
+    assert_eq!(response.memory_append, None);
 }
 
 #[tokio::test]
@@ -2247,20 +2262,35 @@ async fn memory_load_error_surfaces_as_prompt_error() {
     }
 }
 
+/// A refused append does not fail the run: the answer stands, and the
+/// response says the transcript was not persisted — a caller can tell the
+/// two endings apart without a hook or the effect log.
 #[tokio::test]
 async fn memory_append_error_does_not_drop_response() {
     let model = MockCompletionModel::text("ack");
     let agent = AgentBuilder::new(model)
         .memory(AppendFailingMemory::default())
         .build();
-    let response: String = agent
+    let response = agent
         .prompt("hello")
         .conversation("t1")
         .await
-        .expect("append failure must not block successful completion")
-        .output;
+        .expect("append failure must not block successful completion");
 
-    assert!(!response.is_empty());
+    assert_eq!(response.output, "ack");
+    assert_eq!(
+        response.messages.as_ref().map(Vec::len),
+        Some(2),
+        "the transcript the run tried to persist"
+    );
+    let report = response
+        .memory_append
+        .as_ref()
+        .and_then(MemoryAppend::failure)
+        .expect("the refused append is reported on the response");
+    assert_eq!(report.kind, rig_core::error::ErrorKind::MemoryBackend);
+    assert!(report.message.contains("append boom"), "{report:?}");
+    assert!(!response.memory_append.as_ref().unwrap().is_acknowledged());
 }
 
 /// Serde compatibility (rig#2265): run records persisted before the

--- a/crates/rig-agent/src/agent/streaming.rs
+++ b/crates/rig-agent/src/agent/streaming.rs
@@ -150,6 +150,20 @@ impl MultiTurnStreamItem {
         Self::StreamAssistantItem(item)
     }
 
+    /// Stamp a `FinalResponse` item with how the run's memory append
+    /// settled; any other item is returned unchanged.
+    pub(crate) fn with_memory_append(
+        self,
+        memory_append: Option<crate::run::MemoryAppend>,
+    ) -> Self {
+        match self {
+            Self::FinalResponse(response) => {
+                Self::FinalResponse(response.with_memory_append(memory_append))
+            }
+            other => other,
+        }
+    }
+
     /// Build a `FinalResponse` item from final-turn content, applying the
     /// run-finalization shaping of `final_response_from_content` (#1928).
     /// The one public entry point to that shaping, for mocks and adapters

--- a/crates/rig-agent/src/agent/streaming/tests.rs
+++ b/crates/rig-agent/src/agent/streaming/tests.rs
@@ -5595,12 +5595,14 @@ async fn streaming_appends_to_memory_after_final_response() {
         .await;
 
     let mut history_in_final = None;
+    let mut memory_append = None;
     while let Some(item) = stream.next().await {
         match item {
             Ok(MultiTurnStreamItem::FinalResponse(res)) => {
                 history_in_final = res
                     .messages()
                     .map(<[rig_core::completion::Message]>::to_vec);
+                memory_append = res.memory_append.clone();
                 break;
             }
             Ok(_) => {}
@@ -5615,9 +5617,49 @@ async fn streaming_appends_to_memory_after_final_response() {
         2,
         "user prompt + assistant response in final history: {final_history:?}"
     );
+    assert_eq!(
+        memory_append,
+        Some(crate::run::MemoryAppend::Acknowledged),
+        "the final item acknowledges the append, as the blocking response does"
+    );
 
     let stored = memory.load(&"stream-thread".into()).await.unwrap();
     assert_eq!(stored.len(), 2, "memory should contain user + assistant");
+}
+
+/// The streaming twin of the blocking refused-append test: the final item
+/// is still delivered, and it reports the append the backend refused.
+#[tokio::test]
+async fn streaming_reports_a_refused_append_on_the_final_response() {
+    let agent = AgentBuilder::new(streaming_text_then_final_model())
+        .memory(rig_core::test_utils::AppendFailingMemory::default())
+        .build();
+
+    let mut stream = agent
+        .stream_prompt("hi there")
+        .conversation("stream-thread")
+        .stream()
+        .await;
+
+    let mut final_response = None;
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(MultiTurnStreamItem::FinalResponse(res)) => {
+                final_response = Some(res);
+                break;
+            }
+            Ok(_) => {}
+            Err(err) => panic!("unexpected streaming error: {err:?}"),
+        }
+    }
+    let response = final_response.expect("the answer stands when the append is refused");
+    assert_eq!(response.messages().map(<[_]>::len), Some(2));
+    let report = response
+        .memory_append()
+        .and_then(crate::run::MemoryAppend::failure)
+        .expect("the refused append is reported on the final item");
+    assert_eq!(report.kind, rig_core::error::ErrorKind::MemoryBackend);
+    assert!(report.message.contains("append boom"), "{report:?}");
 }
 
 #[tokio::test]

--- a/crates/rig-agent/src/agent/streaming/tests.rs
+++ b/crates/rig-agent/src/agent/streaming/tests.rs
@@ -5636,7 +5636,7 @@ async fn streaming_reports_a_refused_append_on_the_final_response() {
         .build();
 
     let mut stream = agent
-        .stream_prompt("hi there")
+        .prompt("hi there")
         .conversation("stream-thread")
         .stream()
         .await;

--- a/crates/rig-agent/src/agent/typed.rs
+++ b/crates/rig-agent/src/agent/typed.rs
@@ -44,6 +44,10 @@ pub struct TypedPromptResponse<T> {
     /// metrics for that request.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub completion_calls: Vec<CompletionCall>,
+    /// How the accepted attempt's conversation-memory append settled; see
+    /// [`PromptResponse::memory_append`](crate::agent::PromptResponse::memory_append).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_append: Option<crate::run::MemoryAppend>,
 }
 
 impl<T> TypedPromptResponse<T> {
@@ -52,6 +56,7 @@ impl<T> TypedPromptResponse<T> {
             output,
             usage,
             completion_calls: Vec::new(),
+            memory_append: None,
         }
     }
 
@@ -360,6 +365,7 @@ where
                         output,
                         usage,
                         completion_calls: response.completion_calls,
+                        memory_append: response.memory_append,
                     })
                 }
                 Err(err) => {

--- a/crates/rig-agent/src/bus/handle.rs
+++ b/crates/rig-agent/src/bus/handle.rs
@@ -250,7 +250,8 @@ pub struct ToolAnswer {
     /// The result.
     pub result: rig_core::tool::ToolResult,
     /// The dispatch context after the tool ran: the inbound values it ran
-    /// with and the result metadata it published.
+    /// with and the result metadata it published. A handler that published
+    /// nothing answers with the inbound values alone.
     pub context: ToolContext,
 }
 
@@ -259,6 +260,10 @@ pub struct ToolAnswer {
 pub struct ToolCall {
     pending: Pending,
     published: Option<std::sync::Arc<rig_core::tool::PublishedContext>>,
+    /// The dispatch snapshot the call was made under: the answer's context
+    /// when the handler published nothing (a handler that is not a tool
+    /// adapter), so the inbound values the tool ran with are never lost.
+    inbound: ToolContext,
 }
 
 impl ToolCall {
@@ -296,7 +301,7 @@ impl Future for ToolCall {
                         .published
                         .as_ref()
                         .and_then(|published| published.take())
-                        .unwrap_or_default(),
+                        .unwrap_or_else(|| this.inbound.for_dispatch()),
                 }
             })),
         }
@@ -431,6 +436,7 @@ impl ToolHandle {
             name: name.into(),
             args: args.into(),
         };
+        let inbound = context.for_dispatch();
         let pending = self.dispatcher.dispatch_tool_with_id(
             self.dispatcher.mint_id(),
             &self.descriptor.key,
@@ -438,7 +444,11 @@ impl ToolHandle {
             context,
         );
         let published = pending.published_context();
-        ToolCall { pending, published }
+        ToolCall {
+            pending,
+            published,
+            inbound,
+        }
     }
 }
 

--- a/crates/rig-agent/src/bus/handle.rs
+++ b/crates/rig-agent/src/bus/handle.rs
@@ -295,14 +295,18 @@ impl Future for ToolCall {
             Poll::Pending => Poll::Pending,
             Poll::Ready(Err(report)) => Poll::Ready(Err(report)),
             Poll::Ready(Ok(outcome)) => Poll::Ready(family::Tool::unwrap(outcome).map(|result| {
-                ToolAnswer {
-                    result,
-                    context: this
-                        .published
-                        .as_ref()
-                        .and_then(|published| published.take())
-                        .unwrap_or_else(|| this.inbound.for_dispatch()),
-                }
+                // Ready is polled once: the snapshot moves out, and like a
+                // published context it is data again — no live scopes.
+                let context = this
+                    .published
+                    .as_ref()
+                    .and_then(|published| published.take())
+                    .unwrap_or_else(|| {
+                        let mut inbound = std::mem::take(&mut this.inbound);
+                        inbound.clear_scope();
+                        inbound
+                    });
+                ToolAnswer { result, context }
             })),
         }
     }
@@ -436,12 +440,16 @@ impl ToolHandle {
             name: name.into(),
             args: args.into(),
         };
+        // The tool runs on a dispatch snapshot (inbound values, no result
+        // metadata a previous call left on `context`); a handler that reads
+        // the scope directly sees the same snapshot the adapter would.
         let inbound = context.for_dispatch();
+        drop(context);
         let pending = self.dispatcher.dispatch_tool_with_id(
             self.dispatcher.mint_id(),
             &self.descriptor.key,
             kind,
-            context,
+            inbound.clone(),
         );
         let published = pending.published_context();
         ToolCall {

--- a/crates/rig-agent/src/bus/handle/tests.rs
+++ b/crates/rig-agent/src/bus/handle/tests.rs
@@ -327,6 +327,80 @@ async fn tool_memory_index_and_embed_handles_call_their_families() {
     assert_eq!(report.kind, ErrorKind::HandlerUnavailable);
 }
 
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
+struct Session(String);
+
+impl rig_core::tool::ContextValue for Session {
+    const KEY: &'static str = "test.session";
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
+struct Stale;
+
+impl rig_core::tool::ContextValue for Stale {
+    const KEY: &'static str = "test.stale";
+}
+
+/// A tool-family handler that is not a tool adapter and publishes nothing.
+struct Silent;
+
+impl rig_core::serve::Serve for Silent {
+    type Family = family::Tool;
+
+    fn descriptor(&self) -> rig_core::effect::HandlerDescriptor {
+        rig_core::effect::HandlerDescriptor {
+            key: rig_core::effect::tool_key("silent"),
+            family: rig_core::effect::FamilyDescriptor::Tool {
+                name: "silent".into(),
+                description: "answers without publishing".into(),
+                parameters: json!({"type": "object"}),
+                embedding: None,
+            },
+            layers: Vec::new(),
+        }
+    }
+
+    async fn serve(
+        &self,
+        _kind: rig_core::effect::EffectKind,
+        _dispatch: rig_core::serve::Dispatch,
+    ) -> rig_core::serve::Reply {
+        rig_core::serve::Reply::Outcome(Ok(rig_core::effect::Outcome::ToolResult {
+            result: rig_core::tool::ToolResult::success(rig_core::tool::ToolOutput::text("silent")),
+        }))
+    }
+}
+
+/// The answer's context is the dispatch snapshot the call ran under when
+/// the handler published nothing: the inbound values it ran with, no
+/// result metadata — never an empty context, and never the caller's
+/// stale result metadata.
+#[tokio::test]
+async fn a_tool_answer_keeps_inbound_values_when_the_handler_publishes_nothing() {
+    let (dispatcher, _registrar, mut driver) = Bus::channel();
+    driver.register("silent", Silent).expect("register");
+    let task = tokio::spawn(driver);
+
+    let tool: ToolHandle = dispatcher
+        .handle(&HandlerKey::from("silent"))
+        .expect("tool");
+    let mut context = ToolContext::new();
+    context.insert(Session("s-1".into())).expect("inbound");
+    context.insert_result(Stale).expect("stale result metadata");
+    let answer = within(tool.call("silent", "{}", context))
+        .await
+        .expect("called");
+    assert_eq!(answer.result.output().as_text(), Some("silent"));
+    assert_eq!(
+        answer.context.get::<Session>().expect("decodes"),
+        Some(Session("s-1".into()))
+    );
+    assert_eq!(answer.context.result::<Stale>().expect("decodes"), None);
+
+    drop((tool, dispatcher));
+    within(task).await.expect("driver ends");
+}
+
 #[tokio::test]
 async fn handles_fail_closed_when_the_driver_is_gone() {
     let (dispatcher, _registrar, mut driver) = Bus::channel();

--- a/crates/rig-agent/src/bus/handle/tests.rs
+++ b/crates/rig-agent/src/bus/handle/tests.rs
@@ -341,8 +341,12 @@ impl rig_core::tool::ContextValue for Stale {
     const KEY: &'static str = "test.stale";
 }
 
-/// A tool-family handler that is not a tool adapter and publishes nothing.
-struct Silent;
+/// A tool-family handler that is not a tool adapter and publishes nothing;
+/// it records what the dispatch's own `ToolContext` scope held.
+struct Silent {
+    /// `(session seen, stale result metadata seen)` on the dispatch scope.
+    seen: std::sync::Arc<std::sync::Mutex<Option<(bool, bool)>>>,
+}
 
 impl rig_core::serve::Serve for Silent {
     type Family = family::Tool;
@@ -363,22 +367,32 @@ impl rig_core::serve::Serve for Silent {
     async fn serve(
         &self,
         _kind: rig_core::effect::EffectKind,
-        _dispatch: rig_core::serve::Dispatch,
+        dispatch: rig_core::serve::Dispatch,
     ) -> rig_core::serve::Reply {
+        let scope = dispatch.scope::<ToolContext>();
+        *self.seen.lock().expect("seen") = scope.map(|context| {
+            (
+                context.get::<Session>().ok().flatten().is_some(),
+                context.result::<Stale>().ok().flatten().is_some(),
+            )
+        });
         rig_core::serve::Reply::Outcome(Ok(rig_core::effect::Outcome::ToolResult {
             result: rig_core::tool::ToolResult::success(rig_core::tool::ToolOutput::text("silent")),
         }))
     }
 }
 
-/// The answer's context is the dispatch snapshot the call ran under when
-/// the handler published nothing: the inbound values it ran with, no
-/// result metadata — never an empty context, and never the caller's
-/// stale result metadata.
+/// The tool runs on a dispatch snapshot — the caller's inbound values, none
+/// of its stale result metadata — whether or not the handler is a tool
+/// adapter; and the answer's context is that snapshot when the handler
+/// published nothing: never an empty context, never stale metadata.
 #[tokio::test]
 async fn a_tool_answer_keeps_inbound_values_when_the_handler_publishes_nothing() {
     let (dispatcher, _registrar, mut driver) = Bus::channel();
-    driver.register("silent", Silent).expect("register");
+    let seen = std::sync::Arc::new(std::sync::Mutex::new(None));
+    driver
+        .register("silent", Silent { seen: seen.clone() })
+        .expect("register");
     let task = tokio::spawn(driver);
 
     let tool: ToolHandle = dispatcher
@@ -391,6 +405,11 @@ async fn a_tool_answer_keeps_inbound_values_when_the_handler_publishes_nothing()
         .await
         .expect("called");
     assert_eq!(answer.result.output().as_text(), Some("silent"));
+    assert_eq!(
+        *seen.lock().expect("seen"),
+        Some((true, false)),
+        "the handler's scope holds the inbound snapshot, not the caller's result metadata"
+    );
     assert_eq!(
         answer.context.get::<Session>().expect("decodes"),
         Some(Session("s-1".into()))

--- a/crates/rig-agent/src/run/mod.rs
+++ b/crates/rig-agent/src/run/mod.rs
@@ -97,7 +97,7 @@ pub mod response;
 pub mod streamed;
 
 pub use policy::{InvalidToolCallAction, InvalidToolCallContext, RetryRequest};
-pub use response::{CompletionCall, PromptError, PromptResponse};
+pub use response::{CompletionCall, MemoryAppend, PromptError, PromptResponse};
 use rig_core::json_utils;
 use transcript::{
     TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER, TranscriptError, assistant_text_from_choice,

--- a/crates/rig-agent/src/run/response.rs
+++ b/crates/rig-agent/src/run/response.rs
@@ -165,13 +165,15 @@ pub struct PromptResponse {
 /// flight produces no response at all. Nothing here is exactly-once: a
 /// backend may have written before it failed.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "memory_append", rename_all = "snake_case")]
+#[serde(tag = "status", rename_all = "snake_case")]
 pub enum MemoryAppend {
     /// The backend acknowledged the append of [`PromptResponse::messages`].
     Acknowledged,
     /// The append was refused — by the backend, a layer on the memory key
     /// or an outcome hook — and the transcript was not persisted. The
-    /// report is the one the effect log records for the dispatch.
+    /// report is what the dispatch settled with, after outcome hooks; the
+    /// effect log records what the handler answered, which an outcome hook
+    /// may have replaced.
     Failed {
         /// Why the append failed.
         report: rig_core::error::ErrorReport,

--- a/crates/rig-agent/src/run/response.rs
+++ b/crates/rig-agent/src/run/response.rs
@@ -128,9 +128,21 @@ pub struct PromptResponse {
     /// metrics for that request.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub completion_calls: Vec<CompletionCall>,
-    /// Accumulated message history for the run (the run's persisted transcript),
-    /// unless memory/history bookkeeping was disabled for the request.
+    /// The run's transcript: the prompt, every accepted assistant turn, every
+    /// committed tool result and the corrective feedback of any retried turn,
+    /// excluding the input history the run started from. This is what a
+    /// configured conversation memory is asked to persist; whether that
+    /// append was acknowledged is [`memory_append`](Self::memory_append).
+    /// `None` only for a response built without a run behind it.
     pub messages: Option<Vec<Message>>,
+    /// How the run's conversation-memory append settled, when the run had a
+    /// memory backend and conversation to append to; `None` when memory was
+    /// not configured for the run, bypassed by explicit history, disabled, or
+    /// the run was resumed (the driver that persisted it owns the append).
+    /// Set by the driver after the append dispatch resolved, so the
+    /// protocol's own `Done` response never carries it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_append: Option<MemoryAppend>,
     /// Structured assistant content for the final turn.
     ///
     /// Where [`output`](Self::output) is the concatenated text, this preserves
@@ -141,6 +153,44 @@ pub struct PromptResponse {
     /// than provider-facing response content.
     #[serde(skip)]
     output_tool_calls: usize,
+}
+
+/// How a finished run's conversation-memory append settled. A run that
+/// completed is a run whose answer stands; whether its transcript was
+/// persisted is a separate fact, and this is it.
+///
+/// An append is one dispatch to the memory backend: acknowledged means the
+/// backend answered that it appended, not that the write is durable beyond
+/// what the backend promises, and a run dropped while the append is in
+/// flight produces no response at all. Nothing here is exactly-once: a
+/// backend may have written before it failed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "memory_append", rename_all = "snake_case")]
+pub enum MemoryAppend {
+    /// The backend acknowledged the append of [`PromptResponse::messages`].
+    Acknowledged,
+    /// The append was refused — by the backend, a layer on the memory key
+    /// or an outcome hook — and the transcript was not persisted. The
+    /// report is the one the effect log records for the dispatch.
+    Failed {
+        /// Why the append failed.
+        report: rig_core::error::ErrorReport,
+    },
+}
+
+impl MemoryAppend {
+    /// Whether the backend acknowledged the append.
+    pub fn is_acknowledged(&self) -> bool {
+        matches!(self, Self::Acknowledged)
+    }
+
+    /// The failure report, when the append failed.
+    pub fn failure(&self) -> Option<&rig_core::error::ErrorReport> {
+        match self {
+            Self::Acknowledged => None,
+            Self::Failed { report } => Some(report),
+        }
+    }
 }
 
 impl std::fmt::Display for PromptResponse {
@@ -158,6 +208,7 @@ impl PromptResponse {
             usage,
             completion_calls: Vec::new(),
             messages: None,
+            memory_append: None,
             output_tool_calls: 0,
         }
     }
@@ -175,6 +226,13 @@ impl PromptResponse {
     /// Attach completion call details to this response.
     pub fn with_completion_calls(mut self, completion_calls: Vec<CompletionCall>) -> Self {
         self.completion_calls = completion_calls;
+        self
+    }
+
+    /// Record how the run's conversation-memory append settled; the driver
+    /// sets this once the append dispatch resolved.
+    pub fn with_memory_append(mut self, memory_append: Option<MemoryAppend>) -> Self {
+        self.memory_append = memory_append;
         self
     }
 
@@ -206,6 +264,12 @@ impl PromptResponse {
     /// The run's accumulated message history, if tracked.
     pub fn messages(&self) -> Option<&[Message]> {
         self.messages.as_deref()
+    }
+
+    /// How the run's conversation-memory append settled, when the run had
+    /// one (see the [field](Self::memory_append)).
+    pub fn memory_append(&self) -> Option<&MemoryAppend> {
+        self.memory_append.as_ref()
     }
 
     /// The structured assistant content for the final turn.

--- a/crates/rig-agent/src/tool/registry.rs
+++ b/crates/rig-agent/src/tool/registry.rs
@@ -200,25 +200,32 @@ impl RegisteredTool {
 
     /// Run the tool here, without a bus, publishing its result metadata
     /// into `context` — the inline path of a standalone tool set.
+    ///
+    /// The tool runs on a dispatch snapshot of `context` (its inbound values,
+    /// no result metadata); only what it published lands back, replacing
+    /// `context`'s result metadata. That holds for every ending — a result,
+    /// a failed result, a handler that answered nothing usable — and for a
+    /// future dropped mid-call, which leaves `context` exactly as it was:
+    /// the caller's inbound values are never moved out or mutated.
     pub async fn execute(&self, args: String, context: &mut ToolContext) -> ToolResult {
         let name = self.definition.name.clone();
         // The context travels beside the call, never in it (format 5): the
-        // inline sink carries it and the slot the tool publishes into.
+        // inline sink carries a snapshot and the slot the tool publishes into.
         let published = rig_core::tool::PublishedContext::new();
         let outcome = rig_core::serve::serve_inline_with(
             &self.handler,
             EffectKind::ToolCall { name, args },
             vec![
-                std::sync::Arc::new(std::mem::take(context)),
+                std::sync::Arc::new(context.for_dispatch()),
                 published.clone() as std::sync::Arc<dyn std::any::Any + Send + Sync>,
             ],
         )
         .await;
+        // What the tool published is this call's result metadata; a handler
+        // that published nothing (or never ran) leaves an empty result map.
+        context.accept_dispatch_result(published.take().unwrap_or_default());
         match outcome {
-            Ok(Outcome::ToolResult { result }) => {
-                *context = published.take().unwrap_or_default();
-                result
-            }
+            Ok(Outcome::ToolResult { result }) => result,
             Ok(other) => ToolResult::failed(ToolExecutionError::other(format!(
                 "tool handler answered with a {} outcome",
                 other.family()

--- a/crates/rig-agent/src/tool/registry/tests.rs
+++ b/crates/rig-agent/src/tool/registry/tests.rs
@@ -153,6 +153,142 @@ async fn cancelled_toolset_dispatch_does_not_retain_stale_result_metadata() {
     assert_eq!(context.result::<Note>().unwrap(), None);
 }
 
+/// A tool-family handler that is not a tool adapter: it answers without
+/// publishing a context (a replayer for a record without output, a host's
+/// own handler).
+struct Silent;
+
+impl rig_core::serve::Serve for Silent {
+    type Family = family::Tool;
+
+    fn descriptor(&self) -> rig_core::effect::HandlerDescriptor {
+        rig_core::effect::HandlerDescriptor {
+            key: tool_key("silent"),
+            family: FamilyDescriptor::Tool {
+                name: "silent".into(),
+                description: "answers without publishing".into(),
+                parameters: serde_json::json!({"type": "object"}),
+                embedding: None,
+            },
+            layers: Vec::new(),
+        }
+    }
+
+    async fn serve(
+        &self,
+        _kind: EffectKind,
+        _dispatch: rig_core::serve::Dispatch,
+    ) -> rig_core::serve::Reply {
+        rig_core::serve::Reply::Outcome(Ok(Outcome::ToolResult {
+            result: ToolResult::success(ToolOutput::text("silent")),
+        }))
+    }
+}
+
+/// A tool-family handler whose answer is a report, not a result.
+struct Refusing;
+
+impl rig_core::serve::Serve for Refusing {
+    type Family = family::Tool;
+
+    fn descriptor(&self) -> rig_core::effect::HandlerDescriptor {
+        rig_core::effect::HandlerDescriptor {
+            key: tool_key("refusing"),
+            family: FamilyDescriptor::Tool {
+                name: "refusing".into(),
+                description: "refuses every call".into(),
+                parameters: serde_json::json!({"type": "object"}),
+                embedding: None,
+            },
+            layers: Vec::new(),
+        }
+    }
+
+    async fn serve(
+        &self,
+        _kind: EffectKind,
+        _dispatch: rig_core::serve::Dispatch,
+    ) -> rig_core::serve::Reply {
+        rig_core::serve::Reply::Outcome(Err(ErrorReport::new(ErrorKind::Other, "refused")))
+    }
+}
+
+/// The inline registration path keeps the caller's inbound values on every
+/// ending: a tool that mutates its inbound slot and publishes, a handler
+/// that publishes nothing, a handler that refuses. Only result metadata
+/// changes, and only to what the call published.
+#[tokio::test]
+async fn registered_tool_execute_keeps_inbound_values_on_every_ending() {
+    let mut context = ToolContext::new();
+    context.insert(Counter(7)).unwrap();
+    context.insert_result(Note("stale".to_string())).unwrap();
+
+    let echo = RegisteredTool::from_tool(Echo);
+    let result = echo.execute(r#"{"value":1}"#.into(), &mut context).await;
+    assert!(result.is_success());
+    assert_eq!(
+        context.get::<Counter>().unwrap(),
+        Some(Counter(7)),
+        "the tool's inbound mutation stays in the call"
+    );
+    assert_eq!(
+        context.result::<Note>().unwrap(),
+        Some(Note("result-metadata".to_string()))
+    );
+
+    let silent = RegisteredTool::from_handler(Silent).expect("a tool-family handler");
+    let result = silent.execute("{}".into(), &mut context).await;
+    assert!(result.is_success());
+    assert_eq!(context.get::<Counter>().unwrap(), Some(Counter(7)));
+    assert_eq!(
+        context.result::<Note>().unwrap(),
+        None,
+        "a handler that published nothing leaves no result metadata"
+    );
+
+    context.insert_result(Note("stale".to_string())).unwrap();
+    let refusing = RegisteredTool::from_handler(Refusing).expect("a tool-family handler");
+    let result = refusing.execute("{}".into(), &mut context).await;
+    assert_eq!(
+        result.error().map(ToolExecutionError::kind),
+        Some(ToolErrorKind::Other)
+    );
+    assert_eq!(context.get::<Counter>().unwrap(), Some(Counter(7)));
+    assert_eq!(context.result::<Note>().unwrap(), None);
+}
+
+/// Dropping an inline execution mid-call leaves the caller's context exactly
+/// as it was: nothing is moved out of it, nothing partial is published.
+#[tokio::test]
+async fn registered_tool_execute_dropped_mid_call_leaves_the_context_unchanged() {
+    let started = Arc::new(AtomicBool::new(false));
+    let tool = RegisteredTool::from_tool(PendingTool(started.clone()));
+    let mut context = ToolContext::new();
+    context.insert(Counter(7)).unwrap();
+    context.insert_result(Note("stale".to_string())).unwrap();
+    let before = context.clone();
+
+    let mut execution = Box::pin(tool.execute("null".into(), &mut context));
+    tokio::time::timeout(
+        Duration::from_secs(1),
+        poll_fn(|cx| {
+            assert!(execution.as_mut().poll(cx).is_pending());
+            started.load(Ordering::SeqCst).then_some(()).map_or_else(
+                || {
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                },
+                Poll::Ready,
+            )
+        }),
+    )
+    .await
+    .expect("pending tool did not start");
+    drop(execution);
+
+    assert_eq!(context, before);
+}
+
 #[tokio::test]
 async fn framework_argument_errors_remain_actionable_to_the_model() {
     let mut set = ToolSet::default();

--- a/crates/rig-core/src/memory.rs
+++ b/crates/rig-core/src/memory.rs
@@ -86,10 +86,15 @@ impl MemoryError {
 ///
 /// Implementors store an ordered list of [`Message`]s per `conversation_id`. Rig
 /// runtimes invoke [`ConversationMemory::load`] before sending a prompt and
-/// [`ConversationMemory::append`] after a successful turn.
+/// [`ConversationMemory::append`] after a successful run.
 ///
 /// Implementations should keep `append` cheap; it runs inline before the agent
-/// returns its response.
+/// returns its response. A load failure fails the run before any model call;
+/// an append failure does not fail the run — the answer stands, the runtime
+/// reports the refused append beside it (rig-agent's `PromptResponse::memory_append`,
+/// the effect log's record) and nothing is retried. Rig promises no
+/// transactional or exactly-once write: a backend that fails after writing
+/// has written.
 pub trait ConversationMemory: WasmCompatSend + WasmCompatSync {
     /// Load the full conversation history for `conversation_id`.
     ///

--- a/crates/rig-verify/tests/corpus_memory.rs
+++ b/crates/rig-verify/tests/corpus_memory.rs
@@ -66,8 +66,9 @@
 //! - Explicit history leaves memory in the required row: the builder
 //!   registered it, the run did not touch it.
 //! - A failed `Append` is a warning: the record holds the store's error
-//!   and the answer stands. A failed `Load` fails the run at the memory
-//!   record, before any completion.
+//!   and the answer stands (the classic engine's response reports the
+//!   refusal as `PromptResponse::memory_append`). A failed `Load` fails
+//!   the run at the memory record, before any completion.
 
 #![allow(clippy::expect_used, clippy::indexing_slicing, clippy::panic)]
 

--- a/tests/core/prompt_response_messages.rs
+++ b/tests/core/prompt_response_messages.rs
@@ -331,17 +331,27 @@ async fn chat_appends_prompt_and_assistant_to_history() {
     let agent = AgentBuilder::new(simple_text_model(2)).build();
     let mut history = Vec::<Message>::new();
 
-    let output = agent
+    let response = agent
         .chat("hi", &mut history)
         .await
-        .expect("chat should succeed")
-        .output;
+        .expect("chat should succeed");
 
-    assert_eq!(output, "hello from mock");
+    assert_eq!(response.output, "hello from mock");
     assert_eq!(
         history.len(),
         2,
         "expected chat to append [User, Assistant], got: {history:#?}"
+    );
+    // `chat` returns the same response `prompt` does: the run's transcript
+    // is on it, and it is exactly what the caller's history gained.
+    assert_eq!(
+        response.messages.as_deref().map(<[Message]>::len),
+        Some(2),
+        "chat keeps the run's messages on the response"
+    );
+    assert_eq!(
+        response.memory_append, None,
+        "caller-owned history bypasses memory: nothing to acknowledge"
     );
 
     match &history[0] {
@@ -463,4 +473,45 @@ async fn sequential_prompts_have_independent_histories() {
         },
         other => panic!("unexpected: {other:?}"),
     }
+}
+
+/// `memory_append` is absent from a response without memory behind it, and
+/// round-trips through serde in both states when set by the driver.
+#[test]
+fn memory_append_is_absent_without_memory_and_round_trips_through_serde() {
+    use rig::agent::{MemoryAppend, PromptResponse};
+
+    let bare = PromptResponse::new("output", Usage::new());
+    assert_eq!(bare.memory_append, None);
+    let json = serde_json::to_value(&bare).expect("serializes");
+    assert!(
+        json.get("memory_append").is_none(),
+        "no memory, no field: {json}"
+    );
+
+    let acknowledged = bare
+        .clone()
+        .with_memory_append(Some(MemoryAppend::Acknowledged));
+    let json = serde_json::to_value(&acknowledged).expect("serializes");
+    assert_eq!(
+        json["memory_append"],
+        serde_json::json!({"memory_append": "acknowledged"})
+    );
+    let restored: PromptResponse = serde_json::from_value(json).expect("deserializes");
+    assert_eq!(restored.memory_append, Some(MemoryAppend::Acknowledged));
+
+    let failed = bare.with_memory_append(Some(MemoryAppend::Failed {
+        report: rig::error::ErrorReport::new(rig::error::ErrorKind::MemoryBackend, "boom"),
+    }));
+    let json = serde_json::to_value(&failed).expect("serializes");
+    assert_eq!(json["memory_append"]["memory_append"], "failed");
+    let restored: PromptResponse = serde_json::from_value(json).expect("deserializes");
+    assert_eq!(restored.memory_append, failed.memory_append);
+    assert_eq!(
+        restored
+            .memory_append()
+            .and_then(MemoryAppend::failure)
+            .map(|report| report.kind),
+        Some(rig::error::ErrorKind::MemoryBackend)
+    );
 }

--- a/tests/core/prompt_response_messages.rs
+++ b/tests/core/prompt_response_messages.rs
@@ -495,7 +495,7 @@ fn memory_append_is_absent_without_memory_and_round_trips_through_serde() {
     let json = serde_json::to_value(&acknowledged).expect("serializes");
     assert_eq!(
         json["memory_append"],
-        serde_json::json!({"memory_append": "acknowledged"})
+        serde_json::json!({"status": "acknowledged"})
     );
     let restored: PromptResponse = serde_json::from_value(json).expect("deserializes");
     assert_eq!(restored.memory_append, Some(MemoryAppend::Acknowledged));
@@ -504,7 +504,7 @@ fn memory_append_is_absent_without_memory_and_round_trips_through_serde() {
         report: rig::error::ErrorReport::new(rig::error::ErrorKind::MemoryBackend, "boom"),
     }));
     let json = serde_json::to_value(&failed).expect("serializes");
-    assert_eq!(json["memory_append"]["memory_append"], "failed");
+    assert_eq!(json["memory_append"]["status"], "failed");
     let restored: PromptResponse = serde_json::from_value(json).expect("deserializes");
     assert_eq!(restored.memory_append, failed.memory_append);
     assert_eq!(


### PR DESCRIPTION
# fix(agent): own the tool context and the memory append across every ending

## Description

Prompt 03 of the #2443 hardening series: an audit of history and `ToolContext` ownership across the futures runner, the sans-IO `AgentRun`, the bus, the effect log and the ECS twin. The existing split — a mutable request projection (`AgentRun::chat_history` + `new_messages`, a per-turn `RequestPatch::history`) beside the append-only records (`RunEntry`, the effect log) — is correct and is kept; no second history authority is introduced. The audit found three ownership defects and two contract gaps, all with tests that fail on the parent head:

- **`RegisteredTool::execute` moved the caller's `ToolContext` out** (`mem::take`) for the length of the call. A future dropped mid-call, a handler that published nothing (a replayer for a record without output, a host's handler), a wrong-family answer or a report all left the caller's context **empty** — its inbound values gone — and on success the tool's *inbound* mutations leaked back. The call now runs on a `for_dispatch()` snapshot and only what the tool published lands, on every ending, as the documented contract already said (`ToolContext`: "map-level mutations affect only that execution"; `PortableDynamicTool::execute_with`: "dropping the execution future leaves the caller's context unchanged").
- **`ToolHandle::call`** dispatched the caller's raw context (stale result metadata included) to the handler's scope and answered with an *empty* context when the handler was not a tool adapter. It now dispatches the inbound snapshot, as the engine does, and its answer keeps that snapshot (scopes cleared, as a published context is) when nothing was published.
- **`Agent::chat`** stripped `messages` from the response it returned while documenting "the same `PromptResponse` as `prompt`". It clones them into the caller's history and leaves the response intact.
- **A finished run's memory append settled invisibly.** A refused append was a `tracing::warn`, an `on_outcome` event (only for a hook opting into memory dispatches) and an effect-log record (only when recording); the caller of `run()`/`stream()` could not tell a persisted transcript from a refused one. `PromptResponse::memory_append: Option<MemoryAppend>` now says how it settled — `Acknowledged`, `Failed { report }`, or `None` when the run had no memory to append to (not configured, explicit history, `without_memory`, resumed). Both surfaces set it before `on_run_settled` and the final item; the answer still stands, nothing is retried, and the docs say plainly that no write is transactional or exactly-once. `TypedPromptResponse` carries it too.
- **`AgentRunner::resume`'s doc** claimed the run's messages were "not appended a second time"; a suspended run never reached the `Done` append. The doc now states what `corpus_resume.rs` pins: the driver that persisted the run owns its memory, `memory_append` is `None`, pending tool calls re-execute on resume (at-least-once), and the inbound tool context is the resumer's. `AgentRunner::conversation` and `ConversationMemory` document the load/append endings.

Retained on purpose (recorded in the external ledger): memory-loaded history is not `validate_canonical`-checked at load (stricter than the universal provider constraint, and it would need an ECS twin for parity); `PublishedContext` publication after settlement stays a documented, unenforced contract; the `ToolContext` key/decode semantics documented on the parent (`Err(Decode)` on a shape mismatch, `Ok(None)` on absence) are unchanged.

No cassette, golden or effect-log fixture changes: the memory records are the same; only the response gained a field.

## Changelog

- *(agent)* `PromptResponse::memory_append` (and `TypedPromptResponse::memory_append`) reports how a run's conversation-memory append settled (`MemoryAppend::Acknowledged` / `Failed { report }`; `None` when the run had no memory to append to), so a refused append is visible to the caller without a hook or the effect log.
- *(agent)* `RegisteredTool::execute` no longer empties the caller's `ToolContext` when the call is dropped, refused or served by a handler that publishes nothing; only published result metadata lands, on every ending.
- *(agent)* `ToolHandle::call` dispatches the inbound snapshot (never a previous call's result metadata) and answers with it when the handler publishes nothing, instead of an empty context.
- *(agent)* `Agent::chat` returns the response with its `messages`, as `prompt` does.
- *(agent)* Docs: `AgentRunner::resume` no longer claims a resumed run's messages were already appended; the persisting driver owns the append. `AgentRunner::conversation` and `ConversationMemory` document the load/append endings and the absence of transactional or exactly-once writes.

## Migration

`PromptResponse` and `TypedPromptResponse` gained a public field, `memory_append: Option<MemoryAppend>` (`#[serde(default)]`, skipped when `None`). Code that builds either by struct literal must add it (`memory_append: None`; nothing in tree does); the constructors and builders (`PromptResponse::new`, `with_memory_append`) cover the rest. Serialized responses without memory are byte-identical; with memory they gain `"memory_append": {"status": "acknowledged"}` or `{"status": "failed", "report": {...}}`.

Callers that relied on `Agent::chat` returning `messages: None` now receive the run's transcript on the response as well as in their history vector.

## Type of change

- [x] Bug fix
- [x] Documentation update

## Testing

Replay mode, no live provider traffic. Base `origin/feat/effect-bus@665560617`.

- Red/green: `registered_tool_execute_keeps_inbound_values_on_every_ending`, `registered_tool_execute_dropped_mid_call_leaves_the_context_unchanged`, `a_tool_answer_keeps_inbound_values_when_the_handler_publishes_nothing` fail with the parent's `registry.rs`/`handle.rs` swapped in (0 passed, 3 failed) and pass with the fix.
- New/extended tests: `memory_append_error_does_not_drop_response`, `memory_appends_full_turn_after_success`, `explicit_with_history_overrides_memory`, `without_memory_disables_for_request`, `streaming_appends_to_memory_after_final_response`, `streaming_reports_a_refused_append_on_the_final_response`, `chat_appends_prompt_and_assistant_to_history`, `memory_append_is_absent_without_memory_and_round_trips_through_serde`.
- [x] `cargo test --locked -p rig-agent --lib` (666 passed), `-p rig-core --lib -- tool::context memory::` (32 passed), `-p rig --test core -- prompt_response_messages golden_memory` (15 passed)
- [x] Independent full-diff review by a separate reviewer; one P1 (typed handle dispatched the raw context) and four P2s fixed in the second commit; dispositions in the external ledger
- [x] `RIG_PROVIDER_TEST_MODE=replay cargo xtask verify --pr --base origin/feat/effect-bus` on head `023018d93`: 31/31 checks passed (fmt, source guards, tooling, workspace clippy, default/core-all/bus-verification/conformance/derive/macro-hygiene tests, doctests, docs, loom, workspace full-tests 7393 passed with one unrelated `rig-ecs::bus_scale` timing flake retried, workspace check, dependency floors, every wasm check and wasm test suite, native-only guards)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated READMEs and Rust docs affected by this change
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did not edit `CHANGELOG.md` or `MIGRATING.md` (they are generated at release)

## Notes

Stacked on `feat/effect-bus` (#2443); retarget to `main` when the parent merges. This child review does not certify the entire #2443 architecture. Coordination with the prompt-02 API rename (`refactor/agentrunner-public-api`): the overlap is the `AgentRunner::resume` rustdoc (moves with `resume` to `Agent`), the `Agent::chat` body and one new streaming test; whichever lands second rebases those three spots.
