### PR TITLE
ci: shorten the gate's critical path and split the dependency floors from the full lane

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,17 @@
+# Test priorities need nextest 0.9.91; older versions warn and ignore the
+# `priority` keys below, so they still run every test, just in default order.
+[nextest-version]
+recommended = "0.9.91"
+
+# The two tests that shell out to a nested Cargo build are the slowest in the
+# tree by an order of magnitude (the facade feature-forwarding guard runs
+# four `cargo check`s over the facade's dependency graph). In lexicographic
+# order they start late and finish minutes after every other test, so the
+# whole all-features run waits on them alone. Start them first.
+[[profile.default.overrides]]
+filter = 'test(portable_tool_facade_is_feature_additive) + binary(macro_hygiene)'
+priority = 100
+
 # Preserve CI retries for ordinary tests while running drift tripwires once.
 # Do not pass --retries to the guards run: it overrides per-test settings.
 [profile.guards]

--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -39,6 +39,13 @@ inputs:
   cache-development:
     description: Allow the bounded development-base warming job to save caches
     default: "false"
+  cache-shared-key:
+    description: >-
+      rust-cache key shared by jobs that compile the same dependency graph
+      (profile, features, environment), replacing the automatic per-job key.
+      Restoring jobs must pass `cache-save-if: "false"` so the warming job
+      is the key's only writer. Empty keeps the per-job key.
+    default: ""
   sccache:
     description: >-
       Enable sccache with the GitHub Actions cache backend. Reserved for the
@@ -92,6 +99,7 @@ runs:
         components: ${{ inputs.components }}
         target: ${{ inputs.target }}
         cache: ${{ inputs.cache }}
+        cache-shared-key: ${{ inputs.cache-shared-key }}
         cache-save-if: ${{ inputs.cache-save-if == 'true' && github.repository == '0xPlaygrounds/rig' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || (inputs.cache-development == 'true' && github.ref == 'refs/heads/feat/effect-bus')) }}
 
     # rust-cache (inside setup-rust-toolchain above) persists *dependency*

--- a/.github/workflows/cache-warm.yaml
+++ b/.github/workflows/cache-warm.yaml
@@ -2,21 +2,23 @@ name: Development cache warm
 
 on:
   push:
-    branches: [feat/effect-bus]
+    branches: [main, feat/effect-bus]
 
 permissions:
   contents: read
 
 concurrency:
-  group: cache-warm-effect-bus
+  group: cache-warm-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # One configuration and one base branch, not every matrix leg. PR merge
-  # refs can restore their base's cache but cannot warm other PRs themselves.
-  # Match ci.yaml's test job ID and setup so rust-cache keys stay compatible.
+  # Two configurations, not every matrix leg. PR merge refs can restore
+  # their base's cache but cannot warm other PRs themselves. The default
+  # graph is warmed for the development base only: on main, cd.yaml's own
+  # `test` job already saves it. Match ci.yaml's test job ID and setup so
+  # rust-cache keys stay compatible.
   test:
-    if: github.repository == '0xPlaygrounds/rig' && github.event_name == 'push'
+    if: github.repository == '0xPlaygrounds/rig' && github.event_name == 'push' && github.ref == 'refs/heads/feat/effect-bus'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -28,3 +30,31 @@ jobs:
           cache-development: "true"
       # Populate the same artifacts without repeating the required CI test run.
       - run: cargo xtask verify --check default-test-build
+
+  # The all-features test graph, shared through one rust-cache key by the two
+  # jobs that build it verbatim — ci.yaml's `doctest` (`cargo test --doc
+  # --workspace --all-features`) and nightly.yaml's `test-all-features`
+  # (`nextest run --workspace --all-features`): same profile, same feature
+  # set, same environment. No sccache, for the quota reason on the
+  # rust-setup input. This job is the key's only writer — both restoring
+  # jobs pass `cache-save-if: "false"` — so the saved entry is always the
+  # complete nextest graph (the doctest build is a subset: bin-only members
+  # have no doctests). It runs on main as well; nothing else writes the key
+  # there, so without it every PR and merge-queue restore would miss.
+  # Before this job every doctest run compiled the whole graph cold: nine of
+  # its ten minutes were dependencies, sixteen seconds were doctests.
+  # rust-cache keeps dependency artifacts only, so workspace crates still
+  # rebuild in every run.
+  all-features:
+    if: github.repository == '0xPlaygrounds/rig' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/rust-setup
+        with:
+          nextest: "true"
+          protoc: "true"
+          cache-development: "true"
+          cache-shared-key: all-features
+      # Compile the all-features test artifacts; execute nothing.
+      - run: cargo xtask verify --check full-test-build

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -34,9 +34,15 @@ jobs:
   run-full-ci:
     uses: ./.github/workflows/nightly.yaml
 
+  # The declared dependency floors are their own lane (see the workflow's
+  # header): on PRs it runs only when a resolver input changes, so this call
+  # is what guarantees every release was built at its floors.
+  run-dependency-floors:
+    uses: ./.github/workflows/dependency-floors.yaml
+
   release-plz:
     name: Release-plz
-    needs: [run-ci, run-full-ci]
+    needs: [run-ci, run-full-ci, run-dependency-floors]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -328,6 +328,45 @@ jobs:
       - name: Run Clippy
         run: cargo xtask verify --check clippy
 
+  # The `test` job's `nextest` sweep runs with `--features bedrock`, which
+  # does not compile the pure default-feature test graph. Check the root
+  # integration tests with the default feature set so feature-gated test
+  # modules cannot accidentally depend on APIs that only exist under optional
+  # features.
+  #
+  # Its own job, not a step ahead of the sweep: the two graphs share no
+  # artifacts (a different feature hash for `rig`, check mode versus build
+  # mode for the dependencies), so as a step it was ~90–100 s of serial
+  # wall-clock on the longest job of the gate — measured 84–103 s across the
+  # last five runs — for work that runs to completion in parallel here.
+  #
+  # `cargo check`, not `cargo test --no-run`: the guarded failure class is
+  # purely type-level, while `--no-run` additionally pays codegen + linking
+  # under a default-feature hash nothing else reuses. Be precise about what
+  # this trades away: the bedrock sweep and nightly's sweep link *superset*
+  # feature configurations, so no lane anywhere links the pure
+  # default-feature binaries — a default-only codegen/link break would
+  # surface first in merge_group's full run. That gap is accepted as
+  # theoretical: `bedrock` is purely additive and the workspace has no
+  # `cfg(not(feature = …))` in test code, so a break that appears only with
+  # features *removed* has no known mechanism.
+  check-default:
+    name: stable / check default features
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      # cache: false — nothing warms this check-mode graph, and a per-job
+      # entry saved on every main push would only add to the contended quota.
+      - name: Install Rust stable
+        uses: ./.github/actions/rust-setup
+        with:
+          cache: "false"
+
+      - name: Check default-feature root test targets
+        run: cargo xtask verify --check default-check
+
   # The PR gate's test sweep. The full `--all-features` run (companion vector
   # stores, Docker-backed integration tests, the nested-`cargo check` facade
   # build guard) lives in nightly.yaml: it runs on a schedule, on demand via
@@ -351,7 +390,7 @@ jobs:
         uses: actions/checkout@v5
 
       # The raw database drivers live in the service-test runner, gated with
