### PR TITLE
fix(effect-bus): targeted stress and Loom hardening of the bus, driver, ECS records and replay

### DIFF
--- a/crates/rig-agent/src/agent/builder.rs
+++ b/crates/rig-agent/src/agent/builder.rs
@@ -607,7 +607,9 @@ impl AgentBuilder<NoToolConfig> {
     /// `model` must be registered on the bus (the key is used as given),
     /// and the host drives it. Everything else the builder registers
     /// (memory, routes, tools) goes through `registrar`, keyed under
-    /// `owner`.
+    /// `owner`. The host records too, through its driver: an agent built
+    /// here holds no driver to tap, and [`record_effects`](Self::record_effects)
+    /// on it fails at build, at this call site.
     #[track_caller]
     pub fn over_bus(
         dispatcher: Dispatcher,

--- a/crates/rig-agent/src/agent/builder.rs
+++ b/crates/rig-agent/src/agent/builder.rs
@@ -404,7 +404,9 @@ impl<ToolState> AgentBuilder<ToolState> {
     }
 
     /// Record every dispatch into the agent's effect log
-    /// ([`Agent::effect_log`]).
+    /// ([`Agent::effect_log`]). For an agent that owns its bus; over a
+    /// host's bus ([`AgentBuilder::over_bus`]) the host records through its
+    /// driver, and asking here fails at build, at the `over_bus` line.
     pub fn record_effects(mut self) -> Self {
         self.record_effects = true;
         self
@@ -462,6 +464,20 @@ impl<ToolState> AgentBuilder<ToolState> {
             )
         }
 
+        /// Recording asked of an agent over a host's bus: the agent holds
+        /// no driver to tap — recording is the host's, through
+        /// `BusDriver::record_to` — so this is the host's programming
+        /// error, reported at the host's `over_bus` line.
+        #[allow(
+            clippy::panic,
+            reason = "recording over a host's bus is a programming error at the host's call site, not a runtime condition; `build` stays infallible for every other case"
+        )]
+        fn recording_over_a_hosts_bus(caller: &'static std::panic::Location<'static>) -> ! {
+            panic!(
+                "the agent built over a host's bus at {caller} cannot record: the host records through its driver (`BusDriver::record_to`)"
+            )
+        }
+
         let Self {
             mut config,
             tool_state,
@@ -476,6 +492,10 @@ impl<ToolState> AgentBuilder<ToolState> {
             retrieval_indexes: _,
             routes,
         } = self;
+        let host = match &model {
+            DefaultModel::Key(_, caller) => Some(*caller),
+            DefaultModel::Labelled(..) => None,
+        };
         // The owner: the label given, else the agent's name (so a named
         // agent's keys are the same in every process — what a log meant
         // for replay elsewhere needs), else a per-process counter.
@@ -531,7 +551,11 @@ impl<ToolState> AgentBuilder<ToolState> {
             config.memory_key = Some(config.bus.key("memory"));
         }
         if record_effects {
-            crate::agent::drive::register_generated(config.bus.enable_recording(record_events));
+            match (host, config.bus.enable_recording(record_events)) {
+                (Some(caller), Err(_)) => recording_over_a_hosts_bus(caller),
+                (None, registered) => crate::agent::drive::register_generated(registered),
+                (Some(_), Ok(())) => {}
+            }
         }
         let tool_server_handle = handle(tool_state, config.bus.owner());
         tool_server_handle.attach(config.bus.registrar());

--- a/crates/rig-agent/src/agent/builder/tests.rs
+++ b/crates/rig-agent/src/agent/builder/tests.rs
@@ -165,3 +165,22 @@ async fn retrieved_tools_are_exposed_only_for_prompted_retrieval() {
         vec!["add", "subtract"]
     );
 }
+
+/// An agent over a host's bus holds no driver to tap: recording is the
+/// host's, through its driver. Asking the builder for it is the host's
+/// programming error, refused at build like a wrong-family host key —
+/// never a debug assertion about generated keys, never a silent agent
+/// that records nothing.
+#[test]
+#[should_panic(expected = "cannot record: the host records through its driver")]
+fn recording_over_a_host_bus_is_refused_at_build() {
+    let (dispatcher, registrar, _driver) = crate::bus::Bus::channel();
+    let _agent = AgentBuilder::over_bus(
+        dispatcher,
+        registrar,
+        "host",
+        rig_core::effect::HandlerKey::from("model"),
+    )
+    .record_effects()
+    .build();
+}

--- a/crates/rig-agent/src/agent/drive.rs
+++ b/crates/rig-agent/src/agent/drive.rs
@@ -27,6 +27,8 @@ use crate::sync::Mutex;
 
 #[cfg(all(test, rig_loom))]
 mod loom_models;
+#[cfg(all(test, not(rig_loom)))]
+mod tests;
 use crate::bus::{BusDriver, Dispatcher, Registrar};
 use rig_core::serve::ErasedHandler;
 use rig_core::serve::ServingPolicy;
@@ -375,10 +377,14 @@ pub(crate) struct Driven<S> {
 }
 
 impl<S> Driven<S> {
-    /// The run is over: it neither drives nor needs waking any more.
+    /// The run is over: it neither drives nor needs waking any more. The
+    /// runs still registered are woken: one of them may have found the
+    /// driver lock taken under this run's last poll and buffered a command
+    /// since that poll's drain, and nothing polls the driver between runs.
     fn finish(&mut self) {
         self.inner = None;
         self.wakers.unregister(self.slot);
+        self.wakers.wake_by_ref();
     }
 
     /// A run that ended with a dispatch still in flight left it because it
@@ -458,6 +464,9 @@ impl<S> Drop for Driven<S> {
             let mut driver_cx = Context::from_waker(&waker);
             let _ = Pin::new(&mut *guard).poll(&mut driver_cx);
         }
+        // As at `finish`: a run that found the lock taken under this poll
+        // takes over once it is released.
+        self.wakers.wake_by_ref();
     }
 }
 

--- a/crates/rig-agent/src/agent/drive/loom_models.rs
+++ b/crates/rig-agent/src/agent/drive/loom_models.rs
@@ -55,7 +55,8 @@ fn loom_a_driven_run_that_finds_the_lock_taken_is_woken() {
                     drop(guard);
                 }
                 thread::yield_now();
-                // The last poll, as `Drop for Driven` does it.
+                // The run's end, as `Driven::finish` and `Drop for Driven`
+                // do it: the runs still registered are woken to take over.
                 std::sync::Arc::clone(&wakers).wake_by_ref();
             })
         };
@@ -111,5 +112,101 @@ fn loom_a_dropped_run_wakes_the_survivors() {
             b_flag.0.load(StdOrdering::SeqCst) >= 1,
             "the survivor was woken"
         );
