### PR TITLE
test: stream-fault cells for both runtimes, and a replay session that cannot be dropped unfinished

### DIFF
--- a/crates/rig-cassette/README.md
+++ b/crates/rig-cassette/README.md
@@ -15,8 +15,13 @@ Pass a fixture root containing provider directories to `ProviderCassette::start`
 
 `CassetteSpec::new` preserves strict interaction order; `.unordered()` permits
 matching any unused interaction. `finish` checks complete consumption and shuts
-down the replay server. Invalid fixtures and failed assertions panic, preserving
-the original test-support behavior.
+down the replay server. A replay session dropped without `finish` panics when
+it still holds an unplayed interaction or a refused request, so a test that
+returns early cannot pass on a recording it never played to the end. The guard
+stays silent while the thread is already panicking, for a fully played session,
+and after `finish_after_test_result` returns a test's own error. Invalid
+fixtures and failed assertions panic, preserving the original test-support
+behavior.
 
 `RIG_PROVIDER_TEST_MODE` defaults to `replay`. `record` contacts the configured
 upstream and overwrites the selected fixture after scrubbing. Controlled offline

--- a/crates/rig-cassette/src/lib.rs
+++ b/crates/rig-cassette/src/lib.rs
@@ -641,7 +641,7 @@ impl ProviderCassette {
 
     /// Finalize after a successful fallible test, preserving its failure otherwise.
     pub async fn finish_after_test_result<E>(
-        self,
+        mut self,
         test_result: Result<Result<(), E>, PanicPayload>,
     ) -> Result<(), E> {
         match test_result {
@@ -651,8 +651,19 @@ impl ProviderCassette {
                 }
                 Ok(())
             }
-            Ok(Err(error)) => Err(error),
+            Ok(Err(error)) => {
+                // The test's own failure is the report; the session it left
+                // unplayed must not replace it with the drop guard's.
+                self.disarm_drop_guard();
+                Err(error)
+            }
             Err(payload) => resume_unwind(payload),
+        }
+    }
+
+    fn disarm_drop_guard(&mut self) {
+        if let CassetteServer::Replay(server) = &mut self.server {
+            server.checked = true;
         }
     }
 
@@ -666,6 +677,8 @@ struct ReplayServer {
     state: Arc<Mutex<ReplayState>>,
     shutdown: Option<oneshot::Sender<()>>,
     task: Option<JoinHandle<()>>,
+    /// `finish` asserted consumption: the drop guard has nothing to add.
+    checked: bool,
 }
 
 impl ReplayServer {
@@ -714,6 +727,7 @@ impl ReplayServer {
             state,
             shutdown: Some(shutdown_tx),
             task: Some(task),
+            checked: false,
         }
     }
 
@@ -721,7 +735,8 @@ impl ReplayServer {
         format!("http://{}", self.addr)
     }
 