-      # their suites. Neither graph below enables those features, so a
+      # their suites. The graph below does not enable those features, so a
       # cold PR run avoids the Lance/Arrow/DataFusion graph and needs no
       # system protoc. The all-features jobs retain both.
       - name: Install Rust stable
@@ -361,25 +400,6 @@ jobs:
           nextest: "true"
           # Repository-repair tests format proposed patches inside isolation.
           components: rustfmt
-
-      # `nextest` below runs with `--features bedrock`, which does not compile
-      # the pure default-feature test graph. Check the root integration tests
-      # with the default feature set so feature-gated test modules cannot
-      # accidentally depend on APIs that only exist under optional features.
-      #
-      # `cargo check`, not `cargo test --no-run`: the guarded failure class is
-      # purely type-level, while `--no-run` additionally pays codegen +
-      # linking under a default-feature hash the `--features bedrock` step
-      # below never reuses. Be precise about what this trades away: the
-      # bedrock run below and nightly's sweep link *superset* feature
-      # configurations, so no lane anywhere links the pure default-feature
-      # binaries — a default-only codegen/link break would surface first in
-      # merge_group's full run. That gap is accepted as theoretical:
-      # `bedrock` is purely additive and the workspace has no
-      # `cfg(not(feature = …))` in test code, so a break that appears only
-      # with features *removed* has no known mechanism.
-      - name: Check default-feature root test targets
-        run: cargo xtask verify --check default-check
 
       # The workspace sweep over the default members' default features, plus
       # the facade's `bedrock` feature. `bedrock` rides along because the
@@ -580,13 +600,21 @@ jobs:
         uses: actions/checkout@v5
 
       # protoc: required because this all-features job enables rig-lancedb.
-      # No sccache: this job is off the critical path and rustdoc's doctest
-      # execution is not cacheable anyway — see the quota note on the
-      # sccache input in the rust-setup action.
+      # No sccache: rustdoc's doctest execution is not cacheable, and the
+      # quota note on the sccache input in the rust-setup action applies.
+      #
+      # `all-features`: the dependency artifacts of `cargo test --doc
+      # --workspace --all-features` are the same units nightly's
+      # `test-all-features` builds, so both restore the one entry
+      # cache-warm.yaml populates from that graph. This was the longest job
+      # of the gate at ~10 minutes, nine of them compiling dependencies cold
+      # for sixteen seconds of doctests.
       - name: Install Rust stable
         uses: ./.github/actions/rust-setup
         with:
           protoc: "true"
+          cache-shared-key: all-features
+          cache-save-if: "false"
 
       # No API keys needed: the doctests that actually execute are pure (the
       # provider examples are all `no_run`/compile-only), so this job stays

--- a/.github/workflows/dependency-floors.yaml
+++ b/.github/workflows/dependency-floors.yaml
@@ -1,0 +1,95 @@
+# The declared dependency requirements are floors, not pins (`tokio = "1"`
+# is `^1`), and a downstream resolves anywhere inside them — usually to
+# whatever its own lockfile already holds. So rig has to actually build at
+# the lowest version it declares, or the floor is a lie that surfaces as a
+# build break in someone else's tree (#2195). Cargo's `-Zdirect-minimal-
+# versions` is nightly-only and dead-ends in this workspace's transitive
+# graph, so `scripts/check-dependency-floors.py` does the equivalent on
+# stable: `cargo update --precise` every direct dependency down to the
+# lowest version the tree admits, then `cargo check --workspace
+# --all-features --all-targets`.
+#
+# Its own lane, separate from nightly.yaml's runtime suites, because the two
+# have different inputs. The floors change when Cargo's resolver inputs
+# change — a manifest anywhere in the workspace, the lockfile, the toolchain,
+# Cargo configuration, the checker itself — while the service suites care
+# about the storage crates' source. Sharing one path filter made a sqlite
+# suite edit resolve and build the whole lowered graph (about eleven
+# minutes) for nothing, and made a manifest edit wait on Docker-backed
+# suites it cannot affect. `checks::floor_lane` in xtask is the local mirror
+# of the filter below; a test keeps the two in step.
+#
+# The accepted tradeoff: a source-only change that starts using an API newer
+# than a declared floor is caught by the scheduled run, the merge queue or
+# the release gate rather than on its own PR. All three still run this lane
+# unconditionally.
+#
+# When it runs:
+#   * nightly at 06:00 UTC;
+#   * on any PR that touches a resolver input (below);
+#   * in the merge queue (`merge_group`), because the squashed batch that
+#     lands on main is not any PR head the filter validated (GitHub does not
+#     support `paths` filters on merge_group events);
+#   * on demand via `gh workflow run dependency-floors.yaml`;
+#   * via `workflow_call` from cd.yaml on every push to main, so release-plz
+#     never publishes a commit that does not build at its floors.
+name: Dependency Floors
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  pull_request:
+    paths:
+      # Every manifest is a resolver input: crates, examples, the service
+      # runner, xtask and the nested compile fixtures all declare
+      # requirements that `cargo update --precise` lowers.
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "**/Cargo.toml"
+      - "rust-toolchain.toml"
+      - ".cargo/**"
+      - "scripts/check-dependency-floors.py"
+      - "scripts/test_dependency_floors.py"
+      # The verification tooling defines the check and prepares its inputs.
+      - "xtask/**"
+      # Editing the lane, or the setup every lane shares, must run the lane.
+      - ".github/workflows/dependency-floors.yaml"
+      - ".github/actions/**"
+  merge_group:
+  workflow_dispatch:
+  workflow_call:
+
+env:
+  CARGO_TERM_COLOR: always
+
+# Disjoint from ci.yaml's and nightly.yaml's groups when all three are
+# invoked from one cd.yaml run (inside a called workflow, `github.workflow`
+# resolves to the CALLER's name). Keyed on the PR number rather than
+# `head_ref` because two forks PRing from identically-named branches share a
+# head_ref.
+concurrency:
+  group: floors-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-floors:
+    name: stable / dependency floors
+    runs-on: ubuntu-latest
+    # `schedule` fires on any fork whose owner has enabled Actions; the
+    # guard also covers the `workflow_call` path on a fork's own cd.yaml.
+    if: github.repository == '0xPlaygrounds/rig'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      # protoc: the lowered all-features graph still contains rig-lancedb.
+      - name: Install Rust stable
+        uses: ./.github/actions/rust-setup
+        with:
+          protoc: "true"
+
+      - name: Build against the declared dependency floors
+        run: cargo xtask verify --check dependency-floors

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,6 +11,10 @@
 #   * every root test binary's `--all-features` configuration — the PR gate
 #     runs the default feature set plus `bedrock`.
 #
+# The declared dependency floors are a separate lane with their own path
+# filter (dependency-floors.yaml): they change with Cargo's resolver inputs,
+# not with the storage crates' source.
+#
 # The PR gate still COMPILES all of the above on every PR: ci.yaml's clippy
 # job lints `--all-features --all-targets`, and doctest/doc build all
 # features, so a nightly failure is almost always a runtime regression rather
@@ -29,8 +33,7 @@
 #     `crates/rig-qdrant/` or bumping its driver in Cargo.toml merges with
 #     zero runtime coverage of the code it changed, and the breakage surfaces
 #     either at 06:00 or, worse, in cd.yaml's `run-full-ci`, where it blocks