+    });
+}
+
+/// Answers at once.
+struct Instant;
+
+impl rig_core::serve::Serve for Instant {
+    type Family = rig_core::effect::family::Dynamic;
+
+    fn descriptor(&self) -> rig_core::effect::HandlerDescriptor {
+        rig_core::effect::HandlerDescriptor {
+            key: rig_core::effect::HandlerKey::from("k"),
+            family: rig_core::effect::FamilyDescriptor::Custom {
+                kind: "test".into(),
+            },
+            layers: Vec::new(),
+        }
+    }
+
+    async fn serve(
+        &self,
+        _kind: rig_core::effect::EffectKind,
+        _dispatch: rig_core::serve::Dispatch,
+    ) -> rig_core::serve::Reply {
+        return rig_core::serve::Reply::Outcome(Ok(rig_core::effect::Outcome::Custom {
+            payload: serde_json::Value::Null,
+        }));
+    }
+}
+
+/// The runtime itself, not a model of it: two runs on one agent bus, each
+/// awaiting one dispatch, polled from two threads through [`Driven`]. A
+/// run that finds the driver lock taken yields and must be woken to take
+/// over — by driver progress under the other run's poll, or by that run's
+/// end after its last drain. Whichever schedule the model picks, both runs
+/// complete: no run is left with its command buffered and nobody driving.
+/// (Fails against a `finish` that unregisters without waking: the run that
+/// lost the lock race under the finishing run's last poll is never polled
+/// again.)
+#[test]
+fn loom_two_contending_runs_both_complete() {
+    use futures::StreamExt;
+    use std::task::{Context, Poll};
+
+    loom::model(|| {
+        let (dispatcher, registrar, mut driver) = crate::bus::Bus::channel();
+        driver.register("k", Instant).expect("a fresh key");
+        let bus = std::sync::Arc::new(super::AgentBus::owned(
+            dispatcher,
+            registrar,
+            driver,
+            "owner".to_owned(),
+            rig_core::serve::ServingPolicy::default(),
+        ));
+        let runs: Vec<_> = (0..2)
+            .map(|_| {
+                let bus = std::sync::Arc::clone(&bus);
+                thread::spawn(move || {
+                    let (wakes, waker) = counting();
+                    let mut cx = Context::from_waker(&waker);
+                    let key = rig_core::effect::HandlerKey::from("k");
+                    let mut run = bus.drive(futures::stream::once(bus.dispatcher().dispatch(
+                        &key,
+                        rig_core::effect::EffectKind::Custom {
+                            kind: std::sync::Arc::from("test"),
+                            payload: serde_json::Value::Null,
+                        },
+                    )));
+                    let mut answered = false;
+                    let mut seen_wakes = 0;
+                    // A run's executor: poll, and poll again only when woken.
+                    for _ in 0..32 {
+                        match run.poll_next_unpin(&mut cx) {
+                            Poll::Ready(Some(outcome)) => answered = outcome.is_ok(),
+                            Poll::Ready(None) => return answered,
+                            Poll::Pending => {
+                                let mut waited = 0;
+                                while wakes.0.load(StdOrdering::SeqCst) == seen_wakes {
+                                    waited += 1;
+                                    assert!(
+                                        waited < 64,
+                                        "a run pending on the bus was never woken"
+                                    );
+                                    thread::yield_now();
+                                }
+                                seen_wakes = wakes.0.load(StdOrdering::SeqCst);
+                            }
+                        }
+                    }
+                    panic!("a run did not complete within its poll budget");
+                })
+            })
+            .collect();
+        for run in runs {
+            assert!(run.join().unwrap(), "every run's dispatch was answered");
+        }
     });
 }

--- a/crates/rig-agent/src/agent/drive/tests.rs
+++ b/crates/rig-agent/src/agent/drive/tests.rs
@@ -34,11 +34,8 @@ fn custom() -> EffectKind {
     }
 }
 