-    async fn assert_consumed(&self, cassette_path: &Path) {
+    async fn assert_consumed(&mut self, cassette_path: &Path) {
+        self.checked = true;
         let state = self.state.lock().await;
         assert_replay_finished(cassette_path, &state.interactions, &state.misses);
     }
@@ -741,6 +756,23 @@ impl Drop for ReplayServer {
     fn drop(&mut self) {
         if let Some(shutdown) = self.shutdown.take() {
             let _ = shutdown.send(());
+        }
+        if self.checked || std::thread::panicking() {
+            return;
+        }
+        // A session dropped without `finish` — a test that returned early,
+        // a helper that forgot — would otherwise pass on a recording it
+        // never played to the end, or on a request the replay refused. Only
+        // that evidence panics; a fully consumed session may end silently.
+        let Ok(state) = self.state.try_lock() else {
+            return;
+        };
+        if let Some(message) = replay_completion_failure_message(
+            &state.cassette_path,
+            &state.interactions,
+            &state.misses,
+        ) {
+            panic!("{message}\n(the replay session was dropped without `finish`)");
         }
     }
 }
@@ -3337,6 +3369,8 @@ pub fn owned_headers(headers: &http_client::HeaderMap) -> Vec<(String, String)> 
 
 #[cfg(test)]
 mod paths;
+#[cfg(test)]
+mod replay_session_tests;
 
 #[cfg(test)]
 mod cached_content_scrub_tests;

--- a/crates/rig-cassette/src/replay_session_tests.rs
+++ b/crates/rig-cassette/src/replay_session_tests.rs
@@ -1,0 +1,203 @@
+//! What a replay session refuses, end to end through `ProviderCassette`:
+//! an interaction left unplayed, a miss the caller swallowed, and a session
+//! dropped without `finish` while it holds either.
+
+use super::*;
+use futures::FutureExt;
+use serde_json::json;
+use std::panic::AssertUnwindSafe;
+
+/// A fixture of `answers.len()` ordered interactions on one route, each
+/// matching the body `{"input": <index>}`.
+fn write_fixture(root: &Path, scenario: &str, answers: &[&str]) {
+    let path = cassette_path(root, "example", scenario);
+    fs::create_dir_all(path.parent().expect("fixture parent")).expect("create fixture directory");
+    let interactions: Vec<_> = answers
+        .iter()
+        .enumerate()
+        .map(|(index, answer)| CassetteInteraction {
+            when: CassetteRequest {
+                path: "/v1/answer".into(),
+                method: "POST".into(),
+                query_param: Vec::new(),
+                header: vec![NameValue {
+                    name: "content-type".into(),
+                    value: "application/json".into(),
+                }],
+                body: Some(json!({ "input": index }).to_string()),
+                body_encoding: BodyEncoding::Utf8,
+            },
+            then: CassetteResponse {
+                status: 200,
+                header: Vec::new(),
+                body: Some((*answer).into()),
+                body_encoding: BodyEncoding::Utf8,
+            },
+        })
+        .collect();
+    fs::write(path, serialize_cassette_interactions(&interactions)).expect("write fixture");
+}
+
+async fn start(root: &Path, scenario: &'static str) -> ProviderCassette {
+    ProviderCassette::start(root, "example", scenario, "https://example.invalid/v1").await
+}
+
+/// Post `{"input": input}` to the session and return the status the replay
+/// answered with: the caller of a provider client sees nothing else.
+async fn post(cassette: &ProviderCassette, input: usize) -> StatusCode {
+    reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("HTTP client")
+        .post(format!("{}/answer", cassette.base_url()))
+        .json(&json!({ "input": input }))
+        .send()
+        .await
+        .expect("local replay response")
+        .status()
+}
+
+fn panic_message(payload: PanicPayload) -> String {
+    payload
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| payload.downcast_ref::<&str>().map(|s| (*s).to_owned()))
+        .expect("a string panic payload")
+}
+
+#[tokio::test]
+async fn finish_refuses_an_interaction_left_unplayed() {
+    let scratch = assert_fs::TempDir::new().expect("temporary fixtures");
+    let root = scratch.path().join("fixtures/cassettes");
+    write_fixture(
+        &root,
+        "pair",
+        &[r#"{"answer":"first"}"#, r#"{"answer":"second"}"#],
+    );
+    let cassette = start(&root, "pair").await;
+    assert_eq!(post(&cassette, 0).await, StatusCode::OK);
+
+    let outcome = AssertUnwindSafe(cassette.finish()).catch_unwind().await;
+
+    let message = panic_message(outcome.expect_err("an unplayed interaction fails finish"));
+    assert!(
+        message.contains("left unused interactions"),
+        "names the failure: {message}"
+    );
+    assert!(
+        message.contains("[1] POST /v1/answer"),
+        "names the interaction: {message}"
+    );
+}
+
+#[tokio::test]
+async fn finish_refuses_a_miss_the_caller_swallowed() {
+    let scratch = assert_fs::TempDir::new().expect("temporary fixtures");
+    let root = scratch.path().join("fixtures/cassettes");
+    write_fixture(&root, "single", &[r#"{"answer":"only"}"#]);
+    let cassette = start(&root, "single").await;
+    // A request the recording never saw: the replay refuses it, and a
+    // provider client would surface that as an ordinary HTTP failure the
+    // test body may well tolerate.
+    assert_eq!(post(&cassette, 7).await, StatusCode::NOT_FOUND);
+    assert_eq!(post(&cassette, 0).await, StatusCode::OK);
+
+    let outcome = AssertUnwindSafe(cassette.finish()).catch_unwind().await;
+
+    let message = panic_message(outcome.expect_err("a swallowed miss fails finish"));
+    assert!(
+        message.contains("received unexpected replay request(s)"),
+        "{message}"
+    );
+    assert!(
+        !message.contains("left unused interactions"),
+        "the recording itself was fully played: {message}"
+    );
+}
+
+#[tokio::test]
+async fn dropping_an_unfinished_session_reports_what_finish_would_have() {
+    let scratch = assert_fs::TempDir::new().expect("temporary fixtures");
+    let root = scratch.path().join("fixtures/cassettes");
+    write_fixture(
+        &root,
+        "pair",
+        &[r#"{"answer":"first"}"#, r#"{"answer":"second"}"#],
+    );
+
+    let outcome = AssertUnwindSafe(async {
+        let cassette = start(&root, "pair").await;
+        assert_eq!(post(&cassette, 0).await, StatusCode::OK);
+        // Returned without `finish`: the second interaction was never played.
+        drop(cassette);
+    })
+    .catch_unwind()
+    .await;
+
+    let message = panic_message(outcome.expect_err("the drop guard fails the test"));
+    assert!(message.contains("left unused interactions"), "{message}");
+    assert!(
+        message.contains("dropped without `finish`"),
+        "names the cause: {message}"
+    );
+}
+
+#[tokio::test]
+async fn dropping_a_fully_played_session_is_silent() {
+    let scratch = assert_fs::TempDir::new().expect("temporary fixtures");
+    let root = scratch.path().join("fixtures/cassettes");
+    write_fixture(&root, "single", &[r#"{"answer":"only"}"#]);
+
+    let cassette = start(&root, "single").await;
+    assert_eq!(post(&cassette, 0).await, StatusCode::OK);
+    drop(cassette);
+}
+
+#[tokio::test]
+async fn a_panicking_test_body_is_reported_not_the_guard() {
+    let scratch = assert_fs::TempDir::new().expect("temporary fixtures");
+    let root = scratch.path().join("fixtures/cassettes");
+    write_fixture(
+        &root,
+        "pair",
+        &[r#"{"answer":"first"}"#, r#"{"answer":"second"}"#],
+    );
+
+    // The body panics while the session is unplayed: the session unwinds
+    // with it, and the guard stays silent so the body's own panic is what
+    // the test reports.
+    let outcome = AssertUnwindSafe(async {
+        let cassette = start(&root, "pair").await;
+        assert_eq!(post(&cassette, 0).await, StatusCode::OK);
+        panic!("the assertion the test was about");
+    })
+    .catch_unwind()
+    .await;
+
+    let message = panic_message(outcome.expect_err("the body panics"));
+    assert_eq!(message, "the assertion the test was about");
+}
+
+#[tokio::test]
+async fn a_fallible_tests_own_error_survives_an_unplayed_session() {
+    let scratch = assert_fs::TempDir::new().expect("temporary fixtures");
+    let root = scratch.path().join("fixtures/cassettes");
+    write_fixture(
+        &root,
+        "pair",
+        &[r#"{"answer":"first"}"#, r#"{"answer":"second"}"#],
+    );
+    let cassette = start(&root, "pair").await;
+    assert_eq!(post(&cassette, 0).await, StatusCode::OK);
+
+    // The fallible wrapper returns the test's error; the session it leaves
+    // unplayed must not turn that into a panic.
+    let outcome = AssertUnwindSafe(cassette.finish_after_test_result(Ok(Err("the test's error"))))
+        .catch_unwind()
+        .await;
+
+    assert_eq!(
+        outcome.expect("no panic replaces the test's error"),
+        Err("the test's error")
+    );
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -444,6 +444,25 @@ Run a native family using its catalog binary and test module, for example:
 cargo test --locked -p rig --test anthropic ecs_outcome -- --nocapture
 ```
 
+### Stream-fault cells
+
+`tests/providers/{gemini,openai}/cassette/stream_faults.rs` and their
+`ecs_stream_faults.rs` twins drive the runner and the native runtime through
+the real adapter into a stream that ends badly: the committed error
+recordings for a setup failure, the committed text stream dropped by its
+consumer, and scripted faults served by `rig::test_utils`'s sequenced
+transport — a recording cut before its terminal (`tests/common/stream_faults.rs`),
+a Gemini refusal, an in-band error after content. Every scripted frame is a
+labelled constant with its provenance beside the cell; no cassette is
+hand-edited and no new fixture is committed. A scripted cell pins what the
+runtime does with the fault (the failure kind, the record, the committed
+history, the tools that never ran, the witness's facts); the request shape it
+would have sent is pinned by the recording's owning test, not by the cell.
+The same fault classifies differently by wire — Gemini's HTTP error envelope
+is `ErrorKind::Http { status }`, the Responses wire's is `ProviderResponse` —
+because the two go through different funnels in `rig_core::provider_response`
+(with and without a captured request id); the cells pin each wire's own kind.
+
 Historical execution logs, proof snapshots, review-application commands and
 archive infrastructure are intentionally not maintained. No historical download
 or cache is required for regression tests. Consumed cassettes and goldens remain

--- a/tests/common/stream_faults.rs
+++ b/tests/common/stream_faults.rs
@@ -1,0 +1,476 @@
+//! Scripted stream faults for the runner/native fault matrix.
+//!
+//! A fault cell serves a real provider adapter a stream that ends badly and
+//! asserts what each runtime does with it: the error it surfaces, the record
+//! it keeps, the history it commits, the tools it runs. The bodies are cut
+//! from committed recordings ([`recorded_sse_frames`]) or, where a wire only
+//! records single terminal frames, assembled from frames a real capture or
+//! the adapter's own unit tests pin; every synthetic frame is a labelled
+//! constant beside its cell. The scripted transport replaces the cassette
+//! proxy for those cells, so their request boundary is pinned by the
+//! recording's owning test, not here. Setup failures replay the committed
+//! error recordings through the ordinary cassette wrappers.
+#![allow(dead_code)]
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use bevy_app::App;
+use bevy_ecs::prelude::*;
+use bytes::Bytes;
+use futures::StreamExt;
+use rig::agent::{MultiTurnStreamItem, StreamingError, StreamingResult};
+use rig::completion::CompletionModel;
+use rig::completion::PromptError;
+use rig::effect::EffectFamily;
+use rig::error::{ErrorKind, ErrorReport};
+use rig::observe::{Action, AdapterEvent, ObservationLog};
+use rig::streaming::{Delta, StreamEvent};
+use rig::test_utils::SequencedStreamingHttpClient;
+use rig::tool::{Tool, ToolContext};
+use rig_ecs::{
+    agent::{Failure, Order, Role, Utterance},
+    bus::{Streamed, Witnessing},
+    systems::spawn_run,
+};
+use rig_effect_log::EffectLog;
+
+use crate::{
+    ecs_agent::EcsAgent,
+    goldens::families,
+    support::{MathError, OperationArgs, Subtract},
+};
+
+/// The recorded SSE frames of one interaction of a scenario: the response
+/// body split at its blank-line delimiters, in wire order.
+pub(crate) fn recorded_sse_frames(
+    provider: &str,
+    scenario: &str,
+    interaction: usize,
+) -> Vec<String> {
+    let recorded = crate::cassettes::recorded_statuses_and_bodies(provider, scenario);
+    let (status, body) = recorded
+        .get(interaction)
+        .unwrap_or_else(|| panic!("{provider}/{scenario} has no interaction {interaction}"));
+    assert_eq!(
+        *status, 200,
+        "{provider}/{scenario}[{interaction}] is not a successful stream"
+    );
+    let frames = sse_frames(body);
+    assert!(
+        frames.len() > 1,
+        "{provider}/{scenario}[{interaction}] streams one frame; nothing can be cut from it"
+    );
+    frames
+}
+
+/// A body's SSE frames, without their delimiters.
+pub(crate) fn sse_frames(body: &str) -> Vec<String> {
+    body.split("\n\n")
+        .filter(|frame| !frame.trim().is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// The frames before the first one `is_terminal` accepts: a recording cut
+/// short of its ending. At least one frame must precede the ending, or the
+/// cut would not be a truncation of anything.
+pub(crate) fn frames_before(frames: &[String], is_terminal: impl Fn(&str) -> bool) -> Vec<String> {
+    let end = frames
+        .iter()
+        .position(|frame| is_terminal(frame))
+        .expect("the recording carries the terminal frame to cut before");
+    assert!(end > 0, "no frame precedes the terminal");
+    frames[..end].to_vec()
+}
+
+/// The `data:` payload of an SSE frame, parsed.
+pub(crate) fn frame_data(frame: &str) -> serde_json::Value {
+    let data = frame
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("data: ")
+                .or_else(|| line.strip_prefix("data:"))
+        })
+        .unwrap_or_else(|| panic!("frame carries no data line: {frame}"));
+    serde_json::from_str(data).unwrap_or_else(|error| panic!("frame data is JSON: {error}: {data}"))
+}
+
+/// The wire bytes of `frames`, each followed by its delimiter.
+pub(crate) fn sse_bytes(frames: &[String]) -> Bytes {
+    let mut body = frames.join("\n\n");
+    body.push_str("\n\n");
+    Bytes::from(body)
+}
+
+/// A transport that answers its one streaming request with `chunks`, then
+/// EOF. A second request fails: every cell scripts exactly one exchange.
+pub(crate) fn scripted(chunks: Vec<Bytes>) -> SequencedStreamingHttpClient {
+    SequencedStreamingHttpClient::new(chunks.into_iter().map(Ok).collect())
+}
+
+/// What the runner's stream delivered before it ended.
+#[derive(Debug, Default)]
+pub(crate) struct Drained {
+    /// The text deltas, concatenated.
+    pub text: String,
+    /// Provider terminal records forwarded to the consumer.
+    pub terminals: usize,
+    /// Committed model tool calls.
+    pub tool_calls: usize,
+    /// Final responses: a successful run yields exactly one.
+    pub finals: usize,
+    /// Every error item, as a report.
+    pub errors: Vec<ErrorReport>,
+}
+
+/// Drain a runner stream to EOF.
+pub(crate) async fn drain(stream: &mut StreamingResult) -> Drained {
+    let mut drained = Drained::default();
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(MultiTurnStreamItem::StreamAssistantItem(StreamEvent::BlockDelta {
+                delta: Delta::Text { text },
+                ..
+            })) => drained.text.push_str(&text),
+            Ok(MultiTurnStreamItem::StreamAssistantItem(StreamEvent::Final(_))) => {
+                drained.terminals += 1;
+            }
+            Ok(MultiTurnStreamItem::ToolCall { .. }) => drained.tool_calls += 1,
+            Ok(MultiTurnStreamItem::FinalResponse(_)) => drained.finals += 1,
+            Ok(_) => {}
+            Err(error) => drained.errors.push(report_of(&error)),
+        }
+    }
+    drained
+}
+
+/// The report a runner stream error carries.
+pub(crate) fn report_of(error: &StreamingError) -> ErrorReport {
+    match error {
+        StreamingError::Completion(error) => ErrorReport::from(error),
+        StreamingError::Report(report) => report.clone(),
+        StreamingError::Prompt(error) => match &**error {
+            PromptError::Report(report) => report.clone(),
+            PromptError::CompletionError(error) => ErrorReport::from(error),
+            PromptError::PromptCancelled { reason, .. } => {
+                ErrorReport::new(ErrorKind::Cancelled, reason.clone())
+            }
+            other => panic!("a provider-shaped failure, not {other:?}"),
+        },
+    }
+}
+
+/// The log as JSON with its delivery batches removed: batch numbers count
+/// schedule passes, which a witness's extra work can shift by a tick, and
+/// the comparison guide already excludes them from golden equality.
+pub(crate) fn log_json_without_deliveries(log: &EffectLog) -> String {
+    let mut log = log.clone();
+    log.header.deliveries = None;
+    serde_json::to_string(&log).expect("the log serializes")
+}
+
+/// The error the one completion record holds. A fault cell records exactly
+/// one completion and nothing after it: no tool, no memory, no retry.
+pub(crate) fn sole_failed_completion(log: &EffectLog) -> &ErrorReport {
+    assert_eq!(
+        families(log),
+        [EffectFamily::Completion],
+        "one completion record and no effect after the fault"
+    );
+    log.records[0]
+        .outcome
+        .as_ref()
+        .expect_err("the completion record holds the fault")
+}
+
+/// The recorded stream error items of the one completion, as
+/// `(position, report)`.
+pub(crate) fn recorded_stream_errors(log: &EffectLog) -> Vec<(usize, ErrorReport)> {
+    log.header
+        .stream_errors
+        .values()
+        .flatten()
+        .map(|error| (error.item, error.error.clone()))
+        .collect()
+}
+
+/// A setup failure: the provider refused the request before any frame.
+/// Both runtimes surface the recorded status and body under the wire's own
+/// classification (`kind`), record the one completion as that failure and
+/// stream nothing.
+pub(crate) fn assert_setup_failure(report: &ErrorReport, kind: ErrorKind, status: u16) {
+    assert_eq!(report.kind, kind, "{report:?}");
+    assert_eq!(report.http_status, Some(status), "{report:?}");
+    let body = report
+        .provider_response_body()
+        .expect("the provider's body travels with the failure");
+    let body: serde_json::Value =
+        serde_json::from_str(body).expect("the recorded error body is JSON");
+    assert!(
+        body.get("error").is_some(),
+        "the provider's error envelope is preserved: {body}"
+    );
+}
+
+/// Counts a tool's executions.
+#[derive(Clone, Default)]
+pub(crate) struct Invocations(Arc<AtomicUsize>);
+
+impl Invocations {
+    pub(crate) fn count(&self) -> usize {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+/// `subtract`, counting its executions: a fault cell's proof that a call
+/// the model issued before the fault never ran.
+#[derive(Clone)]
+pub(crate) struct CountedSubtract(pub(crate) Invocations);
+
+impl Tool for CountedSubtract {
+    const NAME: &'static str = Subtract::NAME;
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i32;
+
+    fn description(&self) -> String {
+        Subtract.description()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        Subtract.parameters()
+    }
+
+    async fn call(
+        &self,
+        context: &mut ToolContext,
+        args: Self::Args,
+    ) -> Result<Self::Output, Self::Error> {
+        self.0.0.fetch_add(1, Ordering::SeqCst);
+        Subtract.call(context, args).await
+    }
+}
+
+/// One native run and everything a cell asserts on afterwards.
+pub(crate) struct NativeRun {
+    /// The answer, or the failure.
+    pub outcome: Result<String, Failure>,
+    /// The recorder's log.
+    pub log: EffectLog,
+    /// The witness's log, when one was installed.
+    pub trace: Option<Arc<ObservationLog>>,
+    /// The committed history, in order: who spoke.
+    pub roles: Vec<Role>,
+    /// The one completion stream's fold, while its effect survives: a
+    /// despawned in-flight effect takes its stream with it.
+    pub stream: Option<Streamed>,
+}
+
+impl NativeRun {
+    pub(crate) fn stream(&self) -> &Streamed {
+        self.stream
+            .as_ref()
+            .expect("the stream's effect survived the run")
+    }
+
+    pub(crate) fn failure(&self) -> &Failure {
+        self.outcome.as_ref().expect_err("the fault fails the run")
+    }
+
+    pub(crate) fn provider_report(&self) -> &ErrorReport {
+        match self.failure() {
+            Failure::Provider(report) => report,
+            other => panic!("a provider failure, not {other:?}"),
+        }
+    }
+
+    pub(crate) fn trace(&self) -> &ObservationLog {
+        self.trace.as_deref().expect("a witnessed run")
+    }
+
+    /// The log without its scheduling-dependent delivery batches.
+    pub(crate) fn log_json(&self) -> String {
+        log_json_without_deliveries(&self.log)
+    }
+}
+
+/// Drive one streamed native run of `prompt` on a fresh world over `model`
+/// with an agent-level budget of two turns; `configure` shapes the agent
+/// before the run is spawned.
+pub(crate) async fn native_run(
+    model: impl CompletionModel + 'static,
+    preamble: &str,
+    prompt: &str,
+    witness: bool,
+    configure: impl FnOnce(&mut EcsAgent),
+) -> NativeRun {
+    let mut ecs = EcsAgent::new(model, preamble, 2);
+    configure(&mut ecs);
+    let trace = witness.then(|| witnessed(&mut ecs.app));
+    let run = spawn_run(ecs.app.world_mut(), ecs.agent, &[], prompt, true, None);
+    let outcome = ecs.wait_for_outcome(run).await;
+    // The run's ending lands before a despawned or dropped handler has
+    // necessarily closed its record; give the owned task the same window
+    // the anthropic cancellation cells do before reading the log.
+    for _ in 0..64 {
+        ecs.app.update();
+        tokio::task::yield_now().await;
+    }
+    let log = ecs.effect_log();
+    let roles = utterance_roles(ecs.app.world_mut(), run);
+    let stream = sole_stream(ecs.app.world_mut());
+    NativeRun {
+        outcome,
+        log,
+        trace,
+        roles,
+        stream,
+    }
+}
+
+/// A failure with the one field that varies between two replays of the same
+/// recording removed: the replay server stamps a live `date` header on every
+/// response, and a provider report keeps the response's headers. Everything
+/// else — kind, status, message, body, the other headers — compares whole.
+pub(crate) fn comparable_failure(failure: &Failure) -> Failure {
+    let mut failure = failure.clone();
+    let report = match &mut failure {
+        Failure::Provider(report)
+        | Failure::Cancelled(report)
+        | Failure::Tool(report)
+        | Failure::Memory(report) => report,
+        _ => return failure,
+    };
+    if let Some(headers) = report
+        .provider_response
+        .as_mut()
+        .and_then(|response| response.headers.as_mut())
+    {
+        headers.remove("date");
+    }
+    failure
+}
+
+/// The fault must read the same with and without a witness: same failure,
+/// same record, same history; and `secret` must not reach the trace.
+pub(crate) fn assert_witness_is_a_side_channel(
+    observed: &NativeRun,
+    plain: &NativeRun,
+    secret: &str,
+) {
+    assert_eq!(
+        comparable_failure(observed.failure()),
+        comparable_failure(plain.failure()),
+        "the witness does not change the failure"
+    );
+    assert_eq!(
+        observed.log_json(),
+        plain.log_json(),
+        "the witness does not change the record"
+    );
+    assert_eq!(observed.roles, plain.roles, "nor the history");
+    assert!(
+        !trace_json(observed.trace()).contains(secret),
+        "the credential never reaches the trace"
+    );
+}
+
+/// The run's committed history, in order: who spoke.
+pub(crate) fn utterance_roles(world: &mut World, run: Entity) -> Vec<Role> {
+    let mut query = world.query_filtered::<(&ChildOf, &Role, &Order), With<Utterance>>();
+    let mut rows: Vec<_> = query
+        .iter(world)
+        .filter(|(parent, ..)| parent.parent() == run)
+        .map(|(_, role, order)| (order.0, *role))
+        .collect();
+    rows.sort_by_key(|(order, _)| *order);
+    rows.into_iter().map(|(_, role)| role).collect()
+}
+
+/// The one stream's fold: its text so far, its error items with their
+/// positions, and its outcome. `None` once its effect is gone.
+pub(crate) fn sole_stream(world: &mut World) -> Option<Streamed> {
+    let mut query = world.query::<&Streamed>();
+    let streams: Vec<_> = query.iter(world).cloned().collect();
+    assert!(
+        streams.len() <= 1,
+        "at most one streamed effect: {streams:?}"
+    );
+    streams.into_iter().next()
+}
+
+/// Install a witness over a fresh log.
+pub(crate) fn witnessed(app: &mut App) -> Arc<ObservationLog> {
+    let log = Arc::new(ObservationLog::default());
+    Witnessing::install(app.world_mut(), log.clone());
+    log
+}
+
+/// Every program ending the witness saw, by code.
+pub(crate) fn endings(log: &ObservationLog) -> Vec<String> {
+    log.trace()
+        .observations
+        .iter()
+        .filter_map(|observation| match &observation.action {
+            Action::Ended { ending } => Some(ending.code.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Every provider-boundary fact, in order.
+pub(crate) fn adapter_events(log: &ObservationLog) -> Vec<AdapterEvent> {
+    log.trace()
+        .observations
+        .iter()
+        .filter_map(|observation| match &observation.action {
+            Action::Adapter { observation } => Some(observation.event.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Every truncation the bus witnessed: items delivered and error items.
+pub(crate) fn truncations(log: &ObservationLog) -> Vec<(usize, usize)> {
+    log.trace()
+        .observations
+        .iter()
+        .filter_map(|observation| match &observation.action {
+            Action::StreamTruncated {
+                delivered, errors, ..
+            } => Some((*delivered, errors.len())),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The bus's decisions in order, by name.
+pub(crate) fn bus_actions(log: &ObservationLog) -> Vec<&'static str> {
+    log.trace()
+        .observations
+        .iter()
+        .filter_map(|observation| match &observation.action {
+            Action::Issued => Some("issued"),
+            Action::Landed { outcome } => Some(match outcome {
+                rig::observe::OutcomeSummary::Err { .. } => "landed_err",
+                _ => "landed_ok",
+            }),
+            Action::Denied { .. } => Some("denied"),
+            Action::Refused { .. } => Some("refused"),
+            Action::Cancelled { .. } => Some("cancelled"),
+            Action::StreamTruncated { .. } => Some("truncated"),
+            Action::Held { .. } => Some("held"),
+            Action::Released => Some("released"),
+            Action::Replaced { .. } => Some("replaced"),
+            Action::Adapter { .. } | Action::Ended { .. } | Action::Host { .. } => None,
+        })
+        .collect()
+}
+
+/// The whole trace, serialized: what an analysis sink would persist.
+pub(crate) fn trace_json(log: &ObservationLog) -> String {
+    serde_json::to_string(&log.trace()).expect("the trace serializes")
+}

--- a/tests/ecs_parity/scenarios.json
+++ b/tests/ecs_parity/scenarios.json
@@ -609,6 +609,7 @@
     "tests/common/cassette_safety.rs",
     "tests/common/cassettes.rs",
     "tests/common/goldens.rs",
+    "tests/common/stream_faults.rs",
     "tests/common/support.rs",
     "tests/data/camponotus_flavomarginatus_ant.jpg",
     "tests/ecs_parity/README.md",
@@ -856,6 +857,7 @@
     "tests/providers/gemini/cassette/ecs_ordering.rs",
     "tests/providers/gemini/cassette/ecs_parity.rs",
     "tests/providers/gemini/cassette/ecs_prompt_caching.rs",
+    "tests/providers/gemini/cassette/ecs_stream_faults.rs",
     "tests/providers/gemini/cassette/ecs_stress_context.rs",
     "tests/providers/gemini/cassette/ecs_stress_main.rs",
     "tests/providers/gemini/cassette/ecs_stress_patch.rs",
@@ -892,6 +894,7 @@
     "tests/providers/gemini/cassette/reasoning_tool_roundtrip.rs",
     "tests/providers/gemini/cassette/regression_suite.rs",
     "tests/providers/gemini/cassette/response_identity.rs",
+    "tests/providers/gemini/cassette/stream_faults.rs",
     "tests/providers/gemini/cassette/stream_terminal_matrix.rs",
     "tests/providers/gemini/cassette/streaming.rs",
     "tests/providers/gemini/cassette/streaming_grammar.rs",
@@ -1071,6 +1074,7 @@
     "tests/providers/openai/cassette/ecs_ordering.rs",
     "tests/providers/openai/cassette/ecs_parity.rs",
     "tests/providers/openai/cassette/ecs_prompt_caching.rs",
+    "tests/providers/openai/cassette/ecs_stream_faults.rs",
     "tests/providers/openai/cassette/ecs_termination.rs",
     "tests/providers/openai/cassette/effect_corpus.rs",
     "tests/providers/openai/cassette/embedding_matrix.rs",
@@ -1105,6 +1109,7 @@
     "tests/providers/openai/cassette/responses_sessions.rs",
     "tests/providers/openai/cassette/responses_tool_args.rs",
     "tests/providers/openai/cassette/responses_tool_choice.rs",
+    "tests/providers/openai/cassette/stream_faults.rs",
     "tests/providers/openai/cassette/streaming.rs",
     "tests/providers/openai/cassette/streaming_grammar.rs",
     "tests/providers/openai/cassette/streaming_grammar_chat.rs",
@@ -13044,6 +13049,50 @@
       "ecs": null
     },
     {
+      "id": "rig::gemini::gemini::cassette::stream_faults::blocked_prompt_is_a_provider_refusal_not_a_truncation",
+      "classification": "agent",
+      "source": "tests/providers/gemini/cassette/stream_faults.rs",
+      "configuration": "root-bedrock",
+      "ecs": {
+        "binary": "gemini",
+        "test": "gemini::cassette::ecs_stream_faults::blocked_prompt_is_a_provider_refusal_not_a_truncation",
+        "source": "tests/providers/gemini/cassette/ecs_stream_faults.rs"
+      }
+    },
+    {
+      "id": "rig::gemini::gemini::cassette::stream_faults::in_band_error_after_content_fails_with_the_envelope",
+      "classification": "agent",
+      "source": "tests/providers/gemini/cassette/stream_faults.rs",
+      "configuration": "root-bedrock",
+      "ecs": {
+        "binary": "gemini",
+        "test": "gemini::cassette::ecs_stream_faults::in_band_error_after_content_fails_with_the_envelope",
+        "source": "tests/providers/gemini/cassette/ecs_stream_faults.rs"
+      }
+    },
+    {
+      "id": "rig::gemini::gemini::cassette::stream_faults::setup_failure_fails_the_run_with_the_recorded_status",
+      "classification": "agent",
+      "source": "tests/providers/gemini/cassette/stream_faults.rs",
+      "configuration": "root-bedrock",
+      "ecs": {
+        "binary": "gemini",
+        "test": "gemini::cassette::ecs_stream_faults::setup_failure_fails_the_run_with_the_recorded_status",
+        "source": "tests/providers/gemini/cassette/ecs_stream_faults.rs"
+      }
+    },
+    {
+      "id": "rig::gemini::gemini::cassette::stream_faults::truncation_after_content_fails_the_run_and_keeps_the_prefix",
+      "classification": "agent",
+      "source": "tests/providers/gemini/cassette/stream_faults.rs",
+      "configuration": "root-bedrock",
+      "ecs": {
+        "binary": "gemini",
+        "test": "gemini::cassette::ecs_stream_faults::truncation_after_content_fails_the_run_and_keeps_the_prefix",
+        "source": "tests/providers/gemini/cassette/ecs_stream_faults.rs"
+      }
+    },
+    {
       "id": "rig::gemini::gemini::cassette::stream_terminal_matrix::gemini_3_flash_does_not_emit_the_intermediate_finish",
       "classification": "shared_provider",
       "source": "tests/providers/gemini/cassette/stream_terminal_matrix.rs",
@@ -22181,6 +22230,61 @@
       "source": "tests/providers/openai/cassette/responses_tool_choice.rs",
       "configuration": "root-bedrock",
       "ecs": null
+    },
+    {
+      "id": "rig::openai::openai::cassette::stream_faults::dropping_the_stream_at_the_first_delta_records_a_cancel",
+      "classification": "agent",
+      "source": "tests/providers/openai/cassette/stream_faults.rs",
+      "configuration": "root-bedrock",
+      "ecs": {
+        "binary": "openai",
+        "test": "openai::cassette::ecs_stream_faults::despawning_the_stream_at_the_first_delta_records_a_cancel",
+        "source": "tests/providers/openai/cassette/ecs_stream_faults.rs"
+      }
+    },
+    {
+      "id": "rig::openai::openai::cassette::stream_faults::error_event_after_content_fails_with_the_provider_error",
+      "classification": "agent",
+      "source": "tests/providers/openai/cassette/stream_faults.rs",
+      "configuration": "root-bedrock",
+      "ecs": {
+        "binary": "openai",
+        "test": "openai::cassette::ecs_stream_faults::error_event_after_content_fails_with_the_provider_error",
+        "source": "tests/providers/openai/cassette/ecs_stream_faults.rs"
+      }
+    },
+    {
+      "id": "rig::openai::openai::cassette::stream_faults::setup_failure_fails_the_run_with_the_recorded_status",
+      "classification": "agent",
+      "source": "tests/providers/openai/cassette/stream_faults.rs",
+      "configuration": "root-bedrock",
+      "ecs": {
+        "binary": "openai",
+        "test": "openai::cassette::ecs_stream_faults::setup_failure_fails_the_run_with_the_recorded_status",
+        "source": "tests/providers/openai/cassette/ecs_stream_faults.rs"
+      }
+    },
+    {
+      "id": "rig::openai::openai::cassette::stream_faults::truncation_after_a_complete_tool_call_never_runs_the_tool",
+      "classification": "agent",
+      "source": "tests/providers/openai/cassette/stream_faults.rs",
+      "configuration": "root-bedrock",
+      "ecs": {
+        "binary": "openai",
+        "test": "openai::cassette::ecs_stream_faults::truncation_after_a_complete_tool_call_never_runs_the_tool",
+        "source": "tests/providers/openai/cassette/ecs_stream_faults.rs"
+      }
+    },
+    {
+      "id": "rig::openai::openai::cassette::stream_faults::truncation_after_content_fails_the_run_and_keeps_the_prefix",
+      "classification": "agent",
+      "source": "tests/providers/openai/cassette/stream_faults.rs",
+      "configuration": "root-bedrock",
+      "ecs": {
+        "binary": "openai",
+        "test": "openai::cassette::ecs_stream_faults::truncation_after_content_fails_the_run_and_keeps_the_prefix",
+        "source": "tests/providers/openai/cassette/ecs_stream_faults.rs"
+      }
     },
     {
       "id": "rig::openai::openai::cassette::streaming::example_streaming_prompt",

--- a/tests/gemini.rs
+++ b/tests/gemini.rs
@@ -30,6 +30,8 @@ mod ecs_termination;
 mod goldens;
 #[path = "common/reasoning.rs"]
 mod reasoning;
+#[path = "common/stream_faults.rs"]
+mod stream_faults;
 #[path = "common/support.rs"]
 mod support;
 

--- a/tests/openai.rs
+++ b/tests/openai.rs
@@ -28,6 +28,8 @@ mod ecs_termination;
 mod goldens;
 #[path = "common/reasoning.rs"]
 mod reasoning;
+#[path = "common/stream_faults.rs"]
+mod stream_faults;
 #[path = "common/support.rs"]
 mod support;
 

--- a/tests/providers/gemini/cassette/ecs_stream_faults.rs
+++ b/tests/providers/gemini/cassette/ecs_stream_faults.rs
@@ -1,0 +1,405 @@
+//! Native counterparts of `stream_faults.rs`: the same recorded setup
+//! failure and scripted faults through the ECS runtime and the real
+//! adapter, with the world's witness installed. Each cell runs with and
+//! without a witness: observation is a side channel, so the failure, the
+//! record and the history must not change with it, and the trace must name
+//! the fault without carrying the request or its credential.
+
+use bytes::Bytes;
+use rig::error::ErrorKind;
+use rig::observe::{AdapterEnding, AdapterErrorBoundary, AdapterEvent, AdapterUsage};
+use rig::prelude::*;
+use rig::providers::gemini::{
+    self,
+    completion::{
+        GEMINI_2_5_FLASH, GEMINI_3_FLASH_PREVIEW,
+        gemini_api_types::{AdditionalParameters, GenerationConfig, ThinkingConfig, ThinkingLevel},
+    },
+};
+use rig::test_utils::SequencedStreamingHttpClient;
+use rig_ecs::agent::{AdditionalParams, MaxTokens, Preamble, Role};
+
+use super::super::support::with_gemini_cassette;
+use super::stream_faults::{
+    BLOCKED_FRAME, CONTENT_FRAME, CONTENT_TEXT, IN_BAND_ERROR_FRAME, MISSING_MODEL, SCRIPTED_KEY,
+    SETUP_MAX_TOKENS, SETUP_PROMPT, gemini_sse, http_error, scripted_client,
+};
+use crate::{
+    ecs_agent::EcsAgent,
+    stream_faults::{
+        NativeRun, adapter_events, assert_setup_failure, bus_actions, comparable_failure, endings,
+        native_run, sole_failed_completion, trace_json, truncations,
+    },
+    support::{STREAMING_PREAMBLE, STREAMING_PROMPT},
+};
+
+/// A scripted-transport model: one streaming exchange, then EOF.
+fn scripted_model(chunks: Vec<Bytes>) -> gemini::CompletionModel<SequencedStreamingHttpClient> {
+    scripted_client(chunks).completion_model(GEMINI_2_5_FLASH)
+}
+
+/// The scripted cells' witness check, over this module's credential.
+fn assert_witness_is_a_side_channel(observed: &NativeRun, plain: &NativeRun) {
+    crate::stream_faults::assert_witness_is_a_side_channel(observed, plain, SCRIPTED_KEY);
+}
+
+/// Every provider-boundary fact of the run's one operation.
+fn boundary(run: &NativeRun) -> Vec<AdapterEvent> {
+    let events = adapter_events(run.trace());
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, AdapterEvent::Started { .. })),
+        "the adapter announces its request: {events:?}"
+    );
+    events
+}
+
+/// The recorded 404 through the native runtime: the run fails as the
+/// provider's response, streams nothing, commits only the prompt, and the
+/// witness sees the request, the status, the envelope and the ending.
+#[tokio::test]
+async fn setup_failure_fails_the_run_with_the_recorded_status() {
+    // The recording's request carries no system instruction at all, which
+    // strict matching distinguishes from an empty one: `Preamble(None)`,
+    // not the helper's `Some("")`.
+    let configure = |ecs: &mut EcsAgent| {
+        ecs.app
+            .world_mut()
+            .entity_mut(ecs.agent)
+            .insert((Preamble(None), MaxTokens(Some(SETUP_MAX_TOKENS))));
+    };
+    let mut runs = Vec::new();
+    for witness in [true, false] {
+        let runs = &mut runs;
+        with_gemini_cassette(
+            "error_envelope/nonexistent_model_streaming_error_preserves_status_and_body",
+            |client| async move {
+                let run = native_run(
+                    client.completion_model(MISSING_MODEL),
+                    "",
+                    SETUP_PROMPT,
+                    witness,
+                    configure,
+                )
+                .await;
+                assert_setup_failure(run.provider_report(), http_error(404), 404);
+                assert_setup_failure(sole_failed_completion(&run.log), http_error(404), 404);
+                assert_eq!(run.roles, [Role::User], "only the prompt is history");
+                assert!(run.stream().text.is_empty(), "{:?}", run.stream);
+                assert_eq!(
+                    run.stream().errors.len(),
+                    1,
+                    "one error item: {:?}",
+                    run.stream().errors
+                );
+                assert_eq!(run.stream().errors[0].0, 0, "the error is the first item");
+                runs.push(run);
+            },
+        )
+        .await;
+    }
+    let (observed, plain) = (&runs[0], &runs[1]);
+    assert_eq!(
+        comparable_failure(observed.failure()),
+        comparable_failure(plain.failure())
+    );
+    assert_eq!(observed.log_json(), plain.log_json());
+
+    let trace = observed.trace();
+    assert_eq!(bus_actions(trace), ["issued", "landed_err"]);
+    assert_eq!(endings(trace), ["provider"]);
+    let events = boundary(observed);
+    assert!(
+        events.contains(&AdapterEvent::Response { status: 404 }),
+        "{events:?}"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AdapterEvent::ErrorEnvelope { error }
+                if error.code.as_deref() == Some("404") && error.status.as_deref() == Some("NOT_FOUND")
+        )),
+        "the envelope's own fields are projected: {events:?}"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AdapterEvent::Finished {
+                ending: AdapterEnding::Error {
+                    boundary: AdapterErrorBoundary::ProviderResponse,
+                    status: Some(404),
+                    retryable: false,
+                    ..
+                }
+            }
+        )),
+        "the attempt closes as a non-retryable provider response: {events:?}"
+    );
+    let rendered = trace_json(trace);
+    assert!(
+        !rendered.contains(SETUP_PROMPT),
+        "the request body never reaches the trace"
+    );
+}
+
+/// The refusal through the native runtime: a non-retryable provider
+/// failure naming the block reason, nothing committed, and the witness sees
+/// the verdict and the usage the provider billed for the refused prompt.
+#[tokio::test]
+async fn blocked_prompt_is_a_provider_refusal_not_a_truncation() {
+    let mut runs = Vec::new();
+    for witness in [true, false] {
+        let run = native_run(
+            scripted_model(vec![gemini_sse(&[BLOCKED_FRAME])]),
+            "",
+            "pong?",
+            witness,
+            |_| {},
+        )
+        .await;
+        let report = run.provider_report();
+        assert_eq!(report.kind, ErrorKind::Provider, "{report:?}");
+        assert!(!report.is_retryable(), "{report:?}");
+        assert!(report.message.contains("block_reason=SAFETY"), "{report:?}");
+        let recorded = sole_failed_completion(&run.log);
+        assert_eq!(recorded.kind, ErrorKind::Provider, "{recorded:?}");
+        assert!(
+            recorded.message.contains("block_reason=SAFETY"),
+            "the record holds the refusal: {recorded:?}"
+        );
+        assert_eq!(run.roles, [Role::User]);
+        assert!(run.stream().text.is_empty());
+        runs.push(run);
+    }
+    let (observed, plain) = (&runs[0], &runs[1]);
+    assert_witness_is_a_side_channel(observed, plain);
+    assert_eq!(endings(observed.trace()), ["provider"]);
+    assert!(truncations(observed.trace()).is_empty(), "not a truncation");
+    let events = boundary(observed);
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AdapterEvent::Provider { verdict } if verdict.block_reason.as_deref() == Some("SAFETY")
+        )),
+        "the verdict names the block: {events:?}"
+    );
+    assert!(
+        events.contains(&AdapterEvent::Usage {
+            usage: AdapterUsage {
+                input_tokens: Some(795),
+                total_tokens: Some(795),
+                ..AdapterUsage::default()
+            }
+        }),
+        "the refused prompt's billed usage is observed: {events:?}"
+    );
+}
+
+/// EOF after content through the native runtime: the run fails as a
+/// truncation, the stream keeps the prefix and no error item (the wire sent
+/// none), history keeps only the prompt, and the bus witnesses the
+/// truncation with what was delivered.
+#[tokio::test]
+async fn truncation_after_content_fails_the_run_and_keeps_the_prefix() {
+    let mut runs = Vec::new();
+    for witness in [true, false] {
+        let run = native_run(
+            scripted_model(vec![gemini_sse(&[CONTENT_FRAME])]),
+            "",
+            "pong?",
+            witness,
+            |_| {},
+        )
+        .await;
+        let report = run.provider_report();
+        assert_eq!(report.kind, ErrorKind::Response, "{report:?}");
+        assert_eq!(report.message, rig::serve::stream_truncated().message);
+        let recorded = sole_failed_completion(&run.log);
+        assert_eq!(recorded.message, rig::serve::stream_truncated().message);
+        assert_eq!(run.stream().text, CONTENT_TEXT);
+        assert!(run.stream().errors.is_empty(), "EOF is not an item");
+        // No terminal record and no error item: the fold never closed, so
+        // the truncation is the effect's outcome (asserted through the
+        // record above), not a folded stream outcome.
+        assert!(run.stream().outcome.is_none(), "{:?}", run.stream().outcome);
+        assert_eq!(run.roles, [Role::User], "the cut turn is not history");
+        runs.push(run);
+    }
+    let (observed, plain) = (&runs[0], &runs[1]);
+    assert_witness_is_a_side_channel(observed, plain);
+    assert_eq!(endings(observed.trace()), ["provider"]);
+    let delivered = observed.stream().events.len();
+    assert_eq!(truncations(observed.trace()), [(delivered, 0)]);
+    let events = boundary(observed);
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AdapterEvent::Finished {
+                ending: AdapterEnding::Eof { after: 1 }
+            }
+        )),
+        "the attempt closes at EOF after one frame: {events:?}"
+    );
+}
+
+/// An error envelope after content through the native runtime: the run
+/// fails with the envelope's classification, the stream keeps the prefix
+/// and the error item at its position, and the witness sees the envelope.
+#[tokio::test]
+async fn in_band_error_after_content_fails_with_the_envelope() {
+    let mut runs = Vec::new();
+    for witness in [true, false] {
+        let run = native_run(
+            scripted_model(vec![gemini_sse(&[CONTENT_FRAME, IN_BAND_ERROR_FRAME])]),
+            "",
+            "pong?",
+            witness,
+            |_| {},
+        )
+        .await;
+        let report = run.provider_report();
+        assert_eq!(report.kind, http_error(503), "{report:?}");
+        assert_eq!(report.http_status, Some(503), "{report:?}");
+        assert!(report.is_retryable(), "{report:?}");
+        assert_eq!(
+            report
+                .provider_response_body()
+                .map(|body| serde_json::from_str::<serde_json::Value>(body).expect("JSON")),
+            Some(serde_json::from_str(IN_BAND_ERROR_FRAME).expect("JSON")),
+            "the envelope is preserved: {report:?}"
+        );
+        let recorded = sole_failed_completion(&run.log);
+        assert_eq!(recorded.http_status, Some(503), "{recorded:?}");
+        assert_eq!(run.stream().text, CONTENT_TEXT);
+        assert_eq!(run.stream().errors.len(), 1, "{:?}", run.stream().errors);
+        assert_eq!(
+            run.stream().errors[0].0,
+            run.stream().events.len(),
+            "the error item follows the delivered content"
+        );
+        assert_eq!(run.roles, [Role::User]);
+        runs.push(run);
+    }
+    let (observed, plain) = (&runs[0], &runs[1]);
+    assert_witness_is_a_side_channel(observed, plain);
+    assert_eq!(endings(observed.trace()), ["provider"]);
+    let events = boundary(observed);
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AdapterEvent::ErrorEnvelope { error }
+                if error.code.as_deref() == Some("503") && error.status.as_deref() == Some("UNAVAILABLE")
+        )),
+        "{events:?}"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AdapterEvent::Finished {
+                ending: AdapterEnding::Error {
+                    boundary: AdapterErrorBoundary::ProviderResponse,
+                    status: Some(503),
+                    retryable: true,
+                    ..
+                }
+            }
+        )),
+        "{events:?}"
+    );
+}
+
+/// The recorded successful stream through the native runtime with a
+/// witness: the answer and the record match an unwitnessed replay, and the
+/// trace carries the dispatch, the verdict, the usage and the settlement.
+#[tokio::test]
+async fn witnessed_success_matches_the_unwitnessed_run() {
+    let configure = |ecs: &mut EcsAgent| {
+        let config = GenerationConfig {
+            thinking_config: Some(ThinkingConfig {
+                thinking_budget: None,
+                thinking_level: Some(ThinkingLevel::Medium),
+                include_thoughts: Some(true),
+            }),
+            ..Default::default()
+        };
+        ecs.app
+            .world_mut()
+            .entity_mut(ecs.agent)
+            .insert(AdditionalParams(Some(
+                serde_json::to_value(AdditionalParameters::default().with_config(config))
+                    .expect("thinking configuration"),
+            )));
+    };
+    let mut runs = Vec::new();
+    for witness in [true, false] {
+        let runs = &mut runs;
+        with_gemini_cassette("streaming/streaming_smoke", |client| async move {
+            let run = native_run(
+                client.completion_model(GEMINI_3_FLASH_PREVIEW),
+                STREAMING_PREAMBLE,
+                STREAMING_PROMPT,
+                witness,
+                configure,
+            )
+            .await;
+            let answer = run.outcome.as_ref().expect("the recorded answer");
+            assert!(!answer.trim().is_empty());
+            assert_eq!(run.roles, [Role::User, Role::Assistant]);
+            runs.push(run);
+        })
+        .await;
+    }
+    let (observed, plain) = (&runs[0], &runs[1]);
+    assert_eq!(observed.outcome, plain.outcome);
+    assert_eq!(observed.log_json(), plain.log_json());
+
+    let trace = observed.trace();
+    assert_eq!(bus_actions(trace), ["issued", "landed_ok"]);
+    assert_eq!(endings(trace), ["settled"]);
+    assert!(truncations(trace).is_empty());
+    let events = boundary(observed);
+    assert!(
+        events.contains(&AdapterEvent::Response { status: 200 }),
+        "{events:?}"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AdapterEvent::Provider { verdict } if verdict.finish_reason.as_deref() == Some("STOP")
+        )),
+        "{events:?}"
+    );
+    let usage = observed
+        .stream()
+        .events
+        .iter()
+        .rev()
+        .find_map(|event| match event {
+            rig::streaming::StreamEvent::Final(final_event) => Some(final_event.usage),
+            _ => None,
+        })
+        .expect("the terminal record's usage");
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AdapterEvent::Usage { usage: observed }
+                if observed.total_tokens == Some(usage.total_tokens)
+        )),
+        "the observed usage is the terminal record's: {events:?}"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AdapterEvent::Finished {
+                ending: AdapterEnding::Terminal
+            }
+        )),
+        "{events:?}"
+    );
+    let rendered = trace_json(trace);
+    assert!(
+        !rendered.contains(STREAMING_PROMPT) && !rendered.contains(STREAMING_PREAMBLE),
+        "the request never reaches the trace"
+    );
+}

--- a/tests/providers/gemini/cassette/stream_faults.rs
+++ b/tests/providers/gemini/cassette/stream_faults.rs
@@ -1,0 +1,219 @@
+//! Gemini stream faults through the runner: the recorded 404 on stream
+//! setup, and scripted faults — a blocked prompt, a stream cut before its
+//! terminal, an in-band error after content — served to the real
+//! `streamGenerateContent` adapter. Native counterparts:
+//! `ecs_stream_faults.rs`. Every cell's hypothesis is that the fault
+//! surfaces as its own kind, with nothing recorded, committed or executed
+//! after it.
+
+use bytes::Bytes;
+use rig::error::ErrorKind;
+use rig::prelude::*;
+use rig::providers::gemini::{self, completion::GEMINI_2_5_FLASH};
+use rig::test_utils::SequencedStreamingHttpClient;
+
+use super::super::support::with_gemini_cassette;
+use crate::stream_faults::{
+    assert_setup_failure, drain, recorded_stream_errors, scripted, sole_failed_completion,
+};
+
+/// The recorded stream-setup failure, `error_envelope/nonexistent_model_streaming_error_preserves_status_and_body`,
+/// carries this model, prompt and budget.
+pub(super) const MISSING_MODEL: &str = "gemini-nonexistent-rig-test";
+pub(super) const SETUP_PROMPT: &str = "Say hi.";
+pub(super) const SETUP_MAX_TOKENS: u64 = 16;
+
+/// A real `streamGenerateContent` content frame without a finish reason,
+/// as `gemini-3.8-flash` streamed it on 2026-09-08 (captured in the
+/// downstream rigcoder Gemini matrix; ids scrubbed by this engine). The
+/// recordings in this tree stream whole answers in one terminal frame, so a
+/// prefix-then-fault stream is assembled from this frame. Synthetic order,
+/// real frames.
+pub(super) const CONTENT_FRAME: &str = r#"{"candidates":[{"content":{"parts":[{"text":"pong"}],"role":"model"},"index":0}],"modelVersion":"gemini-3.8-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":1,"promptTokenCount":795,"promptTokensDetails":[{"modality":"TEXT","tokenCount":795}],"serviceTier":"standard","thoughtsTokenCount":60,"totalTokenCount":856}}"#;
+/// The text [`CONTENT_FRAME`] carries.
+pub(super) const CONTENT_TEXT: &str = "pong";
+/// The whole body Gemini answered a refused prompt with, same capture: one
+/// feedback chunk, no candidates, then the stream closes (#2475).
+pub(super) const BLOCKED_FRAME: &str = r#"{"promptFeedback":{"blockReason":"SAFETY"},"usageMetadata":{"promptTokenCount":795,"totalTokenCount":795}}"#;
+/// An error envelope in band under HTTP 200: the envelope Gemini returned
+/// for an overloaded model in the same capture, in the frame position the
+/// adapter's unit tests pin (`in_band_http_errors_match_unary_classification`).
+pub(super) const IN_BAND_ERROR_FRAME: &str = r#"{"error":{"code":503,"message":"The model is overloaded. Please try again later.","status":"UNAVAILABLE"}}"#;
+/// Gemini's classification of an HTTP error envelope on the streamed path:
+/// the transport's status, with the envelope preserved on the report (the
+/// metadata-less funnel in `rig_core::provider_response`; the Responses
+/// wire's request-id funnel classifies the same fault as `ProviderResponse`).
+pub(super) fn http_error(status: u16) -> ErrorKind {
+    ErrorKind::Http {
+        status: Some(status),
+    }
+}
+/// A key the scripted cells send: it must never reach a trace.
+pub(super) const SCRIPTED_KEY: &str = "scripted-fault-key-7f3a9c";
+
+/// Gemini's SSE framing of `frames`.
+pub(super) fn gemini_sse(frames: &[&str]) -> Bytes {
+    Bytes::from(
+        frames
+            .iter()
+            .map(|frame| format!("data: {frame}\n\n"))
+            .collect::<String>(),
+    )
+}
+
+/// A client over a transport that answers one streaming request with
+/// `chunks`, then EOF.
+pub(super) fn scripted_client(chunks: Vec<Bytes>) -> gemini::Client<SequencedStreamingHttpClient> {
+    gemini::Client::builder()
+        .api_key(SCRIPTED_KEY)
+        .http_client(scripted(chunks))
+        .build()
+        .expect("client should build")
+}
+
+/// The model refuses the request before any frame: the run fails with the
+/// recorded 404 and its body, streams nothing, and records the one
+/// completion as that failure.
+#[tokio::test]
+async fn setup_failure_fails_the_run_with_the_recorded_status() {
+    // The fixture census wants the scenario as a literal at the wrapper call.
+    with_gemini_cassette(
+        "error_envelope/nonexistent_model_streaming_error_preserves_status_and_body",
+        |client| async move {
+            let agent = client
+                .agent(MISSING_MODEL)
+                .max_tokens(SETUP_MAX_TOKENS)
+                .record_effects_with_events()
+                .build();
+            let mut stream = agent.stream_prompt(SETUP_PROMPT).stream().await;
+            let drained = drain(&mut stream).await;
+            drop(stream);
+
+            assert_eq!(drained.finals, 0, "no final response: {drained:?}");
+            assert_eq!(drained.terminals, 0, "no terminal record: {drained:?}");
+            assert!(drained.text.is_empty(), "no text: {drained:?}");
+            assert_eq!(drained.errors.len(), 1, "one error item: {drained:?}");
+            assert_setup_failure(&drained.errors[0], http_error(404), 404);
+
+            let log = agent.take_effect_log().expect("recording");
+            assert_setup_failure(sole_failed_completion(&log), http_error(404), 404);
+            let errors = recorded_stream_errors(&log);
+            assert_eq!(errors.len(), 1, "one recorded error item: {errors:?}");
+            assert_eq!(errors[0].0, 0, "the error is the stream's first item");
+        },
+    )
+    .await;
+}
+
+/// A refused prompt is the provider's verdict, not a transport truncation:
+/// the run fails as a non-retryable provider error naming the block reason,
+/// and the record holds that error rather than "ended before its terminal".
+#[tokio::test]
+async fn blocked_prompt_is_a_provider_refusal_not_a_truncation() {
+    let client = scripted_client(vec![gemini_sse(&[BLOCKED_FRAME])]);
+    let agent = client
+        .agent(GEMINI_2_5_FLASH)
+        .record_effects_with_events()
+        .build();
+    let mut stream = agent.stream_prompt("pong?").stream().await;
+    let drained = drain(&mut stream).await;
+    drop(stream);
+
+    assert_eq!(drained.finals, 0, "{drained:?}");
+    assert!(drained.text.is_empty(), "{drained:?}");
+    assert_eq!(drained.errors.len(), 1, "{drained:?}");
+    let report = &drained.errors[0];
+    assert_eq!(report.kind, ErrorKind::Provider, "{report:?}");
+    assert!(!report.is_retryable(), "{report:?}");
+    assert!(
+        report.message.contains("block_reason=SAFETY"),
+        "the block reason is named: {report:?}"
+    );
+
+    let log = agent.take_effect_log().expect("recording");
+    let recorded = sole_failed_completion(&log);
+    assert_eq!(recorded.kind, ErrorKind::Provider, "{recorded:?}");
+    assert!(
+        recorded.message.contains("block_reason=SAFETY"),
+        "the record holds the refusal, not a truncation: {recorded:?}"
+    );
+}
+
+/// The stream closes after content without a terminal record: the run
+/// fails as a truncation, the text prefix was delivered, no final response
+/// is assembled, and the record holds the truncation.
+#[tokio::test]
+async fn truncation_after_content_fails_the_run_and_keeps_the_prefix() {
+    let client = scripted_client(vec![gemini_sse(&[CONTENT_FRAME])]);
+    let agent = client
+        .agent(GEMINI_2_5_FLASH)
+        .record_effects_with_events()
+        .build();
+    let mut stream = agent.stream_prompt("pong?").stream().await;
+    let drained = drain(&mut stream).await;
+    drop(stream);
+
+    assert_eq!(drained.text, CONTENT_TEXT, "{drained:?}");
+    assert_eq!(drained.finals, 0, "{drained:?}");
+    assert_eq!(drained.terminals, 0, "{drained:?}");
+    assert!(!drained.errors.is_empty(), "{drained:?}");
+    for report in &drained.errors {
+        assert_eq!(report.kind, ErrorKind::Response, "{report:?}");
+        assert!(
+            report.message.contains("terminal record"),
+            "a truncation, by name: {report:?}"
+        );
+    }
+
+    let log = agent.take_effect_log().expect("recording");
+    let recorded = sole_failed_completion(&log);
+    assert_eq!(recorded.kind, ErrorKind::Response, "{recorded:?}");
+    assert_eq!(recorded.message, rig::serve::stream_truncated().message);
+}
+
+/// An error envelope after content: the run fails with the envelope's
+/// classification (a 503, retryable, body preserved), the prefix was
+/// delivered, and the error item sits after the content items.
+#[tokio::test]
+async fn in_band_error_after_content_fails_with_the_envelope() {
+    let client = scripted_client(vec![gemini_sse(&[CONTENT_FRAME, IN_BAND_ERROR_FRAME])]);
+    let agent = client
+        .agent(GEMINI_2_5_FLASH)
+        .record_effects_with_events()
+        .build();
+    let mut stream = agent.stream_prompt("pong?").stream().await;
+    let drained = drain(&mut stream).await;
+    drop(stream);
+
+    assert_eq!(drained.text, CONTENT_TEXT, "{drained:?}");
+    assert_eq!(drained.finals, 0, "{drained:?}");
+    assert_eq!(drained.terminals, 0, "{drained:?}");
+    assert_eq!(drained.errors.len(), 1, "{drained:?}");
+    let report = &drained.errors[0];
+    assert_eq!(report.kind, http_error(503), "{report:?}");
+    assert_eq!(report.http_status, Some(503), "{report:?}");
+    assert!(report.is_retryable(), "{report:?}");
+    assert_eq!(
+        report
+            .provider_response_body()
+            .map(|body| serde_json::from_str::<serde_json::Value>(body).expect("JSON")),
+        Some(serde_json::from_str(IN_BAND_ERROR_FRAME).expect("JSON")),
+        "the envelope is preserved: {report:?}"
+    );
+
+    let log = agent.take_effect_log().expect("recording");
+    let recorded = sole_failed_completion(&log);
+    assert_eq!(recorded.kind, http_error(503), "{recorded:?}");
+    assert_eq!(recorded.http_status, Some(503), "{recorded:?}");
+    let errors = recorded_stream_errors(&log);
+    assert_eq!(errors.len(), 1, "{errors:?}");
+    let delivered = log.records[0]
+        .events
+        .as_ref()
+        .map_or(0, |events| events.len());
+    assert!(delivered > 0, "content items precede the error");
+    assert_eq!(
+        errors[0].0, delivered,
+        "the error item sits after the delivered content"
+    );
+}

--- a/tests/providers/gemini/mod.rs
+++ b/tests/providers/gemini/mod.rs
@@ -26,6 +26,7 @@ mod cassette {
     mod ecs_ordering;
     mod ecs_parity;
     mod ecs_prompt_caching;
+    mod ecs_stream_faults;
     mod ecs_stress_context;
     mod ecs_stress_main;
     #[path = "ecs_stress/main_golden.rs"]
@@ -73,6 +74,7 @@ mod cassette {
     mod reasoning_tool_roundtrip;
     mod regression_suite;
     mod response_identity;
+    mod stream_faults;
     mod stream_terminal_matrix;
     mod streaming;
     mod streaming_grammar;

--- a/tests/providers/openai/cassette/ecs_stream_faults.rs
+++ b/tests/providers/openai/cassette/ecs_stream_faults.rs
@@ -1,0 +1,310 @@
+//! Native counterparts of `stream_faults.rs`: the same recorded setup
+//! failure, the same drop of the recorded stream and the same scripted
+//! faults through the ECS runtime and the real Responses adapter, with the
+//! world's witness installed. Each cell runs with and without a witness:
+//! observation is a side channel, so the failure, the record and the
+//! history must not change with it. The Responses adapter attaches no
+//! provider diagnostics yet, so the trace carries the bus's facts only.
+
+use bevy_ecs::prelude::*;
+use bytes::Bytes;
+use rig::error::ErrorKind;
+use rig::prelude::*;
+use rig::providers::openai::{self, GPT_4O};
+use rig::test_utils::SequencedStreamingHttpClient;
+use rig_ecs::{
+    agent::{Failure, MaxTokens, Preamble, Role},
+    bus::{BusSet, EffectOutcome, RigSchedule, Streamed},
+    systems::RigSet,
+};
+
+use super::super::support::with_openai_cassette;
+use super::stream_faults::{
+    ERROR_EVENT, MISSING_MODEL, SCRIPTED_KEY, SETUP_KIND, SETUP_MAX_TOKENS, SETUP_PROMPT,
+    delta_text, scripted_client, text_prefix_frames, tool_call_prefix_frames,
+};
+use crate::{
+    ecs_agent::EcsAgent,
+    stream_faults::{
+        CountedSubtract, Invocations, NativeRun, adapter_events, assert_setup_failure, bus_actions,
+        comparable_failure, endings, native_run, sole_failed_completion, sse_bytes, trace_json,
+        truncations,
+    },
+    support::{
+        Adder, STREAMING_PREAMBLE, STREAMING_PROMPT, STREAMING_TOOLS_PREAMBLE,
+        STREAMING_TOOLS_PROMPT,
+    },
+};
+
+/// A scripted-transport model: one streaming exchange, then EOF.
+fn scripted_model(
+    chunks: Vec<Bytes>,
+) -> openai::responses_api::ResponsesCompletionModel<SequencedStreamingHttpClient> {
+    scripted_client(chunks).completion_model(GPT_4O)
+}
+
+/// The scripted cells' witness check, over this module's credential.
+fn assert_witness_is_a_side_channel(observed: &NativeRun, plain: &NativeRun) {
+    crate::stream_faults::assert_witness_is_a_side_channel(observed, plain, SCRIPTED_KEY);
+}
+
+/// The bus's facts for a failed run, in order, and no provider facts: the
+/// Responses adapter does not attach diagnostics.
+fn assert_bus_only_failure(run: &NativeRun, actions: &[&str]) {
+    let trace = run.trace();
+    assert_eq!(bus_actions(trace), actions);
+    assert_eq!(endings(trace), ["provider"]);
+    assert!(
+        adapter_events(trace).is_empty(),
+        "no provider diagnostics on this wire: {:?}",
+        adapter_events(trace)
+    );
+}
+
+/// The recorded 400 through the native runtime: the run fails as the
+/// provider's response, streams nothing, commits only the prompt.
+#[tokio::test]
+async fn setup_failure_fails_the_run_with_the_recorded_status() {
+    // The recording's request carries no system instruction at all, which
+    // strict matching distinguishes from an empty one: `Preamble(None)`,
+    // not the helper's `Some("")`.
+    let configure = |ecs: &mut EcsAgent| {
+        ecs.app
+            .world_mut()
+            .entity_mut(ecs.agent)
+            .insert((Preamble(None), MaxTokens(Some(SETUP_MAX_TOKENS))));
+    };
+    let mut runs = Vec::new();
+    for witness in [true, false] {
+        let runs = &mut runs;
+        with_openai_cassette(
+            "error_envelope/nonexistent_model_streaming_error_preserves_status_and_body",
+            |client| async move {
+                let run = native_run(
+                    client.completion_model(MISSING_MODEL),
+                    "",
+                    SETUP_PROMPT,
+                    witness,
+                    configure,
+                )
+                .await;
+                assert_setup_failure(run.provider_report(), SETUP_KIND, 400);
+                assert_setup_failure(sole_failed_completion(&run.log), SETUP_KIND, 400);
+                assert_eq!(run.roles, [Role::User], "only the prompt is history");
+                assert!(run.stream().text.is_empty(), "{:?}", run.stream);
+                assert_eq!(run.stream().errors.len(), 1, "{:?}", run.stream().errors);
+                assert_eq!(run.stream().errors[0].0, 0, "the error is the first item");
+                runs.push(run);
+            },
+        )
+        .await;
+    }
+    let (observed, plain) = (&runs[0], &runs[1]);
+    assert_eq!(
+        comparable_failure(observed.failure()),
+        comparable_failure(plain.failure())
+    );
+    assert_eq!(observed.log_json(), plain.log_json());
+    assert_bus_only_failure(observed, &["issued", "landed_err"]);
+    assert!(
+        !trace_json(observed.trace()).contains(SETUP_PROMPT),
+        "the request body never reaches the trace"
+    );
+}
+
+/// EOF after content through the native runtime: the run fails as a
+/// truncation, the stream keeps the prefix, history keeps only the prompt,
+/// and the bus witnesses the truncation with what was delivered.
+#[tokio::test]
+async fn truncation_after_content_fails_the_run_and_keeps_the_prefix() {
+    let frames = text_prefix_frames();
+    let prefix = delta_text(&frames);
+    let mut runs = Vec::new();
+    for witness in [true, false] {
+        let run = native_run(
+            scripted_model(vec![sse_bytes(&frames)]),
+            STREAMING_PREAMBLE,
+            STREAMING_PROMPT,
+            witness,
+            |_| {},
+        )
+        .await;
+        let report = run.provider_report();
+        assert_eq!(report.kind, ErrorKind::Response, "{report:?}");
+        assert_eq!(report.message, rig::serve::stream_truncated().message);
+        assert_eq!(
+            sole_failed_completion(&run.log).message,
+            rig::serve::stream_truncated().message
+        );
+        assert_eq!(run.stream().text, prefix);
+        assert!(run.stream().errors.is_empty(), "EOF is not an item");
+        assert!(run.stream().outcome.is_none(), "{:?}", run.stream().outcome);
+        assert_eq!(run.roles, [Role::User], "the cut turn is not history");
+        runs.push(run);
+    }
+    let (observed, plain) = (&runs[0], &runs[1]);
+    assert_witness_is_a_side_channel(observed, plain);
+    assert_bus_only_failure(observed, &["issued", "truncated", "landed_err"]);
+    let delivered = observed.stream().events.len();
+    assert_eq!(truncations(observed.trace()), [(delivered, 0)]);
+}
+
+/// EOF after a complete tool call through the native runtime: the call is
+/// never dispatched, the tool never runs, no assistant turn is committed,
+/// and the run fails as a truncation.
+#[tokio::test]
+async fn truncation_after_a_complete_tool_call_never_runs_the_tool() {
+    let frames = tool_call_prefix_frames();
+    let mut runs = Vec::new();
+    for witness in [true, false] {
+        let invocations = Invocations::default();
+        let counted = invocations.clone();
+        let run = native_run(
+            scripted_model(vec![sse_bytes(&frames)]),
+            STREAMING_TOOLS_PREAMBLE,
+            STREAMING_TOOLS_PROMPT,
+            witness,
+            move |ecs| {
+                ecs.tool(Adder);
+                ecs.tool(CountedSubtract(counted));
+            },
+        )
+        .await;
+        let report = run.provider_report();
+        assert_eq!(report.kind, ErrorKind::Response, "{report:?}");
+        assert_eq!(
+            sole_failed_completion(&run.log).message,
+            rig::serve::stream_truncated().message,
+            "one completion and no tool effect"
+        );
+        assert_eq!(invocations.count(), 0, "the tool never ran");
+        assert_eq!(run.roles, [Role::User], "the call is not history");
+        assert!(
+            run.stream()
+                .events
+                .iter()
+                .any(|event| matches!(event, rig::streaming::StreamEvent::BlockEnd { .. })),
+            "the call streamed to its end before the cut: {:?}",
+            run.stream().events
+        );
+        runs.push(run);
+    }
+    let (observed, plain) = (&runs[0], &runs[1]);
+    assert_witness_is_a_side_channel(observed, plain);
+    assert_bus_only_failure(observed, &["issued", "truncated", "landed_err"]);
+    assert_eq!(truncations(observed.trace()).len(), 1);
+}
+
+/// An error event after content through the native runtime: the run fails
+/// with the provider's error, the stream keeps the prefix and the error
+/// item at its position, and history keeps only the prompt.
+#[tokio::test]
+async fn error_event_after_content_fails_with_the_provider_error() {
+    let mut frames = text_prefix_frames();
+    let prefix = delta_text(&frames);
+    frames.push(ERROR_EVENT.to_owned());
+    let mut runs = Vec::new();
+    for witness in [true, false] {
+        let run = native_run(
+            scripted_model(vec![sse_bytes(&frames)]),
+            STREAMING_PREAMBLE,
+            STREAMING_PROMPT,
+            witness,
+            |_| {},
+        )
+        .await;
+        let report = run.provider_report();
+        assert_eq!(report.kind, ErrorKind::ProviderResponse, "{report:?}");
+        assert!(
+            report
+                .provider_response_body()
+                .is_some_and(|body| body.contains("boom")),
+            "{report:?}"
+        );
+        assert_eq!(
+            sole_failed_completion(&run.log).kind,
+            ErrorKind::ProviderResponse
+        );
+        assert_eq!(run.stream().text, prefix);
+        assert_eq!(run.stream().errors.len(), 1, "{:?}", run.stream().errors);
+        assert_eq!(
+            run.stream().errors[0].0,
+            run.stream().events.len(),
+            "the error item follows the delivered content"
+        );
+        assert_eq!(run.roles, [Role::User]);
+        runs.push(run);
+    }
+    let (observed, plain) = (&runs[0], &runs[1]);
+    assert_witness_is_a_side_channel(observed, plain);
+    assert_bus_only_failure(observed, &["issued", "landed_err"]);
+    assert!(
+        truncations(observed.trace()).is_empty(),
+        "an error, not EOF"
+    );
+}
+
+/// Despawn the issued completion once its stream has delivered text: the
+/// consumer dropping the runner's stream, on this runtime. A run-level
+/// `Cancelled` would instead leave the in-flight stream to its handler
+/// (CONTRACT §9.1); the despawn is what ends the exchange mid-answer.
+fn despawn_at_first_text(
+    mut commands: Commands,
+    streams: Query<(Entity, &Streamed), Without<EffectOutcome>>,
+) {
+    for (entity, stream) in &streams {
+        if !stream.text.is_empty() {
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
+/// The issued completion is despawned at the recorded stream's first text
+/// delta: the run fails as cancelled, the completion is recorded as
+/// cancelled and no answer is committed. The replay marked the interaction
+/// consumed when it matched the request, so `finish` still passes; the
+/// despawn lands on the response body, which the replay does not track.
+#[tokio::test]
+async fn despawning_the_stream_at_the_first_delta_records_a_cancel() {
+    let mut runs = Vec::new();
+    for witness in [true, false] {
+        let runs = &mut runs;
+        with_openai_cassette("streaming/streaming_smoke", |client| async move {
+            let run = native_run(
+                client.completion_model(GPT_4O),
+                STREAMING_PREAMBLE,
+                STREAMING_PROMPT,
+                witness,
+                |ecs| {
+                    ecs.app.add_systems(
+                        RigSchedule,
+                        despawn_at_first_text
+                            .after(BusSet::Collect)
+                            .before(RigSet::Fold),
+                    );
+                },
+            )
+            .await;
+            assert!(
+                matches!(run.failure(), Failure::Cancelled(_)),
+                "a cancelled run, not {:?}",
+                run.failure()
+            );
+            let recorded = sole_failed_completion(&run.log);
+            assert_eq!(recorded.kind, ErrorKind::Cancelled, "{recorded:?}");
+            assert!(run.stream.is_none(), "the despawned effect took its stream");
+            assert_eq!(run.roles, [Role::User], "no answer is committed");
+            runs.push(run);
+        })
+        .await;
+    }
+    let (observed, plain) = (&runs[0], &runs[1]);
+    assert_eq!(
+        comparable_failure(observed.failure()),
+        comparable_failure(plain.failure())
+    );
+    assert_eq!(observed.log_json(), plain.log_json());
+    let trace = observed.trace();
+    assert_eq!(endings(trace), ["cancelled"]);
+    assert_eq!(bus_actions(trace), ["issued", "cancelled"]);
+}

--- a/tests/providers/openai/cassette/stream_faults.rs
+++ b/tests/providers/openai/cassette/stream_faults.rs
@@ -1,0 +1,302 @@
+//! OpenAI Responses stream faults through the runner: the recorded 400 on
+//! stream setup, a consumer that drops the recorded stream mid-answer, and
+//! scripted faults cut from the committed recordings — a stream that ends
+//! before its terminal, one that ends after a complete tool call, one that
+//! carries an error event after content — served to the real Responses
+//! adapter. Native counterparts: `ecs_stream_faults.rs`. Every cell's
+//! hypothesis is that the fault surfaces as its own kind, with nothing
+//! recorded, committed or executed after it.
+
+use bytes::Bytes;
+use futures::StreamExt;
+use rig::agent::MultiTurnStreamItem;
+use rig::effect::EffectFamily;
+use rig::error::ErrorKind;
+use rig::prelude::*;
+use rig::providers::openai::{self, GPT_4O};
+use rig::streaming::{Delta, StreamEvent};
+use rig::test_utils::SequencedStreamingHttpClient;
+
+use super::super::support::with_openai_cassette;
+use crate::{
+    goldens::families,
+    stream_faults::{
+        CountedSubtract, Invocations, assert_setup_failure, drain, frame_data, frames_before,
+        recorded_sse_frames, recorded_stream_errors, scripted, sole_failed_completion, sse_bytes,
+    },
+    support::{
+        Adder, STREAMING_PREAMBLE, STREAMING_PROMPT, STREAMING_TOOLS_PREAMBLE,
+        STREAMING_TOOLS_PROMPT,
+    },
+};
+
+/// The recorded stream-setup failure, `error_envelope/nonexistent_model_streaming_error_preserves_status_and_body`,
+/// carries this model, prompt and budget.
+pub(super) const MISSING_MODEL: &str = "gpt-4o-mini-nonexistent-rig-test";
+pub(super) const SETUP_PROMPT: &str = "Say hi.";
+pub(super) const SETUP_MAX_TOKENS: u64 = 16;
+/// The Responses adapter's classification of a rejected request: the
+/// provider's response, preserved on the report.
+pub(super) const SETUP_KIND: ErrorKind = ErrorKind::ProviderResponse;
+
+/// The recorded text stream the cut cells derive from, and the recorded
+/// tool-call turn (its first interaction: the call, then the terminal).
+pub(super) const TEXT_STREAM: &str = "streaming/streaming_smoke";
+pub(super) const TOOL_STREAM: &str = "streaming_tools/streaming_tools_smoke";
+/// An error event, the shape the adapter's unit tests pin
+/// (`streaming_error_event_preserves_full_payload`).
+pub(super) const ERROR_EVENT: &str = r#"event: error
+data: {"type":"error","error":{"message":"boom","code":"server_error","type":"server_error"}}"#;
+/// A key the scripted cells send: it must never reach a trace.
+pub(super) const SCRIPTED_KEY: &str = "sk-scripted-fault-key-7f3a9c";
+
+/// The frames of the recorded text stream up to, not including, the text
+/// item's completion: content deltas, then nothing.
+pub(super) fn text_prefix_frames() -> Vec<String> {
+    let frames = recorded_sse_frames("openai", TEXT_STREAM, 0);
+    frames_before(&frames, |frame| {
+        frame.starts_with("event: response.output_text.done")
+    })
+}
+
+/// The text the deltas of `frames` carry.
+pub(super) fn delta_text(frames: &[String]) -> String {
+    frames
+        .iter()
+        .filter(|frame| frame.starts_with("event: response.output_text.delta"))
+        .map(|frame| {
+            frame_data(frame)["delta"]
+                .as_str()
+                .expect("a text delta")
+                .to_owned()
+        })
+        .collect()
+}
+
+/// The frames of the recorded tool-call turn up to, not including, the
+/// response's completion: the whole `subtract` call, then nothing.
+pub(super) fn tool_call_prefix_frames() -> Vec<String> {
+    let frames = recorded_sse_frames("openai", TOOL_STREAM, 0);
+    let prefix = frames_before(&frames, |frame| {
+        frame.starts_with("event: response.completed")
+    });
+    assert!(
+        prefix
+            .iter()
+            .any(|frame| frame.starts_with("event: response.output_item.done")),
+        "the cut keeps the completed call: {prefix:?}"
+    );
+    prefix
+}
+
+/// A client over a transport that answers one streaming request with
+/// `chunks`, then EOF.
+pub(super) fn scripted_client(chunks: Vec<Bytes>) -> openai::Client<SequencedStreamingHttpClient> {
+    openai::Client::builder()
+        .api_key(SCRIPTED_KEY)
+        .http_client(scripted(chunks))
+        .build()
+        .expect("client should build")
+}
+
+/// The model refuses the request before any frame: the run fails with the
+/// recorded 400 and its body, streams nothing, and records the one
+/// completion as that failure.
+#[tokio::test]
+async fn setup_failure_fails_the_run_with_the_recorded_status() {
+    // The fixture census wants the scenario as a literal at the wrapper call.
+    with_openai_cassette(
+        "error_envelope/nonexistent_model_streaming_error_preserves_status_and_body",
+        |client| async move {
+            let agent = client
+                .agent(MISSING_MODEL)
+                .max_tokens(SETUP_MAX_TOKENS)
+                .record_effects_with_events()
+                .build();
+            let mut stream = agent.stream_prompt(SETUP_PROMPT).stream().await;
+            let drained = drain(&mut stream).await;
+            drop(stream);
+
+            assert_eq!(drained.finals, 0, "no final response: {drained:?}");
+            assert_eq!(drained.terminals, 0, "no terminal record: {drained:?}");
+            assert!(drained.text.is_empty(), "no text: {drained:?}");
+            assert_eq!(drained.errors.len(), 1, "one error item: {drained:?}");
+            assert_setup_failure(&drained.errors[0], SETUP_KIND, 400);
+
+            let log = agent.take_effect_log().expect("recording");
+            assert_setup_failure(sole_failed_completion(&log), SETUP_KIND, 400);
+            let errors = recorded_stream_errors(&log);
+            assert_eq!(errors.len(), 1, "one recorded error item: {errors:?}");
+            assert_eq!(errors[0].0, 0, "the error is the stream's first item");
+        },
+    )
+    .await;
+}
+
+/// The stream closes after content without a terminal record: the run
+/// fails as a truncation, the text prefix was delivered, no final response
+/// is assembled, and the record holds the truncation.
+#[tokio::test]
+async fn truncation_after_content_fails_the_run_and_keeps_the_prefix() {
+    let frames = text_prefix_frames();
+    let prefix = delta_text(&frames);
+    assert!(
+        !prefix.is_empty(),
+        "the recording streams text before its end"
+    );
+    let client = scripted_client(vec![sse_bytes(&frames)]);
+    let agent = client
+        .agent(GPT_4O)
+        .preamble(STREAMING_PREAMBLE)
+        .record_effects_with_events()
+        .build();
+    let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+    let drained = drain(&mut stream).await;
+    drop(stream);
+
+    assert_eq!(drained.text, prefix, "{drained:?}");
+    assert_eq!(drained.finals, 0, "{drained:?}");
+    assert_eq!(drained.terminals, 0, "{drained:?}");
+    assert!(!drained.errors.is_empty(), "{drained:?}");
+    for report in &drained.errors {
+        assert_eq!(report.kind, ErrorKind::Response, "{report:?}");
+        assert!(
+            report.message.contains("terminal record"),
+            "a truncation, by name: {report:?}"
+        );
+    }
+
+    let log = agent.take_effect_log().expect("recording");
+    let recorded = sole_failed_completion(&log);
+    assert_eq!(recorded.kind, ErrorKind::Response, "{recorded:?}");
+    assert_eq!(recorded.message, rig::serve::stream_truncated().message);
+}
+
+/// The stream closes after a complete tool call without a terminal record:
+/// the call is not committed, the tool never runs, and the run fails as a
+/// truncation with the one completion recorded.
+#[tokio::test]
+async fn truncation_after_a_complete_tool_call_never_runs_the_tool() {
+    let frames = tool_call_prefix_frames();
+    let invocations = Invocations::default();
+    let client = scripted_client(vec![sse_bytes(&frames)]);
+    let agent = client
+        .agent(GPT_4O)
+        .preamble(STREAMING_TOOLS_PREAMBLE)
+        .tool(Adder)
+        .tool(CountedSubtract(invocations.clone()))
+        .record_effects_with_events()
+        .build();
+    let mut stream = agent
+        .stream_prompt(STREAMING_TOOLS_PROMPT)
+        .max_turns(2)
+        .stream()
+        .await;
+    let drained = drain(&mut stream).await;
+    drop(stream);
+
+    assert_eq!(drained.tool_calls, 0, "no call is committed: {drained:?}");
+    assert_eq!(drained.finals, 0, "{drained:?}");
+    assert_eq!(drained.terminals, 0, "{drained:?}");
+    assert!(!drained.errors.is_empty(), "{drained:?}");
+    for report in &drained.errors {
+        assert_eq!(report.kind, ErrorKind::Response, "{report:?}");
+    }
+    assert_eq!(invocations.count(), 0, "the tool never ran");
+
+    let log = agent.take_effect_log().expect("recording");
+    assert_eq!(
+        families(&log),
+        [EffectFamily::Completion],
+        "no tool effect follows the cut turn"
+    );
+    let recorded = sole_failed_completion(&log);
+    assert_eq!(recorded.message, rig::serve::stream_truncated().message);
+}
+
+/// An error event after content: the run fails with the provider's error
+/// (body preserved), the prefix was delivered, and the error item sits
+/// after the content items.
+#[tokio::test]
+async fn error_event_after_content_fails_with_the_provider_error() {
+    let mut frames = text_prefix_frames();
+    let prefix = delta_text(&frames);
+    frames.push(ERROR_EVENT.to_owned());
+    let client = scripted_client(vec![sse_bytes(&frames)]);
+    let agent = client
+        .agent(GPT_4O)
+        .preamble(STREAMING_PREAMBLE)
+        .record_effects_with_events()
+        .build();
+    let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+    let drained = drain(&mut stream).await;
+    drop(stream);
+
+    assert_eq!(drained.text, prefix, "{drained:?}");
+    assert_eq!(drained.finals, 0, "{drained:?}");
+    assert_eq!(drained.terminals, 0, "{drained:?}");
+    assert_eq!(drained.errors.len(), 1, "{drained:?}");
+    let report = &drained.errors[0];
+    assert_eq!(report.kind, ErrorKind::ProviderResponse, "{report:?}");
+    assert!(
+        report
+            .provider_response_body()
+            .is_some_and(|body| body.contains("boom")),
+        "the event's payload is preserved: {report:?}"
+    );
+
+    let log = agent.take_effect_log().expect("recording");
+    let recorded = sole_failed_completion(&log);
+    assert_eq!(recorded.kind, ErrorKind::ProviderResponse, "{recorded:?}");
+    let errors = recorded_stream_errors(&log);
+    assert_eq!(errors.len(), 1, "{errors:?}");
+    let delivered = log.records[0]
+        .events
+        .as_ref()
+        .map_or(0, |events| events.len());
+    assert!(delivered > 0, "content items precede the error");
+    assert_eq!(
+        errors[0].0, delivered,
+        "the error item sits after the delivered content"
+    );
+}
+
+/// The consumer drops the recorded stream at its first text delta: the
+/// completion is recorded as cancelled and no answer is assembled. The
+/// replay marked the interaction consumed when it matched the request, so
+/// `finish` still passes; the drop lands on the response body, which the
+/// replay does not track.
+#[tokio::test]
+async fn dropping_the_stream_at_the_first_delta_records_a_cancel() {
+    with_openai_cassette("streaming/streaming_smoke", |client| async move {
+        let agent = client
+            .agent(GPT_4O)
+            .preamble(STREAMING_PREAMBLE)
+            .record_effects_with_events()
+            .build();
+        {
+            let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+            while let Some(item) = stream.next().await {
+                match item {
+                    Ok(MultiTurnStreamItem::StreamAssistantItem(StreamEvent::BlockDelta {
+                        delta: Delta::Text { .. },
+                        ..
+                    })) => break,
+                    Ok(MultiTurnStreamItem::FinalResponse(_)) => {
+                        panic!("the answer arrived before the first delta")
+                    }
+                    Err(error) => panic!("no error before the drop: {error}"),
+                    Ok(_) => {}
+                }
+            }
+            // Dropped here, mid-answer.
+        }
+        for _ in 0..64 {
+            tokio::task::yield_now().await;
+        }
+        let log = agent.take_effect_log().expect("recording");
+        let recorded = sole_failed_completion(&log);
+        assert_eq!(recorded.kind, ErrorKind::Cancelled, "{recorded:?}");
+    })
+    .await;
+}

--- a/tests/providers/openai/mod.rs
+++ b/tests/providers/openai/mod.rs
@@ -29,6 +29,7 @@ mod cassette {
     mod ecs_ordering;
     mod ecs_parity;
     mod ecs_prompt_caching;
+    mod ecs_stream_faults;
     mod ecs_termination;
     mod effect_corpus;
     mod embedding_matrix;
@@ -64,6 +65,7 @@ mod cassette {
     mod responses_sessions;
     mod responses_tool_args;
     mod responses_tool_choice;
+    mod stream_faults;
     mod streaming;
     mod streaming_grammar;
     mod streaming_grammar_chat;


### PR DESCRIPTION
# test: stream-fault cells for both runtimes, and a replay session that cannot be dropped unfinished

## Description

Child of #2443 (base `feat/effect-bus`). Closes the coverage gaps the cassette
and consumer-verification audit found for the behavior #2443 introduces, and
fixes the one piece of cassette machinery that hid errors.

**What was not covered.** Streaming setup failures had runner/native coverage
for Anthropic only; no provider had runner or native coverage of a stream
ending before its terminal record, of an in-band error after content, of a
tool call issued before a truncation, or of OpenAI cancellation; no
cassette-backed run installed the world's witness; and a `ProviderCassette`
replay session dropped without `finish` passed silently on unplayed
interactions and swallowed misses.

**Stream-fault cells** (`tests/providers/{gemini,openai}/cassette/stream_faults.rs`
and their `ecs_stream_faults.rs` twins, shared support in
`tests/common/stream_faults.rs`), each through the real adapter, the rig-agent
runner and the native ECS runtime independently:

| Cell | Gemini | OpenAI (Responses) | Evidence |
| --- | --- | --- | --- |
| Setup failure (non-2xx before any frame) | 404, runner + native | 400, runner + native | replayed committed `error_envelope` recordings; the runner's and the native request bodies match the model-level recording |
| Blocked prompt (#2475) | runner + native | — | real Gemini 3.8-flash body (downstream capture, 2026-09-08), served synthetically |
| EOF before the terminal record | runner + native | runner + native | Gemini: real content frame from the same capture; OpenAI: `streaming/streaming_smoke` cut before `output_text.done` |
| EOF after a complete tool call | — (single-frame wire) | runner + native | `streaming_tools/streaming_tools_smoke` cut before `response.completed`; the tool's executions are counted |
| In-band error after content | runner + native (503 envelope under 200) | runner + native (`event: error`) | envelope shapes the adapters' unit tests pin, appended to the real prefix |
| Consumer drops / despawns the stream at the first delta | — | runner + native | replayed `streaming/streaming_smoke`, consumed whole |
| Witnessed success equals the unwitnessed run | native | — | replayed `streaming/streaming_smoke` twice |

Every cell asserts the failure kind and status, the provider body where one
exists, the text prefix delivered, that no final response or terminal record
is synthesized, that the one completion record holds the fault and no effect
follows it, that history holds only the prompt, and (native) the stream's
error items and their positions. Native cells run with and without the
witness: the failure, the record (minus scheduling-dependent delivery batch
numbers, which the comparison guide already excludes) and the history are
identical, the trace names the ending (`provider` / `cancelled` / `settled`),
the bus's decisions (`issued`, `truncated`, `landed_err`, `cancelled`), and —
on Gemini, the only wire with provider diagnostics — the boundary facts
(`Response {404}`, `ErrorEnvelope`, `Finished { Error | Eof | Terminal }`,
the verdict's `block_reason`, the billed usage of a refused prompt); the
request body and the credential never reach the trace.

No cassette is added or edited. Scripted faults are cut from committed
recordings or assembled from labelled real frames; every synthetic frame is a
constant with its provenance beside its cell. The nine runner/native pairs are
registered in `tests/ecs_parity/scenarios.json` (`cargo xtask check-ecs-scenarios`
against a fresh `--features bedrock` listing passes: 323 native mappings).

**Cassette engine.** `ReplayServer` now panics on drop when the session was
never `finish`ed and still holds an unplayed interaction or a refused request;
it never panics while unwinding, and a fully played session may be dropped
silently. Five negative tests through the public `ProviderCassette` API pin
`finish` refusing an unplayed interaction, `finish` refusing a miss the caller
swallowed as an ordinary HTTP error, the drop guard, its silence on a fully
played session, and no double panic when `finish` itself fails.

**Findings not changed here.** Gemini classifies an HTTP error envelope
(404 setup failure, in-band 503) as `ErrorKind::Http { status }` while the
Responses and Anthropic wires classify the same fault as `ProviderResponse`;
both preserve the body. Pre-existing rig-core taxonomy, pinned per wire.
Native EOF truncation leaves `Streamed.outcome == None` (no terminal, no
error item) while the effect outcome is `stream_truncated()`; pinned with a
comment. Only the Gemini adapter attaches provider diagnostics; the OpenAI
cells pin that the trace carries bus facts only.

**Unsupported honestly.** A Gemini prefix-then-fault stream cannot be cut from
the in-tree REST recordings (all single-frame), hence the labelled real
frames. A transient 429/5xx followed by a successful retry has no recording in
this tree and neither runtime retries a stream setup failure; not represented.
The downstream consumer harness (rigcoder-verify) pins an older #2443 head and
its cassettes embed its own tools and workspace path, so they were read for
provenance only, not replayed.

Independent review: a reviewer who did not implement the change reviewed the
complete diff; findings and dispositions are in the ledger under
`many_rigs/reviews/rig-2443-04-cassette-coverage/`.

## Changelog

- *(test)* stream-fault cells for the runner and the native ECS runtime on the Gemini and OpenAI Responses wires: setup failure, blocked prompt, EOF before the terminal, EOF after a complete tool call, in-band error after content, consumer drop, witnessed success.
- *(rig-cassette)* a replay session dropped without `finish` panics when it holds an unplayed interaction or a refused request, so a test that returns early cannot pass on a recording it never played.

## Migration

None.

## Testing

```sh
RIG_PROVIDER_TEST_MODE=replay cargo nextest run --locked -p rig --all-features --test gemini --test openai -E 'test(stream_faults) | test(cassette_safety)'
cargo test --locked -p rig-cassette --all-features
cargo nextest list --locked -p rig --features bedrock --message-format json > target/ecs-tests.json && cargo xtask check-ecs-scenarios target/ecs-tests.json
RIG_PROVIDER_TEST_MODE=replay cargo xtask verify --pr --base origin/feat/effect-bus
```

Mutation check: feeding the uncut recordings to the four OpenAI truncation
cells fails all four.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated READMEs and Rust docs affected by this change
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did not edit `CHANGELOG.md` or `MIGRATING.md` (they are generated at release)

## Notes

Sibling child PRs: the AgentRunner public-API refactor renames
`agent.stream_prompt(p).stream().await` to `agent.prompt(p).stream()`; the
eight runner call sites here use the base's current API and take that
mechanical rewrite when the two meet. No file overlaps with the history /
tool-context child.