-#     release-plz on an already-merged commit. These PRs share the scheduled
-#     run's rust-cache entry, so the common PR pays nothing;
+#     release-plz on an already-merged commit;
 #   * in the merge queue (`merge_group`), because the squashed batch that
 #     actually lands on main is not any PR head the filters above validated;
 #   * on demand via `gh workflow run nightly.yaml`;
@@ -82,7 +85,8 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "crates/*/Cargo.toml"
-      - "scripts/check-dependency-floors.py"
+      # The setup every lane shares; editing it must run the lane.
+      - ".github/actions/**"
   # The repo merges through a merge queue (ALLGREEN, squash, batches up to
   # 5), so the commit that actually lands on main is the merge-group commit —
   # not the PR head that the `pull_request` triggers above validated. Without
@@ -144,6 +148,12 @@ jobs:
       # per-compilation-unit cache entries, this lane is not
       # latency-critical, and the repo's 10GB Actions cache quota is
       # contended — see the sccache input's note in the rust-setup action.
+      #
+      # `all-features` is the rust-cache key cache-warm.yaml populates from
+      # exactly this build graph (profile, features, environment) on trusted
+      # pushes; ci.yaml's doctest job restores the same entry. Without it
+      # every run compiled the ~970 dependency crates cold before the first
+      # test started.
       - name: Install Rust stable
         uses: ./.github/actions/rust-setup
         with:
@@ -151,6 +161,9 @@ jobs:
           protoc: "true"
           # Repository-repair tests format proposed patches inside isolation.
           components: rustfmt
+          cache-shared-key: all-features
+          # The warmer is the key's only writer (see cache-warm.yaml).
+          cache-save-if: "false"
 
       # The workspace-wide sweep over every feature. This is the step that
       # was ci.yaml's `Test with latest nextest release` before the fast/full
@@ -163,33 +176,3 @@ jobs:
       # archived in 2023 and pins Node 20.
       - name: Test with all features
         run: cargo xtask verify --check full-tests
-
-  # The declared dependency requirements are floors, not pins (`tokio = "1"`
-  # is `^1`), and a downstream resolves anywhere inside them — usually to
-  # whatever its own lockfile already holds. So rig has to actually build at
-  # the lowest version it declares, or the floor is a lie that surfaces as a
-  # build break in someone else's tree (#2195). Cargo's `-Zdirect-minimal-
-  # versions` is nightly-only and dead-ends in this workspace's transitive
-  # graph, so `scripts/check-dependency-floors.py` does the equivalent on
-  # stable: `cargo update --precise` every direct dependency down to the
-  # lowest version the tree admits, then `cargo check --workspace
-  # --all-features --all-targets`. It runs here rather than on the PR gate
-  # because it is a full all-features build; the `pull_request` paths above
-  # still run it on every PR that touches a manifest, the lockfile, or the
-  # script itself, which is where a floor can silently rot (a PR that starts
-  # using an API newer than the declared floor).
-  dependency-floors:
-    name: stable / dependency floors
-    runs-on: ubuntu-latest
-    if: github.repository == '0xPlaygrounds/rig'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Install Rust stable
-        uses: ./.github/actions/rust-setup
-        with:
-          protoc: "true"
-
-      - name: Build against the declared dependency floors
-        run: cargo xtask verify --check dependency-floors

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ edition = "2024"
 # raised floors, forcing downstream users to `cargo update` a dozen crates
 # just to take a point release (#2195). Raise a floor when rig starts using
 # an API the old floor lacks, and say so in the changelog.
-# `scripts/check-dependency-floors.py` (CI: nightly.yaml `dependency-floors`)
+# `scripts/check-dependency-floors.py` (CI: dependency-floors.yaml)
 # downgrades every direct dependency to its floor and builds the workspace,
 # so a floor that has silently rotted fails there rather than downstream.
 #

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -22,15 +22,38 @@ manifests, dependencies, verification tooling, and unknown inputs broaden the
 plan conservatively. Read the printed selection and skip reasons.
 
 `--pr` requires an explicit intended base and includes every existing fast CI
-check. Changes affecting the full lane also select full verification. It is the
-local execution part of preparing a PR, not the independent review or remote CI
-gate. `--full` executes supported workspace tests, all example/consumer targets,
-feature combinations, documentation, dependency-floor checks, concurrency
-models, and the native/WASM matrix. Ignored tests, including live-provider,
-model, and service tests, remain opt-in; neither mode records cassettes or
-regenerates goldens.
+check, plus two independently triggered lanes. `full-tests` (the all-features
+workspace run with the Docker-backed storage suites) joins for the storage
+crates, the integration suites and their support, the facade
+feature-forwarding guard, the root manifest and lockfile, and the verification
+tooling. `dependency-floors` joins for Cargo's resolver inputs: any manifest,
+the lockfile, the toolchain, Cargo configuration, the floor checker, and the
+verification tooling. A storage-suite edit therefore runs the suites without
+resolving floors; a floor-checker edit runs the floors and its own tests
+without the suites. The predicates are `checks::full_lane` and
+`checks::floor_lane`, and a test keeps them equal to the `pull_request.paths`
+filters of `nightly.yaml` and `dependency-floors.yaml`; the conservative
+fallbacks for shared inputs (`.github/`, other `scripts/` files, unknown
+files) may select more than CI would, never less; the floor checker and its
+isolation tests select only the floors, the tooling check and formatting. A
+source-only change that starts using an API newer than a declared floor is caught by the scheduled run, the merge
+queue or the release gate rather than on its own PR; that tradeoff is
+deliberate. `--pr` is the local execution part of preparing a PR, not the
+independent review or remote CI gate. `--full` executes supported workspace
+tests, all example/consumer targets, feature combinations, documentation,
+dependency-floor checks, concurrency models, and the native/WASM matrix.
+Ignored tests, including live-provider, model, and service tests, remain
+opt-in; neither mode records cassettes or regenerates goldens.
 