-/// Answers at once, or never: the shape of a run that finishes on its own
-/// and of one that is dropped mid-flight.
-struct Handler {
-    answers: bool,
-}
+/// Answers at once.
+struct Handler;
 
 impl Serve for Handler {
     type Family = rig_core::effect::family::Dynamic;
@@ -54,9 +51,6 @@ impl Serve for Handler {
     }
 
     async fn serve(&self, _kind: EffectKind, _dispatch: Dispatch) -> Reply {
-        if !self.answers {
-            std::future::pending::<()>().await;
-        }
         Reply::Outcome(Ok(Outcome::Custom {
             payload: serde_json::Value::Null,
         }))
@@ -65,12 +59,10 @@ impl Serve for Handler {
 
 /// An owned agent bus serving `k`, and another run's waker registered on
 /// it — a run that found the driver lock taken and is waiting to drive.
-fn bus_with_a_waiting_run(answers: bool) -> (AgentBus, Arc<Counting>) {
+fn bus_with_a_waiting_run() -> (AgentBus, Arc<Counting>) {
     let policy = ServingPolicy::default();
     let (dispatcher, registrar, mut driver) = Bus::channel_with(policy);
-    driver
-        .register("k", Handler { answers })
-        .expect("a fresh key");
+    driver.register("k", Handler).expect("a fresh key");
     let bus = AgentBus::owned(dispatcher, registrar, driver, "owner".to_owned(), policy);
     let waiting = Arc::new(Counting(AtomicUsize::new(0)));
     let slot = bus.wakers.slot();
@@ -84,45 +76,54 @@ fn bus_with_a_waiting_run(answers: bool) -> (AgentBus, Arc<Counting>) {
 /// the finished run's last drain; nothing else polls the driver between
 /// runs, so the finished run must wake the runs still registered, which
 /// then take the lock and drive. (The obligation the loom model of the
-/// protocol assumes of a run's end.)
+/// protocol assumes of a run's end.) Exactly one wake, at the end: the
+/// polls that serve the run's own dispatch wake nobody.
 #[test]
 fn a_finished_run_wakes_the_runs_that_registered_while_it_drove() {
-    let (bus, waiting) = bus_with_a_waiting_run(true);
+    let (bus, waiting) = bus_with_a_waiting_run();
     let key = HandlerKey::from("k");
     let mut run = bus.drive(futures::stream::once(
         bus.dispatcher().dispatch(&key, custom()),
     ));
     let mut cx = Context::from_waker(noop_waker_ref());
-    let mut answered = false;
-    for _ in 0..16 {
-        match run.poll_next_unpin(&mut cx) {
-            Poll::Ready(Some(outcome)) => answered = outcome.is_ok(),
-            Poll::Ready(None) => break,
-            Poll::Pending => {}
-        }
-    }
-    assert!(answered, "the run served its own dispatch while it drove");
     assert!(
-        waiting.0.load(Ordering::SeqCst) >= 1,
-        "the run that stopped driving must wake the runs still registered"
+        matches!(run.poll_next_unpin(&mut cx), Poll::Ready(Some(Ok(_)))),
+        "the run served its own dispatch while it drove"
+    );
+    assert_eq!(
+        waiting.0.load(Ordering::SeqCst),
+        0,
+        "serving the run's own dispatch woke nobody"
+    );
+    assert!(matches!(run.poll_next_unpin(&mut cx), Poll::Ready(None)));
+    assert_eq!(
+        waiting.0.load(Ordering::SeqCst),
+        1,
+        "the run that stopped driving woke the runs still registered, once"
     );
 }
 
-/// The same obligation for a run dropped mid-flight: its last driver poll
-/// settles its own cancelled dispatch, and the runs still registered are
-/// woken to take over the bus.
+/// The same obligation for a run dropped while live: its answer landed
+/// but its stream was never polled to its end, so `Drop` gives the driver
+/// its last poll (nothing in flight to settle) and wakes the runs still
+/// registered to take over the bus. Exactly one wake, from the drop.
 #[test]
 fn a_dropped_run_wakes_the_runs_that_registered_while_it_drove() {
-    let (bus, waiting) = bus_with_a_waiting_run(false);
+    let (bus, waiting) = bus_with_a_waiting_run();
     let key = HandlerKey::from("k");
     let mut run = bus.drive(futures::stream::once(
         bus.dispatcher().dispatch(&key, custom()),
     ));
     let mut cx = Context::from_waker(noop_waker_ref());
-    assert!(run.poll_next_unpin(&mut cx).is_pending());
+    assert!(matches!(
+        run.poll_next_unpin(&mut cx),
+        Poll::Ready(Some(Ok(_)))
+    ));
+    assert_eq!(waiting.0.load(Ordering::SeqCst), 0);
     drop(run);
-    assert!(
-        waiting.0.load(Ordering::SeqCst) >= 1,
-        "the dropped run must wake the runs still registered"
+    assert_eq!(
+        waiting.0.load(Ordering::SeqCst),
+        1,
+        "the dropped run woke the runs still registered, once"
     );
 }

--- a/crates/rig-agent/src/agent/drive/tests.rs
+++ b/crates/rig-agent/src/agent/drive/tests.rs
@@ -1,0 +1,128 @@
+//! The driver protocol between runs: whoever is awaiting drives, and a run
+//! that stops driving hands the bus to the runs still waiting on it.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    task::{Context, Poll, Wake, Waker},
+};
+
+use futures::{StreamExt, task::noop_waker_ref};
+
+use super::*;
+use crate::bus::Bus;
+use rig_core::{
+    effect::{EffectKind, FamilyDescriptor, HandlerDescriptor, HandlerKey, Outcome},
+    serve::{Dispatch, Reply, Serve},
+};
+
+/// A waker that counts its wakes: another run's, registered on the bus.
+struct Counting(AtomicUsize);
+
+impl Wake for Counting {
+    fn wake(self: Arc<Self>) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+fn custom() -> EffectKind {
+    EffectKind::Custom {
+        kind: Arc::from("test"),
+        payload: serde_json::Value::Null,
+    }
+}
+
+/// Answers at once, or never: the shape of a run that finishes on its own
+/// and of one that is dropped mid-flight.
+struct Handler {
+    answers: bool,
+}
+
+impl Serve for Handler {
+    type Family = rig_core::effect::family::Dynamic;
+
+    fn descriptor(&self) -> HandlerDescriptor {
+        HandlerDescriptor {
+            key: HandlerKey::from("k"),
+            family: FamilyDescriptor::Custom {
+                kind: "test".into(),
+            },
+            layers: Vec::new(),
+        }
+    }
+
+    async fn serve(&self, _kind: EffectKind, _dispatch: Dispatch) -> Reply {
+        if !self.answers {
+            std::future::pending::<()>().await;
+        }
+        Reply::Outcome(Ok(Outcome::Custom {
+            payload: serde_json::Value::Null,
+        }))
+    }
+}
+
+/// An owned agent bus serving `k`, and another run's waker registered on
+/// it — a run that found the driver lock taken and is waiting to drive.
+fn bus_with_a_waiting_run(answers: bool) -> (AgentBus, Arc<Counting>) {
+    let policy = ServingPolicy::default();
+    let (dispatcher, registrar, mut driver) = Bus::channel_with(policy);
+    driver
+        .register("k", Handler { answers })
+        .expect("a fresh key");
+    let bus = AgentBus::owned(dispatcher, registrar, driver, "owner".to_owned(), policy);
+    let waiting = Arc::new(Counting(AtomicUsize::new(0)));
+    let slot = bus.wakers.slot();
+    bus.wakers
+        .register(slot, &Waker::from(Arc::clone(&waiting)));
+    (bus, waiting)
+}
+
+/// A run that finished drove the bus last. Another run that registered
+/// its waker and found the lock taken may have buffered a command since
+/// the finished run's last drain; nothing else polls the driver between
+/// runs, so the finished run must wake the runs still registered, which
+/// then take the lock and drive. (The obligation the loom model of the
+/// protocol assumes of a run's end.)
+#[test]
+fn a_finished_run_wakes_the_runs_that_registered_while_it_drove() {
+    let (bus, waiting) = bus_with_a_waiting_run(true);
+    let key = HandlerKey::from("k");
+    let mut run = bus.drive(futures::stream::once(
+        bus.dispatcher().dispatch(&key, custom()),
+    ));
+    let mut cx = Context::from_waker(noop_waker_ref());
+    let mut answered = false;
+    for _ in 0..16 {
+        match run.poll_next_unpin(&mut cx) {
+            Poll::Ready(Some(outcome)) => answered = outcome.is_ok(),
+            Poll::Ready(None) => break,
+            Poll::Pending => {}
+        }
+    }
+    assert!(answered, "the run served its own dispatch while it drove");
+    assert!(
+        waiting.0.load(Ordering::SeqCst) >= 1,
+        "the run that stopped driving must wake the runs still registered"
+    );
+}
+
+/// The same obligation for a run dropped mid-flight: its last driver poll
+/// settles its own cancelled dispatch, and the runs still registered are
+/// woken to take over the bus.
+#[test]
+fn a_dropped_run_wakes_the_runs_that_registered_while_it_drove() {
+    let (bus, waiting) = bus_with_a_waiting_run(false);
+    let key = HandlerKey::from("k");
+    let mut run = bus.drive(futures::stream::once(
+        bus.dispatcher().dispatch(&key, custom()),
+    ));
+    let mut cx = Context::from_waker(noop_waker_ref());
+    assert!(run.poll_next_unpin(&mut cx).is_pending());
+    drop(run);
+    assert!(
+        waiting.0.load(Ordering::SeqCst) >= 1,
+        "the dropped run must wake the runs still registered"
+    );
+}

--- a/crates/rig-agent/src/bus/dispatcher.rs
+++ b/crates/rig-agent/src/bus/dispatcher.rs
@@ -106,8 +106,10 @@ struct CommandQueue {
     /// the buffer was full — **one slot per value**, however many times it
     /// is polled while parked (a frame-ticked host polls it once per frame
     /// with a fresh waker each time; the value's `AtomicWaker` keeps only
-    /// the latest). All woken when the driver drains; a slot whose value
-    /// was dropped is skipped.
+    /// the latest). All woken whenever the driver drains — the buffer is
+    /// empty after every drain, however it emptied — and when the bus
+    /// closes or a chain is cancelled; a slot whose value was dropped is
+    /// skipped.
     senders: Vec<Weak<AtomicWaker>>,
 }
 
@@ -251,18 +253,19 @@ impl Shared {
     }
 
     /// Take every buffered command (the driver's side), registering `cx` as
-    /// the waker to wake on the next enqueue, and release any parked sender.
+    /// the waker to wake on the next enqueue, and release every parked
+    /// sender: the buffer is empty after a drain, whether this drain took
+    /// the commands that filled it or something else already dropped them
+    /// (an orphaned descendant failed by [`Self::fail_cancelled_buffered`]).
+    /// A sender woken to a buffer that has since refilled parks again; a
+    /// sender left parked on a buffer with room would never be woken.
     pub(super) fn drain(&self, cx: &Context<'_>) -> VecDeque<Box<Command>> {
         // Raw waker clone/drop callbacks may reenter the dispatcher too.
         let next_driver = cx.waker().clone();
         let mut queue = self.queue.lock().unwrap_or_else(PoisonError::into_inner);
         let commands = std::mem::take(&mut queue.commands);
         let previous_driver = queue.driver.replace(next_driver);
-        let senders = if commands.is_empty() {
-            Vec::new()
-        } else {
-            std::mem::take(&mut queue.senders)
-        };
+        let senders = std::mem::take(&mut queue.senders);
         drop(queue);
         drop(previous_driver);
         wake_parked(senders);

--- a/crates/rig-agent/src/bus/loom_models.rs
+++ b/crates/rig-agent/src/bus/loom_models.rs
@@ -817,21 +817,15 @@ fn loom_capacity_freed_by_orphan_removal_wakes_a_parked_sender() {
                 assert!(shared.end_in_flight(EffectId::from_raw(1)));
                 shared.fail_cancelled_buffered();
                 let (_, waker) = recording();
-                let taken = shared.drain(&Context::from_waker(&waker));
-                assert!(taken.len() <= 1, "the bound is bus-wide");
-                taken
+                shared.drain(&Context::from_waker(&waker));
             })
         };
-        let taken = driver.join().unwrap();
+        driver.join().unwrap();
         if let Some((flag, _slot)) = sender.join().unwrap() {
             assert!(
                 flag.0.load(StdOrdering::SeqCst),
                 "a sender parked on capacity the driver freed was never woken"
             );
         }
-        assert!(
-            shared.buffered() + taken.len() <= 1,
-            "the bound is bus-wide"
-        );
     });
 }

--- a/crates/rig-agent/src/bus/loom_models.rs
+++ b/crates/rig-agent/src/bus/loom_models.rs
@@ -748,3 +748,90 @@ fn loom_cancel_wakes_a_sender_parking_below_a_completed_middle() {
         }
     });
 }