-Full validation needs the repository toolchain, nextest, Clippy, rustfmt,
+There is no separate workspace-wide `cargo check --all-targets`: `full-tests`
+compiles every member's lib, bin, test and example targets under the same
+all-features graph (Cargo's default `test` target selection), and `clippy`
+checks the default members' `--all-targets`. No member declares a bench
+target; one added to a non-default member would need a locked-version owner.
+
+Full validation needs the repository toolchain, nextest (0.9.91 or newer
+honours the test priorities in `.config/nextest.toml`; older versions warn
+and run every test in default order), Clippy, rustfmt,
 protoc, Docker for service integrations, Node, and wasm-bindgen-test-runner
 matching the lockfile. The dependency-floor script and its isolation tests also need Python 3.11+.
 CI installs its required tools through `.github/actions/rust-setup`. A missing
@@ -132,19 +155,32 @@ run. Other tests retain their prior retry policy. Command-line retry settings
 would override these per-test rules, so that run deliberately does not pass
 `--retries`. See [nextest retry precedence](https://nexte.st/docs/features/retries/).
 
-Only trusted upstream pushes may write shared caches. One warming job targets
-`feat/effect-bus` and the default/bedrock test configuration; fork PRs and PR merge
-refs remain read-only. PRs can restore their base branch's caches under
+Only trusted upstream pushes may write shared caches. The warmer runs on
+pushes to `main` and `feat/effect-bus`: the default/bedrock test configuration
+under the `test` job's own key (development base only; `main`'s own CI run
+saves that one), and the all-features test graph under the shared
+`all-features` key that CI's `doctest` job and the nightly `test-all-features`
+job restore without saving (same profile, features and environment; none uses
+sccache), so the warmer is that key's only writer.
+Fork PRs and PR merge refs remain read-only. PRs can restore their base
+branch's caches under
 [GitHub's cache visibility rules](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching).
 Other matrix configurations are not multiplied into development-base caches.
-The warmer's explicit `default-test-build` check compiles the identical
-default/bedrock artifacts with nextest `--no-run`; it makes no test-execution
-claim and is never substituted for `default-tests` in verification. Conformance
-passes explicit Cargo test-target selectors matching its existing nextest
-filter, preserving the four executed binaries and their package/feature graph
-while avoiding compilation of unused harnesses.
-Cache warming still consumes runner time and quota; its benefit can only be
-measured after the workflow lands and trusted pushes populate that base cache.
+The warmer's explicit `default-test-build` and `full-test-build` checks compile
+the identical artifacts with nextest `--no-run`; they make no test-execution
+claim and are never substituted for `default-tests` or `full-tests` in
+verification. rust-cache keeps dependency artifacts only, so workspace crates
+still compile in every run. Conformance passes explicit Cargo test-target
+selectors matching its existing nextest filter, preserving the four executed
+binaries and their package/feature graph while avoiding compilation of unused
+harnesses. Cache warming still consumes runner time and quota; its benefit can
+only be measured after the workflow lands and trusted pushes populate that
+base cache.
+
+The all-features run starts its two nested-Cargo tests first (a nextest
+priority override): the facade feature-forwarding guard alone runs four
+`cargo check`s over the facade's graph and, in default order, finished
+minutes after every other test.
 
 ## PR completion
 

--- a/xtask/src/verify/checks.rs
+++ b/xtask/src/verify/checks.rs
@@ -268,16 +268,12 @@ pub(super) fn all() -> Vec<Check> {
                 "not package(rig-derive)",
             ])],
         ),
-        check(
-            "workspace-check",
-            vec![cargo(&[
-                "check",
-                "--locked",
-                "--workspace",
-                "--all-features",
-                "--all-targets",
-            ])],
-        ),
+        // No separate `cargo check --workspace --all-features --all-targets`:
+        // full-tests compiles every workspace member's lib, bin, test and
+        // example targets under the same feature set (Cargo's default `test`
+        // target selection), clippy checks the default members' `--all-targets`,
+        // and no member declares a bench target. Keep it that way, or a bench
+        // in a non-default member needs a locked-version owner again.
         // Existing repository floor checker; new verification tooling is Rust.
         check(
             "dependency-floors",
@@ -377,19 +373,29 @@ pub(super) fn all() -> Vec<Check> {
     }
     checks
 }