+
+/// Capacity freed without a drain: a sender is parked on a full buffer whose
+/// one command is a descendant of a dispatch that is then cancelled. The
+/// driver's release drops that orphan from the buffer and drains. Whichever
+/// way the sender's parks interleave with the cancel's wake and the release,
+/// the model ends with the sender either sent or woken after its last park —
+/// never parked on a buffer with room, which nothing would ever wake. Fails
+/// against a drain that wakes parked senders only when it took a command.
+#[test]
+fn loom_capacity_freed_by_orphan_removal_wakes_a_parked_sender() {
+    loom::model(|| {
+        let shared = Arc::new(Shared::new(rig_core::serve::ServingPolicy {
+            command_capacity: 1,
+            ..rig_core::serve::ServingPolicy::default()
+        }));
+        shared.dispatcher_opened();
+        let _root = shared
+            .begin_in_flight(EffectId::from_raw(1), HandlerKey::from("root"), None)
+            .ok()
+            .expect("nothing cancelled");
+        let root = shared.retained_lineage(EffectId::from_raw(1));
+        let (mut child, _child_receiver) = command(2);
+        child.parent = Some(EffectId::from_raw(1));
+        child.lineage = super::dispatcher::Lineage::new(child.id, Some(root));
+        let (_, waker) = recording();
+        let slot = std::sync::Arc::new(futures::task::AtomicWaker::new());
+        assert!(matches!(
+            shared.enqueue(child, &slot, &Context::from_waker(&waker)),
+            Enqueue::Sent
+        ));
+        let sender = {
+            let shared = Arc::clone(&shared);
+            thread::spawn(move || {
+                let (mut cmd, _receiver) = command(3);
+                let (flag, waker) = recording();
+                let cx = Context::from_waker(&waker);
+                let slot = std::sync::Arc::new(futures::task::AtomicWaker::new());
+                loop {
+                    // The send stage of a `Pending`: park, and poll again
+                    // only when woken.
+                    flag.0.store(false, StdOrdering::SeqCst);
+                    match shared.enqueue(cmd, &slot, &cx) {
+                        Enqueue::Sent => return None,
+                        Enqueue::Parked(kept) => {
+                            cmd = kept;
+                            thread::yield_now();
+                            if !flag.0.load(StdOrdering::SeqCst) {
+                                // Still parked: the value (and its slot)
+                                // lives on, waiting for a wake.
+                                return Some((flag, slot));
+                            }
+                        }
+                        Enqueue::Refused(_) | Enqueue::Cancelled(_) | Enqueue::Closed => {
+                            panic!("an unrelated sender is parked or sent")
+                        }
+                    }
+                }
+            })
+        };
+        let driver = {
+            let shared = Arc::clone(&shared);
+            thread::spawn(move || {
+                // The root's task observes its cancel, then the driver
+                // releases it: the orphaned child leaves the buffer, and the
+                // poll loop drains again.
+                shared.cancel_descendants(EffectId::from_raw(1));
+                assert!(shared.end_in_flight(EffectId::from_raw(1)));
+                shared.fail_cancelled_buffered();
+                let (_, waker) = recording();
+                let taken = shared.drain(&Context::from_waker(&waker));
+                assert!(taken.len() <= 1, "the bound is bus-wide");
+                taken
+            })
+        };
+        let taken = driver.join().unwrap();
+        if let Some((flag, _slot)) = sender.join().unwrap() {
+            assert!(
+                flag.0.load(StdOrdering::SeqCst),
+                "a sender parked on capacity the driver freed was never woken"
+            );
+        }
+        assert!(
+            shared.buffered() + taken.len() <= 1,
+            "the bound is bus-wide"
+        );
+    });
+}

--- a/crates/rig-agent/src/bus/replay/tests.rs
+++ b/crates/rig-agent/src/bus/replay/tests.rs
@@ -1160,3 +1160,113 @@ async fn a_record_names_the_scope_of_the_program_that_made_it() {
     let restored: EffectLog = serde_json::from_value(json).expect("restores");
     assert_eq!(restored[1].scope.as_deref(), Some("run-1"));
 }
+
+/// A stream whose *fold* fails — a tool call closed with malformed
+/// arguments under `UnparseableToolInput::Error` — reaches the consumer as
+/// the provider sent it (the malformed close is an `Ok` item; the
+/// consumer's own accumulator reports it) while the record's outcome is
+/// the fold's error. A replay with kept events re-emits the items as they
+/// were and nothing more: the consumer re-derives the same error and a
+/// re-record folds to the same outcome. It never appends the folded error
+/// as an item the live consumer did not receive.
+#[tokio::test]
+async fn kept_events_replay_a_fold_error_as_the_items_that_produced_it() {
+    use rig_core::streaming::{
+        BlockClose, BlockId, BlockKind, Delta, StreamFinal, ToolCallEnd, UnparseableToolInput,
+    };
+
+    struct Items(Vec<Result<StreamEvent, ErrorReport>>);
+    impl Serve for Items {
+        type Family = rig_core::effect::family::Completion;
+        fn descriptor(&self) -> HandlerDescriptor {
+            HandlerDescriptor {
+                key: "model".into(),
+                family: FamilyDescriptor::Completion {
+                    model: rig_core::completion::ModelRef::new("malformed"),
+                    capabilities: rig_core::completion::ProviderCapabilities::default(),
+                },
+                layers: vec![],
+            }
+        }
+        async fn serve(&self, _: EffectKind, _dispatch: Dispatch) -> Reply {
+            Reply::Stream(Box::pin(futures::stream::iter(self.0.clone())))
+        }
+    }
+    let call = || BlockId::wire("call_1");
+    let items = vec![
+        Ok(StreamEvent::BlockStart {
+            id: call(),
+            kind: BlockKind::ToolCall,
+        }),
+        Ok(StreamEvent::BlockDelta {
+            id: call(),
+            delta: Delta::ToolName {
+                name: "lookup".to_owned(),
+            },
+        }),
+        Ok(StreamEvent::BlockDelta {
+            id: call(),
+            delta: Delta::ToolArguments {
+                arguments: "{not json".to_owned(),
+            },
+        }),
+        Ok(StreamEvent::BlockEnd {
+            id: call(),
+            end: BlockClose::ToolCall(ToolCallEnd::new(UnparseableToolInput::Error)),
+            block: None,
+        }),
+        Ok(StreamEvent::Final(StreamFinal::new(
+            "test",
+            rig_core::completion::Usage::new(),
+        ))),
+    ];
+    let key = HandlerKey::from("model");
+    let (dispatcher, _, mut driver) = Bus::channel();
+    let recorder = EffectLogRecorder::keeping_stream_events();
+    driver.register(key.clone(), Items(items.clone())).unwrap();
+    driver.record_to(recorder.clone());
+    let _live = spawn(driver);
+    let live = within(
+        dispatcher
+            .dispatch_stream(&key, completion_kind(true))
+            .collect::<Vec<_>>(),
+    )
+    .await;
+    assert_eq!(
+        serde_json::to_value(&live).unwrap(),
+        serde_json::to_value(&items).unwrap(),
+        "the consumer receives the items as the provider sent them"
+    );
+    drop(dispatcher);
+    let log = recorder.take();
+    assert_eq!(log.len(), 1);
+    let report = log[0]
+        .outcome
+        .as_ref()
+        .expect_err("the fold's error is the record's outcome");
+    assert_eq!(report.kind, ErrorKind::Response, "{report:?}");
+
+    let (dispatcher, _, mut driver) = Bus::channel();
+    super::register_all(&log, &mut driver).expect("fresh keys");
+    let again = EffectLogRecorder::keeping_stream_events();
+    driver.record_to(again.clone());
+    let _replay = spawn(driver);
+    let replayed = within(
+        dispatcher
+            .dispatch_stream(&key, completion_kind(true))
+            .collect::<Vec<_>>(),
+    )
+    .await;
+    assert_eq!(
+        serde_json::to_value(&replayed).unwrap(),
+        serde_json::to_value(&live).unwrap(),
+        "a replay re-emits the live items and nothing more"
+    );
+    drop(dispatcher);
+    let rerecorded = again.take();
+    assert_eq!(
+        serde_json::to_value(&rerecorded[0].outcome).unwrap(),
+        serde_json::to_value(&log[0].outcome).unwrap(),
+        "a re-record of the replay folds to the same outcome"
+    );
+}

--- a/crates/rig-core/src/serve/handler/tests.rs
+++ b/crates/rig-core/src/serve/handler/tests.rs
@@ -495,3 +495,118 @@ async fn provider_context_survives_inner_dispatch_and_explicit_call_context_wins
         )));
     }
 }
+
+/// Recording is consumer-invisible: whatever shape a handler answers in —
+/// a completed response, a setup failure, a stream with an in-band error,
+/// one cut short before its terminal, one with a frame after it — the
+/// items a streaming consumer receives and the outcome a unary consumer
+/// receives are the same with an observer attached and without one, and
+/// the observer is told exactly one outcome.
+#[test]
+fn an_observer_never_changes_what_the_consumer_receives() {
+    use crate::{
+        message::{AssistantContent, DocumentSourceKind, Image},
+        streaming::{BlockId, StreamFinal, UnknownPayload},
+    };
+
+    type Shape = fn() -> Reply;
+    fn terminal() -> Result<StreamEvent, ErrorReport> {
+        Ok(StreamEvent::Final(StreamFinal::new(
+            "test",
+            Default::default(),
+        )))
+    }
+    fn text(fragment: &str) -> Result<StreamEvent, ErrorReport> {
+        Ok(StreamEvent::text(
+            BlockId::minted(crate::streaming::MintKind::Text, 0),
+            fragment,
+        ))
+    }
+    fn items(items: Vec<Result<StreamEvent, ErrorReport>>) -> Reply {
+        Reply::Stream(Box::pin(futures::stream::iter(items)))
+    }
+    let shapes: [(&str, Shape); 6] = [
+        ("a completed response with an image", || {
+            Reply::Outcome(Ok(Outcome::Completion(CompletionResponse::new(
+                vec![
+                    AssistantContent::text("done"),
+                    AssistantContent::Image(Image {
+                        data: DocumentSourceKind::base64("aW1hZ2U="),
+                        ..Image::default()
+                    }),
+                ],
+                Default::default(),
+                "test",
+            ))))
+        }),
+        ("a setup failure", || {
+            Reply::Outcome(Err(ErrorReport::new(ErrorKind::Provider, "refused")))
+        }),
+        ("an in-band error before the terminal", || {
+            items(vec![
+                Err(ErrorReport::new(ErrorKind::Response, "mid-stream")),
+                text("after"),
+                terminal(),
+            ])
+        }),
+        ("a stream cut short before its terminal", || {
+            items(vec![text("prefix")])
+        }),
+        ("a frame after the terminal", || {
+            items(vec![
+                text("body"),
+                terminal(),
+                Ok(StreamEvent::Unknown(UnknownPayload::new(
+                    serde_json::json!({
+                        "late": true
+                    }),
+                ))),
+            ])
+        }),
+        ("a stream that ends at once", || items(Vec::new())),
+    ];
+    for (name, shape) in shapes {
+        for streaming in [true, false] {
+            let seen = Arc::new(Mutex::new(Seen::default()));
+            let observed = Observed {
+                observer: Box::new(Observer(seen.clone())),
+                told: false,
+            };
+            let (bare, watched) = if streaming {
+                (
+                    serde_json::to_value(block_on(
+                        shape()
+                            .observed(true, None, None)
+                            .into_stream()
+                            .collect::<Vec<_>>(),
+                    )),
+                    serde_json::to_value(block_on(
+                        shape()
+                            .observed(true, Some(observed), None)
+                            .into_stream()
+                            .collect::<Vec<_>>(),
+                    )),
+                )
+            } else {
+                (
+                    serde_json::to_value(block_on(
+                        shape().observed(false, None, None).into_outcome(),
+                    )),
+                    serde_json::to_value(block_on(
+                        shape().observed(false, Some(observed), None).into_outcome(),
+                    )),
+                )
+            };
+            assert_eq!(
+                bare.expect("serde"),
+                watched.expect("serde"),
+                "{name}, streaming: {streaming}"
+            );
+            assert_eq!(
+                seen.lock().expect("seen").outcomes.len(),
+                1,
+                "{name}, streaming: {streaming}: one outcome told"
+            );
+        }
+    }
+}

--- a/crates/rig-core/src/serve/handler/tests.rs
+++ b/crates/rig-core/src/serve/handler/tests.rs
@@ -517,10 +517,7 @@ fn an_observer_never_changes_what_the_consumer_receives() {
         )))
     }
     fn text(fragment: &str) -> Result<StreamEvent, ErrorReport> {
-        Ok(StreamEvent::text(
-            BlockId::minted(crate::streaming::MintKind::Text, 0),
-            fragment,
-        ))
+        Ok(StreamEvent::text(BlockId::wire("text-0"), fragment))
     }
     fn items(items: Vec<Result<StreamEvent, ErrorReport>>) -> Reply {
         Reply::Stream(Box::pin(futures::stream::iter(items)))

--- a/crates/rig-core/src/serve/layer/tests.rs
+++ b/crates/rig-core/src/serve/layer/tests.rs
@@ -561,3 +561,117 @@ async fn tool_argument_patches_keep_the_bound_target_and_reach_inner_policy() {
     );
     assert_eq!(tap.patched.lock().expect("patches").len(), 1);
 }
+
+/// A layered dispatch is resolved exactly once whichever future is dropped:
+/// the layer's own (its inner handler still pending, the observer moved
+/// inward by `Dispatch::inner`) resolves the record as cancelled once; a
+/// layer whose `after` is dropped mid-decision leaves the handler's answer
+/// as the one resolution, with no cancellation after it.
+#[test]
+fn a_dropped_layer_resolves_its_record_exactly_once() {
+    use std::task::Context;
+
+    use futures::task::noop_waker_ref;
+
+    use super::super::Resolver;
+
+    /// Answers when told to, from outside.
+    struct Deferred(Arc<Mutex<Option<Resolver>>>);
+    impl Serve for Deferred {
+        type Family = family::Dynamic;
+        fn descriptor(&self) -> HandlerDescriptor {
+            HandlerDescriptor {
+                key: HandlerKey::from("deferred"),
+                family: FamilyDescriptor::Custom {
+                    kind: "test".into(),
+                },
+                layers: Vec::new(),
+            }
+        }
+        async fn serve(&self, _: EffectKind, _: Dispatch) -> Reply {
+            let (resolver, answer) = super::super::deferred();
+            *self.0.lock().expect("slot") = Some(resolver);
+            Reply::Outcome(answer.await)
+        }
+    }
+    /// Decides `after` only when told to, from outside.
+    struct Deciding(Arc<Mutex<Option<futures::channel::oneshot::Sender<()>>>>);
+    impl Intercept for Deciding {
+        fn name(&self) -> String {
+            "deciding".to_owned()
+        }
+        async fn before(&self, _: EffectId, _: &EffectKind) -> Decision {
+            Decision::Proceed
+        }
+        async fn after(
+            &self,
+            _: EffectId,
+            _: &EffectKind,
+            _: &Result<Outcome, ErrorReport>,
+        ) -> Verdict {
+            let (decide, decided) = futures::channel::oneshot::channel();
+            *self.0.lock().expect("slot") = Some(decide);
+            let _ = decided.await;
+            Verdict::Keep
+        }
+    }
+
+    // The layer's future dropped while its handler is pending.
+    let slot = Arc::new(Mutex::new(None));
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let handler = ErasedHandler::new(Deferred(slot.clone())).layered(Policy::observing("p", &seen));
+    let tap = Arc::new(Tapped::default());
+    let mut serving = handler.handle(
+        custom(json!(1)),
+        tapped(Dispatch::new(EffectId::from_raw(1), false), &tap),
+    );
+    assert!(
+        serving
+            .as_mut()
+            .poll(&mut Context::from_waker(noop_waker_ref()))
+            .is_pending()
+    );
+    let resolver = slot
+        .lock()
+        .expect("slot")
+        .take()
+        .expect("the handler is waiting");
+    drop(serving);
+    assert!(resolver.is_closed());
+    {
+        let outcomes = tap.outcomes.lock().expect("outcomes");
+        assert_eq!(outcomes.len(), 1, "{outcomes:?}");
+        assert_eq!(
+            outcomes[0].as_ref().expect_err("cancelled").kind,
+            ErrorKind::Cancelled
+        );
+    }
+
+    // The layer's `after` dropped while it decides: the handler answered,
+    // the record holds that answer, and nothing else is told.
+    let (handler, _served) = echo();
+    let decide = Arc::new(Mutex::new(None));
+    let handler = handler.layered(Deciding(decide.clone()));
+    let tap = Arc::new(Tapped::default());
+    let mut serving = handler.handle(
+        custom(json!(2)),
+        tapped(Dispatch::new(EffectId::from_raw(2), false), &tap),
+    );
+    assert!(
+        serving
+            .as_mut()
+            .poll(&mut Context::from_waker(noop_waker_ref()))
+            .is_pending()
+    );
+    assert!(
+        decide.lock().expect("slot").is_some(),
+        "`after` is deciding"
+    );
+    drop(serving);
+    let outcomes = tap.outcomes.lock().expect("outcomes");
+    assert_eq!(outcomes.len(), 1, "{outcomes:?}");
+    assert!(
+        matches!(&outcomes[0], Ok(Outcome::Custom { payload }) if payload == &json!(2)),
+        "the handler's answer is the one resolution: {outcomes:?}"
+    );
+}