+/// Inputs whose change runs the full runtime lane (`full-tests`): the
+/// service-backed integration suites, the crates they cover, the facade
+/// feature-forwarding guard, and the shared build/verification inputs whose
+/// effect on those suites cannot be narrowed. Mirrors nightly.yaml's
+/// `pull_request.paths`; `lanes_mirror_ci_path_filters` pins the agreement.
 pub(super) fn full_lane(path: &str) -> bool {
     [
         "Cargo.toml",
         "Cargo.lock",
         ".github/workflows/nightly.yaml",
-        "scripts/check-dependency-floors.py",
         "tests/tool_facade_features.rs",
         "tests/integrations.rs",
     ]
     .contains(&path)
         || path.starts_with("tests/integrations/")
         || path.starts_with("test-support/")
-        || (path.starts_with("crates/") && path.ends_with("/Cargo.toml"))
+        || path.starts_with(".github/actions/")
+        // `crates/*/Cargo.toml`: the workspace members' manifests, not the
+        // nested compile fixtures beneath them (those have their own owners).
+        || path
+            .strip_prefix("crates/")
+            .and_then(|rest| rest.strip_suffix("/Cargo.toml"))
+            .is_some_and(|name| !name.contains('/'))
         || [
             "rig-lancedb",
             "rig-mongodb",
@@ -404,4 +410,26 @@ pub(super) fn full_lane(path: &str) -> bool {
         .any(|p| path.starts_with(&format!("crates/{p}/")))
         || path.starts_with("xtask/")
         || path.starts_with(".config/")
+}
+/// Inputs whose change runs `dependency-floors`: everything Cargo's resolver
+/// reads (manifests, the lockfile, the toolchain, Cargo configuration), the
+/// floor checker, and the verification tooling that defines the check.
+/// Mirrors dependency-floors.yaml's `pull_request.paths`. A source-only edit
+/// that starts using an API newer than a declared floor is deliberately not
+/// a trigger: the scheduled run, the merge queue and the release gate still
+/// execute the floors on every landed combination.
+pub(super) fn floor_lane(path: &str) -> bool {
+    [
+        "Cargo.toml",
+        "Cargo.lock",
+        "rust-toolchain.toml",
+        "scripts/check-dependency-floors.py",
+        "scripts/test_dependency_floors.py",
+        ".github/workflows/dependency-floors.yaml",
+    ]
+    .contains(&path)
+        || path.ends_with("/Cargo.toml")
+        || path.starts_with(".cargo/")
+        || path.starts_with(".github/actions/")
+        || path.starts_with("xtask/")
 }

--- a/xtask/src/verify/preflight.rs
+++ b/xtask/src/verify/preflight.rs
@@ -253,8 +253,8 @@ pub(super) fn run(root: &Path, plan: &[Check]) -> Result<()> {
             "clippy",
             "doctests",
             "docs",
-            "workspace-check",
             "full-tests",
+            "full-test-build",
             "dependency-floors",
         ]
         .contains(&check.id.as_str())

--- a/xtask/src/verify/selection.rs
+++ b/xtask/src/verify/selection.rs
@@ -40,10 +40,28 @@ pub(super) fn changes(
     paths.extend(execute::other_inputs(root, target)?);
     Ok(paths)
 }
-fn broad(all: &[Check], reason: &str, full: bool) -> Vec<Check> {
+/// The two expensive lanes on top of the fast PR set. They have separate
+/// triggers (`checks::full_lane`, `checks::floor_lane`) both locally and in
+/// CI, so a storage-suite edit no longer resolves dependency floors and a
+/// manifest edit no longer waits on the service suites unless it also
+/// matches that lane.
+#[derive(Clone, Copy)]
+struct Lanes {
+    full: bool,
+    floors: bool,
+}
+impl Lanes {
+    const ALL: Self = Self {
+        full: true,
+        floors: true,
+    };
+}
+fn broad(all: &[Check], reason: &str, lanes: Lanes) -> Vec<Check> {
     all.iter()
-        .filter(|c| {
-            full || !["full-tests", "dependency-floors", "workspace-check"].contains(&c.id.as_str())
+        .filter(|c| match c.id.as_str() {
+            "full-tests" => lanes.full,
+            "dependency-floors" => lanes.floors,
+            _ => true,
         })
         .cloned()
         .map(|mut c| {
@@ -153,12 +171,19 @@ pub(super) fn plan(
             .as_deref()
             .ok_or_else(|| invalid("missing check ID"))?;
         let mut out = Vec::new();
-        if id == "default-test-build" {
+        // Cache warming: compile exactly the artifacts a test check needs,
+        // without executing it or claiming its result. Each alias keeps its
+        // source check's package/feature graph so rust-cache entries match.
+        let warming = [
+            ("default-test-build", "default-tests"),
+            ("full-test-build", "full-tests"),
+        ];
+        if let Some((_, source)) = warming.iter().find(|(alias, _)| *alias == id) {
             add(
                 &mut out,
                 all,
-                "default-tests",
-                "cache warming only: compile default test artifacts; executes no tests",
+                source,
+                "cache warming only: compile test artifacts; executes no tests",
             )?;
             if let Some(check) = out.first_mut() {
                 check.id = id.into();
@@ -179,7 +204,7 @@ pub(super) fn plan(
         return Ok(broad(
             all,
             "exhaustive supported repository verification",
-            true,
+            Lanes::ALL,
         ));
     }
     if opts.mode == Mode::Pr {
@@ -203,17 +228,24 @@ pub(super) fn plan(
             check: None,
         };
         let local = plan(root, metadata, &changed, paths, all)?;
-        let triggers: Vec<_> = paths.iter().filter(|p| checks::full_lane(p)).collect();
-        let fallback = local.iter().find(|check| check.id == "full-tests");
-        let needs_full = !triggers.is_empty() || fallback.is_some();
+        let full_triggers: Vec<_> = paths.iter().filter(|p| checks::full_lane(p)).collect();
+        let floor_triggers: Vec<_> = paths.iter().filter(|p| checks::floor_lane(p)).collect();
+        let fallback = |id: &str| local.iter().find(|check| check.id == id);
+        let lanes = Lanes {
+            full: !full_triggers.is_empty() || fallback("full-tests").is_some(),
+            floors: !floor_triggers.is_empty() || fallback("dependency-floors").is_some(),
+        };
+        let fallbacks: Vec<_> = ["full-tests", "dependency-floors"]
+            .into_iter()
+            .filter_map(|id| fallback(id).map(|c| format!("{id}: {}", c.reason)))
+            .collect();
         let reason = format!(
-            "complete intended PR diff; preserves required lanes; full-lane inputs: {triggers:?}; {}",
-            fallback.map_or("no conservative full fallback", |c| c.reason.as_str())
+            "complete intended PR diff; preserves required lanes; full-lane inputs: {full_triggers:?}; floor-lane inputs: {floor_triggers:?}; conservative fallbacks: {fallbacks:?}"
         );
-        let mut required = broad(all, &reason, needs_full);
+        let mut required = broad(all, &reason, lanes);
         // The fast PR lane skips facade-build-tests. Preserve this targeted
         // owner when its generated lock selected it without a full-lane trigger.
-        if !needs_full
+        if !lanes.full
             && let Some(facade) = local
                 .iter()
                 .find(|c| c.id == "provider-tool_facade_features")
@@ -242,6 +274,19 @@ pub(super) fn plan(
             }
             continue;
         }
+        if path == "scripts/check-dependency-floors.py"
+            || path == "scripts/test_dependency_floors.py"
+        {
+            // The floor checker and its isolation tests touch nothing else.
+            add(&mut out, all, "tooling", "floor checker isolation tests")?;
+            add(
+                &mut out,
+                all,
+                "dependency-floors",
+                "floor checker changed: resolve and build the lowered graph",
+            )?;
+            continue;
+        }
         if path == "Cargo.lock"
             || path.ends_with("Cargo.toml")
             || path == "rust-toolchain.toml"
@@ -259,10 +304,19 @@ pub(super) fn plan(
             .iter()
             .any(|p| path.starts_with(p))
         {
+            // Shared inputs broaden to every runtime check. Dependency floors
+            // join only for resolver inputs: nextest configuration, shared
+            // test support or facade source cannot change what Cargo resolves.
+            let lanes = Lanes {
+                full: true,
+                floors: checks::floor_lane(path)
+                    || path.starts_with(".github/")
+                    || path.starts_with("scripts/"),
+            };
             return Ok(broad(
                 all,
                 &format!("conservative fallback: shared/build/verification input {path}"),
-                true,
+                lanes,
             ));
         }
         if path.starts_with("tests/ecs_parity/") {
@@ -316,7 +370,7 @@ pub(super) fn plan(
                 return Ok(broad(
                     all,
                     &format!("unknown provider/target for {path}"),
-                    true,
+                    Lanes::ALL,
                 ));
             }
             let id = format!("provider-{name}");
@@ -345,7 +399,7 @@ pub(super) fn plan(
                 return Ok(broad(
                     all,
                     &format!("unmodeled package asset or generator {path}"),
-                    true,
+                    Lanes::ALL,
                 ));
             }
             affected.insert(name.to_string());
@@ -354,7 +408,7 @@ pub(super) fn plan(
         return Ok(broad(
             all,
             &format!("unknown input {path}; cannot safely narrow"),
-            true,
+            Lanes::ALL,
         ));
     }
     if paths.iter().any(|p| p != "DEVELOPING.md") {

--- a/xtask/src/verify/tests.rs
+++ b/xtask/src/verify/tests.rs
@@ -4,7 +4,7 @@ fn opts(mode: &str) -> Options {
     Options::parse(vec![mode.into(), "--base".into(), "HEAD".into()]).unwrap()
 }
 fn metadata() -> Value {
-    serde_json::json!({"packages":[{"name":"rig","manifest_path":"/repo/Cargo.toml","targets":[{"name":"anthropic","kind":["test"]}]},{"name":"rig-ecs","manifest_path":"/repo/crates/rig-ecs/Cargo.toml","dependencies":[]},{"name":"example","manifest_path":"/repo/examples/example/Cargo.toml","dependencies":[{"name":"rig-ecs"}]}]})
+    serde_json::json!({"packages":[{"name":"rig","manifest_path":"/repo/Cargo.toml","targets":[{"name":"anthropic","kind":["test"]}]},{"name":"rig-ecs","manifest_path":"/repo/crates/rig-ecs/Cargo.toml","dependencies":[]},{"name":"rig-sqlite","manifest_path":"/repo/crates/rig-sqlite/Cargo.toml","dependencies":[]},{"name":"example","manifest_path":"/repo/examples/example/Cargo.toml","dependencies":[{"name":"rig-ecs"}]}]})
 }
 fn ids(mode: &str, paths: &[&str]) -> BTreeSet<String> {
     selection::plan(
@@ -62,9 +62,200 @@ fn planner_and_dependency_edits_cannot_skip_checks() {
         "xtask/src/main.rs",
         "Cargo.lock",
         "crates/rig-ecs/Cargo.toml",
-        ".config/nextest.toml",
+        "examples/agent/Cargo.toml",
+        "rust-toolchain.toml",
+        ".cargo/config.toml",
+        ".github/actions/rust-setup/action.yml",
     ] {
-        assert_eq!(ids("--changed", &[p]), ids("--full", &[]));
+        assert_eq!(ids("--changed", &[p]), ids("--full", &[]), "{p}");
+    }
+    // Shared runtime inputs broaden to every runtime check, but cannot
+    // change what Cargo resolves, so the floors stay out.
+    let mut without_floors = ids("--full", &[]);
+    without_floors.remove("dependency-floors");
+    for p in [
+        ".config/nextest.toml",
+        "src/lib.rs",
+        "tests/common/mod.rs",
+        "test-support/service-tests/src/lib.rs",
+    ] {
+        assert_eq!(ids("--changed", &[p]), without_floors, "{p}");
+    }
+}
+#[test]
+fn full_and_floor_lanes_select_independently() {
+    // A storage-suite edit runs the service suites, not the floors.
+    for p in [
+        "crates/rig-sqlite/src/lib.rs",
+        "tests/integrations/sqlite.rs",
+    ] {
+        let pr = ids("--pr", &[p]);
+        assert!(pr.contains("full-tests"), "{p}: {pr:?}");
+        assert!(!pr.contains("dependency-floors"), "{p}: {pr:?}");
+    }
+    // The floor checker runs the floors and its own tests, nothing else.
+    let changed = ids("--changed", &["scripts/check-dependency-floors.py"]);
+    assert_eq!(
+        changed,
+        BTreeSet::from(["dependency-floors".into(), "fmt".into(), "tooling".into()])
+    );
+    let pr = ids("--pr", &["scripts/check-dependency-floors.py"]);
+    assert!(pr.contains("dependency-floors"));
+    assert!(!pr.contains("full-tests"));
+    // Resolver inputs run both.
+    for p in ["Cargo.lock", "crates/rig-ecs/Cargo.toml"] {
+        let pr = ids("--pr", &[p]);
+        assert!(
+            pr.contains("full-tests") && pr.contains("dependency-floors"),
+            "{p}"
+        );
+    }
+    // The lane predicates are exactly the CI path filters.
+    for p in ["crates/rig-sqlite/src/lib.rs", "tests/integrations.rs"] {
+        assert!(checks::full_lane(p) && !checks::floor_lane(p), "{p}");
+    }
+    for p in [
+        "examples/agent/Cargo.toml",
+        "rust-toolchain.toml",
+        ".cargo/config.toml",
+        "scripts/check-dependency-floors.py",
+    ] {
+        assert!(checks::floor_lane(p) && !checks::full_lane(p), "{p}");
+    }
+}
+
+/// GitHub's `paths` filter for a workflow's `pull_request` trigger, read by
+/// line scan: the lists are plain quoted scalars, and xtask carries no YAML
+/// parser.
+fn ci_path_filter(workflow: &str) -> Vec<String> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+    let text = std::fs::read_to_string(root.join(workflow)).unwrap();
+    let mut lines = text.lines().peekable();
+    while let Some(line) = lines.next() {
+        if line.trim() != "pull_request:" {
+            continue;
+        }
+        assert_eq!(lines.next().map(str::trim), Some("paths:"), "{workflow}");
+        let mut globs = Vec::new();
+        let mut indent = None;
+        for line in lines.by_ref() {
+            let trimmed = line.trim();
+            let depth = line.len() - line.trim_start().len();
+            // Comments between items are skipped; a comment or key that
+            // dedents past the items ends the list.
+            if trimmed.starts_with('#') && indent.is_none_or(|i| depth >= i) {
+                continue;
+            }
+            let Some(glob) = trimmed.strip_prefix("- ") else {
+                break;
+            };
+            if indent.is_some_and(|i| i != depth) {
+                break;
+            }
+            indent = Some(depth);
+            globs.push(glob.trim_matches('"').to_string());
+        }
+        assert!(!globs.is_empty(), "{workflow}: empty paths filter");
+        return globs;
+    }
+    panic!("{workflow}: no pull_request paths filter");
+}
+/// `**` matches any number of segments, `*` matches within one segment.
+fn glob_matches(glob: &str, path: &str) -> bool {
+    fn segments(pattern: &[&str], path: &[&str]) -> bool {
+        match (pattern.first(), path.first()) {
+            (None, None) => true,
+            (Some(&"**"), _) => {
+                segments(&pattern[1..], path) || (!path.is_empty() && segments(pattern, &path[1..]))
+            }
+            (Some(p), Some(s)) => {
+                let ok = match p.split_once('*') {
+                    Some((prefix, suffix)) => {
+                        assert!(!suffix.contains('*'), "unsupported glob {p}");
+                        s.len() >= prefix.len() + suffix.len()
+                            && s.starts_with(prefix)
+                            && s.ends_with(suffix)
+                    }
+                    None => p == s,
+                };
+                ok && segments(&pattern[1..], &path[1..])
+            }
+            _ => false,
+        }
+    }
+    let pattern: Vec<_> = glob.split('/').collect();
+    let path: Vec<_> = path.split('/').collect();
+    segments(&pattern, &path)
+}
+#[test]
+fn lanes_mirror_ci_path_filters() {
+    assert!(glob_matches(
+        "crates/*/Cargo.toml",
+        "crates/rig-ecs/Cargo.toml"
+    ));
+    assert!(!glob_matches(
+        "crates/*/Cargo.toml",
+        "crates/rig-ecs/src/Cargo.toml"
+    ));
+    assert!(glob_matches(
+        "**/Cargo.toml",
+        "tests/fixtures/tool_facade/Cargo.toml"
+    ));
+    assert!(glob_matches(
+        "crates/rig-sqlite/**",
+        "crates/rig-sqlite/src/lib.rs"
+    ));
+    assert!(!glob_matches(
+        "crates/rig-sqlite/**",
+        "crates/rig-sqlite2/src/lib.rs"
+    ));
+    let full = ci_path_filter(".github/workflows/nightly.yaml");
+    let floors = ci_path_filter(".github/workflows/dependency-floors.yaml");
+    let corpus = [
+        "Cargo.toml",
+        "Cargo.lock",
+        "rust-toolchain.toml",
+        ".cargo/config.toml",
+        ".config/nextest.toml",
+        ".github/workflows/ci.yaml",
+        ".github/workflows/nightly.yaml",
+        ".github/workflows/dependency-floors.yaml",
+        ".github/actions/rust-setup/action.yml",
+        "README.md",
+        "DEVELOPING.md",
+        "src/lib.rs",
+        "tests/common/mod.rs",
+        "tests/integrations.rs",
+        "tests/integrations/sqlite.rs",
+        "tests/integrations/lancedb/mod.rs",
+        "tests/tool_facade_features.rs",
+        "tests/fixtures/tool_facade/Cargo.toml",
+        "tests/fixtures/tool_facade/Cargo.lock",
+        "tests/cassettes/openai/completion.yaml",
+        "tests/providers/openai/mod.rs",
+        "test-support/service-tests/Cargo.toml",
+        "test-support/service-tests/src/lib.rs",
+        "scripts/check-dependency-floors.py",
+        "scripts/test_dependency_floors.py",
+        "scripts/release-notes.sh",
+        "xtask/Cargo.toml",
+        "xtask/src/verify/checks.rs",
+        "examples/agent/Cargo.toml",
+        "examples/agent/src/main.rs",
+        "crates/rig-core/Cargo.toml",
+        "crates/rig-core/src/lib.rs",
+        "crates/rig-agent/src/bus/mod.rs",
+        "crates/rig-sqlite/src/lib.rs",
+        "crates/rig-sqlite/Cargo.toml",
+        "crates/rig-lancedb/examples/demo.rs",
+        "crates/rig-milvus/src/lib.rs",
+        "crates/rig-derive/tests/fixtures/core_renamed/Cargo.toml",
+    ];
+    for path in corpus {
+        let ci_full = full.iter().any(|g| glob_matches(g, path));
+        let ci_floors = floors.iter().any(|g| glob_matches(g, path));
+        assert_eq!(ci_full, checks::full_lane(path), "full lane: {path}");
+        assert_eq!(ci_floors, checks::floor_lane(path), "floor lane: {path}");
     }
 }
 #[test]
@@ -294,13 +485,102 @@ fn symlink_inputs_can_still_run_fresh_without_cache() {
 }
 #[test]
 fn full_covers_workspace_and_example_targets() {
+    // full-tests owns the locked-version compile of every member's lib, bin,
+    // test and example targets: Cargo's default `test` target selection,
+    // which any narrowing flag would silently drop.
     let all = checks::all();
     let c = all.iter().find(|c| c.id == "full-tests").unwrap();
-    assert!(c.steps[0].args.contains(&"--workspace".into()));
-    let c = all.iter().find(|c| c.id == "workspace-check").unwrap();
-    for flag in ["--workspace", "--all-features", "--all-targets"] {
+    for flag in ["--workspace", "--all-features"] {
         assert!(c.steps[0].args.contains(&flag.into()));
     }
+    for flag in [
+        "--lib",
+        "--bins",
+        "--bin",
+        "--tests",
+        "--test",
+        "--examples",
+        "--example",
+        "--benches",
+    ] {
+        assert!(!c.steps[0].args.contains(&flag.into()), "{flag}");
+    }
+    assert!(!all.iter().any(|c| c.id == "workspace-check"));
+    // Bench targets are the one target class outside cargo test's default
+    // selection; none exists, so nothing needs the removed workspace check.
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+    let metadata: Value = serde_json::from_str(
+        &output(
+            root,
+            "cargo",
+            &["metadata", "--locked", "--no-deps", "--format-version", "1"],
+        )
+        .expect("cargo metadata --no-deps for the bench guard"),
+    )
+    .unwrap();
+    let packages = metadata["packages"].as_array().unwrap();
+    assert!(packages.len() > 20, "workspace members not found");
+    for package in packages {
+        let manifest = Path::new(package["manifest_path"].as_str().unwrap());
+        let benches = package["targets"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|t| t["kind"].as_array().unwrap().iter().any(|k| k == "bench"));
+        assert!(
+            !benches && !manifest.with_file_name("benches").is_dir(),
+            "{} declares a bench target; full-tests does not compile benches, so a locked-version owner is needed (see checks.rs)",
+            manifest.display()
+        );
+    }
+}
+#[test]
+fn prioritized_tests_exist() {
+    // A renamed test would silently restore the all-features tail.
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+    let config = std::fs::read_to_string(root.join(".config/nextest.toml")).unwrap();
+    let block = config
+        .split("[[profile.default.overrides]]")
+        .skip(1)
+        .find(|b| b.contains("priority = 100"))
+        .expect("a default-profile override with priority 100");
+    let config = block.split("\n[").next().unwrap();
+    let sources: Vec<String> = execute::tracked_inputs(root)
+        .unwrap()
+        .into_iter()
+        .filter(|p| p.ends_with(".rs") && p.contains("tests/"))
+        .collect();
+    let mut checked = 0;
+    for line in config
+        .lines()
+        .filter(|l| l.trim_start().starts_with("filter = "))
+    {
+        for (kind, rest) in ["test(", "binary("].into_iter().flat_map(|kind| {
+            line.match_indices(kind)
+                .map(move |(i, _)| (kind, &line[i + kind.len()..]))
+        }) {
+            let name = rest.split(')').next().unwrap();
+            if !name.chars().all(|c| c.is_alphanumeric() || c == '_') {
+                continue;
+            }
+            checked += 1;
+            let found = if kind == "binary(" {
+                sources
+                    .iter()
+                    .any(|p| p.ends_with(&format!("/tests/{name}.rs")))
+            } else {
+                sources.iter().any(|p| {
+                    std::fs::read_to_string(root.join(p))
+                        .is_ok_and(|text| text.contains(&format!("fn {name}(")))
+                })
+            };
+            assert!(found, "{kind}{name}) names no tracked test");
+        }
+    }
+    assert!(
+        checked >= 2,
+        "expected the prioritized nested-Cargo tests, found {checked}"
+    );
 }
 
 #[test]
@@ -744,27 +1024,35 @@ fn tool_versions_require_the_exact_pinned_version() {
 }
 
 #[test]
-fn cache_warming_compiles_the_default_graph_without_claiming_test_execution() {
-    let mut options = Options::parse(vec!["--check".into(), "default-test-build".into()]).unwrap();
-    options.check = Some("default-test-build".into());
+fn cache_warming_compiles_the_test_graphs_without_claiming_test_execution() {
     let all = checks::all();
-    let plan = selection::plan(
-        Path::new("/repo"),
-        &metadata(),
-        &options,
-        &BTreeSet::new(),
-        &all,
-    )
-    .unwrap();
-    let default = all.iter().find(|c| c.id == "default-tests").unwrap();
-    let mut expected = default.steps[0].clone();
-    let index = expected.args.iter().position(|a| a == "--retries").unwrap();
-    expected.args.drain(index..index + 2);
-    expected.args.push("--no-run".into());
-    assert_eq!(plan[0].steps, vec![expected]);
-    assert_ne!(plan[0].id, default.id);
-    assert!(!all.iter().any(|c| c.id == "default-test-build"));
-    assert!(!default.steps[0].args.contains(&"--no-run".into()));
+    for (alias, source) in [
+        ("default-test-build", "default-tests"),
+        ("full-test-build", "full-tests"),
+    ] {
+        let options = Options::parse(vec!["--check".into(), alias.into()]).unwrap();
+        let plan = selection::plan(
+            Path::new("/repo"),
+            &metadata(),
+            &options,
+            &BTreeSet::new(),
+            &all,
+        )
+        .unwrap();
+        let executed = all.iter().find(|c| c.id == source).unwrap();
+        let mut expected = executed.steps[0].clone();
+        let index = expected.args.iter().position(|a| a == "--retries").unwrap();
+        expected.args.drain(index..index + 2);
+        expected.args.push("--no-run".into());
+        assert_eq!(plan.len(), 1);
+        assert_eq!(plan[0].steps, vec![expected], "{alias}");
+        assert_eq!(plan[0].id, alias);
+        assert!(!all.iter().any(|c| c.id == alias));
+        assert!(!executed.steps[0].args.contains(&"--no-run".into()));
+        assert!(plan[0].reason.contains("executes no tests"));
+        // The build alone launches no nested Cargo and needs no Docker.
+        assert!(preflight::fixture_manifests(&plan).is_empty(), "{alias}");
+    }
 }
 #[test]
 fn conformance_compiles_exactly_its_executed_targets() {


### PR DESCRIPTION
## Description

Shortens the PR gate's critical path and separates two lanes that shared one trigger. Every change is anchored on a measurement from the last five hosted runs of #2443 and its child PRs (job logs and numbers in the ledger below); nothing here changes runtime code or public API.

**What was slow, and what changes**

| observation (hosted, ubuntu-latest) | change |
|---|---|
| `stable / doctest` is the longest job of the gate (603–617 s on four of the last five runs). Its log reads "No cache found" every run: 973 dependency crates compile cold for 9 of its 9.6 minutes, then 16 s of doctests. | cache-warm.yaml gains an `all-features` job that compiles the all-features test graph (`cargo xtask verify --check full-test-build`: the `full-tests` command with nextest `--no-run`, executes nothing) under a shared rust-cache key. The doctest job and nightly's `test all features` job restore it; they build the same dependency units (test profile, all features, workspace, no sccache in any of the three). New `cache-shared-key` input on `.github/actions/rust-setup`. |
| `stable / test` (583–779 s) starts with a serial `default-check` step of 84–103 s that shares no artifacts with the sweep that follows (different feature hash, check mode vs build mode). | The check is unchanged but runs in its own job, `stable / check default features`; the `test` job is the sweep plus the registration check. |
| Nightly's all-features run (1332–1613 s) ends on one test: `portable_tool_facade_is_feature_additive` (four nested `cargo check`s, 412 s) starts at its lexicographic position and finished 239 s after every other test (run 34658159450). Locally it is last too. | `.config/nextest.toml` gives that test and the `macro_hygiene` consumer priority 100 so they start first. `[nextest-version] recommended = "0.9.91"`; older nextest warns and keeps the default order (verified with 0.9.67: a warning, all tests run). CI installs 0.9.143. |
| nightly.yaml had one `pull_request.paths` filter for two unrelated jobs, so a sqlite suite edit resolved and built the lowered dependency graph (632–677 s of runner time) and a floor-checker edit waited on the Docker suites. Locally `--pr` coupled them the same way: 387 s of floors on every full-lane plan. | The floors get their own workflow, dependency-floors.yaml, whose filter is Cargo's resolver inputs: every manifest (`**/Cargo.toml`), `Cargo.lock`, `rust-toolchain.toml`, `.cargo/**`, the checker, `xtask/**`, the shared setup action, the workflow itself. Same schedule, `merge_group`, `workflow_dispatch` and `workflow_call`; cd.yaml calls all three lanes before release-plz. Locally `checks::full_lane` and the new `checks::floor_lane` select the two checks independently, in PR mode and in the conservative fallbacks; `scripts/check-dependency-floors.py` alone selects the floors and its own isolation tests. A test line-scans both workflows' `paths` and asserts the predicates agree with the globs over a 39-path corpus. |
| `workspace-check` (`cargo check --workspace --all-features --all-targets`, 134 s of every local full-lane plan, no hosted job) compiles nothing that another check does not: `full-tests` builds every member's lib, bin, test and example targets under the same all-features graph (Cargo's default `test` target selection; verified on a crate with examples), clippy checks the default members' `--all-targets`, and no manifest declares a bench, `test = false` or `harness = false` target. | Removed. `full_covers_workspace_and_example_targets` now pins that `full-tests` passes no target-narrowing flag; the checks.rs comment states the condition under which an owner is needed again. |

**What stops running where, and why that is safe**

- Dependency floors no longer run on PRs whose diff is only storage-crate source, `tests/integrations/**`, `test-support/**` source, `.config/**`, the facade guard test or nightly.yaml itself. None of those can change what Cargo resolves. A source-only change that starts using an API above a declared floor is caught by the scheduled run, the merge queue (every batch) or the release gate instead of on its own PR; that tradeoff is deliberate and documented in DEVELOPING.md. Floors still run on every manifest, lockfile, toolchain, Cargo-config, checker or tooling change.
- Full tests no longer run on a PR that touches only the floor checker.
- Newly triggered (previously nothing ran in CI): floors on `examples/*/Cargo.toml`, `xtask/Cargo.toml`, `test-support/service-tests/Cargo.toml`, nested fixture manifests, `rust-toolchain.toml`, `.cargo/**`; both lanes on `.github/actions/**` (the setup every lane shares).
- `default-check`, doctests, the facade guard and the floors keep their exact commands. Nothing leaves the release gate: cd.yaml's release-plz needs ci, nightly and floors.

**Measured and projected**

- Local like-for-like reproduction of the doctest job's two cache states (M2 Max, 12 cores, CI's `line-tables-only` / incremental-off, fresh target): cold 371 s (1018 crates); dependencies warm and every workspace crate recompiled 23 s (30 crates); no-op 15 s. The hosted saving is a projection until the first trusted push to `feat/effect-bus` after merge populates the entry (this PR's own run cannot restore what does not exist yet); the mechanism is the one that already makes the `test` job compile 14 crates instead of 422 on child PRs.
- `default-check` off the `test` job: 84–103 s measured on that job's critical path; the job's remaining steps are unchanged.
- Facade test first: tail of 239 s on the last cold nightly run, 214 s on the previous one.
- Floors decoupled: 632–677 s of runner time per affected hosted PR; 387 s per affected local `--pr` plan.
- Local plans (dry-run, baseline selector vs this branch, same edit applied to both trees): see the table in the ledger; e.g. a sqlite suite edit `--pr` drops from 31 to 30 checks (no floors), the floor checker from 31 to 4 in changed mode, `Cargo.lock` stays at 31.
- Local `--pr` plan for this branch executed in full (see Testing).

## Changelog

None (CI and verification tooling only).

## Migration

None.

## Testing

- `cargo test --locked -p xtask` (64 passed), `cargo clippy --locked -p xtask --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `python3 -B -m unittest discover -s scripts -p test_dependency_floors.py`.
- Independent full-diff review by a subagent that did not implement the change; findings and dispositions in `reviews/rig-ci-05-ledger.md` (outside the repository).
- Final plan on the committed head eb27e3e62: `RIG_PROVIDER_TEST_MODE=replay cargo xtask verify --pr --base origin/feat/effect-bus` — **30/30 passed, exit 0**, all executed fresh (nextest 0.9.144, wasm-bindgen-test-runner 0.2.118, protoc 32.1, Docker via OrbStack). full-tests: 7391 passed, 213 skipped; dependency-floors passed. Wall time 7048 s on a machine shared with three other sessions' full plans (load average 45–140), so per-check times are not comparable to earlier runs. In that run the prioritized `macro_hygiene` test ran second and the facade guard started first; under that load its four nested `cargo check`s took the whole 1072 s of the suite, so the tail reduction could not be measured locally and rests on the hosted numbers above.
- Three independent full-diff reviews (subagents that did not implement the change); one P1 (the shared cache key had two writers on main), fixed; every P2/P3 addressed; third pass found no P0/P1.
- nextest 0.9.67 accepts the new configuration with a warning; 0.9.144 accepts it silently.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated READMEs and Rust docs affected by this change
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did not edit `CHANGELOG.md` or `MIGRATING.md` (they are generated at release)

## Notes

- Not done, with reasons: grouping the 13 wasm jobs (saves runner minutes, which are free for this public repository, at the cost of 13 check names and no wall-clock change); warming doc/clippy's check-mode dependencies (off the critical path after this change; the Actions cache is already at 11.3 GB against a 10 GB quota); precise `--pr` selection (the "every fast check" policy is deliberate and a redesign, not a bounded change). sccache on `test guards` was checked and kept: 62 % hits on child PRs; the 0 % run was #2443 itself, whose base (`main`) cannot read this branch's entries.
- The new cache entry adds roughly 2.5 GB to a quota already over its limit; GitHub's LRU eviction will drop the least-recently-accessed entries (currently main's superseded 09-09 nightly caches). Nothing deletes another lane's cache explicitly.
- Required-check names: `stable / dependency floors` now reports from dependency-floors.yaml and `stable / check default features` is new. The repository's rulesets configure no required status checks (audited earlier in this series), so nothing needs migrating; if a required-check list is added later, use these names.
- This review certifies the CI/verification change against `feat/effect-bus`; it does not certify the #2443 architecture.