--- a/crates/rig-ecs/src/bus/collect.rs
+++ b/crates/rig-ecs/src/bus/collect.rs
@@ -364,12 +364,14 @@ pub fn settle(
                 }
             }
         }
-        commands.entity(entity).remove::<(
-            InFlight,
-            Observed,
-            CollectedOutcome,
-            super::record::ReplacedBy,
-        )>();
+        // The collection marker goes first, on its own: the `Remove<InFlight>`
+        // observers read its absence as "settled" and its presence as an
+        // answered effect leaving flight unsettled (a despawn from the
+        // outcome observer), whose record they close instead.
+        commands.entity(entity).remove::<CollectedOutcome>();
+        commands
+            .entity(entity)
+            .remove::<(InFlight, Observed, super::record::ReplacedBy)>();
         progress.mark();
     }
 }

--- a/crates/rig-ecs/src/bus/plugin.rs
+++ b/crates/rig-ecs/src/bus/plugin.rs
@@ -59,7 +59,8 @@ impl Progress {
 
 /// How many effects `Dispatch` has taken this tick, against
 /// [`ServingPolicy::command_capacity`]: the per-tick intake bound. Reset by
-/// the runner at the start of every tick.
+/// the runner at the start of every tick, and at the start of every pass a
+/// host runs itself (each such pass is that host's tick).
 #[derive(Resource, Debug, Default, Clone, Copy)]
 pub struct Intake(pub usize);
 
@@ -211,3 +212,6 @@ pub fn run_to_quiescence(world: &mut World) {
         .resource_mut::<super::collect::CollectionBudget>()
         .in_runner = false;
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/rig-ecs/src/bus/plugin/tests.rs
+++ b/crates/rig-ecs/src/bus/plugin/tests.rs
@@ -1,0 +1,74 @@
+#![allow(clippy::unwrap_used)]
+use super::*;
+use crate::bus::{Handlers, Issued, PendingEffect};
+use rig_core::effect::{EffectKind, FamilyDescriptor};
+
+fn custom() -> EffectKind {
+    EffectKind::Custom {
+        kind: "test".into(),
+        payload: serde_json::Value::Null,
+    }
+}
+
+fn world_with_capacity(command_capacity: usize, pending: usize) -> World {
+    let mut world = World::new();
+    install_bus(
+        &mut world,
+        ServingPolicy {
+            command_capacity,
+            ..ServingPolicy::default()
+        },
+    );
+    Handlers::with(&mut world, |handlers| {
+        handlers.register_open(
+            "open",
+            FamilyDescriptor::Custom {
+                kind: "test".into(),
+            },
+        )
+    })
+    .unwrap()
+    .unwrap();
+    for _ in 0..pending {
+        world.spawn(PendingEffect::new("open", custom()));
+    }
+    world
+}
+
+fn issued(world: &mut World) -> usize {
+    world.query::<&Issued>().iter(world).count()
+}
+
+/// The intake bound measures issues per tick: the runner takes at most
+/// `command_capacity` effects in one tick, however many passes the tick
+/// runs, and the rest wait for later ticks rather than for anything else.
+#[test]
+fn the_runner_bounds_intake_per_tick_and_the_rest_wait_for_later_ticks() {
+    let mut world = world_with_capacity(2, 5);
+    run_to_quiescence(&mut world);
+    assert_eq!(issued(&mut world), 2, "one tick issues at most the bound");
+    run_to_quiescence(&mut world);
+    assert_eq!(issued(&mut world), 4);
+    run_to_quiescence(&mut world);
+    assert_eq!(issued(&mut world), 5);
+}
+
+/// A host that runs `RigSchedule` itself, pass by pass (as `DeliveryBatch`
+/// and the collection budget support), never calls the runner that resets
+/// the tick's intake. Each of its passes is a tick for the bound: a queue
+/// longer than `command_capacity` drains over several passes instead of
+/// stalling at the bound for the life of the world.
+#[test]
+fn a_host_driven_pass_is_a_tick_for_the_intake_bound() {
+    let mut world = world_with_capacity(2, 5);
+    world.run_schedule(RigSchedule);
+    assert_eq!(issued(&mut world), 2, "one pass issues at most the bound");
+    for _ in 0..4 {
+        world.run_schedule(RigSchedule);
+    }
+    assert_eq!(
+        issued(&mut world),
+        5,
+        "the intake bound must reset for every host-driven pass"
+    );
+}

--- a/crates/rig-ecs/src/bus/record.rs
+++ b/crates/rig-ecs/src/bus/record.rs
@@ -106,14 +106,19 @@ impl Recording {
 #[derive(Resource, Default)]
 pub struct DeliveryBatch(pub u64);
 
-/// Begin the next pass's observation group.
+/// Begin the next pass's observation group. A pass the host runs itself
+/// (outside [`run_to_quiescence`](super::run_to_quiescence)) is that
+/// host's tick: its stream budget and its intake bound start afresh here,
+/// as the runner starts them at the top of each of its ticks.
 pub fn begin_delivery_pass(
     mut batch: ResMut<DeliveryBatch>,
     mut budget: ResMut<super::collect::CollectionBudget>,
+    mut intake: ResMut<super::plugin::Intake>,
 ) {
     batch.0 += 1;
     if !budget.in_runner {
         budget.remaining = super::collect::STREAM_WORK_PER_TICK;
+        intake.0 = 0;
     }
 }
 
@@ -340,6 +345,7 @@ impl rig_core::serve::Observe for WorldObserver {
 pub type CancellationView = (
     &'static Issued,
     Option<&'static EffectOutcome>,
+    Has<super::collect::CollectedOutcome>,
     Option<&'static super::effect::Publishing>,
     Option<&'static super::effect::ToolOutputs>,
     Option<&'static Observed>,
@@ -348,6 +354,12 @@ pub type CancellationView = (
 /// An in-flight effect losing `InFlight` without an outcome — a despawn,
 /// its own or an ancestor's — is a cancelled dispatch: the record says so,
 /// as it does when a consumer drops its `Pending` on rig-bus.
+///
+/// An effect losing `InFlight` with an outcome landed but not yet settled
+/// — despawned from the `On<Add, EffectOutcome>` observer that is its
+/// readiness signal, before `settle` ran — is an answered dispatch whose
+/// settlement will never happen: the record closes here with the answer
+/// the handler gave, as `settle` would have closed it.
 pub fn record_cancelled(
     removed: On<Remove, InFlight>,
     effects: Query<CancellationView>,
@@ -357,27 +369,45 @@ pub fn record_cancelled(
     let Some(recording) = recording else {
         return;
     };
-    if let Ok((Issued(id), None, publishing, outputs, observed)) =
+    let Ok((Issued(id), outcome, collected, publishing, outputs, observed)) =
         effects.get(removed.event().entity)
-    {
-        let original = observed.and_then(|observed| observed.0.take_outcome());
-        if observed.is_some_and(|observed| observed.0.is_discarded()) {
-            return;
+    else {
+        return;
+    };
+    if observed.is_some_and(|observed| observed.0.is_discarded()) {
+        return;
+    }
+    match outcome {
+        // Landed but not settled: `settle` retires `CollectedOutcome` before
+        // it retires `InFlight`, so its presence here means settlement never
+        // ran (the entity is being despawned with its answer on it).
+        Some(EffectOutcome(landed)) if collected => {
+            let original = observed.and_then(|observed| observed.0.take_outcome());
+            if observed.is_none()
+                && let Some(outputs) = outputs
+            {
+                recording.tool_output(*id, outputs.0.result_context());
+            }
+            recording.resolve(*id, original.unwrap_or_else(|| landed.clone()));
         }
-        let output = publishing
-            .and_then(|published| published.0.result_context())
-            .or_else(|| outputs.map(|outputs| outputs.0.result_context()));
-        if let Some(output) = output {
-            recording.tool_output(*id, output);
+        Some(_) => {}
+        None => {
+            let original = observed.and_then(|observed| observed.0.take_outcome());
+            let output = publishing
+                .and_then(|published| published.0.result_context())
+                .or_else(|| outputs.map(|outputs| outputs.0.result_context()));
+            if let Some(output) = output {
+                recording.tool_output(*id, output);
+            }
+            if original.as_ref().is_some_and(|answer| {
+                !answer
+                    .as_ref()
+                    .is_err_and(|error| error.kind == rig_core::error::ErrorKind::Cancelled)
+            }) {
+                recording.delivery(batch.0, *id, rig_core::effect::DeliveryKind::Cancelled);
+            }
+            recording.resolve(*id, original.unwrap_or_else(|| Err(cancelled())));
         }
-        if original.as_ref().is_some_and(|answer| {
-            !answer
-                .as_ref()
-                .is_err_and(|error| error.kind == rig_core::error::ErrorKind::Cancelled)
-        }) {
-            recording.delivery(batch.0, *id, rig_core::effect::DeliveryKind::Cancelled);
-        }
-        recording.resolve(*id, original.unwrap_or_else(|| Err(cancelled())));
     }
 }
 

--- a/crates/rig-ecs/src/bus/record/tests.rs
+++ b/crates/rig-ecs/src/bus/record/tests.rs
@@ -97,8 +97,8 @@ fn a_despawn_from_the_outcome_observer_still_closes_the_record() {
         "the observer despawned the effect as its outcome landed"
     );
     let log = recorder.log();
+    assert_eq!(log.len(), 1, "the record closed: {log:?}");
     let record = log.first().unwrap();
-    assert_eq!(log.len(), 1, "one record: {log:?}");
     assert_eq!(
         serde_json::to_value(&record.outcome).unwrap(),
         serde_json::to_value(Ok::<_, ErrorReport>(answer)).unwrap(),

--- a/crates/rig-ecs/src/bus/record/tests.rs
+++ b/crates/rig-ecs/src/bus/record/tests.rs
@@ -46,3 +46,62 @@ fn cancellation_and_terminal_observation_have_one_recording_boundary() {
         assert!(!observed.is_discarded());
     }
 }
+
+/// The readiness signal the module names — an `On<Add, EffectOutcome>`
+/// observer — may consume the answer and despawn the effect right there.
+/// The record still closes with the answer the handler gave: the despawn
+/// reaches `Remove<InFlight>` with the outcome landed but not yet settled,
+/// and that outcome, not a cancellation and not silence, is what the
+/// record takes.
+#[test]
+fn a_despawn_from_the_outcome_observer_still_closes_the_record() {
+    use crate::bus::{Handlers, InFlight, PendingEffect, WorldOutcome, run_to_quiescence};
+    use rig_core::effect::FamilyDescriptor;
+
+    let mut world = World::new();
+    crate::bus::install_bus(&mut world, Default::default());
+    let recorder = rig_effect_log::EffectLogRecorder::new();
+    Recording::install(&mut world, recorder.clone());
+    Handlers::with(&mut world, |handlers| {
+        handlers.register_open(
+            "open",
+            FamilyDescriptor::Custom {
+                kind: "test".into(),
+            },
+        )
+    })
+    .unwrap()
+    .unwrap();
+    world.add_observer(|added: On<Add, EffectOutcome>, mut commands: Commands| {
+        commands.entity(added.event().entity).despawn();
+    });
+    let kind = EffectKind::Custom {
+        kind: "test".into(),
+        payload: serde_json::Value::Null,
+    };
+    let effect = world.spawn(PendingEffect::new("open", kind)).id();
+    run_to_quiescence(&mut world);
+    assert!(
+        world.get::<InFlight>(effect).is_some(),
+        "issued to the open key"
+    );
+    let answer = Outcome::Custom {
+        payload: serde_json::json!("answered"),
+    };
+    world
+        .entity_mut(effect)
+        .insert(WorldOutcome::new(Ok(answer.clone())));
+    run_to_quiescence(&mut world);
+    assert!(
+        world.get_entity(effect).is_err(),
+        "the observer despawned the effect as its outcome landed"
+    );
+    let log = recorder.log();
+    let record = log.first().unwrap();
+    assert_eq!(log.len(), 1, "one record: {log:?}");
+    assert_eq!(
+        serde_json::to_value(&record.outcome).unwrap(),
+        serde_json::to_value(Ok::<_, ErrorReport>(answer)).unwrap(),
+        "the record holds the handler's answer, not a cancellation"
+    );
+}

--- a/crates/rig-effect-log/src/replay.rs
+++ b/crates/rig-effect-log/src/replay.rs
@@ -638,9 +638,15 @@ impl Serve for EffectLogReplayer {
                         }
                         // Merge kept successful events and errors by original item
                         // position, including late frames after the first terminal.
-                        // A setup failure may have a folded error without any
-                        // stream items. A canonical truncation is reconstructed by EOF,
-                        // not an invented in-band error.
+                        // The record's outcome is appended as one last error item
+                        // only when nothing kept produces it: not an error item
+                        // (kept at its position), not the fold of the kept events
+                        // (a terminal, or a malformed block the consumer's own
+                        // fold reports again — appending it would hand the
+                        // consumer an item the live stream never carried), and
+                        // not a truncation (reconstructed by EOF, never an
+                        // invented in-band error). What remains is an outcome
+                        // the stream never reached — a cancellation mid-stream.
                         if let (Some(events), true) = (record.events, dispatch.is_stream()) {
                             let errors = self
                                 .stream_errors
@@ -648,17 +654,18 @@ impl Serve for EffectLogReplayer {
                                 .cloned()
                                 .unwrap_or_default();
                             let mut tap = rig_core::serve::StreamTap::new();
-                            let truncated = errors.is_empty()
-                                && record.outcome.as_ref().is_err_and(|error| {
-                                    error == &rig_core::serve::stream_truncated()
-                                })
-                                && !events
-                                    .iter()
-                                    .any(|event| tap.observe(&Ok(event.clone())).is_some());
-                            let fallback = if errors.is_empty() && !truncated {
-                                record.outcome.err()
-                            } else {
-                                None
+                            let folded = events
+                                .iter()
+                                .any(|event| tap.observe(&Ok(event.clone())).is_some());
+                            let fallback = match record.outcome {
+                                Err(error)
+                                    if errors.is_empty()
+                                        && !folded
+                                        && error != rig_core::serve::stream_truncated() =>
+                                {
+                                    Some(error)
+                                }
+                                Ok(_) | Err(_) => None,
                             };
                             let total = events.len() + errors.len();
                             let mut errors = errors.into_iter().peekable();


### PR DESCRIPTION
## Description

Targeted correctness hardening of the effect bus introduced in #2443. This child PR targets `feat/effect-bus`. Each fix comes from a concrete interleaving or state that the existing suites did not cover; every fix has a reproducer that fails on the parent head (`665560617`) and passes after. Existing streaming, replay, cancellation and publication guarantees are unchanged. Four are liveness or record-loss defects, one is replay fidelity, one is a misdiagnosis.

- **Bus, parked senders.** `Shared::drain` woke the senders parked on a full command buffer only when it took a command. When `fail_cancelled_buffered` dropped an orphaned descendant from the buffer, the drain that followed found it empty and woke nobody: a sender that had parked in between (a handler's nested dispatch, or a consumer on another executor thread) waited for an enqueue that might never come. A drain now releases every parked sender; a woken sender that finds the buffer full again parks again. Loom model `loom_capacity_freed_by_orphan_removal_wakes_a_parked_sender` over the production `enqueue`/`cancel_descendants`/`fail_cancelled_buffered`/`drain` fails on the parent and passes here.
- **Agent driver, lost wakeup between runs.** `Driven::finish` and `Drop for Driven` unregistered the run's waker and woke nobody. Two runs on clones of one agent on a multi-threaded runtime: run B enqueues while A holds the driver lock (the wake reaches A alone, B registers only after its inner poll), B's `try_lock` fails, A's inner completes on that poll and A ends; B's command sits in the buffer with nothing polling the driver. Both paths now wake the registered runs after unregistering. Pinned by `agent/drive/tests.rs` and by `loom_two_contending_runs_both_complete`, which drives two real `Driven`s from two threads and fails on the parent ("a run pending on the bus was never woken").
- **ECS, intake bound for host-driven passes.** `Intake` was reset only by `run_to_quiescence`; a host running `RigSchedule` itself (the supported mode `DeliveryBatch` and the collection budget already treat as a tick) issued at most `command_capacity` effects for the life of the world and then stalled silently. `begin_delivery_pass` now resets intake for a host-run pass. `plugin/tests.rs` states what the bound measures (issues per tick) in both modes.
- **ECS, record lost on despawn from the readiness observer.** Despawning an effect from its `On<Add, EffectOutcome>` observer — the readiness signal the module documents — removed `InFlight` with the outcome landed but not yet settled; `settle` found no entity and `record_cancelled` only handled a missing outcome, so the record never closed and was absent from the log. `record_cancelled` now closes a landed-but-unsettled record with the observed (or landed) answer and its tool output, as `settle` would have.
- **Effect log, kept-events replay of a fold error.** A stream whose fold fails (a tool call closed with malformed arguments under `UnparseableToolInput::Error`) is delivered live as `Ok` items and recorded with the fold's error as its outcome. The replayer appended that outcome as one more `Err` item the live consumer never received, and a re-record gained a `stream_errors` entry the golden lacks. The outcome is appended only when nothing kept produces it: no error item, no fold of the kept events, not a truncation — which leaves a mid-stream cancellation, replayed as before.
- **Builder, recording over a host's bus.** `AgentBuilder::over_bus(..).record_effects().build()` routed the refusal through `register_generated`: a debug assertion about generated keys changing family, and in release an agent that silently recorded nothing. It is now refused at build at the host's `over_bus` line, the same treatment as a wrong-family host key; `record_effects` documents it.

Two pins with no behaviour change: recording is consumer-invisible across six reply shapes (`an_observer_never_changes_what_the_consumer_receives`), and a layered dispatch is resolved exactly once whichever future is dropped (`a_dropped_layer_resolves_its_record_exactly_once`).

Loom bounds: the two new models run under `LOOM_MAX_PREEMPTIONS=3` like the existing thirteen; they explore the production synchronisation operations named above, with `Waker`s and `futures` channels treated as data, and they are bounded exploration of those operations, not a proof of the whole runtime or of Bevy scheduling.

## Changelog

- *(rig-agent)* A sender parked on the bus's full command buffer is woken whenever the driver drains, so capacity freed by an orphaned descendant's removal never strands it.
- *(rig-agent)* A run that finishes or is dropped wakes the other runs on its agent, so a run that found the driver busy under the last poll takes over instead of hanging with its command buffered.
- *(rig-agent)* `AgentBuilder::over_bus(..).record_effects()` is refused at build at the `over_bus` line instead of a debug assertion about generated keys (release builds recorded nothing).
- *(rig-ecs)* A host that runs `RigSchedule` itself gets a fresh intake bound every pass instead of stalling after `command_capacity` issues.
- *(rig-ecs)* An effect despawned from its `On<Add, EffectOutcome>` observer still closes its record with the handler's answer.
- *(rig-effect-log)* A kept-events replay of a stream whose fold failed re-emits the live items only; the folded error is no longer appended as an extra error item.

## Migration

None. `AgentBuilder::over_bus(..).record_effects().build()` now panics at build in every profile with a message naming the `over_bus` call site; it panicked in debug builds before (with a message about generated keys) and produced a non-recording agent in release. Record through the host's driver (`BusDriver::record_to`) instead.

## Type of change

- [x] Bug fix

## Testing

Head `d28505ee7`, base `origin/feat/effect-bus` = `665560617`. All runs local, replay mode, task-owned target directory, wasm-bindgen-test-runner 0.2.118 (lockfile match).

- Each reproducer was run against the base and fails there: `loom_capacity_freed_by_orphan_removal_wakes_a_parked_sender`, `loom_two_contending_runs_both_complete`, both `agent::drive::tests`, `plugin::tests::a_host_driven_pass_is_a_tick_for_the_intake_bound`, `record::tests::a_despawn_from_the_outcome_observer_still_closes_the_record`, `kept_events_replay_a_fold_error_as_the_items_that_produced_it`, `recording_over_a_host_bus_is_refused_at_build` (the base panics with a different message).
- Loom: `RUSTFLAGS=--cfg rig_loom LOOM_MAX_PREEMPTIONS=3 cargo test -p rig-agent --lib --release loom_`: 15 passed.
- `cargo nextest run -p rig-agent -p rig-ecs -p rig-effect-log -p rig-verify -p rig-core --all-features`: 3668 passed, 2 skipped.
- `cargo clippy --all-features --all-targets -- -D warnings` on the touched crates, `cargo fmt --all -- --check`, workspace docs with `-D warnings`, `git diff --check`: passed.
- wasm: `bus_wasm` (rig-agent), `bus_wasm` and `run_wasm` (rig-ecs) under wasm32-unknown-unknown: passed.
- `RIG_PROVIDER_TEST_MODE=replay cargo xtask verify --pr --base origin/feat/effect-bus`: 28 selected checks passed (fmt, source-guards, tooling, clippy, default-check, default-tests, scenario-registrations, core-all, bus-verification, macro-hygiene, conformance, derive, doctests, docs, loom, the nine wasm lanes, three wasm test targets, native-only guards). `full-tests`, `workspace-check`, `dependency-floors` were outside the PR selection (no full-lane inputs). The first attempt stopped at `default-tests` on the stream-id guard, fixed in `d28505ee7`; the plan was continued with `--reuse` and every check executed (none reused), then repeated from scratch without reuse (result below).
- Independent full-diff review by a reviewer who did not implement the change: approve with two P2 test-strength fixes and three nits, all applied; final pass on the fix commits: approve.

A second, fresh plan without reuse on the same head (`d28505ee7`) passed all 28 selected checks as well (default-tests 7008 passed, core-all 2667, bus-verification 815).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated READMEs and Rust docs affected by this change
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did not edit `CHANGELOG.md` or `MIGRATING.md` (they are generated at release)

## Notes

Confirmed by audit but deliberately left out of this PR (design rulings or format changes, reported in the task handoff): the bare-`Held` idiom releasing a batch-owned hold under `ToolPolicy.concurrency`; positional replay guessing between identical-payload records (no resolution ordinal); a resumed rig-agent run not appending its last turn to memory; a hook dispatch to the run's in-flight key deadlocking under `serial_per_handler`; `Scene::load` not refusing ids already issued in the destination world. This child review certifies the diff here, not the whole #2443 architecture.
