### PR TITLE
refactor(agent)!: one way to a runner, and a lazy stream

### DIFF
--- a/crates/rig-agent/examples/raw_response_hook.rs
+++ b/crates/rig-agent/examples/raw_response_hook.rs
@@ -105,8 +105,7 @@ async fn main() -> Result<()> {
     println!("\nstreaming:");
     let mut stream = agent
         .prompt("What does a system fingerprint identify?")
-        .stream()
-        .await;
+        .stream();
     while let Some(item) = stream.next().await {
         if let MultiTurnStreamItem::FinalResponse(final_response) = item? {
             println!("  => {}", final_response.output);

--- a/crates/rig-agent/examples/raw_response_hook.rs
+++ b/crates/rig-agent/examples/raw_response_hook.rs
@@ -104,7 +104,7 @@ async fn main() -> Result<()> {
 
     println!("\nstreaming:");
     let mut stream = agent
-        .stream_prompt("What does a system fingerprint identify?")
+        .prompt("What does a system fingerprint identify?")
         .stream()
         .await;
     while let Some(item) = stream.next().await {

--- a/crates/rig-agent/examples/retry_on_truncation.rs
+++ b/crates/rig-agent/examples/retry_on_truncation.rs
@@ -178,7 +178,7 @@ async fn main() -> Result<()> {
         .add_hook(GrowCapOnTruncation::new(8, 256))
         .build();
     let mut stream = streaming_agent
-        .stream_prompt("Explain Rig's finish reasons.")
+        .prompt("Explain Rig's finish reasons.")
         .max_turns(8)
         .stream()
         .await;

--- a/crates/rig-agent/examples/retry_on_truncation.rs
+++ b/crates/rig-agent/examples/retry_on_truncation.rs
@@ -180,8 +180,7 @@ async fn main() -> Result<()> {
     let mut stream = streaming_agent
         .prompt("Explain Rig's finish reasons.")
         .max_turns(8)
-        .stream()
-        .await;
+        .stream();
     while let Some(item) = stream.next().await {
         if let MultiTurnStreamItem::FinalResponse(final_response) = item? {
             println!("  => {}", final_response.output);

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -741,7 +741,7 @@ impl Agent {
     /// let response = agent.prompt("What is 2 + 2?").max_turns(3).await?;
     /// println!("{}", response.output);
     ///
-    /// let mut stream = agent.prompt("And 3 + 3?").stream().await;
+    /// let mut stream = agent.prompt("And 3 + 3?").stream();
     /// while let Some(item) = stream.next().await {
     ///     let item = item?;
     ///     // text deltas, tool calls and results, then `FinalResponse`

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -767,9 +767,13 @@ impl Agent {
     /// [`add_hook`](AgentRunner::add_hook),
     /// [`tool_context`](AgentRunner::tool_context),
     /// [`tool_concurrency`](AgentRunner::tool_concurrency), the model
-    /// selection and telemetry settings. The unhandled-invalid-tool-call
-    /// policy is the run's on the blocking path and the runner's on the
-    /// streamed path. Conversation memory is neither loaded nor appended:
+    /// selection and telemetry settings. Two run-side values still show
+    /// through: the run's persisted tool choice is what invalid-call hooks
+    /// see and what gates a `Skip`, while the request's tool choice is the
+    /// runner's; and the output tool the run committed stays committed even
+    /// though the schema and mode advertising it are the runner's. The
+    /// unhandled-invalid-tool-call policy is the run's on the blocking path
+    /// and the runner's on the streamed path. Conversation memory is neither loaded nor appended:
     /// the history is already in the run, and the driver that persisted it
     /// owns its memory. Drive it like any runner: `.await`,
     /// [`stream`](AgentRunner::stream) or

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -757,13 +757,21 @@ impl Agent {
     ///
     /// The state a driver serialized between steps (see [`AgentRun`]) is
     /// picked up where it stopped — its pending tool calls execute, its next
-    /// model turn is asked for — under this agent's hooks, tools, bus and
-    /// settings, plus whatever the returned runner is configured with. The
-    /// run carries its own prompt and history, so neither
-    /// [`history`](AgentRunner::history) nor conversation memory applies:
-    /// nothing is loaded, and the run's messages are not appended a second
-    /// time. Drive it like any runner: `.await`, [`stream`](AgentRunner::stream)
-    /// or [`run_channel`](AgentRunner::run_channel). The run must have been
+    /// model turn is asked for — under this agent's hooks, tools and bus.
+    /// The run is authoritative for everything it carries: its prompt, its
+    /// history, its turn budget, its invalid-tool-call budget and policy,
+    /// its output schema and tool choice. The runner supplies only what a
+    /// run does not persist: [`add_hook`](AgentRunner::add_hook),
+    /// [`tool_context`](AgentRunner::tool_context),
+    /// [`tool_concurrency`](AgentRunner::tool_concurrency), the model
+    /// selection ([`using_model`](AgentRunner::using_model)) and telemetry
+    /// settings; the run-shaping setters ([`max_turns`](AgentRunner::max_turns),
+    /// [`history`](AgentRunner::history), …) have no effect on a resumed
+    /// run. Conversation memory is neither loaded nor appended: the history
+    /// is already in the run, and the driver that persisted it owns its
+    /// memory. Drive it like any runner: `.await`,
+    /// [`stream`](AgentRunner::stream) or
+    /// [`run_channel`](AgentRunner::run_channel). The run must have been
     /// suspended by the same rig version.
     ///
     /// ```rust,no_run

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -758,18 +758,20 @@ impl Agent {
     /// The state a driver serialized between steps (see [`AgentRun`]) is
     /// picked up where it stopped — its pending tool calls execute, its next
     /// model turn is asked for — under this agent's hooks, tools and bus.
-    /// The run is authoritative for everything it carries: its prompt, its
-    /// history, its turn budget, its invalid-tool-call budget and policy,
-    /// its output schema and tool choice. The runner supplies only what a
-    /// run does not persist: [`add_hook`](AgentRunner::add_hook),
+    /// The run is authoritative for what it persisted: its prompt, its
+    /// history, its turn budget and its invalid-tool-call retry budget, so
+    /// [`history`](AgentRunner::history) and [`max_turns`](AgentRunner::max_turns)
+    /// on the returned runner have no effect. Everything else still comes
+    /// from the agent and the runner: the request shape (preamble, documents,
+    /// sampling parameters, additional params, tool choice, output mode),
+    /// [`add_hook`](AgentRunner::add_hook),
     /// [`tool_context`](AgentRunner::tool_context),
     /// [`tool_concurrency`](AgentRunner::tool_concurrency), the model
-    /// selection ([`using_model`](AgentRunner::using_model)) and telemetry
-    /// settings; the run-shaping setters ([`max_turns`](AgentRunner::max_turns),
-    /// [`history`](AgentRunner::history), …) have no effect on a resumed
-    /// run. Conversation memory is neither loaded nor appended: the history
-    /// is already in the run, and the driver that persisted it owns its
-    /// memory. Drive it like any runner: `.await`,
+    /// selection and telemetry settings. The unhandled-invalid-tool-call
+    /// policy is the run's on the blocking path and the runner's on the
+    /// streamed path. Conversation memory is neither loaded nor appended:
+    /// the history is already in the run, and the driver that persisted it
+    /// owns its memory. Drive it like any runner: `.await`,
     /// [`stream`](AgentRunner::stream) or
     /// [`run_channel`](AgentRunner::run_channel). The run must have been
     /// suspended by the same rig version.

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -421,13 +421,6 @@ impl Agent {
         self.name().unwrap_or(UNKNOWN_AGENT_NAME)
     }
 
-    /// Build a hook-aware [`AgentRunner`] for this agent, seeded with the
-    /// agent's default hook stack. Attach more hooks with
-    /// [`AgentRunner::add_hook`], then call [`AgentRunner::run`].
-    pub fn runner(&self, prompt: impl Into<Message>) -> AgentRunner {
-        AgentRunner::from_agent(self, prompt)
-    }
-
     /// The key of this agent's default model on its bus (a completion key;
     /// `.raw()` for the wire string).
     pub fn model_key(&self) -> &Key<family::Completion> {
@@ -716,7 +709,7 @@ impl Agent {
     /// Resolve the provider-facing tool definitions available for a prompt.
     ///
     /// This read-only view does not expose tool dispatch. Agent execution and
-    /// tool lifecycle hooks remain owned by [`Self::runner`].
+    /// tool lifecycle hooks remain owned by [`Self::prompt`].
     pub async fn tool_definitions(
         &self,
         prompt: Option<String>,
@@ -726,16 +719,33 @@ impl Agent {
 }
 
 impl Agent {
-    /// Run `prompt` through the agent loop. The returned [`AgentRunner`] is the
-    /// run: configure it (history, turn budget, tool context, hooks, …) and
-    /// `.await` it for the [`PromptResponse`], whose `output` is the accepted
-    /// assistant text.
+    /// Start a run from `prompt`. The returned [`AgentRunner`] is the run:
+    /// configure it (history, turn budget, tool context, hooks, …), then pick
+    /// how to drive it. Nothing happens until it is driven.
+    ///
+    /// - `.await` (or [`run`](AgentRunner::run)) folds the whole loop to a
+    ///   [`PromptResponse`], whose `output` is the accepted assistant text.
+    /// - [`stream`](AgentRunner::stream) yields every provider delta, tool
+    ///   event and the final response as a stream.
+    /// - [`run_channel`](AgentRunner::run_channel) splits the run into a
+    ///   future and an event feed for a host with its own executor or tick.
+    ///
+    /// The medium is chosen by the terminal call alone: an awaited runner asks
+    /// the provider for a complete response, a streamed one for a stream.
+    /// Hooks, tools, memory and the resulting history are the same in each.
     ///
     /// ```rust,no_run
     /// # use rig_agent::Agent;
+    /// # use futures::StreamExt;
     /// # async fn example(agent: Agent) -> Result<(), Box<dyn std::error::Error>> {
     /// let response = agent.prompt("What is 2 + 2?").max_turns(3).await?;
     /// println!("{}", response.output);
+    ///
+    /// let mut stream = agent.prompt("And 3 + 3?").stream().await;
+    /// while let Some(item) = stream.next().await {
+    ///     let item = item?;
+    ///     // text deltas, tool calls and results, then `FinalResponse`
+    /// }
     /// # Ok(())
     /// # }
     /// ```
@@ -743,9 +753,10 @@ impl Agent {
         AgentRunner::from_agent(self, prompt)
     }
 
-    /// Run one turn against caller-owned history, appending only the messages
-    /// the run committed. Returns the same [`PromptResponse`] as
-    /// [`prompt`](Self::prompt).
+    /// Run `prompt` against caller-owned history with the agent's defaults,
+    /// then append the messages the run committed to `chat_history`. This is
+    /// [`prompt`](Self::prompt) with [`history`](AgentRunner::history) plus
+    /// the write-back; the runner form is the one to configure or stream.
     #[tracing::instrument(skip(self, prompt, chat_history), fields(agent_name = self.name_or_default()))]
     pub async fn chat(
         &self,
@@ -759,21 +770,6 @@ impl Agent {
             chat_history.extend(messages);
         }
         Ok(response)
-    }
-
-    /// Run `prompt` as a stream: configure the returned runner, then call
-    /// [`AgentRunner::stream`] or [`AgentRunner::run_channel`].
-    pub fn stream_prompt(&self, prompt: impl Into<Message>) -> AgentRunner {
-        AgentRunner::from_agent(self, prompt)
-    }
-
-    /// [`stream_prompt`](Self::stream_prompt) with canonical chat history.
-    pub fn stream_chat<I, T>(&self, prompt: impl Into<Message>, chat_history: I) -> AgentRunner
-    where
-        I: IntoIterator<Item = T>,
-        T: Into<Message>,
-    {
-        AgentRunner::from_agent(self, prompt).history(chat_history)
     }
 
     /// Run `prompt` and deserialize the accepted structured response as `T`.

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -773,9 +773,9 @@ impl Agent {
     /// runner's; and the output tool the run committed stays committed even
     /// though the schema and mode advertising it are the runner's. The
     /// unhandled-invalid-tool-call policy is the run's on the blocking path
-    /// and the runner's on the streamed path. Conversation memory is neither loaded nor appended:
-    /// the history is already in the run, and the driver that persisted it
-    /// owns its memory. Drive it like any runner: `.await`,
+    /// and the runner's on the streamed path. Conversation memory is neither
+    /// loaded nor appended: the history is already in the run, and the driver
+    /// that persisted it owns its memory. Drive it like any runner: `.await`,
     /// [`stream`](AgentRunner::stream) or
     /// [`run_channel`](AgentRunner::run_channel). The run must have been
     /// suspended by the same rig version.

--- a/crates/rig-agent/src/agent/completion.rs
+++ b/crates/rig-agent/src/agent/completion.rs
@@ -1,5 +1,5 @@
 use super::hook::{HookStack, RequestPatch};
-use super::run::OutputMode;
+use super::run::{AgentRun, OutputMode};
 use super::runner::AgentRunner;
 use super::typed::TypedRun;
 use crate::bus::{BusDriver, Dispatcher, ModelHandle};
@@ -751,6 +751,31 @@ impl Agent {
     /// ```
     pub fn prompt(&self, prompt: impl Into<Message>) -> AgentRunner {
         AgentRunner::from_agent(self, prompt)
+    }
+
+    /// Continue a persisted run instead of starting one from a prompt.
+    ///
+    /// The state a driver serialized between steps (see [`AgentRun`]) is
+    /// picked up where it stopped — its pending tool calls execute, its next
+    /// model turn is asked for — under this agent's hooks, tools, bus and
+    /// settings, plus whatever the returned runner is configured with. The
+    /// run carries its own prompt and history, so neither
+    /// [`history`](AgentRunner::history) nor conversation memory applies:
+    /// nothing is loaded, and the run's messages are not appended a second
+    /// time. Drive it like any runner: `.await`, [`stream`](AgentRunner::stream)
+    /// or [`run_channel`](AgentRunner::run_channel). The run must have been
+    /// suspended by the same rig version.
+    ///
+    /// ```rust,no_run
+    /// # use rig_agent::{Agent, AgentRun};
+    /// # async fn example(agent: Agent, saved: &str) -> Result<(), Box<dyn std::error::Error>> {
+    /// let run: AgentRun = serde_json::from_str(saved)?;
+    /// let response = agent.resume(run).tool_concurrency(4).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn resume(&self, run: AgentRun) -> AgentRunner {
+        AgentRunner::resuming(self, run)
     }
 
     /// Run `prompt` against caller-owned history with the agent's defaults,

--- a/crates/rig-agent/src/agent/completion/request_identity_tests.rs
+++ b/crates/rig-agent/src/agent/completion/request_identity_tests.rs
@@ -72,7 +72,7 @@ fn golden_agent(model: MockCompletionModel) -> Agent {
 async fn scripted_tool_turn_requests_match_golden() {
     let model = golden_model();
     let agent = golden_agent(model.clone());
-    let _ = agent.runner("add 2 and 3").max_turns(3).run().await;
+    let _ = agent.prompt("add 2 and 3").max_turns(3).run().await;
 
     let requests = model
         .requests()

--- a/crates/rig-agent/src/agent/engine.rs
+++ b/crates/rig-agent/src/agent/engine.rs
@@ -1878,7 +1878,7 @@ fn record_tool_result(span: &tracing::Span, result: &ToolResult) {
 /// chain across chat and tool spans.
 pub(crate) struct UnaryTurnSource {
     /// Sequences chat and tool spans into a linear `follows_from` chain (the
-    /// streaming surface parents into a tree instead and does not chain).
+    /// streaming surface parents the same tree but does not chain).
     ///
     /// Atomic rather than `Cell` despite being driven by a single sequential
     /// task: `run_tool_calls` passes `chain_span` as a closure into

--- a/crates/rig-agent/src/agent/engine/tests.rs
+++ b/crates/rig-agent/src/agent/engine/tests.rs
@@ -332,7 +332,7 @@ async fn completion_response_hook_and_calls_carry_identity_metadata() {
         .with_provider_request_id("req_1")]))
     .add_hook(hook.clone())
     .build()
-    .runner(Message::user("prompt"))
+    .prompt(Message::user("prompt"))
     .run()
     .await
     .expect("blocking response");
@@ -357,7 +357,7 @@ async fn completion_response_hook_and_calls_carry_identity_metadata() {
 async fn absent_identity_metadata_stays_none() {
     let response = AgentBuilder::new(MockCompletionModel::new([MockTurn::text("reply")]))
         .build()
-        .runner(Message::user("prompt"))
+        .prompt(Message::user("prompt"))
         .run()
         .await
         .expect("blocking response");
@@ -387,7 +387,7 @@ async fn failed_attempt_error_carries_its_own_request_id() {
     .tool(crate::test_utils::MockAddTool)
     .add_hook(hook.clone())
     .build()
-    .runner(Message::user("add 2 and 3"))
+    .prompt(Message::user("add 2 and 3"))
     .max_turns(4)
     .run()
     .await
@@ -479,7 +479,7 @@ async fn model_turn_finished_identity_blocking_tool_only_and_text() {
     .tool(crate::test_utils::MockAddTool)
     .add_hook(hook.clone())
     .build()
-    .runner(Message::user("add 2 and 3"))
+    .prompt(Message::user("add 2 and 3"))
     .max_turns(3)
     .run()
     .await
@@ -530,7 +530,7 @@ async fn model_turn_finished_identity_streamed_tool_only_and_text() {
         .tool(crate::test_utils::MockAddTool)
         .add_hook(hook.clone())
         .build()
-        .runner(Message::user("add 2 and 3"))
+        .prompt(Message::user("add 2 and 3"))
         .max_turns(3)
         .stream()
         .await;
@@ -574,7 +574,7 @@ async fn model_turn_finished_identity_streamed_reasoning_only() {
     let mut stream = AgentBuilder::new(model)
         .add_hook(hook.clone())
         .build()
-        .runner(Message::user("think"))
+        .prompt(Message::user("think"))
         .stream()
         .await;
     while let Some(item) = stream.next().await {
@@ -632,7 +632,7 @@ async fn retried_turn_reports_the_retried_attempts_own_identity() {
     ]))
     .add_hook(hook.clone())
     .build()
-    .runner(Message::user("prompt"))
+    .prompt(Message::user("prompt"))
     .max_turns(3)
     .run()
     .await
@@ -775,7 +775,7 @@ async fn hook_events_carry_raw_streamed() {
     ]]))
     .add_hook(hook.clone())
     .build()
-    .stream_prompt("prompt")
+    .prompt("prompt")
     .stream()
     .await;
     let mut finals = Vec::new();
@@ -860,7 +860,7 @@ async fn completion_calls_carry_each_attempts_own_raw_streamed() {
         .tool(crate::test_utils::MockAddTool)
         .add_hook(hook.clone())
         .build()
-        .stream_prompt("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(3)
         .stream()
         .await;
@@ -989,7 +989,7 @@ async fn retried_turn_records_the_retried_attempts_own_raw_streamed() {
         .add_hook(probe.clone())
         .add_hook(retry.clone())
         .build()
-        .stream_prompt("prompt")
+        .prompt("prompt")
         .max_turns(3)
         .stream()
         .await;
@@ -1038,7 +1038,7 @@ async fn response_scoped_id_is_not_promoted_into_history() {
         MockTurn::text("reply").with_response_id("chatcmpl-123")
     ]))
     .build()
-    .runner(prompt)
+    .prompt(prompt)
     .run()
     .await
     .expect("blocking response");
@@ -1061,7 +1061,7 @@ async fn message_id_is_promoted_into_history() {
         MockTurn::text("reply").with_message_id("msg_abc")
     ]))
     .build()
-    .runner(prompt)
+    .prompt(prompt)
     .run()
     .await
     .expect("blocking response");
@@ -1091,7 +1091,7 @@ async fn streaming_completion_response_receives_canonical_fields() {
     ]]))
     .add_hook(hook.clone())
     .build()
-    .runner(prompt.clone())
+    .prompt(prompt.clone())
     .stream()
     .await;
     while let Some(item) = stream.next().await {
@@ -1118,7 +1118,7 @@ async fn streaming_completion_response_without_provider_message_id_reports_none(
     ]]))
     .add_hook(hook.clone())
     .build()
-    .runner("canonical prompt")
+    .prompt("canonical prompt")
     .stream()
     .await;
     while let Some(item) = stream.next().await {
@@ -1140,7 +1140,7 @@ async fn streaming_completion_response_runs_before_buffered_final_is_exposed() {
     ]]))
     .add_hook(hook.clone())
     .build()
-    .runner("canonical prompt")
+    .prompt("canonical prompt")
     .stream()
     .await;
     let mut provider_finals = 0;
@@ -1181,7 +1181,7 @@ async fn streaming_completion_response_stop_preserves_provider_final() {
     ]]))
     .add_hook(hook.clone())
     .build()
-    .runner(prompt.clone())
+    .prompt(prompt.clone())
     .stream()
     .await;
     let mut saw_provider_final = false;
@@ -1240,7 +1240,7 @@ async fn streaming_model_turn_stop_preserves_completed_provider_final() {
     ]]))
     .add_hook(StopCompletedModelTurn)
     .build()
-    .runner(prompt.clone())
+    .prompt(prompt.clone())
     .stream()
     .await;
 
@@ -1284,7 +1284,7 @@ async fn provider_error_after_final_suppresses_finish_hook_and_buffered_final() 
     ]]))
     .add_hook(hook.clone())
     .build()
-    .runner("canonical prompt")
+    .prompt("canonical prompt")
     .stream()
     .await;
     let mut saw_provider_final = false;
@@ -1339,7 +1339,7 @@ async fn visible_assistant_items_after_final_are_rejected() {
         ]]))
         .add_hook(hook.clone())
         .build()
-        .runner("canonical prompt")
+        .prompt("canonical prompt")
         .stream()
         .await;
         let mut saw_provider_final = false;
@@ -1384,7 +1384,7 @@ async fn visible_item_after_non_emittable_final_is_rejected() {
     ]]))
     .add_hook(hook.clone())
     .build()
-    .runner("canonical prompt")
+    .prompt("canonical prompt")
     .stream()
     .await;
     let mut error = None;
@@ -1421,7 +1421,7 @@ async fn streaming_completion_response_normalizes_interleaved_content() {
     .tool(MockAddTool)
     .add_hook(hook.clone())
     .build()
-    .runner("go")
+    .prompt("go")
     .max_turns(3)
     .stream()
     .await;
@@ -1489,7 +1489,7 @@ async fn streamed_tool_call_items_share_one_block_id() {
     let mut stream = AgentBuilder::new(streaming_model())
         .tool(MockAddTool)
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(2)
         .stream()
         .await;
@@ -1577,7 +1577,7 @@ async fn per_run_overrides_do_not_mutate_the_source_agent() {
         .build();
 
     let overridden = agent
-        .runner("prompt")
+        .prompt("prompt")
         .max_turns(7)
         .preamble("overridden preamble")
         .temperature(0.9)
@@ -1599,7 +1599,7 @@ async fn per_run_overrides_do_not_mutate_the_source_agent() {
     assert!(agent.config.conversation_id.is_none());
 
     // ...so a fresh runner still sees the agent's baseline.
-    let fresh = agent.runner("another prompt");
+    let fresh = agent.prompt("another prompt");
     assert_eq!(fresh.config.max_turns, 2);
     assert_eq!(fresh.config.preamble.as_deref(), Some("original preamble"));
     assert_eq!(fresh.config.temperature, Some(0.2));
@@ -1628,7 +1628,7 @@ async fn prompt_surfaces_reject_second_tool_roundtrip_request_at_budget_one() {
     let streaming_recorded = streaming_model.clone();
     let streaming_agent = AgentBuilder::new(streaming_model).tool(MockAddTool).build();
     let mut stream = streaming_agent
-        .stream_prompt("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(1)
         .stream()
         .await;
@@ -1658,7 +1658,7 @@ async fn run_and_stream_behave_identically_for_a_tool_call() {
     let blocking = AgentBuilder::new(blocking_model())
         .tool(MockAddTool)
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(2)
         .add_hook(blocking_hook.clone())
         .run()
@@ -1671,7 +1671,7 @@ async fn run_and_stream_behave_identically_for_a_tool_call() {
     let mut stream = AgentBuilder::new(streaming_model())
         .tool(MockAddTool)
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(2)
         .add_hook(streaming_hook.clone())
         .stream()
@@ -1826,7 +1826,7 @@ mod structured_tool_results {
             .tool(MockFailingTool::new(ToolErrorKind::Timeout))
             .add_hook(hook.clone())
             .build()
-            .runner("go")
+            .prompt("go")
             .max_turns(3)
             .run()
             .await
@@ -1877,7 +1877,7 @@ mod structured_tool_results {
         .add_hook(observer.clone())
         .add_hook(TimeoutTerminator)
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(5)
         .run()
         .await
@@ -1921,7 +1921,7 @@ mod structured_tool_results {
             .add_hook(hook.clone())
             .add_hook(StatusProbe(status.clone()))
             .build()
-            .runner("go")
+            .prompt("go")
             .max_turns(3)
             .run()
             .await
@@ -1944,7 +1944,7 @@ mod structured_tool_results {
             .tool(MockHandledFailureTool)
             .add_hook(hook.clone())
             .build()
-            .runner("go")
+            .prompt("go")
             .max_turns(3)
             .run()
             .await
@@ -1983,7 +1983,7 @@ mod structured_tool_results {
             .add_hook(SkipHook)
             .add_hook(observer.clone())
             .build()
-            .runner("go")
+            .prompt("go")
             .max_turns(3)
             .run()
             .await
@@ -2007,7 +2007,7 @@ mod structured_tool_results {
             .tool(MockDeniedTool)
             .add_hook(hook.clone())
             .build()
-            .runner("go")
+            .prompt("go")
             .max_turns(3)
             .run()
             .await
@@ -2028,7 +2028,7 @@ mod structured_tool_results {
             .tool(MockFailingTool::new(ToolErrorKind::PermissionDenied))
             .add_hook(hook.clone())
             .build()
-            .runner("go")
+            .prompt("go")
             .max_turns(3)
             .run()
             .await
@@ -2102,7 +2102,7 @@ mod structured_tool_results {
                     .add_hook(SkipHook)
                     .add_hook(probe.clone())
                     .build()
-                    .runner("go")
+                    .prompt("go")
                     .max_turns(3)
                     .stream()
                     .await;
@@ -2118,7 +2118,7 @@ mod structured_tool_results {
                     .add_hook(SkipHook)
                     .add_hook(probe.clone())
                     .build()
-                    .runner("go")
+                    .prompt("go")
                     .max_turns(3)
                     .run()
                     .await
@@ -2218,7 +2218,7 @@ mod structured_tool_results {
                     .add_hook(nested_stack())
                     .add_hook(probe.clone())
                     .build()
-                    .runner("go")
+                    .prompt("go")
                     .max_turns(3)
                     .stream()
                     .await;
@@ -2233,7 +2233,7 @@ mod structured_tool_results {
                     .add_hook(nested_stack())
                     .add_hook(probe.clone())
                     .build()
-                    .runner("go")
+                    .prompt("go")
                     .max_turns(3)
                     .run()
                     .await
@@ -2269,7 +2269,7 @@ mod structured_tool_results {
         .tool(MockAddTool)
         .add_hook(hook.clone())
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(3)
         .run()
         .await
@@ -2319,7 +2319,7 @@ mod structured_tool_results {
                     .tool(MockMetadataTool)
                     .add_hook(probe)
                     .build()
-                    .runner("go")
+                    .prompt("go")
                     .max_turns(3)
                     .stream()
                     .await;
@@ -2333,7 +2333,7 @@ mod structured_tool_results {
                     .tool(MockMetadataTool)
                     .add_hook(probe)
                     .build()
-                    .runner("go")
+                    .prompt("go")
                     .max_turns(3)
                     .run()
                     .await
@@ -2388,7 +2388,7 @@ mod structured_tool_results {
             .add_hook(Redact)
             .add_hook(observer.clone())
             .build()
-            .runner("go")
+            .prompt("go")
             .max_turns(3)
             .run()
             .await
@@ -2407,7 +2407,7 @@ mod structured_tool_results {
             .tool(MockFailingTool::new(ToolErrorKind::Timeout))
             .add_hook(blocking.clone())
             .build()
-            .runner("go")
+            .prompt("go")
             .max_turns(3)
             .run()
             .await
@@ -2418,7 +2418,7 @@ mod structured_tool_results {
             .tool(MockFailingTool::new(ToolErrorKind::Timeout))
             .add_hook(streaming.clone())
             .build()
-            .runner("go")
+            .prompt("go")
             .max_turns(3)
             .stream()
             .await;
@@ -2461,7 +2461,7 @@ mod structured_tool_results {
         .tool(MockFailingTool::new(ToolErrorKind::Timeout))
         .add_hook(observer.clone())
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(3)
         .tool_concurrency(2)
         .run()
@@ -2718,7 +2718,7 @@ mod span_safety_net {
             .record_content_telemetry(true)
             .tool(MockAddTool)
             .build();
-        let _ = agent.runner("add 2 and 3").max_turns(3).run().await;
+        let _ = agent.prompt("add 2 and 3").max_turns(3).run().await;
     }
 
     async fn run_blocking_response_retry_with_content_telemetry() {
@@ -2733,7 +2733,7 @@ mod span_safety_net {
             TestRetryMode::Repeat,
         ))
         .build()
-        .runner("question")
+        .prompt("question")
         .max_turns(2)
         .run()
         .await
@@ -2758,7 +2758,7 @@ mod span_safety_net {
             TestRetryMode::Repeat,
         ))
         .build()
-        .runner("question")
+        .prompt("question")
         .max_turns(2)
         .stream()
         .await;
@@ -2782,7 +2782,7 @@ mod span_safety_net {
         .record_content_telemetry(true)
         .add_hook(StopCompletedModelTurn)
         .build()
-        .runner("question")
+        .prompt("question")
         .run()
         .await
         .expect_err("blocking model-turn stop should cancel the run");
@@ -2802,7 +2802,7 @@ mod span_safety_net {
         .record_content_telemetry(true)
         .add_hook(StopCompletedModelTurn)
         .build()
-        .runner("question")
+        .prompt("question")
         .stream()
         .await;
 
@@ -2856,7 +2856,7 @@ mod span_safety_net {
             let agent = AgentBuilder::new(MockCompletionModel::text("done"))
                 .name("contract-agent")
                 .build();
-            let runner = agent.runner("hello");
+            let runner = agent.prompt("hello");
             let span = build_chat_span!(runner, None, "chat", "chat");
             let Some(metadata) = span.metadata() else {
                 panic!("chat span was disabled");
@@ -3050,7 +3050,7 @@ mod span_safety_net {
             .tool(MockAddTool)
             .build();
         let response = agent
-            .runner("add 2 and 3")
+            .prompt("add 2 and 3")
             .max_turns(3)
             .run()
             .await
@@ -3186,7 +3186,7 @@ mod span_safety_net {
                 .tool(MockAddTool)
                 .build();
             agent
-                .runner("add 2 and 3")
+                .prompt("add 2 and 3")
                 .max_turns(3)
                 .run()
                 .await
@@ -3325,7 +3325,7 @@ mod span_safety_net {
             .tool(RawOutputTool)
             .add_hook(RedactResultHook)
             .build()
-            .runner("go")
+            .prompt("go")
             .max_turns(3)
             .run()
             .await
@@ -3368,7 +3368,7 @@ mod span_safety_net {
         .tool(RawOutputTool)
         .add_hook(StopOnResultHook)
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(2)
         .run()
         .await;
@@ -3450,7 +3450,7 @@ async fn run_and_stream_same_message_history_for_parallel_tool_calls() {
     let blocking = AgentBuilder::new(blocking_model)
         .tool(MockAddTool)
         .build()
-        .runner("add two pairs")
+        .prompt("add two pairs")
         .max_turns(3)
         .tool_concurrency(4)
         .run()
@@ -3471,7 +3471,7 @@ async fn run_and_stream_same_message_history_for_parallel_tool_calls() {
     let mut stream = AgentBuilder::new(streaming_model)
         .tool(MockAddTool)
         .build()
-        .runner("add two pairs")
+        .prompt("add two pairs")
         .max_turns(3)
         .stream()
         .await;
@@ -3558,7 +3558,7 @@ async fn run_preserves_tool_call_order_under_out_of_order_completion() {
             order: Arc::new(AtomicU32::new(0)),
         })
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(3)
         .tool_concurrency(4)
         .run()
@@ -3644,7 +3644,7 @@ async fn stream_and_run_same_message_history_for_parallel_tool_calls_under_concu
     let blocking = AgentBuilder::new(blocking_model)
         .tool(MockAddTool)
         .build()
-        .runner("add two pairs")
+        .prompt("add two pairs")
         .max_turns(3)
         .tool_concurrency(4)
         .run()
@@ -3665,7 +3665,7 @@ async fn stream_and_run_same_message_history_for_parallel_tool_calls_under_concu
     let stream = AgentBuilder::new(streaming_model)
         .tool(MockAddTool)
         .build()
-        .runner("add two pairs")
+        .prompt("add two pairs")
         .max_turns(3)
         .tool_concurrency(4)
         .stream()
@@ -3707,7 +3707,7 @@ async fn stream_preserves_history_order_under_out_of_order_completion() {
             order: Arc::new(AtomicU32::new(0)),
         })
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(3)
         .tool_concurrency(4)
         .stream()
@@ -3752,7 +3752,7 @@ async fn stream_emits_tool_results_in_call_order_after_batch_settles_under_concu
             order: Arc::new(AtomicU32::new(0)),
         })
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(3)
         .tool_concurrency(4)
         .stream()
@@ -3816,7 +3816,7 @@ async fn stream_executes_tools_concurrently_under_concurrency() {
     let stream = AgentBuilder::new(model)
         .tool(MockBarrierTool::new(barrier))
         .build()
-        .runner("hit the barrier twice")
+        .prompt("hit the barrier twice")
         .max_turns(3)
         .tool_concurrency(2)
         .stream()
@@ -3853,7 +3853,7 @@ async fn stream_emits_model_tool_calls_then_atomic_execution_items() {
         let mut stream = AgentBuilder::new(model)
             .tool(MockAddTool)
             .build()
-            .runner("add two pairs")
+            .prompt("add two pairs")
             .max_turns(3)
             .tool_concurrency(concurrency)
             .stream()
@@ -3986,7 +3986,7 @@ async fn stream_concurrent_tool_result_terminate_drains_in_flight_siblings() {
             slow_started: slow_started.clone(),
         })
         .build()
-        .runner("add two pairs")
+        .prompt("add two pairs")
         .max_turns(3)
         .tool_concurrency(2)
         .add_hook(TerminateAfterSiblingStartedHook {
@@ -4100,7 +4100,7 @@ async fn concurrent_simultaneous_tool_terminations_pick_call_order_on_both_drive
         AgentBuilder::new(two_terminating_tools_blocking_model())
             .tool(MockAddTool)
             .build()
-            .runner("go")
+            .prompt("go")
             .max_turns(3)
             .tool_concurrency(2)
             .add_hook(OrderedTerminateHook {
@@ -4115,7 +4115,7 @@ async fn concurrent_simultaneous_tool_terminations_pick_call_order_on_both_drive
     let mut stream = AgentBuilder::new(two_terminating_tools_streaming_model())
         .tool(MockAddTool)
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(3)
         .tool_concurrency(2)
         .add_hook(OrderedTerminateHook {
@@ -4183,7 +4183,7 @@ async fn default_concurrency_terminate_skips_remaining_tools_on_both_drivers() {
             calls: blocking_calls.clone(),
         })
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(3)
         .add_hook(TerminateOnFirstToolHook)
         .run()
@@ -4201,7 +4201,7 @@ async fn default_concurrency_terminate_skips_remaining_tools_on_both_drivers() {
             calls: streaming_calls.clone(),
         })
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(3)
         .add_hook(TerminateOnFirstToolHook)
         .stream()
@@ -4330,7 +4330,7 @@ async fn concurrent_terminate_drops_beyond_window_sibling_but_drains_in_flight()
             sibling_started: sibling_started.clone(),
         })
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(3)
         .tool_concurrency(2)
         .add_hook(TerminateOnArgZeroAfterSiblingHook { sibling_started })
@@ -4456,7 +4456,7 @@ async fn concurrent_termination_surfaces_no_execution_items() {
             a_done: a_done.clone(),
         })
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(3)
         .tool_concurrency(2)
         .add_hook(TerminateAfterSiblingDoneHook {
@@ -4525,7 +4525,7 @@ async fn stream_tool_execution_committed_carries_effective_rewritten_args() {
         .tool(MockAddTool)
         .add_hook(RewriteToolArgsHook(json!({"x": 2, "y": 40})))
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(3)
         .stream()
         .await;
@@ -4592,7 +4592,7 @@ async fn stream_hook_skip_surfaces_result_without_execution_commit() {
         })
         .add_hook(SkipHook)
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(3)
         .stream()
         .await;
@@ -4658,7 +4658,7 @@ async fn required_with_empty_active_tools_errors_locally_without_provider_call()
         .tool_choice(ToolChoice::Required)
         .add_hook(EmptyActiveToolsHook)
         .build()
-        .runner("go")
+        .prompt("go")
         .run()
         .await
         .expect_err("Required with an empty active_tools filter must fail locally");
@@ -4707,7 +4707,7 @@ async fn specific_naming_filtered_out_tool_errors_locally_without_provider_call(
         })
         .add_hook(FilterToAddHook)
         .build()
-        .runner("go")
+        .prompt("go")
         .run()
         .await
         .expect_err("Specific naming a filtered-out tool must fail locally");
@@ -4791,7 +4791,7 @@ async fn concurrent_tool_execution_stays_within_the_configured_bound() {
     let _ = AgentBuilder::new(model)
         .tool(probe)
         .build()
-        .runner("probe concurrency")
+        .prompt("probe concurrency")
         .max_turns(3)
         .tool_concurrency(cap)
         .run()
@@ -4822,7 +4822,7 @@ async fn tool_concurrency_zero_is_clamped_and_does_not_hang() {
     let run = AgentBuilder::new(model)
         .tool(MockAddTool)
         .build()
-        .runner("add")
+        .prompt("add")
         .max_turns(3)
         .tool_concurrency(0)
         .run();
@@ -4897,7 +4897,7 @@ async fn observes_gates_text_delta_dispatch() {
     let hook = ToolOnlyHook::default();
     let mut stream = AgentBuilder::new(model)
         .build()
-        .runner("hi")
+        .prompt("hi")
         .add_hook(hook.clone())
         .stream()
         .await;
@@ -4967,7 +4967,7 @@ async fn run_terminates_from_each_shared_event() {
         let err = AgentBuilder::new(blocking_model())
             .tool(MockAddTool)
             .build()
-            .runner("add 2 and 3")
+            .prompt("add 2 and 3")
             .max_turns(3)
             .add_hook(TerminateOn(kind))
             .run()
@@ -4992,7 +4992,7 @@ async fn stream_terminates_from_each_shared_event() {
         let mut stream = AgentBuilder::new(streaming_model())
             .tool(MockAddTool)
             .build()
-            .runner("add 2 and 3")
+            .prompt("add 2 and 3")
             .max_turns(3)
             .add_hook(TerminateOn(kind))
             .stream()
@@ -5025,7 +5025,7 @@ async fn multi_hook_stack_parity_across_run_and_stream() {
     let blocking = AgentBuilder::new(blocking_model())
         .tool(MockAddTool)
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(3)
         .add_hook(a_block.clone())
         .add_hook(b_block.clone())
@@ -5038,7 +5038,7 @@ async fn multi_hook_stack_parity_across_run_and_stream() {
     let mut stream = AgentBuilder::new(streaming_model())
         .tool(MockAddTool)
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(3)
         .add_hook(a_stream.clone())
         .add_hook(b_stream.clone())
@@ -5115,7 +5115,7 @@ async fn invalid_tool_call_repair_parity_across_run_and_stream() {
     let blocking = AgentBuilder::new(blocking_model)
         .tool(MockAddTool)
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(3)
         .add_hook(blocking_hook.clone())
         .add_hook(RepairInvalidToHook("add"))
@@ -5142,7 +5142,7 @@ async fn invalid_tool_call_repair_parity_across_run_and_stream() {
     let mut stream = AgentBuilder::new(streaming_model)
         .tool(MockAddTool)
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(3)
         .add_hook(streaming_hook.clone())
         .add_hook(RepairInvalidToHook("add"))
@@ -5199,7 +5199,7 @@ async fn invalid_tool_call_scalar_args_are_canonical_across_run_and_complete_str
     ]))
     .tool(EchoStringArgs)
     .build()
-    .runner("echo a string")
+    .prompt("echo a string")
     .max_turns(3)
     .add_hook(blocking_hook.clone())
     .add_hook(CaptureAndRepairInvalidHook {
@@ -5224,7 +5224,7 @@ async fn invalid_tool_call_scalar_args_are_canonical_across_run_and_complete_str
     ]))
     .tool(EchoStringArgs)
     .build()
-    .runner("echo a string")
+    .prompt("echo a string")
     .max_turns(3)
     .add_hook(streaming_hook.clone())
     .add_hook(CaptureAndRepairInvalidHook {
@@ -5368,7 +5368,7 @@ async fn run_blocking_scenario(prompt: &'static str, turns: &[ScriptedTurn]) -> 
     let response = AgentBuilder::new(model)
         .tool(MockAddTool)
         .build()
-        .runner(prompt)
+        .prompt(prompt)
         .max_turns(8)
         .add_hook(hook.clone())
         .run()
@@ -5394,7 +5394,7 @@ async fn run_streaming_scenario(
     let mut stream = AgentBuilder::new(model)
         .tool(MockAddTool)
         .build()
-        .runner(prompt)
+        .prompt(prompt)
         .max_turns(8)
         .add_hook(hook.clone())
         .stream()
@@ -5536,7 +5536,7 @@ async fn invalid_tool_call_skip_parity_across_run_and_stream() {
     let blocking = AgentBuilder::new(blocking_model)
         .tool(MockAddTool)
         .build()
-        .runner("do the thing")
+        .prompt("do the thing")
         .max_turns(3)
         .add_hook(blocking_hook.clone())
         .add_hook(SkipInvalidHook("tool not permitted"))
@@ -5560,7 +5560,7 @@ async fn invalid_tool_call_skip_parity_across_run_and_stream() {
     let mut stream = AgentBuilder::new(streaming_model)
         .tool(MockAddTool)
         .build()
-        .runner("do the thing")
+        .prompt("do the thing")
         .max_turns(3)
         .add_hook(streaming_hook.clone())
         .add_hook(SkipInvalidHook("tool not permitted"))
@@ -5628,7 +5628,7 @@ async fn recovered_turn_suppresses_completion_response_on_both_drivers() {
     let blocking = AgentBuilder::new(blocking_model)
         .tool(MockAddTool)
         .build()
-        .runner("compute")
+        .prompt("compute")
         .max_turns(3)
         .add_hook(blocking_hook.clone())
         .add_hook(RepairInvalidToHook("add"))
@@ -5651,7 +5651,7 @@ async fn recovered_turn_suppresses_completion_response_on_both_drivers() {
     let mut stream = AgentBuilder::new(streaming_model)
         .tool(MockAddTool)
         .build()
-        .runner("compute")
+        .prompt("compute")
         .max_turns(3)
         .add_hook(streaming_hook.clone())
         .add_hook(RepairInvalidToHook("add"))
@@ -5717,7 +5717,7 @@ async fn runner_add_hook_appends_to_agent_default_hooks() {
         .tool(MockAddTool)
         .add_hook(agent_hook.clone())
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(3)
         .add_hook(runner_hook.clone())
         .run()
@@ -5772,7 +5772,7 @@ async fn valid_tool_call_skip_parity_across_run_and_stream() {
     let blocking = AgentBuilder::new(blocking_model)
         .tool(MockAddTool)
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(3)
         .add_hook(blocking_hook.clone())
         .add_hook(SkipToolCallHook("skipped by policy"))
@@ -5789,7 +5789,7 @@ async fn valid_tool_call_skip_parity_across_run_and_stream() {
     let mut stream = AgentBuilder::new(streaming_model)
         .tool(MockAddTool)
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(3)
         .add_hook(streaming_hook.clone())
         .add_hook(SkipToolCallHook("skipped by policy"))
@@ -5933,7 +5933,7 @@ async fn check_tool_target_patch_is_refused(streaming: bool) {
         .tool(RenameBoundaryTool::<false>(original.clone()))
         .tool(RenameBoundaryTool::<true>(safe.clone()))
         .build()
-        .runner("perform the requested operation")
+        .prompt("perform the requested operation")
         .max_turns(3)
         .add_hook(RenameToolTargetHook)
         .add_hook(policy.clone())
@@ -6185,7 +6185,7 @@ async fn valid_tool_call_rewrite_args_parity_across_run_and_stream() {
     let blocking = AgentBuilder::new(blocking_model)
         .tool(MockAddTool)
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(3)
         .add_hook(blocking_hook.clone())
         .add_hook(RewriteToolArgsHook(replacement.clone()))
@@ -6202,7 +6202,7 @@ async fn valid_tool_call_rewrite_args_parity_across_run_and_stream() {
     let mut stream = AgentBuilder::new(streaming_model)
         .tool(MockAddTool)
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(3)
         .add_hook(streaming_hook.clone())
         .add_hook(RewriteToolArgsHook(replacement))
@@ -6247,7 +6247,7 @@ async fn string_tool_call_without_rewrite_is_canonical_across_run_and_stream() {
     ))
     .tool(EchoStringArgs)
     .build()
-    .runner("echo a string")
+    .prompt("echo a string")
     .max_turns(3)
     .add_hook(blocking_hook.clone())
     .run()
@@ -6262,7 +6262,7 @@ async fn string_tool_call_without_rewrite_is_canonical_across_run_and_stream() {
     ))
     .tool(EchoStringArgs)
     .build()
-    .runner("echo a string")
+    .prompt("echo a string")
     .max_turns(3)
     .add_hook(streaming_hook.clone())
     .stream()
@@ -6300,7 +6300,7 @@ async fn string_tool_call_rewrite_is_canonical_json_across_run_and_stream() {
     ))
     .tool(EchoStringArgs)
     .build()
-    .runner("echo a string")
+    .prompt("echo a string")
     .max_turns(3)
     .add_hook(blocking_hook.clone())
     .add_hook(RewriteToolArgsHook(replacement.clone()))
@@ -6316,7 +6316,7 @@ async fn string_tool_call_rewrite_is_canonical_json_across_run_and_stream() {
     ))
     .tool(EchoStringArgs)
     .build()
-    .runner("echo a string")
+    .prompt("echo a string")
     .max_turns(3)
     .add_hook(streaming_hook.clone())
     .add_hook(RewriteToolArgsHook(replacement))
@@ -6356,7 +6356,7 @@ async fn blocking_turn_dispatches_the_registry_generation_it_advertised() {
     let runner = AgentBuilder::new(model)
         .tool_server_handle(handle.clone())
         .build()
-        .runner("use the generation tool")
+        .prompt("use the generation tool")
         .max_turns(3);
 
     let run = runner.run();
@@ -6401,7 +6401,7 @@ async fn streaming_turn_dispatches_the_registry_generation_it_advertised() {
     let runner = AgentBuilder::new(model)
         .tool_server_handle(handle.clone())
         .build()
-        .runner("use the generation tool")
+        .prompt("use the generation tool")
         .max_turns(3);
 
     let drive = async {
@@ -6464,7 +6464,7 @@ async fn valid_tool_result_rewrite_parity_across_run_and_stream() {
     let blocking = AgentBuilder::new(blocking_model)
         .tool(MockAddTool)
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(3)
         .add_hook(blocking_hook.clone())
         .add_hook(RewriteToolResultHook("redacted-result"))
@@ -6481,7 +6481,7 @@ async fn valid_tool_result_rewrite_parity_across_run_and_stream() {
     let mut stream = AgentBuilder::new(streaming_model)
         .tool(MockAddTool)
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(3)
         .add_hook(streaming_hook.clone())
         .add_hook(RewriteToolResultHook("redacted-result"))
@@ -6543,7 +6543,7 @@ async fn rewrite_result_is_delivered_verbatim_not_reparsed() {
     let result = AgentBuilder::new(model)
         .tool(MockAddTool)
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(3)
         .add_hook(RewriteToolResultHook(IMAGE_JSON))
         .run()
@@ -6644,7 +6644,7 @@ async fn patch_request_parity_across_run_and_stream() {
         .additional_params(json!({"baseline": "keep"}))
         .add_hook(PatchRequestHook)
         .build()
-        .runner("go")
+        .prompt("go")
         .replace_additional_params(json!({"runner": "keep", "injected": false}))
         .max_turns(2)
         .run()
@@ -6668,7 +6668,7 @@ async fn patch_request_parity_across_run_and_stream() {
         .additional_params(json!({"baseline": "keep"}))
         .add_hook(PatchRequestHook)
         .build()
-        .runner("go")
+        .prompt("go")
         .replace_additional_params(json!({"runner": "keep", "injected": false}))
         .max_turns(2)
         .stream()
@@ -6851,7 +6851,7 @@ async fn extra_context_appears_after_static_context_on_both_surfaces() {
             text: "injected",
         })
         .build()
-        .runner("go")
+        .prompt("go")
         .run()
         .await
         .expect("blocking run should succeed");
@@ -6866,7 +6866,7 @@ async fn extra_context_appears_after_static_context_on_both_surfaces() {
             text: "injected",
         })
         .build()
-        .runner("go")
+        .prompt("go")
         .stream()
         .await;
     while let Some(item) = stream.next().await {
@@ -6890,7 +6890,7 @@ async fn multiple_hooks_extra_context_append_in_registration_order() {
             text: "2",
         })
         .build()
-        .runner("go")
+        .prompt("go")
         .run()
         .await
         .expect("run should succeed");
@@ -6934,7 +6934,7 @@ async fn dynamic_context_preserves_query_selection_formatting_and_order_on_both_
             },
         )
         .build()
-        .runner("current blocking query")
+        .prompt("current blocking query")
         .history(vec![Message::user("ignored history query")])
         .run()
         .await
@@ -6957,7 +6957,7 @@ async fn dynamic_context_preserves_query_selection_formatting_and_order_on_both_
             },
         )
         .build()
-        .runner(Message::User {
+        .prompt(Message::User {
             content: vec![UserContent::image_url(
                 "https://example.com/prompt.png",
                 None,
@@ -7021,7 +7021,7 @@ async fn dynamic_context_and_application_hooks_follow_registration_order() {
             text: "after dynamic context",
         })
         .build()
-        .runner("query")
+        .prompt("query")
         .run()
         .await
         .expect("run should succeed");
@@ -7057,7 +7057,7 @@ async fn dynamic_context_and_application_hooks_follow_registration_order() {
             },
         )
         .build()
-        .runner("query")
+        .prompt("query")
         .run()
         .await
         .expect_err("an earlier stop hook should terminate before retrieval");
@@ -7072,7 +7072,7 @@ async fn dynamic_context_retrieval_failure_stops_before_provider_io_on_both_surf
     let error = AgentBuilder::new(blocking_model)
         .dynamic_context(1, FailingContextIndex)
         .build()
-        .runner("retrieve this")
+        .prompt("retrieve this")
         .run()
         .await
         .expect_err("failed retrieval should stop the run");
@@ -7088,7 +7088,7 @@ async fn dynamic_context_retrieval_failure_stops_before_provider_io_on_both_surf
     let mut stream = AgentBuilder::new(streaming_model)
         .dynamic_context(1, FailingContextIndex)
         .build()
-        .runner("retrieve this")
+        .prompt("retrieve this")
         .stream()
         .await;
     let error = stream
@@ -7120,7 +7120,7 @@ async fn retrieved_tool_query_selection_is_unchanged_on_both_surfaces() {
             ToolSet::from_tools(vec![MockAddTool]),
         )
         .build()
-        .runner("blocking retrieval query")
+        .prompt("blocking retrieval query")
         .history(vec![Message::user("blocking history query")])
         .run()
         .await
@@ -7135,7 +7135,7 @@ async fn retrieved_tool_query_selection_is_unchanged_on_both_surfaces() {
             ToolSet::from_tools(vec![MockAddTool]),
         )
         .build()
-        .runner(Message::User {
+        .prompt(Message::User {
             content: vec![UserContent::image_url(
                 "https://example.com/blocking.png",
                 None,
@@ -7161,7 +7161,7 @@ async fn retrieved_tool_query_selection_is_unchanged_on_both_surfaces() {
         ToolSet::from_tools(vec![MockAddTool]),
     )
     .build()
-    .runner("streaming retrieval query")
+    .prompt("streaming retrieval query")
     .history(vec![Message::user("streaming history query")])
     .stream()
     .await;
@@ -7180,7 +7180,7 @@ async fn retrieved_tool_query_selection_is_unchanged_on_both_surfaces() {
         ToolSet::from_tools(vec![MockAddTool]),
     )
     .build()
-    .runner(Message::User {
+    .prompt(Message::User {
         content: vec![UserContent::image_url(
             "https://example.com/streaming.png",
             None,
@@ -7232,7 +7232,7 @@ async fn extra_context_is_per_turn_non_sticky() {
         .tool(MockAddTool)
         .add_hook(ExtraContextTurnOneHook)
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(3)
         .run()
         .await
@@ -7245,7 +7245,7 @@ async fn extra_context_is_per_turn_non_sticky() {
         .tool(MockAddTool)
         .add_hook(ExtraContextTurnOneHook)
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(3)
         .stream()
         .await;
@@ -7299,7 +7299,7 @@ async fn history_patch_changes_sent_messages_not_transcript_on_both_surfaces() {
     let blocking = AgentBuilder::new(blocking_model)
         .add_hook(HistoryOverrideHook)
         .build()
-        .runner("real prompt")
+        .prompt("real prompt")
         .run()
         .await
         .expect("blocking run should succeed");
@@ -7317,7 +7317,7 @@ async fn history_patch_changes_sent_messages_not_transcript_on_both_surfaces() {
     let stream = AgentBuilder::new(streaming_model)
         .add_hook(HistoryOverrideHook)
         .build()
-        .runner("real prompt")
+        .prompt("real prompt")
         .stream()
         .await;
     let final_response = drive_to_final_response(stream).await;
@@ -7341,7 +7341,7 @@ async fn model_turn_finished_fires_once_per_accepted_turn_including_tool_only() 
         .tool(MockAddTool)
         .add_hook(blocking_hook.clone())
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(3)
         .run()
         .await
@@ -7362,7 +7362,7 @@ async fn model_turn_finished_fires_once_per_accepted_turn_including_tool_only() 
         .tool(MockAddTool)
         .add_hook(streaming_hook.clone())
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(3)
         .stream()
         .await;
@@ -7393,7 +7393,7 @@ async fn reasoning_only_turn_fires_completion_response() {
     ]]))
     .add_hook(hook.clone())
     .build()
-    .runner("reason")
+    .prompt("reason")
     .stream()
     .await;
     while let Some(item) = stream.next().await {
@@ -7472,7 +7472,7 @@ async fn streaming_model_turn_finished_carries_canonical_committed_content() {
         .tool(MockAddTool)
         .add_hook(hook.clone())
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(3)
         .stream()
         .await;
@@ -7546,7 +7546,7 @@ async fn chained_rewrites_compose_across_hooks() {
         .add_hook(WrapResult("B"))
         .add_hook(recorder.clone())
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(3)
         .run()
         .await
@@ -7574,7 +7574,7 @@ async fn chained_rewrites_compose_across_hooks() {
         .add_hook(WrapResult("B"))
         .add_hook(stream_recorder.clone())
         .build()
-        .runner("add 2 and 3")
+        .prompt("add 2 and 3")
         .max_turns(3)
         .stream()
         .await;
@@ -7718,7 +7718,7 @@ async fn initial_output_tool_collision_uses_a_unique_synthetic_name() {
         .output_schema::<Answer>()
         .output_mode(OutputMode::Tool)
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(2)
         .run()
         .await
@@ -7808,7 +7808,7 @@ async fn late_output_tool_collision_fails_before_blocking_provider_for_all_choic
                 second_turn_patch,
             })
             .build()
-            .runner("go")
+            .prompt("go")
             .max_turns(3)
             .run()
             .await
@@ -7859,7 +7859,7 @@ async fn late_output_tool_collision_fails_before_streaming_provider() {
             second_turn_patch: None,
         })
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(3)
         .stream()
         .await;
@@ -7924,7 +7924,7 @@ async fn late_output_tool_collision_is_checked_after_active_tools_filtering() {
             second_turn_patch: Some(RequestPatch::new().active_tools(["add"])),
         })
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(4)
         .run()
         .await
@@ -7981,7 +7981,7 @@ async fn retrieved_output_tool_collision_fails_before_provider_request() {
         .output_schema::<Answer>()
         .output_mode(OutputMode::Tool)
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(3)
         .run()
         .await
@@ -8045,7 +8045,7 @@ async fn active_tools_filter_does_not_let_output_tool_collide_with_a_filtered_re
         .output_mode(OutputMode::Tool)
         .add_hook(ActiveToolsAddOnly)
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(2)
         .run()
         .await
@@ -8121,7 +8121,7 @@ async fn model_turn_finished_content_carries_output_tool_call_in_tool_mode() {
     .output_mode(OutputMode::Tool)
     .add_hook(hook.clone())
     .build()
-    .runner("go")
+    .prompt("go")
     .max_turns(2)
     .run()
     .await
@@ -8146,7 +8146,7 @@ async fn model_turn_finished_content_carries_output_tool_call_in_tool_mode() {
     .output_mode(OutputMode::Tool)
     .add_hook(s_hook.clone())
     .build()
-    .runner("go")
+    .prompt("go")
     .max_turns(2)
     .stream()
     .await;
@@ -8171,7 +8171,7 @@ async fn output_tool_finalization_emits_no_complete_tool_call_stream_item() {
     .output_schema::<Answer>()
     .output_mode(OutputMode::Tool)
     .build()
-    .runner("go")
+    .prompt("go")
     .max_turns(2)
     .stream()
     .await;
@@ -8298,7 +8298,7 @@ async fn human_in_the_loop_approve_deny_edit_parity_across_run_and_stream() {
     let blocking = AgentBuilder::new(blocking_model)
         .tool(MockAddTool)
         .build()
-        .runner("carry out the plan")
+        .prompt("carry out the plan")
         .max_turns(3)
         .add_hook(blocking_recorder.clone())
         .add_hook(blocking_approver.clone())
@@ -8316,7 +8316,7 @@ async fn human_in_the_loop_approve_deny_edit_parity_across_run_and_stream() {
     let mut stream = AgentBuilder::new(streaming_model)
         .tool(MockAddTool)
         .build()
-        .runner("carry out the plan")
+        .prompt("carry out the plan")
         .max_turns(3)
         .add_hook(streaming_recorder.clone())
         .add_hook(streaming_approver.clone())
@@ -8418,7 +8418,7 @@ async fn human_in_the_loop_abort_terminates_the_run() {
     let err = AgentBuilder::new(blocking_model)
         .tool(MockAddTool)
         .build()
-        .runner("do the sensitive thing")
+        .prompt("do the sensitive thing")
         .max_turns(3)
         .add_hook(HumanApprovalHook::new([Decision::Abort(ABORT_REASON)]))
         .run()
@@ -8439,7 +8439,7 @@ async fn human_in_the_loop_abort_terminates_the_run() {
     let mut stream = AgentBuilder::new(streaming_model)
         .tool(MockAddTool)
         .build()
-        .runner("do the sensitive thing")
+        .prompt("do the sensitive thing")
         .max_turns(3)
         .add_hook(HumanApprovalHook::new([Decision::Abort(ABORT_REASON)]))
         .stream()
@@ -8540,7 +8540,7 @@ async fn approval_policy_allow_list_with_sticky_decisions() {
         .tool(MockAddTool)
         .tool(MockSubtractTool)
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(3)
         .add_hook(recorder.clone())
         .add_hook(policy.clone())
@@ -8785,7 +8785,7 @@ async fn model_turn_finished_reports_termination_and_effective_max_tokens_blocki
         .max_tokens(64)
         .add_hook(probe.clone())
         .build()
-        .runner("question")
+        .prompt("question")
         .run()
         .await
         .expect("truncated turn is still an answer");
@@ -8813,7 +8813,7 @@ async fn model_turn_finished_reports_termination_and_effective_max_tokens_stream
         .max_tokens(64)
         .add_hook(probe.clone())
         .build()
-        .runner("question")
+        .prompt("question")
         .stream()
         .await;
     while let Some(item) = stream.next().await {
@@ -8838,7 +8838,7 @@ async fn model_turn_finished_reports_absent_reason_and_absent_cap_as_none() {
     AgentBuilder::new(MockCompletionModel::from_turns([MockTurn::text("done")]))
         .add_hook(probe.clone())
         .build()
-        .runner("question")
+        .prompt("question")
         .run()
         .await
         .expect("run");
@@ -8862,7 +8862,7 @@ async fn model_turn_finished_reports_tool_calls_for_a_mislabelled_tool_turn() {
     .tool(MockAddTool)
     .add_hook(probe.clone())
     .build()
-    .runner("question")
+    .prompt("question")
     .max_turns(2)
     .run()
     .await
@@ -8902,7 +8902,7 @@ async fn model_turn_finished_reports_tool_calls_for_a_mislabelled_streamed_tool_
         .tool(MockAddTool)
         .add_hook(probe.clone())
         .build()
-        .runner("question")
+        .prompt("question")
         .max_turns(2)
         .stream()
         .await;
@@ -8933,7 +8933,7 @@ async fn model_turn_finished_passes_an_unmapped_reason_through_verbatim() {
     ]))
     .add_hook(probe.clone())
     .build()
-    .runner("question")
+    .prompt("question")
     .run()
     .await
     .expect("run");
@@ -8980,7 +8980,7 @@ async fn streaming_retry_reports_the_second_attempts_own_effective_max_tokens() 
             TestRetryMode::Repeat,
         ))
         .build()
-        .runner("question")
+        .prompt("question")
         .max_turns(2)
         .stream()
         .await;
@@ -9015,7 +9015,7 @@ async fn a_portable_hook_can_retry_a_truncated_tool_free_turn() {
     let response = AgentBuilder::new(model.clone())
         .add_hook(hook.clone())
         .build()
-        .runner("question")
+        .prompt("question")
         .max_turns(2)
         .run()
         .await
@@ -9054,7 +9054,7 @@ async fn retry_reports_the_second_attempts_own_effective_max_tokens() {
             TestRetryMode::Repeat,
         ))
         .build()
-        .runner("question")
+        .prompt("question")
         .max_turns(2)
         .run()
         .await
@@ -9092,7 +9092,7 @@ async fn blocking_model_turn_repeat_preserves_prompt_history_with_fresh_preparat
             TestRetryMode::Repeat,
         ))
         .build()
-        .runner("question")
+        .prompt("question")
         .max_turns(2)
         .run()
         .await
@@ -9132,7 +9132,7 @@ async fn blocking_model_turn_feedback_preserves_rejected_response() {
             TestRetryMode::Feedback("try another approach"),
         ))
         .build()
-        .runner("question")
+        .prompt("question")
         .max_turns(2)
         .run()
         .await
@@ -9174,7 +9174,7 @@ async fn blocking_empty_feedback_retry_omits_empty_assistant_history() {
             TestRetryMode::Feedback("provide an answer"),
         ))
         .build()
-        .runner("question")
+        .prompt("question")
         .max_turns(2)
         .run()
         .await
@@ -9222,7 +9222,7 @@ async fn streaming_model_turn_retry_marks_rollback_and_matches_blocking_accounti
             TestRetryMode::Repeat,
         ))
         .build()
-        .runner("question")
+        .prompt("question")
         .max_turns(2)
         .stream()
         .await;
@@ -9274,7 +9274,7 @@ async fn streaming_feedback_retry_matches_blocking_history_and_usage() {
         TestRetryMode::Feedback("correct the answer"),
     ))
     .build()
-    .runner("question")
+    .prompt("question")
     .max_turns(2)
     .run()
     .await
@@ -9296,7 +9296,7 @@ async fn streaming_feedback_retry_matches_blocking_history_and_usage() {
         TestRetryMode::Feedback("correct the answer"),
     ))
     .build()
-    .runner("question")
+    .prompt("question")
     .max_turns(2)
     .stream()
     .await;
@@ -9355,7 +9355,7 @@ async fn streaming_empty_feedback_retry_omits_empty_assistant_history() {
             TestRetryMode::Feedback("provide an answer"),
         ))
         .build()
-        .runner("question")
+        .prompt("question")
         .max_turns(2)
         .stream()
         .await;
@@ -9415,7 +9415,7 @@ async fn response_retry_preserves_model_turn_hook_order_across_surfaces() {
         TestRetryMode::Repeat,
     ))
     .build()
-    .runner("question")
+    .prompt("question")
     .max_turns(2)
     .run()
     .await
@@ -9439,7 +9439,7 @@ async fn response_retry_preserves_model_turn_hook_order_across_surfaces() {
         TestRetryMode::Repeat,
     ))
     .build()
-    .runner("question")
+    .prompt("question")
     .max_turns(2)
     .stream()
     .await;
@@ -9512,7 +9512,7 @@ async fn streaming_model_turn_retry_respects_max_turns() {
             TestRetryMode::Repeat,
         ))
         .build()
-        .runner("question")
+        .prompt("question")
         .max_turns(1)
         .stream()
         .await;
@@ -9561,7 +9561,7 @@ async fn model_turn_retry_rejects_tool_turn_before_tool_hooks_or_execution() {
     .add_hook(recorder.clone())
     .add_hook(AlwaysRepeatModelTurn)
     .build()
-    .runner("add")
+    .prompt("add")
     .max_turns(2)
     .run()
     .await
@@ -9597,7 +9597,7 @@ async fn streaming_model_turn_retry_rejects_tool_turn_without_committed_executio
     .add_hook(recorder.clone())
     .add_hook(AlwaysRepeatModelTurn)
     .build()
-    .runner("add")
+    .prompt("add")
     .max_turns(2)
     .stream()
     .await;
@@ -9683,8 +9683,8 @@ async fn concurrent_runs_of_same_agent_have_independent_retry_budgets() {
     .add_hook(hook)
     .build();
 
-    let first = agent.runner("first").max_turns(2).run();
-    let second = agent.runner("second").max_turns(2).run();
+    let first = agent.prompt("first").max_turns(2).run();
+    let second = agent.prompt("second").max_turns(2).run();
     let (first, second) = tokio::join!(first, second);
     let first = first.expect("first run");
     let second = second.expect("second run");
@@ -9929,7 +9929,7 @@ mod run_lifecycle {
         let mut stream = AgentBuilder::new(model)
             .add_hook(hook.clone())
             .build()
-            .runner(Message::user("hi"))
+            .prompt(Message::user("hi"))
             .stream()
             .await;
         while let Some(item) = stream.next().await {
@@ -9975,7 +9975,7 @@ mod run_lifecycle {
         let mut stream = AgentBuilder::new(model)
             .add_hook(hook.clone())
             .build()
-            .runner(Message::user("hi"))
+            .prompt(Message::user("hi"))
             .stream()
             .await;
         let first = stream.next().await.expect("terminal item");
@@ -10012,7 +10012,7 @@ mod run_lifecycle {
             .tool(crate::test_utils::MockAddTool)
             .add_hook(hook.clone())
             .build()
-            .runner(Message::user("add 2 and 3"))
+            .prompt(Message::user("add 2 and 3"))
             .max_turns(1)
             .stream()
             .await;
@@ -10077,7 +10077,7 @@ mod run_lifecycle {
             .tool(crate::test_utils::MockAddTool)
             .add_hook(probe.clone())
             .build()
-            .runner(Message::user("add 2 and 3"))
+            .prompt(Message::user("add 2 and 3"))
             .max_turns(3)
             .stream()
             .await;
@@ -10141,7 +10141,7 @@ async fn outcome_replacement_preserves_tool_execution_commit_disposition() {
             })
             .add_hook(ReplaceOutcome { skip_dispatch })
             .build()
-            .runner("go")
+            .prompt("go")
             .max_turns(3)
             .stream()
             .await;
@@ -10223,7 +10223,7 @@ async fn outcome_stop_is_terminal_through_nested_hooks_on_both_surfaces() {
                 .add_hook(stack)
                 .build();
             let error = if streaming {
-                let mut stream = agent.runner("go").max_turns(3).stream().await;
+                let mut stream = agent.prompt("go").max_turns(3).stream().await;
                 let mut error = None;
                 while let Some(item) = stream.next().await {
                     match item {
@@ -10238,7 +10238,7 @@ async fn outcome_stop_is_terminal_through_nested_hooks_on_both_surfaces() {
                 error.expect("stream must stop")
             } else {
                 agent
-                    .runner("go")
+                    .prompt("go")
                     .max_turns(3)
                     .run()
                     .await

--- a/crates/rig-agent/src/agent/engine/tests.rs
+++ b/crates/rig-agent/src/agent/engine/tests.rs
@@ -532,8 +532,7 @@ async fn model_turn_finished_identity_streamed_tool_only_and_text() {
         .build()
         .prompt(Message::user("add 2 and 3"))
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     while let Some(item) = stream.next().await {
         item.expect("stream item");
     }
@@ -575,8 +574,7 @@ async fn model_turn_finished_identity_streamed_reasoning_only() {
         .add_hook(hook.clone())
         .build()
         .prompt(Message::user("think"))
-        .stream()
-        .await;
+        .stream();
     while let Some(item) = stream.next().await {
         item.expect("stream item");
     }
@@ -776,8 +774,7 @@ async fn hook_events_carry_raw_streamed() {
     .add_hook(hook.clone())
     .build()
     .prompt("prompt")
-    .stream()
-    .await;
+    .stream();
     let mut finals = Vec::new();
     let mut final_response = None;
     while let Some(item) = stream.next().await {
@@ -862,8 +859,7 @@ async fn completion_calls_carry_each_attempts_own_raw_streamed() {
         .build()
         .prompt("add 2 and 3")
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
 
     let mut forwarded_calls = Vec::new();
     let mut finals = Vec::new();
@@ -991,8 +987,7 @@ async fn retried_turn_records_the_retried_attempts_own_raw_streamed() {
         .build()
         .prompt("prompt")
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
 
     let mut finals = Vec::new();
     let mut final_response = None;
@@ -1092,8 +1087,7 @@ async fn streaming_completion_response_receives_canonical_fields() {
     .add_hook(hook.clone())
     .build()
     .prompt(prompt.clone())
-    .stream()
-    .await;
+    .stream();
     while let Some(item) = stream.next().await {
         item.expect("stream item");
     }
@@ -1119,8 +1113,7 @@ async fn streaming_completion_response_without_provider_message_id_reports_none(
     .add_hook(hook.clone())
     .build()
     .prompt("canonical prompt")
-    .stream()
-    .await;
+    .stream();
     while let Some(item) = stream.next().await {
         item.expect("stream item");
     }
@@ -1141,8 +1134,7 @@ async fn streaming_completion_response_runs_before_buffered_final_is_exposed() {
     .add_hook(hook.clone())
     .build()
     .prompt("canonical prompt")
-    .stream()
-    .await;
+    .stream();
     let mut provider_finals = 0;
     while let Some(item) = stream.next().await {
         if matches!(
@@ -1182,8 +1174,7 @@ async fn streaming_completion_response_stop_preserves_provider_final() {
     .add_hook(hook.clone())
     .build()
     .prompt(prompt.clone())
-    .stream()
-    .await;
+    .stream();
     let mut saw_provider_final = false;
     let mut saw_run_final = false;
     let mut error = None;
@@ -1241,8 +1232,7 @@ async fn streaming_model_turn_stop_preserves_completed_provider_final() {
     .add_hook(StopCompletedModelTurn)
     .build()
     .prompt(prompt.clone())
-    .stream()
-    .await;
+    .stream();
 
     let mut provider_finals = 0;
     let mut saw_retry = false;
@@ -1285,8 +1275,7 @@ async fn provider_error_after_final_suppresses_finish_hook_and_buffered_final() 
     .add_hook(hook.clone())
     .build()
     .prompt("canonical prompt")
-    .stream()
-    .await;
+    .stream();
     let mut saw_provider_final = false;
     let mut error = None;
     while let Some(item) = stream.next().await {
@@ -1340,8 +1329,7 @@ async fn visible_assistant_items_after_final_are_rejected() {
         .add_hook(hook.clone())
         .build()
         .prompt("canonical prompt")
-        .stream()
-        .await;
+        .stream();
         let mut saw_provider_final = false;
         let mut error = None;
         while let Some(item) = stream.next().await {
@@ -1385,8 +1373,7 @@ async fn visible_item_after_non_emittable_final_is_rejected() {
     .add_hook(hook.clone())
     .build()
     .prompt("canonical prompt")
-    .stream()
-    .await;
+    .stream();
     let mut error = None;
     while let Some(item) = stream.next().await {
         if let Err(err) = item {
@@ -1423,8 +1410,7 @@ async fn streaming_completion_response_normalizes_interleaved_content() {
     .build()
     .prompt("go")
     .max_turns(3)
-    .stream()
-    .await;
+    .stream();
     while let Some(item) = stream.next().await {
         item.expect("stream item");
     }
@@ -1491,8 +1477,7 @@ async fn streamed_tool_call_items_share_one_block_id() {
         .build()
         .prompt("add 2 and 3")
         .max_turns(2)
-        .stream()
-        .await;
+        .stream();
 
     let mut delta_ids = Vec::new();
     let mut completed_ids = Vec::new();
@@ -1627,11 +1612,7 @@ async fn prompt_surfaces_reject_second_tool_roundtrip_request_at_budget_one() {
     let streaming_model = streaming_model();
     let streaming_recorded = streaming_model.clone();
     let streaming_agent = AgentBuilder::new(streaming_model).tool(MockAddTool).build();
-    let mut stream = streaming_agent
-        .prompt("add 2 and 3")
-        .max_turns(1)
-        .stream()
-        .await;
+    let mut stream = streaming_agent.prompt("add 2 and 3").max_turns(1).stream();
     let mut streaming_err = None;
     while let Some(item) = stream.next().await {
         if let Err(err) = item {
@@ -1674,8 +1655,7 @@ async fn run_and_stream_behave_identically_for_a_tool_call() {
         .prompt("add 2 and 3")
         .max_turns(2)
         .add_hook(streaming_hook.clone())
-        .stream()
-        .await;
+        .stream();
 
     let mut final_response = None;
     while let Some(item) = stream.next().await {
@@ -2104,8 +2084,7 @@ mod structured_tool_results {
                     .build()
                     .prompt("go")
                     .max_turns(3)
-                    .stream()
-                    .await;
+                    .stream();
                 while let Some(item) = stream.next().await {
                     if let Err(err) = item {
                         panic!("stream item errored: {err}");
@@ -2220,8 +2199,7 @@ mod structured_tool_results {
                     .build()
                     .prompt("go")
                     .max_turns(3)
-                    .stream()
-                    .await;
+                    .stream();
                 while let Some(item) = stream.next().await {
                     if let Err(err) = item {
                         panic!("stream item errored: {err}");
@@ -2321,8 +2299,7 @@ mod structured_tool_results {
                     .build()
                     .prompt("go")
                     .max_turns(3)
-                    .stream()
-                    .await;
+                    .stream();
                 while let Some(item) = stream.next().await {
                     if let Err(error) = item {
                         panic!("stream item errored: {error}");
@@ -2420,8 +2397,7 @@ mod structured_tool_results {
             .build()
             .prompt("go")
             .max_turns(3)
-            .stream()
-            .await;
+            .stream();
         while let Some(item) = stream.next().await {
             if let Err(err) = item {
                 panic!("stream item errored: {err}");
@@ -2760,8 +2736,7 @@ mod span_safety_net {
         .build()
         .prompt("question")
         .max_turns(2)
-        .stream()
-        .await;
+        .stream();
 
         let mut saw_final = false;
         while let Some(item) = stream.next().await {
@@ -2803,8 +2778,7 @@ mod span_safety_net {
         .add_hook(StopCompletedModelTurn)
         .build()
         .prompt("question")
-        .stream()
-        .await;
+        .stream();
 
         let mut provider_finals = 0;
         let mut agent_finals = 0;
@@ -3473,8 +3447,7 @@ async fn run_and_stream_same_message_history_for_parallel_tool_calls() {
         .build()
         .prompt("add two pairs")
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     let mut final_response = None;
     while let Some(item) = stream.next().await {
         if let Ok(MultiTurnStreamItem::FinalResponse(resp)) =
@@ -3668,8 +3641,7 @@ async fn stream_and_run_same_message_history_for_parallel_tool_calls_under_concu
         .prompt("add two pairs")
         .max_turns(3)
         .tool_concurrency(4)
-        .stream()
-        .await;
+        .stream();
     let final_response = drive_to_final_response(stream).await;
 
     let blocking_messages = blocking.messages.expect("blocking messages");
@@ -3710,8 +3682,7 @@ async fn stream_preserves_history_order_under_out_of_order_completion() {
         .prompt("go")
         .max_turns(3)
         .tool_concurrency(4)
-        .stream()
-        .await;
+        .stream();
     // Timeout so a regression to sequential execution fails cleanly instead
     // of hanging (the first call only completes once the second runs).
     let final_response = tokio::time::timeout(
@@ -3755,8 +3726,7 @@ async fn stream_emits_tool_results_in_call_order_after_batch_settles_under_concu
         .prompt("go")
         .max_turns(3)
         .tool_concurrency(4)
-        .stream()
-        .await;
+        .stream();
 
     let mut streamed_result_ids = Vec::new();
     let mut final_response = None;
@@ -3819,8 +3789,7 @@ async fn stream_executes_tools_concurrently_under_concurrency() {
         .prompt("hit the barrier twice")
         .max_turns(3)
         .tool_concurrency(2)
-        .stream()
-        .await;
+        .stream();
 
     tokio::time::timeout(
         std::time::Duration::from_secs(5),
@@ -3856,8 +3825,7 @@ async fn stream_emits_model_tool_calls_then_atomic_execution_items() {
             .prompt("add two pairs")
             .max_turns(3)
             .tool_concurrency(concurrency)
-            .stream()
-            .await;
+            .stream();
         let mut markers = Vec::new();
         while let Some(item) = stream.next().await {
             match item.unwrap_or_else(|err| panic!("stream item errored: {err}")) {
@@ -3992,8 +3960,7 @@ async fn stream_concurrent_tool_result_terminate_drains_in_flight_siblings() {
         .add_hook(TerminateAfterSiblingStartedHook {
             sibling_started: slow_started,
         })
-        .stream()
-        .await;
+        .stream();
 
     let (saw_error, saw_final_response) =
         tokio::time::timeout(std::time::Duration::from_secs(5), async move {
@@ -4121,8 +4088,7 @@ async fn concurrent_simultaneous_tool_terminations_pick_call_order_on_both_drive
         .add_hook(OrderedTerminateHook {
             gate: Arc::new(tokio::sync::Notify::new()),
         })
-        .stream()
-        .await;
+        .stream();
 
     let stream_err = tokio::time::timeout(std::time::Duration::from_secs(5), async move {
         while let Some(item) = stream.next().await {
@@ -4204,8 +4170,7 @@ async fn default_concurrency_terminate_skips_remaining_tools_on_both_drivers() {
         .prompt("go")
         .max_turns(3)
         .add_hook(TerminateOnFirstToolHook)
-        .stream()
-        .await;
+        .stream();
     let mut saw_error = false;
     while let Some(item) = stream.next().await {
         if let Err(err) = item {
@@ -4334,8 +4299,7 @@ async fn concurrent_terminate_drops_beyond_window_sibling_but_drains_in_flight()
         .max_turns(3)
         .tool_concurrency(2)
         .add_hook(TerminateOnArgZeroAfterSiblingHook { sibling_started })
-        .stream()
-        .await;
+        .stream();
 
     let (saw_error, saw_final) =
         tokio::time::timeout(std::time::Duration::from_secs(5), async move {
@@ -4462,8 +4426,7 @@ async fn concurrent_termination_surfaces_no_execution_items() {
         .add_hook(TerminateAfterSiblingDoneHook {
             a_done: a_done.clone(),
         })
-        .stream()
-        .await;
+        .stream();
 
     let (exec_commits, results, saw_error, saw_final) =
         tokio::time::timeout(std::time::Duration::from_secs(5), async move {
@@ -4527,8 +4490,7 @@ async fn stream_tool_execution_committed_carries_effective_rewritten_args() {
         .build()
         .prompt("go")
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
 
     let mut model_args = None;
     let mut exec_args = None;
@@ -4594,8 +4556,7 @@ async fn stream_hook_skip_surfaces_result_without_execution_commit() {
         .build()
         .prompt("go")
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
 
     let mut exec_commits = 0;
     let mut results = 0;
@@ -4899,8 +4860,7 @@ async fn observes_gates_text_delta_dispatch() {
         .build()
         .prompt("hi")
         .add_hook(hook.clone())
-        .stream()
-        .await;
+        .stream();
     while stream.next().await.is_some() {}
 
     assert_eq!(
@@ -4995,8 +4955,7 @@ async fn stream_terminates_from_each_shared_event() {
             .prompt("add 2 and 3")
             .max_turns(3)
             .add_hook(TerminateOn(kind))
-            .stream()
-            .await;
+            .stream();
 
         let mut saw_error = false;
         let mut saw_final = false;
@@ -5042,8 +5001,7 @@ async fn multi_hook_stack_parity_across_run_and_stream() {
         .max_turns(3)
         .add_hook(a_stream.clone())
         .add_hook(b_stream.clone())
-        .stream()
-        .await;
+        .stream();
     while stream.next().await.is_some() {}
 
     // Both hooks in the stack saw the same events (both ran on every Continue).
@@ -5146,8 +5104,7 @@ async fn invalid_tool_call_repair_parity_across_run_and_stream() {
         .max_turns(3)
         .add_hook(streaming_hook.clone())
         .add_hook(RepairInvalidToHook("add"))
-        .stream()
-        .await;
+        .stream();
     let mut final_response = None;
     while let Some(item) = stream.next().await {
         if let Ok(MultiTurnStreamItem::FinalResponse(resp)) =
@@ -5231,8 +5188,7 @@ async fn invalid_tool_call_scalar_args_are_canonical_across_run_and_complete_str
         replacement: EchoStringArgs::NAME,
         args: streaming_args.clone(),
     })
-    .stream()
-    .await;
+    .stream();
     let mut final_response = None;
     while let Some(item) = stream.next().await {
         if let MultiTurnStreamItem::FinalResponse(response) =
@@ -5397,8 +5353,7 @@ async fn run_streaming_scenario(
         .prompt(prompt)
         .max_turns(8)
         .add_hook(hook.clone())
-        .stream()
-        .await;
+        .stream();
     let mut final_response = None;
     while let Some(item) = stream.next().await {
         if let Ok(MultiTurnStreamItem::FinalResponse(resp)) =
@@ -5564,8 +5519,7 @@ async fn invalid_tool_call_skip_parity_across_run_and_stream() {
         .max_turns(3)
         .add_hook(streaming_hook.clone())
         .add_hook(SkipInvalidHook("tool not permitted"))
-        .stream()
-        .await;
+        .stream();
     let mut final_response = None;
     while let Some(item) = stream.next().await {
         if let Ok(MultiTurnStreamItem::FinalResponse(resp)) =
@@ -5655,8 +5609,7 @@ async fn recovered_turn_suppresses_completion_response_on_both_drivers() {
         .max_turns(3)
         .add_hook(streaming_hook.clone())
         .add_hook(RepairInvalidToHook("add"))
-        .stream()
-        .await;
+        .stream();
     while stream.next().await.is_some() {}
 
     // Recovery still reaches the same final answer.
@@ -5793,8 +5746,7 @@ async fn valid_tool_call_skip_parity_across_run_and_stream() {
         .max_turns(3)
         .add_hook(streaming_hook.clone())
         .add_hook(SkipToolCallHook("skipped by policy"))
-        .stream()
-        .await;
+        .stream();
     let mut final_response = None;
     while let Some(item) = stream.next().await {
         if let Ok(MultiTurnStreamItem::FinalResponse(resp)) =
@@ -5939,7 +5891,7 @@ async fn check_tool_target_patch_is_refused(streaming: bool) {
         .add_hook(policy.clone())
         .add_hook(observed.clone());
     if streaming {
-        let mut stream = runner.stream().await;
+        let mut stream = runner.stream();
         let mut finished = false;
         while let Some(item) = stream.next().await {
             if let MultiTurnStreamItem::FinalResponse(response) =
@@ -6206,8 +6158,7 @@ async fn valid_tool_call_rewrite_args_parity_across_run_and_stream() {
         .max_turns(3)
         .add_hook(streaming_hook.clone())
         .add_hook(RewriteToolArgsHook(replacement))
-        .stream()
-        .await;
+        .stream();
     let mut final_response = None;
     while let Some(item) = stream.next().await {
         if let Ok(MultiTurnStreamItem::FinalResponse(resp)) =
@@ -6265,8 +6216,7 @@ async fn string_tool_call_without_rewrite_is_canonical_across_run_and_stream() {
     .prompt("echo a string")
     .max_turns(3)
     .add_hook(streaming_hook.clone())
-    .stream()
-    .await;
+    .stream();
     let mut final_output = None;
     while let Some(item) = stream.next().await {
         if let MultiTurnStreamItem::FinalResponse(response) =
@@ -6320,8 +6270,7 @@ async fn string_tool_call_rewrite_is_canonical_json_across_run_and_stream() {
     .max_turns(3)
     .add_hook(streaming_hook.clone())
     .add_hook(RewriteToolArgsHook(replacement))
-    .stream()
-    .await;
+    .stream();
     let mut final_output = None;
     while let Some(item) = stream.next().await {
         if let MultiTurnStreamItem::FinalResponse(response) =
@@ -6405,7 +6354,7 @@ async fn streaming_turn_dispatches_the_registry_generation_it_advertised() {
         .max_turns(3);
 
     let drive = async {
-        let mut stream = runner.stream().await;
+        let mut stream = runner.stream();
         let mut final_output = None;
         while let Some(item) = stream.next().await {
             if let MultiTurnStreamItem::FinalResponse(response) =
@@ -6485,8 +6434,7 @@ async fn valid_tool_result_rewrite_parity_across_run_and_stream() {
         .max_turns(3)
         .add_hook(streaming_hook.clone())
         .add_hook(RewriteToolResultHook("redacted-result"))
-        .stream()
-        .await;
+        .stream();
     let mut final_response = None;
     while let Some(item) = stream.next().await {
         if let Ok(MultiTurnStreamItem::FinalResponse(resp)) =
@@ -6671,8 +6619,7 @@ async fn patch_request_parity_across_run_and_stream() {
         .prompt("go")
         .replace_additional_params(json!({"runner": "keep", "injected": false}))
         .max_turns(2)
-        .stream()
-        .await;
+        .stream();
     while let Some(item) = stream.next().await {
         let _ = item.map_err(|err| panic!("stream item errored: {err}"));
     }
@@ -6867,8 +6814,7 @@ async fn extra_context_appears_after_static_context_on_both_surfaces() {
         })
         .build()
         .prompt("go")
-        .stream()
-        .await;
+        .stream();
     while let Some(item) = stream.next().await {
         let _ = item.map_err(|err| panic!("stream item errored: {err}"));
     }
@@ -6968,8 +6914,7 @@ async fn dynamic_context_preserves_query_selection_formatting_and_order_on_both_
             Message::user("older history query"),
             Message::user("latest history query"),
         ])
-        .stream()
-        .await;
+        .stream();
     while let Some(item) = stream.next().await {
         item.expect("streaming dynamic-context run should succeed");
     }
@@ -7089,8 +7034,7 @@ async fn dynamic_context_retrieval_failure_stops_before_provider_io_on_both_surf
         .dynamic_context(1, FailingContextIndex)
         .build()
         .prompt("retrieve this")
-        .stream()
-        .await;
+        .stream();
     let error = stream
         .next()
         .await
@@ -7163,8 +7107,7 @@ async fn retrieved_tool_query_selection_is_unchanged_on_both_surfaces() {
     .build()
     .prompt("streaming retrieval query")
     .history(vec![Message::user("streaming history query")])
-    .stream()
-    .await;
+    .stream();
     while let Some(item) = stream.next().await {
         item.expect("stream item should succeed");
     }
@@ -7191,8 +7134,7 @@ async fn retrieved_tool_query_selection_is_unchanged_on_both_surfaces() {
         Message::user("older streaming history query"),
         Message::user("latest streaming history query"),
     ])
-    .stream()
-    .await;
+    .stream();
     while let Some(item) = stream.next().await {
         item.expect("stream item should succeed");
     }
@@ -7247,8 +7189,7 @@ async fn extra_context_is_per_turn_non_sticky() {
         .build()
         .prompt("add 2 and 3")
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     while let Some(item) = stream.next().await {
         let _ = item.map_err(|err| panic!("stream item errored: {err}"));
     }
@@ -7318,8 +7259,7 @@ async fn history_patch_changes_sent_messages_not_transcript_on_both_surfaces() {
         .add_hook(HistoryOverrideHook)
         .build()
         .prompt("real prompt")
-        .stream()
-        .await;
+        .stream();
     let final_response = drive_to_final_response(stream).await;
     assert!(
         request_has_sentinel(streaming_probe.requests().first().expect("one request")),
@@ -7364,8 +7304,7 @@ async fn model_turn_finished_fires_once_per_accepted_turn_including_tool_only() 
         .build()
         .prompt("add 2 and 3")
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     while let Some(item) = stream.next().await {
         let _ = item.map_err(|err| panic!("stream item errored: {err}"));
     }
@@ -7394,8 +7333,7 @@ async fn reasoning_only_turn_fires_completion_response() {
     .add_hook(hook.clone())
     .build()
     .prompt("reason")
-    .stream()
-    .await;
+    .stream();
     while let Some(item) = stream.next().await {
         item.expect("reasoning-only stream item");
     }
@@ -7474,8 +7412,7 @@ async fn streaming_model_turn_finished_carries_canonical_committed_content() {
         .build()
         .prompt("go")
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     let _ = drive_to_final_response(stream).await;
 
     assert_eq!(
@@ -7576,8 +7513,7 @@ async fn chained_rewrites_compose_across_hooks() {
         .build()
         .prompt("add 2 and 3")
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     while let Some(item) = stream.next().await {
         let _ = item.map_err(|err| panic!("stream item errored: {err}"));
     }
@@ -7861,8 +7797,7 @@ async fn late_output_tool_collision_fails_before_streaming_provider() {
         .build()
         .prompt("go")
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
 
     let mut collisions = Vec::new();
     let mut saw_final_response = false;
@@ -8148,8 +8083,7 @@ async fn model_turn_finished_content_carries_output_tool_call_in_tool_mode() {
     .build()
     .prompt("go")
     .max_turns(2)
-    .stream()
-    .await;
+    .stream();
     while stream.next().await.is_some() {}
     assert!(
         *s_hook.saw_output_tool_call.lock().expect("lock"),
@@ -8173,8 +8107,7 @@ async fn output_tool_finalization_emits_no_complete_tool_call_stream_item() {
     .build()
     .prompt("go")
     .max_turns(2)
-    .stream()
-    .await;
+    .stream();
 
     let mut saw_complete_output_tool_call = false;
     let mut final_has_output = false;
@@ -8320,8 +8253,7 @@ async fn human_in_the_loop_approve_deny_edit_parity_across_run_and_stream() {
         .max_turns(3)
         .add_hook(streaming_recorder.clone())
         .add_hook(streaming_approver.clone())
-        .stream()
-        .await;
+        .stream();
     let mut final_response = None;
     while let Some(item) = stream.next().await {
         if let Ok(MultiTurnStreamItem::FinalResponse(resp)) =
@@ -8442,8 +8374,7 @@ async fn human_in_the_loop_abort_terminates_the_run() {
         .prompt("do the sensitive thing")
         .max_turns(3)
         .add_hook(HumanApprovalHook::new([Decision::Abort(ABORT_REASON)]))
-        .stream()
-        .await;
+        .stream();
     let mut stream_error = None;
     while let Some(item) = stream.next().await {
         match item {
@@ -8814,8 +8745,7 @@ async fn model_turn_finished_reports_termination_and_effective_max_tokens_stream
         .add_hook(probe.clone())
         .build()
         .prompt("question")
-        .stream()
-        .await;
+        .stream();
     while let Some(item) = stream.next().await {
         item.expect("streaming item");
     }
@@ -8904,8 +8834,7 @@ async fn model_turn_finished_reports_tool_calls_for_a_mislabelled_streamed_tool_
         .build()
         .prompt("question")
         .max_turns(2)
-        .stream()
-        .await;
+        .stream();
     while let Some(item) = stream.next().await {
         item.expect("streaming item");
     }
@@ -8982,8 +8911,7 @@ async fn streaming_retry_reports_the_second_attempts_own_effective_max_tokens() 
         .build()
         .prompt("question")
         .max_turns(2)
-        .stream()
-        .await;
+        .stream();
     while let Some(item) = stream.next().await {
         item.expect("streaming item");
     }
@@ -9224,8 +9152,7 @@ async fn streaming_model_turn_retry_marks_rollback_and_matches_blocking_accounti
         .build()
         .prompt("question")
         .max_turns(2)
-        .stream()
-        .await;
+        .stream();
 
     let mut retries = Vec::new();
     let mut provider_finals = 0;
@@ -9298,8 +9225,7 @@ async fn streaming_feedback_retry_matches_blocking_history_and_usage() {
     .build()
     .prompt("question")
     .max_turns(2)
-    .stream()
-    .await;
+    .stream();
     let mut saw_retry = false;
     let mut streaming = None;
     while let Some(item) = stream.next().await {
@@ -9357,8 +9283,7 @@ async fn streaming_empty_feedback_retry_omits_empty_assistant_history() {
         .build()
         .prompt("question")
         .max_turns(2)
-        .stream()
-        .await;
+        .stream();
 
     let mut retries = Vec::new();
     let mut provider_finals = 0;
@@ -9441,8 +9366,7 @@ async fn response_retry_preserves_model_turn_hook_order_across_surfaces() {
     .build()
     .prompt("question")
     .max_turns(2)
-    .stream()
-    .await;
+    .stream();
     while let Some(item) = stream.next().await {
         item.expect("streaming retry item");
     }
@@ -9514,8 +9438,7 @@ async fn streaming_model_turn_retry_respects_max_turns() {
         .build()
         .prompt("question")
         .max_turns(1)
-        .stream()
-        .await;
+        .stream();
 
     let mut saw_rollback = false;
     let mut error = None;
@@ -9599,8 +9522,7 @@ async fn streaming_model_turn_retry_rejects_tool_turn_without_committed_executio
     .build()
     .prompt("add")
     .max_turns(2)
-    .stream()
-    .await;
+    .stream();
 
     let mut execution_commits = 0;
     let mut tool_results = 0;
@@ -9930,8 +9852,7 @@ mod run_lifecycle {
             .add_hook(hook.clone())
             .build()
             .prompt(Message::user("hi"))
-            .stream()
-            .await;
+            .stream();
         while let Some(item) = stream.next().await {
             item.expect("stream item");
         }
@@ -9976,8 +9897,7 @@ mod run_lifecycle {
             .add_hook(hook.clone())
             .build()
             .prompt(Message::user("hi"))
-            .stream()
-            .await;
+            .stream();
         let first = stream.next().await.expect("terminal item");
         assert!(matches!(
             first,
@@ -10014,8 +9934,7 @@ mod run_lifecycle {
             .build()
             .prompt(Message::user("add 2 and 3"))
             .max_turns(1)
-            .stream()
-            .await;
+            .stream();
         let mut saw_error = false;
         while let Some(item) = stream.next().await {
             if item.is_err() {
@@ -10079,8 +9998,7 @@ mod run_lifecycle {
             .build()
             .prompt(Message::user("add 2 and 3"))
             .max_turns(3)
-            .stream()
-            .await;
+            .stream();
         while let Some(item) = stream.next().await {
             item.expect("stream item");
         }
@@ -10143,8 +10061,7 @@ async fn outcome_replacement_preserves_tool_execution_commit_disposition() {
             .build()
             .prompt("go")
             .max_turns(3)
-            .stream()
-            .await;
+            .stream();
         let mut committed = 0;
         let mut results = 0;
         while let Some(item) = stream.next().await {
@@ -10223,7 +10140,7 @@ async fn outcome_stop_is_terminal_through_nested_hooks_on_both_surfaces() {
                 .add_hook(stack)
                 .build();
             let error = if streaming {
-                let mut stream = agent.prompt("go").max_turns(3).stream().await;
+                let mut stream = agent.prompt("go").max_turns(3).stream();
                 let mut error = None;
                 while let Some(item) = stream.next().await {
                     match item {

--- a/crates/rig-agent/src/agent/mod.rs
+++ b/crates/rig-agent/src/agent/mod.rs
@@ -41,7 +41,7 @@
 //! let prompt_response = agent.prompt("Prompt").await?;
 //!
 //! // Per-run overrides stay inside the hook-aware runner.
-//! let response = agent.runner("Prompt").temperature(0.9).run().await?;
+//! let response = agent.prompt("Prompt").temperature(0.9).run().await?;
 //! # Ok(())
 //! # }
 //! ```

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -596,6 +596,8 @@ impl std::future::IntoFuture for AgentRunner {
 }
 
 #[cfg(test)]
+mod entry_tests;
+#[cfg(test)]
 mod ignore_tests;
 #[cfg(test)]
 mod settled_tests;

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -422,12 +422,15 @@ pub(crate) fn build_agent_run(
 }
 
 impl AgentRunner {
+    /// [`run_under`](Self::run_under) that also reports the usage a failed
+    /// run consumed; `ambient` is the span the typed run was started in.
     pub(crate) async fn run_with_error_usage(
         mut self,
+        ambient: tracing::Span,
     ) -> (Result<PromptResponse, PromptError>, Usage) {
         let usage = Arc::new(Mutex::new(Usage::new()));
         self.error_usage = Some(usage.clone());
-        let result = self.run().await;
+        let result = self.run_under(ambient).await;
         let observed = result.as_ref().map_or_else(
             |_| {
                 *usage

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -374,8 +374,11 @@ impl AgentRunner {
     /// streaming driver.
     pub(crate) fn build_run(&self, history_override: Option<Vec<Message>>) -> AgentRun {
         let prompt = match &self.origin {
-            // Cloned, not moved: the runner stays whole for the driver that
-            // takes it next.
+            // Cloned, not moved: `build_run` is shared by both drivers over
+            // `&self`, and the runner is handed whole to the driver next. The
+            // copy is one transcript per resumed run — the order of the runner
+            // clone a typed run already makes per attempt — and it spares a
+            // "taken" placeholder state in `RunOrigin`.
             RunOrigin::Resume(run) => return (**run).clone(),
             RunOrigin::Prompt(prompt) => prompt.clone(),
         };
@@ -438,8 +441,9 @@ impl AgentRunner {
 
     /// Open the per-run agent span, recording the prompt when content
     /// telemetry is enabled. Shared by the blocking and streaming surfaces.
-    pub(crate) fn open_agent_span(&self) -> (tracing::Span, bool) {
+    pub(crate) fn open_agent_span(&self, ambient: tracing::Span) -> (tracing::Span, bool) {
         let (agent_span, created_agent_span) = acquire_agent_span(
+            ambient,
             self.agent_name_or_default(),
             self.config.preamble.as_deref(),
             self.config.record_telemetry_content,
@@ -515,7 +519,7 @@ impl AgentRunner {
     /// [`PromptResponse`]. Hooks fire at every observable point; the first hook
     /// to terminate cancels the run.
     pub async fn run(self) -> Result<PromptResponse, PromptError> {
-        let (agent_span, created_agent_span) = self.open_agent_span();
+        let (agent_span, created_agent_span) = self.open_agent_span(tracing::Span::current());
         let bus = self.config.bus.clone();
         let hook_ctx = self.hook_context(false);
         // A resumed run brought its history with it: nothing is loaded and

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -517,9 +517,20 @@ impl AgentRunner {
 
     /// Drive the agent loop to completion, returning the aggregated
     /// [`PromptResponse`]. Hooks fire at every observable point; the first hook
-    /// to terminate cancels the run.
-    pub async fn run(self) -> Result<PromptResponse, PromptError> {
-        let (agent_span, created_agent_span) = self.open_agent_span(tracing::Span::current());
+    /// to terminate cancels the run. The run belongs to the span this method
+    /// (or `.await`) was called in, wherever the future is polled.
+    pub fn run(
+        self,
+    ) -> impl Future<Output = Result<PromptResponse, PromptError>> + rig_core::wasm_compat::WasmCompatSend
+    {
+        // Like `stream()`: the run belongs to the span it was started in,
+        // not to whichever task first polls the future.
+        let ambient = tracing::Span::current();
+        self.run_under(ambient)
+    }
+
+    async fn run_under(self, ambient: tracing::Span) -> Result<PromptResponse, PromptError> {
+        let (agent_span, created_agent_span) = self.open_agent_span(ambient);
         let bus = self.config.bus.clone();
         let hook_ctx = self.hook_context(false);
         // A resumed run brought its history with it: nothing is loaded and

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -24,6 +24,7 @@
 use std::sync::{Arc, Mutex};
 
 use futures::StreamExt;
+use tracing_futures::Instrument;
 
 use super::{
     completion::{Agent, AgentConfig},
@@ -529,7 +530,8 @@ impl AgentRunner {
         // Like `stream()`: the run belongs to the span it was started in,
         // not to whichever task first polls the future.
         let ambient = tracing::Span::current();
-        self.run_under(ambient)
+        let run_under = ambient.clone();
+        async move { self.run_under(run_under).await }.instrument(ambient)
     }
 
     async fn run_under(self, ambient: tracing::Span) -> Result<PromptResponse, PromptError> {

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -5,15 +5,14 @@
 //! performs no IO and carries no hooks. `AgentRunner` pairs that machine with
 //! the side-effecting concerns — building and sending completion requests,
 //! executing tools, loading/saving conversation memory — and fires an
-//! [`AgentHook`] at every observable point. [`Agent::prompt`] and
-//! [`Agent::stream_prompt`] both return an `AgentRunner`, and you can build
-//! one directly to drive an agent with custom, composable hooks:
+//! [`AgentHook`] at every observable point. [`Agent::prompt`] returns an
+//! `AgentRunner`; configure it and drive it with custom, composable hooks:
 //!
 //! ```rust,no_run
 //! # use rig_agent::Agent;
 //! # async fn example(agent: Agent) -> Result<(), Box<dyn std::error::Error>> {
 //! let response = agent
-//!     .runner("What is 2 + 2?")
+//!     .prompt("What is 2 + 2?")
 //!     .max_turns(3)
 //!     .run()
 //!     .await?;
@@ -44,7 +43,7 @@ use super::UNKNOWN_AGENT_NAME;
 
 /// A hook-aware driver over [`AgentRun`].
 ///
-/// Construct one from an [`Agent`] with [`Agent::runner`], attach hooks with
+/// Construct one from an [`Agent`] with [`Agent::prompt`], attach hooks with
 /// [`add_hook`](Self::add_hook), then call
 /// [`run`](Self::run) (blocking) or
 /// [`stream`](Self::stream)
@@ -85,8 +84,9 @@ pub(crate) type HistoryAndMemory = (
 
 impl AgentRunner {
     /// Build a runner from an agent, seeding it with the agent's default hook
-    /// stack. Prefer [`Agent::runner`].
-    pub fn from_agent(agent: &Agent, prompt: impl Into<Message>) -> Self {
+    /// stack. The one construction site behind [`Agent::prompt`] and the
+    /// typed and extractor runs.
+    pub(crate) fn from_agent(agent: &Agent, prompt: impl Into<Message>) -> Self {
         Self {
             config: agent.config.clone(),
             prompt: prompt.into(),

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -43,11 +43,11 @@ use super::UNKNOWN_AGENT_NAME;
 
 /// A hook-aware driver over [`AgentRun`].
 ///
-/// Construct one from an [`Agent`] with [`Agent::prompt`], attach hooks with
-/// [`add_hook`](Self::add_hook), then call
-/// [`run`](Self::run) (blocking) or
-/// [`stream`](Self::stream)
-/// (incremental). Hooks are held in a [`HookStack`](super::hook::HookStack), an ordered,
+/// Construct one with [`Agent::prompt`] (a fresh run) or [`Agent::resume`]
+/// (a persisted one), attach hooks with [`add_hook`](Self::add_hook), then
+/// call [`run`](Self::run) (blocking), [`stream`](Self::stream)
+/// (incremental) or [`run_channel`](Self::run_channel) (a future plus an
+/// event feed). Hooks are held in a [`HookStack`](super::hook::HookStack), an ordered,
 /// runtime-composable list; `run()` and `stream()` share the same loop and fire
 /// the same events, so they behave identically apart from the streamed delta
 /// events the medium adds.
@@ -58,7 +58,9 @@ pub struct AgentRunner {
     /// never the source [`Agent`]. `description` rides along unused during
     /// execution — an accepted tradeoff for a single shared config type.
     pub(crate) config: AgentConfig,
-    pub(crate) prompt: Message,
+    /// Where the run starts: a prompt ([`Agent::prompt`]) or a persisted
+    /// run to continue ([`Agent::resume`]).
+    pub(crate) origin: RunOrigin,
     pub(crate) chat_history: Option<Vec<Message>>,
     pub(crate) max_invalid_tool_call_retries: usize,
     pub(crate) tool_server_handle: ToolServerHandle,
@@ -70,9 +72,15 @@ pub struct AgentRunner {
     pub(crate) unhandled_invalid_tool_call: UnhandledInvalidToolCall,
     pub(crate) concurrency: usize,
     pub(crate) error_usage: Option<Arc<Mutex<Usage>>>,
-    /// A persisted run to continue instead of a fresh one from `prompt`
-    /// ([`resume`](Self::resume)).
-    pub(crate) resume: Option<Box<AgentRun>>,
+}
+
+/// Where a run starts. A prompt builds a fresh [`AgentRun`] (after any
+/// memory load); a persisted run is continued as it is, so neither a prompt
+/// nor a history nor a memory load applies to it.
+#[derive(Clone)]
+pub(crate) enum RunOrigin {
+    Prompt(Message),
+    Resume(Box<AgentRun>),
 }
 
 /// The `(history_override, memory_handle)` pair resolved for one run by
@@ -87,9 +95,18 @@ impl AgentRunner {
     /// stack. The one construction site behind [`Agent::prompt`] and the
     /// typed and extractor runs.
     pub(crate) fn from_agent(agent: &Agent, prompt: impl Into<Message>) -> Self {
+        Self::new(agent, RunOrigin::Prompt(prompt.into()))
+    }
+
+    /// Build a runner that continues `run` ([`Agent::resume`]).
+    pub(crate) fn resuming(agent: &Agent, run: AgentRun) -> Self {
+        Self::new(agent, RunOrigin::Resume(Box::new(run)))
+    }
+
+    fn new(agent: &Agent, origin: RunOrigin) -> Self {
         Self {
             config: agent.config.clone(),
-            prompt: prompt.into(),
+            origin,
             chat_history: None,
             max_invalid_tool_call_retries: 0,
             tool_server_handle: agent.tool_server_handle.clone(),
@@ -100,22 +117,7 @@ impl AgentRunner {
             unhandled_invalid_tool_call: UnhandledInvalidToolCall::Fail,
             concurrency: 1,
             error_usage: None,
-            resume: None,
         }
-    }
-
-    /// Continue a persisted run instead of starting one from the prompt:
-    /// the state a driver serialized between steps (see [`AgentRun`]) is
-    /// picked up where it stopped — its pending tool calls execute, its
-    /// next model turn is asked for — under this agent's hooks, tools,
-    /// bus and settings. The runner's prompt and history are ignored (the
-    /// run carries its own), as is conversation memory (its history is
-    /// already in the run; nothing is loaded, and the run's messages are
-    /// not appended a second time). The run must have been suspended by
-    /// the same rig version.
-    pub fn resume(mut self, run: AgentRun) -> Self {
-        self.resume = Some(Box::new(run));
-        self
     }
 
     /// Append a hook to the stack (on top of any the agent already carries).
@@ -364,13 +366,21 @@ impl AgentRunner {
         self.config.name.as_deref().unwrap_or(UNKNOWN_AGENT_NAME)
     }
 
-    /// Build the sans-IO [`AgentRun`] for this runner's configuration.
-    /// `history_override` replaces the configured chat history (e.g. with
-    /// memory-loaded history). Delegates to [`build_agent_run`] — the single
-    /// construction site shared with the streaming driver.
+    /// The [`AgentRun`] this runner drives: the persisted run it continues,
+    /// or a fresh one from its prompt and configuration. `history_override`
+    /// replaces the configured chat history (e.g. with memory-loaded
+    /// history) and applies only to a fresh run. Delegates to
+    /// [`build_agent_run`] — the single construction site shared with the
+    /// streaming driver.
     pub(crate) fn build_run(&self, history_override: Option<Vec<Message>>) -> AgentRun {
+        let prompt = match &self.origin {
+            // Cloned, not moved: the runner stays whole for the driver that
+            // takes it next.
+            RunOrigin::Resume(run) => return (**run).clone(),
+            RunOrigin::Prompt(prompt) => prompt.clone(),
+        };
         let run = build_agent_run(
-            self.prompt.clone(),
+            prompt,
             self.config.max_turns,
             self.max_invalid_tool_call_retries,
             self.unhandled_invalid_tool_call,
@@ -429,18 +439,16 @@ impl AgentRunner {
     /// Open the per-run agent span, recording the prompt when content
     /// telemetry is enabled. Shared by the blocking and streaming surfaces.
     pub(crate) fn open_agent_span(&self) -> (tracing::Span, bool) {
-        // A resumed run ignores the prompt it was built with (its state
-        // carries the real one): the span records none.
-        let prompt_recorded = self.resume.is_none();
         let (agent_span, created_agent_span) = acquire_agent_span(
             self.agent_name_or_default(),
             self.config.preamble.as_deref(),
             self.config.record_telemetry_content,
         );
 
-        if prompt_recorded
-            && self.config.record_telemetry_content
-            && let Some(text) = self.prompt.rag_text()
+        // A resumed run's prompt is inside its state: the span records none.
+        if self.config.record_telemetry_content
+            && let RunOrigin::Prompt(prompt) = &self.origin
+            && let Some(text) = prompt.rag_text()
         {
             agent_span.record("gen_ai.prompt", text);
         }
@@ -506,7 +514,7 @@ impl AgentRunner {
     /// Drive the agent loop to completion, returning the aggregated
     /// [`PromptResponse`]. Hooks fire at every observable point; the first hook
     /// to terminate cancels the run.
-    pub async fn run(mut self) -> Result<PromptResponse, PromptError> {
+    pub async fn run(self) -> Result<PromptResponse, PromptError> {
         let (agent_span, created_agent_span) = self.open_agent_span();
         let bus = self.config.bus.clone();
         let hook_ctx = self.hook_context(false);
@@ -514,10 +522,9 @@ impl AgentRunner {
         // nothing is saved — no `Memory` dispatch, no memory hook event, no
         // record in the log — so its continuation is exactly the reference
         // log's tail and a memory backend that is down cannot fail it.
-        let resumed = self.resume.take();
-        let (history_override, memory_handle) = match &resumed {
-            Some(_) => (None, None),
-            None => {
+        let (history_override, memory_handle) = match &self.origin {
+            RunOrigin::Resume(_) => (None, None),
+            RunOrigin::Prompt(_) => {
                 // A memory load is a dispatch too: drive the bus while resolving.
                 let resolve = self.resolve_history_and_memory(&hook_ctx);
                 futures::pin_mut!(resolve);
@@ -528,10 +535,7 @@ impl AgentRunner {
                 }
             }
         };
-        let run = match resumed {
-            Some(run) => *run,
-            None => self.build_run(history_override),
-        };
+        let run = self.build_run(history_override);
 
         // Fold the shared engine to its final response. The blocking surface
         // uses a unary model transport and ignores the intermediate items the

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -559,49 +559,52 @@ impl AgentRunner {
 
         // Fold the shared engine to its final response. The blocking surface
         // uses a unary model transport and ignores the intermediate items the
-        // engine yields; the engine is driven under the caller's ambient span
-        // (no `instrument`), keeping the agent span detached and the chat/tool
-        // spans on the blocking `follows_from` chain.
+        // engine yields. The fold runs under the agent span: an adopted span
+        // (the caller's, already entered by `run`) parents the chat/tool
+        // spans as before, and a created `invoke_agent` does too instead of
+        // leaving them to whatever span polls the future. The blocking
+        // `follows_from` chain between chat/tool spans is unaffected.
         let record_telemetry_content = self.config.record_telemetry_content;
         let driver = drive_agent(
             self,
             UnaryTurnSource::new(record_telemetry_content),
             run,
-            agent_span,
+            agent_span.clone(),
             created_agent_span,
             memory_handle,
             hook_ctx,
         );
         let driver = bus.drive(Box::pin(driver));
-        futures::pin_mut!(driver);
-
-        let mut response = None;
-        while let Some(item) = driver.next().await {
-            match item {
-                Ok(DriveItem::Done(done)) => response = Some(*done),
-                Ok(DriveItem::Item(_)) => {}
-                Err(err) => {
-                    // The engine settles an error ending *after* yielding
-                    // it (`on_run_settled` with `SettledOutcome::Error`),
-                    // so the fold drains the engine before returning: a
-                    // fold that returned here dropped the engine at the
-                    // yield and the settled hook never fired for a
-                    // blocking run that a hook stopped or a provider
-                    // refused, while the streaming surface's consumer,
-                    // polling to the end, saw it fire.
-                    let error = streaming_error_into_prompt(err);
-                    while driver.next().await.is_some() {}
-                    return Err(error);
+        let fold = async move {
+            futures::pin_mut!(driver);
+            let mut response = None;
+            while let Some(item) = driver.next().await {
+                match item {
+                    Ok(DriveItem::Done(done)) => response = Some(*done),
+                    Ok(DriveItem::Item(_)) => {}
+                    Err(err) => {
+                        // The engine settles an error ending *after* yielding
+                        // it (`on_run_settled` with `SettledOutcome::Error`),
+                        // so the fold drains the engine before returning: a
+                        // fold that returned here dropped the engine at the
+                        // yield and the settled hook never fired for a
+                        // blocking run that a hook stopped or a provider
+                        // refused, while the streaming surface's consumer,
+                        // polling to the end, saw it fire.
+                        let error = streaming_error_into_prompt(err);
+                        while driver.next().await.is_some() {}
+                        return Err(error);
+                    }
                 }
             }
-        }
-
-        // The engine yields `Done` unless it errored (handled above).
-        response.ok_or_else(|| {
-            PromptError::CompletionError(CompletionError::ResponseError(
-                "agent run ended without producing a final response".to_string(),
-            ))
-        })
+            // The engine yields `Done` unless it errored (handled above).
+            response.ok_or_else(|| {
+                PromptError::CompletionError(CompletionError::ResponseError(
+                    "agent run ended without producing a final response".to_string(),
+                ))
+            })
+        };
+        fold.instrument(agent_span).await
     }
 }
 

--- a/crates/rig-agent/src/agent/runner/entry_tests.rs
+++ b/crates/rig-agent/src/agent/runner/entry_tests.rs
@@ -1,0 +1,204 @@
+//! The entry-point contract: `Agent::prompt` is the one way to a runner and
+//! the terminal call alone chooses the medium; `Agent::resume` continues a
+//! run without a prompt; `stream()` does nothing until it is polled.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+};
+
+use futures::StreamExt;
+
+use crate::{
+    agent::{AgentBuilder, AgentHook, HookContext, MultiTurnStreamItem, RunStart, RunStartAction},
+    completion::Message,
+    run::AgentRun,
+    test_utils::{CountingMemory, MockCompletionModel, MockStreamEvent},
+};
+
+/// Records what the run-scoped context said about the medium.
+#[derive(Clone, Default)]
+struct MediumProbe {
+    seen: Arc<AtomicBool>,
+    streaming: Arc<AtomicBool>,
+}
+
+impl AgentHook for MediumProbe {
+    async fn on_run_start(&self, ctx: &HookContext, _event: RunStart<'_>) -> RunStartAction {
+        self.seen.store(true, Ordering::SeqCst);
+        self.streaming.store(ctx.is_streaming(), Ordering::SeqCst);
+        RunStartAction::Continue
+    }
+}
+
+fn unary_model() -> MockCompletionModel {
+    MockCompletionModel::text("collected")
+}
+
+fn streaming_model() -> MockCompletionModel {
+    MockCompletionModel::from_stream_turns([[
+        MockStreamEvent::text("streamed"),
+        MockStreamEvent::final_response(crate::completion::Usage::new()),
+    ]])
+}
+
+/// An awaited runner asks the provider for a complete response and tells its
+/// hooks so: the mock scripted only unary turns, and it answers.
+#[tokio::test]
+async fn an_awaited_prompt_runs_unary() {
+    let probe = MediumProbe::default();
+    let agent = AgentBuilder::new(unary_model())
+        .add_hook(probe.clone())
+        .build();
+
+    let response = agent.prompt("go").await.expect("a unary run");
+
+    assert_eq!(response.output, "collected");
+    assert!(probe.seen.load(Ordering::SeqCst));
+    assert!(!probe.streaming.load(Ordering::SeqCst));
+}
+
+/// The same runner, streamed, asks the provider for a stream instead: the
+/// mock scripted only stream turns, and it answers.
+#[tokio::test]
+async fn a_streamed_prompt_runs_streaming() {
+    let probe = MediumProbe::default();
+    let agent = AgentBuilder::new(streaming_model())
+        .add_hook(probe.clone())
+        .build();
+
+    let mut stream = agent.prompt("go").stream();
+    let mut final_output = None;
+    while let Some(item) = stream.next().await {
+        if let MultiTurnStreamItem::FinalResponse(response) = item.expect("a stream item") {
+            final_output = Some(response.output);
+        }
+    }
+
+    assert_eq!(final_output.as_deref(), Some("streamed"));
+    assert!(probe.seen.load(Ordering::SeqCst));
+    assert!(probe.streaming.load(Ordering::SeqCst));
+}
+
+/// The medium is not a property of the runner: a runner built for one
+/// medium and driven in the other reaches the provider through the other
+/// operation. The mock has no turn scripted for it, so the run fails at the
+/// provider — nothing in between silently switched medium.
+#[tokio::test]
+async fn the_terminal_alone_chooses_the_medium() {
+    let agent = AgentBuilder::new(unary_model()).build();
+    let mut stream = agent.prompt("go").stream();
+    let first = stream.next().await.expect("the stream yields its error");
+    assert!(first.is_err(), "a unary-only mock cannot serve a stream");
+
+    let agent = AgentBuilder::new(streaming_model()).build();
+    let result = agent.prompt("go").await;
+    assert!(
+        result.is_err(),
+        "a stream-only mock cannot serve a unary call"
+    );
+}
+
+/// `stream()` is lazy: building the stream loads no memory and touches no
+/// hook; dropping it unpolled leaves the run unstarted.
+#[tokio::test]
+async fn a_stream_does_nothing_until_polled() {
+    let memory = CountingMemory::default();
+    let probe = MediumProbe::default();
+    let agent = AgentBuilder::new(streaming_model())
+        .memory(memory.clone())
+        .add_hook(probe.clone())
+        .build();
+
+    let stream = agent.prompt("go").conversation("thread").stream();
+    assert_eq!(memory.load_count(), 0, "no load before the first poll");
+    assert!(!probe.seen.load(Ordering::SeqCst));
+    drop(stream);
+    assert_eq!(memory.load_count(), 0, "an unpolled stream does nothing");
+    assert_eq!(memory.append_count(), 0);
+
+    let mut stream = agent.prompt("go").conversation("thread").stream();
+    let _ = stream.next().await.expect("the first poll starts the run");
+    assert_eq!(memory.load_count(), 1, "the first poll loads memory");
+    while stream.next().await.is_some() {}
+    assert_eq!(memory.append_count(), 1, "a completed run saves once");
+}
+
+/// `Agent::resume` continues a run from its own state: no prompt is
+/// supplied, the run's prompt reaches the provider, and the runner's
+/// per-run settings still apply.
+#[tokio::test]
+async fn resume_continues_a_run_without_a_prompt() {
+    let model = unary_model();
+    let recorded = model.clone();
+    let agent = AgentBuilder::new(model).build();
+    let run = AgentRun::from_spec(&agent.run_spec(), Message::user("from the run"), None);
+
+    let response = agent
+        .resume(run)
+        .max_turns(2)
+        .await
+        .expect("the resumed run completes");
+
+    assert_eq!(response.output, "collected");
+    let requests = recorded.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0]
+            .chat_history
+            .last()
+            .and_then(Message::rag_text)
+            .as_deref(),
+        Some("from the run"),
+        "the run's own prompt is what the provider saw"
+    );
+}
+
+/// A resumed run carries its history: even with memory and a conversation
+/// configured, nothing is loaded and nothing is appended.
+#[tokio::test]
+async fn resume_neither_loads_nor_saves_memory() {
+    let memory = CountingMemory::default();
+    let agent = AgentBuilder::new(unary_model())
+        .memory(memory.clone())
+        .build();
+    let run = AgentRun::from_spec(&agent.run_spec(), Message::user("from the run"), None);
+
+    let response = agent
+        .resume(run)
+        .conversation("thread")
+        .await
+        .expect("the resumed run completes");
+
+    assert_eq!(response.output, "collected");
+    assert_eq!(memory.load_count(), 0);
+    assert_eq!(memory.append_count(), 0);
+}
+
+/// The number of hook events is the same whichever medium drives the run:
+/// one run start each.
+#[tokio::test]
+async fn both_media_fire_run_start_once() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    #[derive(Clone)]
+    struct Count(Arc<AtomicUsize>);
+    impl AgentHook for Count {
+        async fn on_run_start(&self, _ctx: &HookContext, _event: RunStart<'_>) -> RunStartAction {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            RunStartAction::Continue
+        }
+    }
+
+    let agent = AgentBuilder::new(unary_model())
+        .add_hook(Count(counter.clone()))
+        .build();
+    agent.prompt("go").await.expect("unary");
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+    let agent = AgentBuilder::new(streaming_model())
+        .add_hook(Count(counter.clone()))
+        .build();
+    let mut stream = agent.prompt("go").stream();
+    while stream.next().await.is_some() {}
+    assert_eq!(counter.load(Ordering::SeqCst), 2);
+}

--- a/crates/rig-agent/src/agent/runner/entry_tests.rs
+++ b/crates/rig-agent/src/agent/runner/entry_tests.rs
@@ -1,6 +1,10 @@
 //! The entry-point contract: `Agent::prompt` is the one way to a runner and
 //! the terminal call alone chooses the medium; `Agent::resume` continues a
 //! run without a prompt; `stream()` does nothing until it is polled.
+//!
+//! The resume tests here continue a pristine run (turn 0, nothing pending):
+//! they pin the entry point, not mid-flight resumption, which
+//! `rig-verify`'s `durable_execution` suite covers.
 
 use std::sync::{
     Arc,
@@ -223,7 +227,13 @@ async fn resume_neither_loads_nor_saves_memory() {
         .build();
     let run = AgentRun::from_spec(&agent.run_spec(), Message::user("from the run"), None);
     let mut stream = agent.resume(run).conversation("thread").stream();
-    while stream.next().await.is_some() {}
+    let mut final_output = None;
+    while let Some(item) = stream.next().await {
+        if let MultiTurnStreamItem::FinalResponse(response) = item.expect("a stream item") {
+            final_output = Some(response.output);
+        }
+    }
+    assert_eq!(final_output.as_deref(), Some("streamed"));
     assert_eq!(memory.load_count(), 0);
     assert_eq!(memory.append_count(), 0);
 }

--- a/crates/rig-agent/src/agent/runner/entry_tests.rs
+++ b/crates/rig-agent/src/agent/runner/entry_tests.rs
@@ -89,13 +89,20 @@ async fn the_terminal_alone_chooses_the_medium() {
     let agent = AgentBuilder::new(unary_model()).build();
     let mut stream = agent.prompt("go").stream();
     let first = stream.next().await.expect("the stream yields its error");
-    assert!(first.is_err(), "a unary-only mock cannot serve a stream");
+    let error = first.expect_err("a unary-only mock cannot serve a stream");
+    assert!(
+        error.to_string().contains("no scripted streaming turn"),
+        "the provider was asked for a stream: {error}"
+    );
 
     let agent = AgentBuilder::new(streaming_model()).build();
-    let result = agent.prompt("go").await;
+    let error = agent
+        .prompt("go")
+        .await
+        .expect_err("a stream-only mock cannot serve a unary call");
     assert!(
-        result.is_err(),
-        "a stream-only mock cannot serve a unary call"
+        error.to_string().contains("no scripted completion turn"),
+        "the provider was asked for a completion: {error}"
     );
 }
 
@@ -125,22 +132,27 @@ async fn a_stream_does_nothing_until_polled() {
 }
 
 /// `Agent::resume` continues a run from its own state: no prompt is
-/// supplied, the run's prompt reaches the provider, and the runner's
-/// per-run settings still apply.
+/// supplied, the run's prompt reaches the provider, and what the runner
+/// still supplies — its hooks — applies.
 #[tokio::test]
 async fn resume_continues_a_run_without_a_prompt() {
     let model = unary_model();
     let recorded = model.clone();
+    let probe = MediumProbe::default();
     let agent = AgentBuilder::new(model).build();
     let run = AgentRun::from_spec(&agent.run_spec(), Message::user("from the run"), None);
 
     let response = agent
         .resume(run)
-        .max_turns(2)
+        .add_hook(probe.clone())
         .await
         .expect("the resumed run completes");
 
     assert_eq!(response.output, "collected");
+    assert!(
+        probe.seen.load(Ordering::SeqCst),
+        "a hook added on the resuming runner fires"
+    );
     let requests = recorded.requests();
     assert_eq!(requests.len(), 1);
     assert_eq!(
@@ -154,8 +166,40 @@ async fn resume_continues_a_run_without_a_prompt() {
     );
 }
 
+/// The streamed twin of the above: a resumed run streams from its own
+/// state, its prompt reaches the provider, and its hooks see the medium.
+#[tokio::test]
+async fn resume_streams_a_run_without_a_prompt() {
+    let model = streaming_model();
+    let recorded = model.clone();
+    let probe = MediumProbe::default();
+    let agent = AgentBuilder::new(model).build();
+    let run = AgentRun::from_spec(&agent.run_spec(), Message::user("from the run"), None);
+
+    let mut stream = agent.resume(run).add_hook(probe.clone()).stream();
+    let mut final_output = None;
+    while let Some(item) = stream.next().await {
+        if let MultiTurnStreamItem::FinalResponse(response) = item.expect("a stream item") {
+            final_output = Some(response.output);
+        }
+    }
+
+    assert_eq!(final_output.as_deref(), Some("streamed"));
+    assert!(probe.streaming.load(Ordering::SeqCst));
+    let requests = recorded.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0]
+            .chat_history
+            .last()
+            .and_then(Message::rag_text)
+            .as_deref(),
+        Some("from the run")
+    );
+}
+
 /// A resumed run carries its history: even with memory and a conversation
-/// configured, nothing is loaded and nothing is appended.
+/// configured, nothing is loaded and nothing is appended — on either medium.
 #[tokio::test]
 async fn resume_neither_loads_nor_saves_memory() {
     let memory = CountingMemory::default();
@@ -171,6 +215,15 @@ async fn resume_neither_loads_nor_saves_memory() {
         .expect("the resumed run completes");
 
     assert_eq!(response.output, "collected");
+    assert_eq!(memory.load_count(), 0);
+    assert_eq!(memory.append_count(), 0);
+
+    let agent = AgentBuilder::new(streaming_model())
+        .memory(memory.clone())
+        .build();
+    let run = AgentRun::from_spec(&agent.run_spec(), Message::user("from the run"), None);
+    let mut stream = agent.resume(run).conversation("thread").stream();
+    while stream.next().await.is_some() {}
     assert_eq!(memory.load_count(), 0);
     assert_eq!(memory.append_count(), 0);
 }

--- a/crates/rig-agent/src/agent/runner/ignore_tests.rs
+++ b/crates/rig-agent/src/agent/runner/ignore_tests.rs
@@ -47,8 +47,7 @@ async fn output_under(policy: UnhandledInvalidToolCall) -> Result<String, String
     let mut stream = agent
         .prompt("go")
         .unhandled_invalid_tool_call(policy)
-        .stream()
-        .await;
+        .stream();
     let mut output = None;
     while let Some(item) = stream.next().await {
         match item {

--- a/crates/rig-agent/src/agent/runner/ignore_tests.rs
+++ b/crates/rig-agent/src/agent/runner/ignore_tests.rs
@@ -45,7 +45,7 @@ async fn output_under(policy: UnhandledInvalidToolCall) -> Result<String, String
     .tool(Add)
     .build();
     let mut stream = agent
-        .stream_prompt("go")
+        .prompt("go")
         .unhandled_invalid_tool_call(policy)
         .stream()
         .await;

--- a/crates/rig-agent/src/agent/runner/prompt_tests.rs
+++ b/crates/rig-agent/src/agent/runner/prompt_tests.rs
@@ -37,7 +37,7 @@ use std::sync::{
 ///
 /// The premise of the whole fix is that the two surfaces disagreeing is
 /// what let truncation surface as a blank answer, yet every other guard
-/// test drives `stream_prompt`. Until `MockTurn::with_finish_reason`
+/// test drives the streamed surface. Until `MockTurn::with_finish_reason`
 /// existed the blocking mock could not report a reason at all, so
 /// `runner.rs`'s `.with_finish_reason(resp.finish_reason())` — and its
 /// propagation through `model_response` → `record_completion_call` → this

--- a/crates/rig-agent/src/agent/runner/settled_tests.rs
+++ b/crates/rig-agent/src/agent/runner/settled_tests.rs
@@ -122,7 +122,7 @@ mod slow_stream {
         let agent = AgentBuilder::over_bus(dispatcher.clone(), registrar.clone(), "golden", key)
             .add_hook(StopOnTextDelta)
             .build();
-        let mut stream = agent.stream_prompt("go").stream().await;
+        let mut stream = agent.prompt("go").stream().await;
         let mut stopped = false;
         while let Some(item) = stream.next().await {
             if let Err(crate::agent::StreamingError::Prompt(error)) = item {
@@ -170,7 +170,7 @@ mod slow_stream {
             .add_hook(StopOnTextDelta)
             .record_effects()
             .build();
-        let mut stream = agent.stream_prompt("go").stream().await;
+        let mut stream = agent.prompt("go").stream().await;
         while let Some(item) = stream.next().await {
             if let Err(crate::agent::StreamingError::Prompt(error)) = item {
                 assert!(matches!(

--- a/crates/rig-agent/src/agent/runner/settled_tests.rs
+++ b/crates/rig-agent/src/agent/runner/settled_tests.rs
@@ -122,7 +122,7 @@ mod slow_stream {
         let agent = AgentBuilder::over_bus(dispatcher.clone(), registrar.clone(), "golden", key)
             .add_hook(StopOnTextDelta)
             .build();
-        let mut stream = agent.prompt("go").stream().await;
+        let mut stream = agent.prompt("go").stream();
         let mut stopped = false;
         while let Some(item) = stream.next().await {
             if let Err(crate::agent::StreamingError::Prompt(error)) = item {
@@ -170,7 +170,7 @@ mod slow_stream {
             .add_hook(StopOnTextDelta)
             .record_effects()
             .build();
-        let mut stream = agent.prompt("go").stream().await;
+        let mut stream = agent.prompt("go").stream();
         while let Some(item) = stream.next().await {
             if let Err(crate::agent::StreamingError::Prompt(error)) = item {
                 assert!(matches!(

--- a/crates/rig-agent/src/agent/runner/tests.rs
+++ b/crates/rig-agent/src/agent/runner/tests.rs
@@ -359,8 +359,7 @@ async fn blocking_and_streaming_preserve_raw_failure_while_rewriting_presentatio
         .build()
         .prompt("go")
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     while let Some(item) = stream.next().await {
         item.expect("stream item");
     }

--- a/crates/rig-agent/src/agent/runner/tests.rs
+++ b/crates/rig-agent/src/agent/runner/tests.rs
@@ -161,7 +161,7 @@ async fn runner_applies_per_run_request_overrides() {
         .max_tokens(10)
         .additional_params(json!({"baseline": true}))
         .build()
-        .runner("go")
+        .prompt("go")
         .preamble("run preamble")
         .document(Document {
             id: "run-one".into(),
@@ -216,7 +216,7 @@ async fn runner_can_merge_additional_params_into_the_baseline() {
     AgentBuilder::new(model.clone())
         .additional_params(json!({"baseline": true, "winner": "baseline"}))
         .build()
-        .runner("go")
+        .prompt("go")
         .merge_additional_params(
             json!({"override": true, "winner": "runner"})
                 .as_object()
@@ -243,7 +243,7 @@ async fn runner_can_replace_additional_params_wholesale() {
     AgentBuilder::new(model.clone())
         .additional_params(json!({"baseline": true}))
         .build()
-        .runner("go")
+        .prompt("go")
         .replace_additional_params(json!({"replacement": true}))
         .run()
         .await
@@ -267,7 +267,7 @@ async fn runner_can_clear_configured_request_defaults() {
         .additional_params(json!({"baseline": true}))
         .tool_choice(ToolChoice::Required)
         .build()
-        .runner("go")
+        .prompt("go")
         .without_preamble()
         .without_temperature()
         .without_max_tokens()
@@ -334,7 +334,7 @@ async fn blocking_and_streaming_preserve_raw_failure_while_rewriting_presentatio
         .tool(MetadataFailingTool)
         .add_hook(blocking.clone())
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(3)
         .run()
         .await
@@ -357,7 +357,7 @@ async fn blocking_and_streaming_preserve_raw_failure_while_rewriting_presentatio
         .tool(MetadataFailingTool)
         .add_hook(streaming.clone())
         .build()
-        .runner("go")
+        .prompt("go")
         .max_turns(3)
         .stream()
         .await;
@@ -412,7 +412,7 @@ async fn agent_dispatch_snapshot_isolates_tool_mutations() {
     .tool(tool.clone())
     .add_hook(results.clone())
     .build()
-    .runner("go")
+    .prompt("go")
     .tool_context(context)
     .max_turns(4)
     .run()

--- a/crates/rig-agent/src/agent/streaming.rs
+++ b/crates/rig-agent/src/agent/streaming.rs
@@ -253,16 +253,34 @@ impl From<rig_core::memory::MemoryError> for StreamingError {
 }
 
 impl AgentRunner {
-    /// Drive the agent loop, streaming assistant content, tool activity, and a
-    /// final response. Hooks fire at every observable point, including streamed
-    /// text and tool-call deltas. Returns the stream after loading any
-    /// configured conversation memory.
+    /// Drive the agent loop as a stream of assistant content, tool activity
+    /// and, last, the [`FinalResponse`](MultiTurnStreamItem::FinalResponse).
+    /// Hooks fire at every observable point, including streamed text and
+    /// tool-call deltas.
+    ///
+    /// Like [`run`](AgentRunner::run), this is lazy: nothing — not the memory
+    /// load, not the agent span — happens until the stream is first polled,
+    /// and a stream that is dropped unpolled has done nothing. A memory-load
+    /// failure is the stream's first (and only) item. The stream is `Send` on
+    /// native targets, so it can be built in synchronous code and handed to
+    /// whatever polls it.
     ///
     /// Shares the drive loop, run construction, tool execution and fail-closed
     /// hook handling with the blocking [`run`](AgentRunner::run) via
     /// `drive_agent`, so the two behave identically apart from the streamed
     /// delta events.
-    pub async fn stream(self) -> StreamingResult {
+    pub fn stream(self) -> StreamingResult {
+        Box::pin(async_stream::stream! {
+            let mut inner = self.start_stream().await;
+            while let Some(item) = inner.next().await {
+                yield item;
+            }
+        })
+    }
+
+    /// The eager half of [`stream`](Self::stream): resolve memory, build the
+    /// run and return the driver as a stream. Called on the first poll.
+    async fn start_stream(self) -> StreamingResult {
         let (agent_span, created_agent_span) = self.open_agent_span();
 
         let bus = self.config.bus.clone();
@@ -405,7 +423,7 @@ impl AgentRunner {
     ) {
         let (mut sender, receiver) = mpsc::channel(RUN_EVENTS_CAPACITY);
         let future = async move {
-            let mut stream = self.stream().await;
+            let mut stream = self.stream();
             let mut response = None;
             let mut forward = true;
             while let Some(item) = stream.next().await {

--- a/crates/rig-agent/src/agent/streaming.rs
+++ b/crates/rig-agent/src/agent/streaming.rs
@@ -263,7 +263,9 @@ impl AgentRunner {
     /// and a stream that is dropped unpolled has done nothing. A memory-load
     /// failure is the stream's first (and only) item. The stream is `Send` on
     /// native targets, so it can be built in synchronous code and handed to
-    /// whatever polls it.
+    /// whatever polls it; it runs under the span it was built in (a caller's
+    /// enabled span is adopted, otherwise a root `invoke_agent` is created),
+    /// not under whichever span first polls it.
     ///
     /// ```rust,no_run
     /// # use rig_agent::{Agent, agent::StreamingResult};
@@ -277,19 +279,27 @@ impl AgentRunner {
     /// hook handling with the blocking [`run`](AgentRunner::run) via
     /// `drive_agent`, so the two behave identically apart from the streamed
     /// delta events.
+    #[must_use = "a stream does nothing until polled"]
     pub fn stream(self) -> StreamingResult {
-        Box::pin(async_stream::stream! {
-            let mut inner = self.start_stream().await;
+        // The span the stream is built under is the one it runs under, not
+        // whichever span first polls it: a host may build the stream in a
+        // request span and hand it to a task of its own.
+        let ambient = tracing::Span::current();
+        let run_under = ambient.clone();
+        let stream = async_stream::stream! {
+            let mut inner = self.start_stream(run_under).await;
             while let Some(item) = inner.next().await {
                 yield item;
             }
-        })
+        };
+        Box::pin(stream.instrument(ambient))
     }
 
     /// The eager half of [`stream`](Self::stream): resolve memory, build the
-    /// run and return the driver as a stream. Called on the first poll.
-    async fn start_stream(self) -> StreamingResult {
-        let (agent_span, created_agent_span) = self.open_agent_span();
+    /// run and return the driver as a stream. Called on the first poll,
+    /// under `ambient` — the span the stream was built in.
+    async fn start_stream(self, ambient: tracing::Span) -> StreamingResult {
+        let (agent_span, created_agent_span) = self.open_agent_span(ambient);
 
         let bus = self.config.bus.clone();
         let hook_ctx = self.hook_context(true);
@@ -423,6 +433,7 @@ impl AgentRunner {
     /// The feed is bounded ([`RUN_EVENTS_CAPACITY`]); when it is full the run
     /// waits for the consumer rather than dropping events. Dropping the feed
     /// lets the run continue to completion unobserved.
+    #[must_use = "the run does nothing until the future is driven"]
     pub fn run_channel(
         self,
     ) -> (

--- a/crates/rig-agent/src/agent/streaming.rs
+++ b/crates/rig-agent/src/agent/streaming.rs
@@ -284,7 +284,13 @@ impl AgentRunner {
         // The span the stream is built under is the one it runs under, not
         // whichever span first polls it: a host may build the stream in a
         // request span and hand it to a task of its own.
-        let ambient = tracing::Span::current();
+        self.stream_under(tracing::Span::current())
+    }
+
+    /// [`stream`](Self::stream) under an explicitly captured ambient span —
+    /// the one terminal that builds the stream lazily inside another future
+    /// ([`run_channel`](Self::run_channel)) captures it at its own call.
+    fn stream_under(self, ambient: tracing::Span) -> StreamingResult {
         let run_under = ambient.clone();
         let stream = async_stream::stream! {
             let mut inner = self.start_stream(run_under).await;
@@ -432,7 +438,9 @@ impl AgentRunner {
     ///
     /// The feed is bounded ([`RUN_EVENTS_CAPACITY`]); when it is full the run
     /// waits for the consumer rather than dropping events. Dropping the feed
-    /// lets the run continue to completion unobserved.
+    /// lets the run continue to completion unobserved. Like
+    /// [`stream`](Self::stream), the run belongs to the span this method was
+    /// called in, wherever the future is later polled.
     #[must_use = "the run does nothing until the future is driven"]
     pub fn run_channel(
         self,
@@ -441,8 +449,12 @@ impl AgentRunner {
         RunEvents,
     ) {
         let (mut sender, receiver) = mpsc::channel(RUN_EVENTS_CAPACITY);
+        // Captured here, not when the future is first polled: the doc above
+        // says to spawn the future, and the run must still belong to the span
+        // that split it.
+        let ambient = tracing::Span::current();
         let future = async move {
-            let mut stream = self.stream();
+            let mut stream = self.stream_under(ambient);
             let mut response = None;
             let mut forward = true;
             while let Some(item) = stream.next().await {

--- a/crates/rig-agent/src/agent/streaming.rs
+++ b/crates/rig-agent/src/agent/streaming.rs
@@ -265,6 +265,14 @@ impl AgentRunner {
     /// native targets, so it can be built in synchronous code and handed to
     /// whatever polls it.
     ///
+    /// ```rust,no_run
+    /// # use rig_agent::{Agent, agent::StreamingResult};
+    /// fn start(agent: &Agent, prompt: &str) -> StreamingResult {
+    ///     // Nothing runs until whoever holds this polls it.
+    ///     agent.prompt(prompt).stream()
+    /// }
+    /// ```
+    ///
     /// Shares the drive loop, run construction, tool execution and fail-closed
     /// hook handling with the blocking [`run`](AgentRunner::run) via
     /// `drive_agent`, so the two behave identically apart from the streamed

--- a/crates/rig-agent/src/agent/streaming.rs
+++ b/crates/rig-agent/src/agent/streaming.rs
@@ -3,7 +3,7 @@ use rig_core::{message::AssistantContent, wasm_compat::WasmCompatSend};
 
 use crate::{
     agent::engine::{DriveItem, StreamingTurnSource, drive_agent, streaming_error_into_prompt},
-    agent::runner::AgentRunner,
+    agent::runner::{AgentRunner, RunOrigin},
     streaming::{BlockClose, Delta, StreamEvent, StreamedUserContent},
 };
 use futures::{SinkExt, Stream, StreamExt, channel::mpsc, stream::FusedStream};
@@ -262,16 +262,15 @@ impl AgentRunner {
     /// hook handling with the blocking [`run`](AgentRunner::run) via
     /// `drive_agent`, so the two behave identically apart from the streamed
     /// delta events.
-    pub async fn stream(mut self) -> StreamingResult {
+    pub async fn stream(self) -> StreamingResult {
         let (agent_span, created_agent_span) = self.open_agent_span();
 
         let bus = self.config.bus.clone();
         let hook_ctx = self.hook_context(true);
         // A resumed run loads nothing and saves nothing (see `run`).
-        let resumed = self.resume.take();
-        let resolved = match &resumed {
-            Some(_) => Ok((None, None)),
-            None => {
+        let resolved = match &self.origin {
+            RunOrigin::Resume(_) => Ok((None, None)),
+            RunOrigin::Prompt(_) => {
                 let resolve = self.resolve_history_and_memory(&hook_ctx);
                 futures::pin_mut!(resolve);
                 let mut driven = bus.drive(futures::stream::once(resolve));
@@ -290,10 +289,7 @@ impl AgentRunner {
             }
         };
 
-        let run = match resumed {
-            Some(run) => *run,
-            None => self.build_run(history_override),
-        };
+        let run = self.build_run(history_override);
         let source = StreamingTurnSource::new(
             &self.config.hooks,
             self.agent_name_or_default().to_string(),

--- a/crates/rig-agent/src/agent/streaming.rs
+++ b/crates/rig-agent/src/agent/streaming.rs
@@ -11,12 +11,9 @@ use serde::{Deserialize, Serialize};
 use std::pin::Pin;
 use tracing_futures::Instrument;
 
+use crate::completion::{CompletionError, PromptError};
 use crate::run::response::{CompletionCall, PromptResponse};
 use crate::run::transcript::assistant_text_from_choice;
-use crate::{
-    agent::Agent,
-    completion::{CompletionError, PromptError},
-};
 use rig_core::message::Message;
 
 // The `Send` bound is dropped exactly where `rig-core`'s `WasmCompat*` markers
@@ -336,8 +333,7 @@ impl AgentRunner {
 /// it parks on back-pressure.
 pub const RUN_EVENTS_CAPACITY: usize = 32;
 
-/// Event feed of an agent run started with [`AgentRunner::run_channel`] or
-/// [`Agent::run_channel`].
+/// Event feed of an agent run started with [`AgentRunner::run_channel`].
 ///
 /// Every [`MultiTurnStreamItem`] the run would have streamed is delivered here
 /// in order, ending with [`MultiTurnStreamItem::FinalResponse`]. The feed is a
@@ -442,23 +438,6 @@ impl AgentRunner {
             })
         };
         (future, RunEvents { receiver })
-    }
-}
-
-impl Agent {
-    /// Run `prompt` with the agent's defaults, returning the driving future and
-    /// a [`RunEvents`] feed. See [`AgentRunner::run_channel`]; to configure the
-    /// run first (history, turn budget, tool context, …), configure the runner
-    /// from [`Agent::stream_prompt`] and call its
-    /// [`run_channel`](AgentRunner::run_channel).
-    pub fn run_channel<P: Into<Message> + WasmCompatSend>(
-        &self,
-        prompt: P,
-    ) -> (
-        impl Future<Output = Result<PromptResponse, PromptError>> + WasmCompatSend + use<P>,
-        RunEvents,
-    ) {
-        AgentRunner::from_agent(self, prompt).run_channel()
     }
 }
 

--- a/crates/rig-agent/src/agent/streaming/tests.rs
+++ b/crates/rig-agent/src/agent/streaming/tests.rs
@@ -60,7 +60,7 @@ async fn public_streaming_request_constructor_preserves_agent_hooks() {
             .build(),
     );
 
-    let mut stream = agent.stream_prompt("go").stream().await;
+    let mut stream = agent.prompt("go").stream().await;
     let error = stream
         .try_next()
         .await
@@ -80,7 +80,7 @@ async fn text_only_stream_without_terminal_record_is_rejected_as_truncated() {
     let model = MockCompletionModel::from_stream_turns([[MockStreamEvent::text("partial answer")]]);
     let agent = Arc::new(AgentBuilder::new(model.clone()).build());
 
-    let mut stream = agent.stream_prompt("go").stream().await;
+    let mut stream = agent.prompt("go").stream().await;
     let mut saw_error = false;
     let mut saw_completion_call = false;
     while let Some(item) = stream.next().await {
@@ -124,7 +124,7 @@ async fn tool_call_stream_without_terminal_record_dispatches_no_tools() {
     )]]);
     let agent = AgentBuilder::new(model.clone()).tool(add_tool).build();
 
-    let mut stream = agent.stream_prompt("go").max_turns(3).stream().await;
+    let mut stream = agent.prompt("go").max_turns(3).stream().await;
     let mut saw_error = false;
     while let Some(item) = stream.next().await {
         if item.is_err() {
@@ -600,7 +600,7 @@ fn usage(input_tokens: u64, output_tokens: u64) -> Usage {
 async fn execution_commit_items_are_not_emitted_when_run_commit_fails() {
     let runner = AgentBuilder::new(MockCompletionModel::default())
         .build()
-        .runner("go");
+        .prompt("go");
     let tool_snapshot = Arc::new(
         runner
             .tool_server_handle
@@ -860,11 +860,7 @@ async fn assert_stream_usage_recorded_on_chat_spans(
         MockStreamEvent::final_response(Usage::default()),
     ]]);
     let warmup_agent = crate::agent::AgentBuilder::new(warmup_model).build();
-    let mut warmup_stream = warmup_agent
-        .stream_prompt("warmup")
-        .max_turns(1)
-        .stream()
-        .await;
+    let mut warmup_stream = warmup_agent.prompt("warmup").max_turns(1).stream().await;
     while let Some(item) = warmup_stream
         .try_next()
         .await
@@ -884,7 +880,7 @@ async fn assert_stream_usage_recorded_on_chat_spans(
 
     async {
         let mut stream = agent
-            .stream_prompt(prompt)
+            .prompt(prompt)
             .history(empty_history)
             .max_turns(max_turns)
             .stream()
@@ -986,11 +982,7 @@ async fn capture_stream_message_telemetry(
         MockStreamEvent::final_response(Usage::default()),
     ]]);
     let warmup_agent = crate::agent::AgentBuilder::new(warmup_model).build();
-    let mut warmup_stream = warmup_agent
-        .stream_prompt("warmup")
-        .max_turns(1)
-        .stream()
-        .await;
+    let mut warmup_stream = warmup_agent.prompt("warmup").max_turns(1).stream().await;
     while let Some(item) = warmup_stream
         .try_next()
         .await
@@ -1019,7 +1011,7 @@ async fn capture_stream_message_telemetry(
     };
 
     let mut stream = agent
-        .stream_prompt("stream prompt secret")
+        .prompt("stream prompt secret")
         .max_turns(1)
         .stream()
         .await;
@@ -1224,7 +1216,7 @@ async fn capture_tool_content_telemetry(record_telemetry_content: bool) -> Captu
     .tool(MockAddTool)
     .build();
     warmup
-        .runner("warmup")
+        .prompt("warmup")
         .max_turns(2)
         .run()
         .await
@@ -1247,7 +1239,7 @@ async fn capture_tool_content_telemetry(record_telemetry_content: bool) -> Captu
         builder.build()
     };
     agent
-        .runner("use the tool")
+        .prompt("use the tool")
         .max_turns(2)
         .run()
         .await
@@ -1311,11 +1303,7 @@ async fn streaming_rejected_message_telemetry_does_not_record_output() {
         MockStreamEvent::final_response(Usage::default()),
     ]]);
     let warmup_agent = crate::agent::AgentBuilder::new(warmup_model).build();
-    let mut warmup_stream = warmup_agent
-        .stream_prompt("warmup")
-        .max_turns(1)
-        .stream()
-        .await;
+    let mut warmup_stream = warmup_agent.prompt("warmup").max_turns(1).stream().await;
     while let Some(item) = warmup_stream
         .try_next()
         .await
@@ -1342,7 +1330,7 @@ async fn streaming_rejected_message_telemetry_does_not_record_output() {
         .build();
 
     let mut stream = agent
-        .stream_prompt("stream rejection prompt")
+        .prompt("stream rejection prompt")
         .max_turns(1)
         .stream()
         .await;
@@ -2016,7 +2004,7 @@ async fn stream_prompt_continues_after_tool_call_turn() {
     let empty_history: &[Message] = &[];
 
     let mut stream = agent
-        .stream_prompt("do tool work")
+        .prompt("do tool work")
         .history(empty_history)
         .max_turns(3)
         .stream()
@@ -2099,7 +2087,7 @@ async fn streaming_prompt_request_tool_concurrency_runs_tools_concurrently() {
 
     let drive = async {
         let mut stream = agent
-            .stream_prompt("hit the barrier twice")
+            .prompt("hit the barrier twice")
             .max_turns(3)
             .tool_concurrency(2)
             .stream()
@@ -2139,7 +2127,7 @@ async fn tool_context_reaches_tool_through_streaming_loop() {
         .unwrap();
 
     let mut stream = agent
-        .stream_prompt("do tool work")
+        .prompt("do tool work")
         .tool_context(tool_context)
         .history(empty_history)
         .max_turns(3)
@@ -2178,7 +2166,7 @@ async fn streaming_tool_runs_with_empty_context_when_none_supplied() {
     let empty_history: &[Message] = &[];
 
     let mut stream = agent
-        .stream_prompt("do tool work")
+        .prompt("do tool work")
         .history(empty_history)
         .max_turns(3)
         .stream()
@@ -2215,7 +2203,7 @@ async fn unknown_tool_call_fails_before_streaming_second_request() {
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
     let mut stream = agent
-        .stream_prompt("use the tool")
+        .prompt("use the tool")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
         .stream()
@@ -2278,7 +2266,7 @@ async fn invalid_tool_call_hook_can_repair_streaming_tool_name() {
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
     let mut stream = agent
-        .stream_prompt("use the tool")
+        .prompt("use the tool")
         .add_hook(RepairDefaultApiHook)
         .max_turns(3)
         .history(Vec::<Message>::new())
@@ -2344,7 +2332,7 @@ async fn invalid_tool_call_context_uses_completed_streaming_tool_call_provider_i
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
     let mut stream = agent
-        .stream_prompt("use the tool")
+        .prompt("use the tool")
         .add_hook(invalid_hook.clone())
         .max_turns(3)
         .stream()
@@ -2401,7 +2389,7 @@ async fn invalid_tool_call_hook_skip_emits_streaming_tool_result() {
         .build();
 
     let mut stream = agent
-        .stream_prompt("use the tool")
+        .prompt("use the tool")
         .add_hook(SkipDefaultApiHook)
         .max_turns(3)
         .history(Vec::<Message>::new())
@@ -2496,7 +2484,7 @@ async fn invalid_tool_call_hook_retries_mixed_streaming_turn_without_executing_v
         .build();
 
     let mut stream = agent
-        .stream_prompt("use the tool")
+        .prompt("use the tool")
         .add_hook(RetryDefaultApiHook)
         .max_turns(3)
         .history(Vec::<Message>::new())
@@ -2622,7 +2610,7 @@ async fn invalid_tool_call_hook_skips_mixed_streaming_turn_without_executing_val
         .build();
 
     let mut stream = agent
-        .stream_prompt("use the tool")
+        .prompt("use the tool")
         .add_hook(SkipDefaultApiHook)
         .max_turns(3)
         .history(Vec::<Message>::new())
@@ -2747,7 +2735,7 @@ async fn invalid_completed_tool_call_skip_preserves_streaming_reasoning_history(
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
     let mut stream = agent
-        .stream_prompt("use the tool")
+        .prompt("use the tool")
         .add_hook(SkipDefaultApiHook)
         .max_turns(3)
         .history(Vec::<Message>::new())
@@ -2800,7 +2788,7 @@ async fn invalid_name_delta_retry_preserves_streaming_reasoning_history() {
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
     let mut stream = agent
-        .stream_prompt("use the tool")
+        .prompt("use the tool")
         .add_hook(RetryDefaultApiHook)
         .max_turns(3)
         .history(Vec::<Message>::new())
@@ -2847,7 +2835,7 @@ async fn invalid_tool_call_hook_skip_resets_streaming_text_delta_state() {
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
     let mut stream = agent
-        .stream_prompt("use the tool")
+        .prompt("use the tool")
         .add_hook(RecordingTextAndSkipInvalidToolHook {
             text: text_hook.clone(),
         })
@@ -2900,7 +2888,7 @@ async fn invalid_tool_call_delta_retry_uses_structured_tool_feedback() {
         .build();
 
     let mut stream = agent
-        .stream_prompt("use the tool")
+        .prompt("use the tool")
         .add_hook(RecordingDeltaAndRetryInvalidToolHook {
             delta: delta_hook.clone(),
         })
@@ -3035,7 +3023,7 @@ async fn invalid_tool_call_delta_context_includes_same_turn_history_and_tool_cal
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
     let mut stream = agent
-        .stream_prompt("use the tool")
+        .prompt("use the tool")
         .add_hook(invalid_hook.clone())
         .max_turns(3)
         .stream()
@@ -3103,7 +3091,7 @@ async fn invalid_tool_call_delta_retry_resets_streaming_text_delta_state() {
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
     let mut stream = agent
-        .stream_prompt("use the tool")
+        .prompt("use the tool")
         .add_hook(RecordingTextAndRetryInvalidToolHook {
             text: text_hook.clone(),
         })
@@ -3156,7 +3144,7 @@ async fn invalid_tool_call_delta_skip_uses_structured_tool_feedback() {
         .build();
 
     let mut stream = agent
-        .stream_prompt("use the tool")
+        .prompt("use the tool")
         .add_hook(RecordingDeltaAndSkipInvalidToolHook {
             delta: delta_hook.clone(),
         })
@@ -3290,7 +3278,7 @@ async fn streaming_retry_budget_exhaustion_history_contains_invalid_tool_call() 
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
     let mut stream = agent
-        .stream_prompt("use the tool")
+        .prompt("use the tool")
         .add_hook(RetryDefaultApiHook)
         .max_turns(3)
         .max_invalid_tool_call_retries(0)
@@ -3343,7 +3331,7 @@ async fn streaming_name_delta_retry_budget_exhaustion_history_includes_same_turn
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
     let mut stream = agent
-        .stream_prompt("use the tool")
+        .prompt("use the tool")
         .add_hook(RetryDefaultApiHook)
         .max_turns(3)
         .max_invalid_tool_call_retries(0)
@@ -3404,7 +3392,7 @@ async fn completed_unknown_tool_call_after_text_fails_before_finish_hook_or_late
         .build();
 
     let mut stream = agent
-        .stream_prompt("use the tool")
+        .prompt("use the tool")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
         .stream()
@@ -3499,7 +3487,7 @@ async fn mixed_streaming_tool_calls_fail_before_any_tool_execution() {
         .build();
 
     let mut stream = agent
-        .stream_prompt("use tools")
+        .prompt("use tools")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
         .stream()
@@ -3584,7 +3572,7 @@ async fn multiple_valid_streaming_tool_calls_execute_after_batch_validation() {
         })
         .build();
 
-    let mut stream = agent.stream_prompt("use tools").max_turns(3).stream().await;
+    let mut stream = agent.prompt("use tools").max_turns(3).stream().await;
     let mut tool_call_names = Vec::new();
     let mut tool_result_ids = Vec::new();
     let mut final_response_text = None;
@@ -3656,7 +3644,7 @@ async fn disallowed_specific_tool_call_fails_before_streaming_second_request() {
         .build();
 
     let mut stream = agent
-        .stream_prompt("use the allowed tool")
+        .prompt("use the allowed tool")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
         .stream()
@@ -3732,7 +3720,7 @@ async fn mixed_specific_tool_calls_fail_before_any_tool_execution() {
         .build();
 
     let mut stream = agent
-        .stream_prompt("use the allowed tool")
+        .prompt("use the allowed tool")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
         .stream()
@@ -3803,7 +3791,7 @@ async fn tool_choice_none_rejects_streaming_tool_call() {
         .build();
 
     let mut stream = agent
-        .stream_prompt("do not use tools")
+        .prompt("do not use tools")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
         .stream()
@@ -3866,7 +3854,7 @@ async fn tool_choice_none_rejects_streaming_tool_call_name_delta_before_hook_or_
         .build();
 
     let mut stream = agent
-        .stream_prompt("do not use tools")
+        .prompt("do not use tools")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
         .stream()
@@ -3929,7 +3917,7 @@ async fn unknown_tool_call_name_delta_fails_before_streaming_delta_hook_or_emit(
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
     let mut stream = agent
-        .stream_prompt("stream a bad tool call")
+        .prompt("stream a bad tool call")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
         .stream()
@@ -3992,7 +3980,7 @@ async fn tool_call_args_delta_before_unknown_name_fails_before_hook_or_emit() {
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
     let mut stream = agent
-        .stream_prompt("stream a bad tool call")
+        .prompt("stream a bad tool call")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
         .stream()
@@ -4050,7 +4038,7 @@ async fn tool_call_args_delta_before_valid_name_buffers_then_emits_in_safe_order
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
     let mut stream = agent
-        .stream_prompt("stream a tool call")
+        .prompt("stream a tool call")
         .add_hook(hook.clone())
         .stream()
         .await;
@@ -4126,7 +4114,7 @@ async fn tool_call_args_delta_without_name_errors_at_stream_end() {
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
     let mut stream = agent
-        .stream_prompt("stream an incomplete tool call")
+        .prompt("stream an incomplete tool call")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
         .stream()
@@ -4197,7 +4185,7 @@ async fn tool_choice_none_buffers_args_then_rejects_name_without_emit() {
         .build();
 
     let mut stream = agent
-        .stream_prompt("do not use tools")
+        .prompt("do not use tools")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
         .stream()
@@ -4256,7 +4244,7 @@ async fn stream_prompt_observes_interleaved_reasoning_deltas_before_unchanged_em
     let agent = AgentBuilder::new(model).build();
 
     let mut stream = agent
-        .stream_prompt("reason about this")
+        .prompt("reason about this")
         .add_hook(hook.clone())
         .stream()
         .await;
@@ -4346,7 +4334,7 @@ async fn stream_prompt_reasoning_delta_stop_prevents_emit_and_later_hook_dispatc
     let agent = AgentBuilder::new(model).build();
 
     let mut stream = agent
-        .stream_prompt("reason about this")
+        .prompt("reason about this")
         .add_hook(stopping.clone())
         .add_hook(later.clone())
         .stream()
@@ -4396,7 +4384,7 @@ async fn stream_prompt_skips_reasoning_delta_hook_without_observation_interest()
     let agent = AgentBuilder::new(model).build();
 
     let mut stream = agent
-        .stream_prompt("reason about this")
+        .prompt("reason about this")
         .add_hook(hook.clone())
         .stream()
         .await;
@@ -4434,7 +4422,7 @@ async fn stream_prompt_reasoning_delta_hook_observes_retried_turns_as_provisiona
     let agent = AgentBuilder::new(model).build();
 
     let mut stream = agent
-        .stream_prompt("reason about this")
+        .prompt("reason about this")
         .add_hook(hook.clone())
         .max_turns(2)
         .stream()
@@ -4475,7 +4463,7 @@ async fn stream_prompt_emits_tool_call_deltas_without_hook() {
     ]]);
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
-    let mut stream = agent.stream_prompt("stream a tool call").stream().await;
+    let mut stream = agent.prompt("stream a tool call").stream().await;
     let mut deltas = Vec::new();
 
     while let Some(item) = stream.next().await {
@@ -4536,7 +4524,7 @@ async fn stream_prompt_emits_tool_call_deltas_after_hook_continue() {
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
     let mut stream = agent
-        .stream_prompt("stream a tool call")
+        .prompt("stream a tool call")
         .add_hook(hook.clone())
         .stream()
         .await;
@@ -4607,7 +4595,7 @@ async fn stream_prompt_tool_call_deltas_hook_termination_prevents_delta_emit() {
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
     let mut stream = agent
-        .stream_prompt("stream a tool call")
+        .prompt("stream a tool call")
         .add_hook(hook.clone())
         .stream()
         .await;
@@ -4671,7 +4659,7 @@ async fn stream_prompt_exposes_completion_calls() {
     let empty_history: &[Message] = &[];
 
     let mut stream = agent
-        .stream_prompt("do tool work")
+        .prompt("do tool work")
         .history(empty_history)
         .max_turns(3)
         .stream()
@@ -4771,7 +4759,7 @@ async fn stream_prompt_emits_completion_call_before_finish_hook_termination() {
     let agent = AgentBuilder::new(model).build();
 
     let mut stream = agent
-        .stream_prompt("say done")
+        .prompt("say done")
         .add_hook(TerminateOnCompletionOutcome)
         .stream()
         .await;
@@ -4819,7 +4807,7 @@ async fn stream_prompt_completion_calls_records_unreported_usage() {
     let empty_history: &[Message] = &[];
 
     let mut stream = agent
-        .stream_prompt("do tool work")
+        .prompt("do tool work")
         .history(empty_history)
         .max_turns(3)
         .stream()
@@ -4855,7 +4843,7 @@ async fn stream_prompt_completion_calls_records_unreported_usage() {
 async fn final_response_matches_streamed_text_when_provider_final_is_textless() {
     let agent = AgentBuilder::new(streaming_text_then_final_model()).build();
 
-    let mut stream = agent.stream_prompt("say hello").stream().await;
+    let mut stream = agent.prompt("say hello").stream().await;
     let mut streamed_text = String::new();
     let mut final_response_text = None;
 
@@ -4882,7 +4870,7 @@ async fn final_response_matches_streamed_text_when_provider_final_is_textless() 
 async fn final_response_preserves_structured_text_metadata() {
     let agent = AgentBuilder::new(streaming_cited_text_then_final_model()).build();
 
-    let mut stream = agent.stream_prompt("answer with citations").stream().await;
+    let mut stream = agent.prompt("answer with citations").stream().await;
     let mut final_response = None;
 
     while let Some(item) = stream.next().await {
@@ -4912,7 +4900,7 @@ async fn final_response_history_preserves_structured_text_metadata() {
 
     let empty_history: &[Message] = &[];
     let mut stream = agent
-        .stream_prompt("answer with citations")
+        .prompt("answer with citations")
         .history(empty_history)
         .stream()
         .await;
@@ -4956,7 +4944,7 @@ async fn tool_follow_up_history_preserves_structured_text_metadata() {
     let empty_history: &[Message] = &[];
 
     let mut stream = agent
-        .stream_prompt("use a tool with citations")
+        .prompt("use a tool with citations")
         .history(empty_history)
         .max_turns(3)
         .stream()
@@ -4992,7 +4980,7 @@ async fn tool_follow_up_history_preserves_structured_text_metadata() {
 async fn final_response_can_remain_empty_for_truly_textless_turns() {
     let agent = AgentBuilder::new(streaming_final_only_model()).build();
 
-    let mut stream = agent.stream_prompt("say nothing").stream().await;
+    let mut stream = agent.prompt("say nothing").stream().await;
     let mut streamed_text = String::new();
     let mut final_response_text = None;
 
@@ -5033,7 +5021,7 @@ async fn empty_turn_truncated_at_max_tokens_is_an_error_not_an_empty_answer() {
     )]]);
     let agent = AgentBuilder::new(model).build();
 
-    let mut stream = agent.stream_prompt("write a long essay").stream().await;
+    let mut stream = agent.prompt("write a long essay").stream().await;
     let mut error = None;
     let mut final_response_text = None;
 
@@ -5084,7 +5072,7 @@ async fn partial_output_truncated_at_max_tokens_stays_a_valid_answer() {
     ]]);
     let agent = AgentBuilder::new(model).build();
 
-    let mut stream = agent.stream_prompt("write a long essay").stream().await;
+    let mut stream = agent.prompt("write a long essay").stream().await;
     let mut final_response = None;
 
     while let Some(item) = stream.next().await {
@@ -5128,10 +5116,7 @@ async fn empty_content_filtered_turn_is_an_error_not_an_empty_answer() {
     )]]);
     let agent = AgentBuilder::new(model).build();
 
-    let mut stream = agent
-        .stream_prompt("something the filter rejects")
-        .stream()
-        .await;
+    let mut stream = agent.prompt("something the filter rejects").stream().await;
     let mut errored = None;
 
     while let Some(item) = stream.next().await {
@@ -5174,7 +5159,7 @@ async fn empty_turn_with_unmodeled_finish_reason_still_finalizes() {
     )]]);
     let agent = AgentBuilder::new(model).build();
 
-    let mut stream = agent.stream_prompt("say nothing").stream().await;
+    let mut stream = agent.prompt("say nothing").stream().await;
     let mut final_response_text = None;
 
     while let Some(item) = stream.next().await {
@@ -5215,7 +5200,7 @@ async fn reasoning_only_turn_truncated_at_max_tokens_is_an_error() {
     ]]);
     let agent = AgentBuilder::new(model).build();
 
-    let mut stream = agent.stream_prompt("solve this carefully").stream().await;
+    let mut stream = agent.prompt("solve this carefully").stream().await;
     let mut error = None;
 
     while let Some(item) = stream.next().await {
@@ -5254,7 +5239,7 @@ async fn reasoning_only_turn_content_filtered_is_an_error() {
     ]]);
     let agent = AgentBuilder::new(model).build();
 
-    let mut stream = agent.stream_prompt("something borderline").stream().await;
+    let mut stream = agent.prompt("something borderline").stream().await;
     let mut errored = None;
 
     while let Some(item) = stream.next().await {
@@ -5299,7 +5284,7 @@ async fn reasoning_then_text_truncated_stays_a_valid_answer() {
     ]]);
     let agent = AgentBuilder::new(model).build();
 
-    let mut stream = agent.stream_prompt("solve this").stream().await;
+    let mut stream = agent.prompt("solve this").stream().await;
     let mut final_response = None;
 
     while let Some(item) = stream.next().await {
@@ -5339,7 +5324,7 @@ async fn reasoning_only_turn_that_stopped_naturally_still_finalizes() {
     ]]);
     let agent = AgentBuilder::new(model).build();
 
-    let mut stream = agent.stream_prompt("say nothing").stream().await;
+    let mut stream = agent.prompt("say nothing").stream().await;
     let mut final_response_text = None;
 
     while let Some(item) = stream.next().await {
@@ -5374,7 +5359,7 @@ async fn reasoning_survives_into_history_when_the_truncated_turn_errors() {
     ]]);
     let agent = AgentBuilder::new(model).build();
 
-    let mut stream = agent.stream_prompt("solve this").stream().await;
+    let mut stream = agent.prompt("solve this").stream().await;
     let mut streamed_reasoning = String::new();
 
     while let Some(item) = stream.next().await {
@@ -5462,7 +5447,7 @@ async fn test_span_context_isolation() -> anyhow::Result<()> {
         .build();
 
     let mut stream = agent
-        .stream_prompt("Say 'hello world' and nothing else.")
+        .prompt("Say 'hello world' and nothing else.")
         .stream()
         .await;
 
@@ -5524,7 +5509,7 @@ async fn test_chat_history_in_final_response() -> anyhow::Result<()> {
     // Send streaming request with history
     let empty_history: &[Message] = &[];
     let mut stream = agent
-        .stream_prompt("Say 'hello' and nothing else.")
+        .prompt("Say 'hello' and nothing else.")
         .history(empty_history)
         .stream()
         .await;
@@ -5589,7 +5574,7 @@ async fn streaming_appends_to_memory_after_final_response() {
         .build();
 
     let mut stream = agent
-        .stream_prompt("hi there")
+        .prompt("hi there")
         .conversation("stream-thread")
         .stream()
         .await;
@@ -5630,7 +5615,7 @@ async fn streaming_reasoning_without_tools_does_not_duplicate_final_history() {
     .build();
 
     let mut stream = agent
-        .stream_prompt("think before answering")
+        .prompt("think before answering")
         .history(Vec::<Message>::new())
         .stream()
         .await;
@@ -5723,7 +5708,7 @@ async fn streaming_with_history_overrides_memory() {
         .build();
 
     let mut stream = agent
-        .stream_prompt("hi")
+        .prompt("hi")
         .conversation("t1")
         .history(vec![Message::user("from-caller")])
         .stream()
@@ -5753,7 +5738,7 @@ async fn streaming_without_memory_disables_for_request() {
         .conversation("default")
         .build();
 
-    let mut stream = agent.stream_prompt("hi").without_memory().stream().await;
+    let mut stream = agent.prompt("hi").without_memory().stream().await;
 
     while let Some(item) = stream.next().await {
         if let Ok(MultiTurnStreamItem::FinalResponse(_)) = item {
@@ -5771,7 +5756,7 @@ async fn streaming_load_error_yields_memory_error() {
         .memory(FailingMemory::default())
         .build();
 
-    let mut stream = agent.stream_prompt("hi").conversation("t1").stream().await;
+    let mut stream = agent.prompt("hi").conversation("t1").stream().await;
 
     let first = stream.next().await.expect("at least one item");
     match first {
@@ -5811,11 +5796,7 @@ async fn streaming_with_filter_shapes_loaded_history() {
     let recorded = model.clone();
     let agent = AgentBuilder::new(model).memory(memory).build();
 
-    let mut stream = agent
-        .stream_prompt("ping")
-        .conversation("t1")
-        .stream()
-        .await;
+    let mut stream = agent.prompt("ping").conversation("t1").stream().await;
     while let Some(item) = stream.next().await {
         if let Ok(MultiTurnStreamItem::FinalResponse(_)) = item {
             break;
@@ -5836,7 +5817,7 @@ async fn streaming_append_error_does_not_suppress_final_response() {
         .memory(AppendFailingMemory::default())
         .build();
 
-    let mut stream = agent.stream_prompt("hi").conversation("t1").stream().await;
+    let mut stream = agent.prompt("hi").conversation("t1").stream().await;
 
     let mut saw_final = false;
     while let Some(item) = stream.next().await {
@@ -5859,10 +5840,7 @@ async fn run_channel_forwards_events_and_resolves() {
     let model = streaming_tool_then_text_model();
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
-    let (run, events) = agent
-        .stream_prompt("do tool work")
-        .max_turns(3)
-        .run_channel();
+    let (run, events) = agent.prompt("do tool work").max_turns(3).run_channel();
     let (response, items) = futures::join!(run, events.collect::<Vec<_>>());
 
     let response = response.expect("run succeeds");
@@ -5892,10 +5870,7 @@ async fn run_channel_survives_dropped_events() {
     let recorded = model.clone();
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
-    let (run, events) = agent
-        .stream_prompt("do tool work")
-        .max_turns(3)
-        .run_channel();
+    let (run, events) = agent.prompt("do tool work").max_turns(3).run_channel();
     drop(events);
 
     let response = run.await.expect("run succeeds without a consumer");
@@ -5910,10 +5885,7 @@ async fn run_channel_try_next_drains_from_a_tick_loop() {
     let model = streaming_tool_then_text_model();
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
-    let (run, mut events) = agent
-        .stream_prompt("do tool work")
-        .max_turns(3)
-        .run_channel();
+    let (run, mut events) = agent.prompt("do tool work").max_turns(3).run_channel();
     let run = tokio::spawn(run);
 
     let mut seen = Vec::new();
@@ -5939,11 +5911,8 @@ async fn run_channel_reports_stream_errors_on_the_future() {
     let model = MockCompletionModel::text("unused");
     let agent = AgentBuilder::new(model).build();
 
-    let (run, events) = agent
-        .stream_prompt("budget of zero")
-        .max_turns(0)
-        .run_channel();
-    let _: (_, RunEvents) = agent.run_channel("plain entry point type-checks");
+    let (run, events) = agent.prompt("budget of zero").max_turns(0).run_channel();
+    let _: (_, RunEvents) = agent.prompt("plain entry point type-checks").run_channel();
     let (response, items) = futures::join!(run, events.collect::<Vec<_>>());
 
     assert!(response.is_err(), "zero-turn budget must fail the run");

--- a/crates/rig-agent/src/agent/streaming/tests.rs
+++ b/crates/rig-agent/src/agent/streaming/tests.rs
@@ -6049,3 +6049,83 @@ async fn a_stream_built_outside_a_span_stays_a_root_when_polled_inside_one() {
         assert_ne!(chat_span.parent_id, Some(poller_id));
     }
 }
+
+/// The blocking terminal follows the same rule: `run()` called inside
+/// `outer` and awaited from a spawned task adopts `outer` — no
+/// `invoke_agent`, the chat span is `outer`'s child.
+#[tokio::test]
+async fn a_blocking_run_belongs_to_the_span_it_was_started_in() {
+    let _isolation = crate::test_utils::scoped_tracing_subscriber_guard().await;
+    let spans = CapturedSpans::default();
+    let subscriber = Registry::default().with(SpanCaptureLayer {
+        spans: spans.clone(),
+    });
+    let _default = tracing::subscriber::set_default(subscriber);
+
+    let warmup_agent = AgentBuilder::new(MockCompletionModel::text("warmup")).build();
+    warmup_agent.prompt("warmup").await.expect("warmup");
+    tracing::callsite::rebuild_interest_cache();
+    spans.clear();
+
+    let agent = AgentBuilder::new(MockCompletionModel::text("done")).build();
+    let outer_span = tracing::info_span!("outer");
+    let run = outer_span.in_scope(|| agent.prompt("go").run());
+    let response = tokio::spawn(run)
+        .await
+        .expect("join")
+        .expect("run succeeds");
+    assert_eq!(response.output(), "done");
+
+    let snapshot = spans.snapshot();
+    let outer_id = snapshot
+        .iter()
+        .find(|span| span.name == "outer")
+        .map(|span| span.id)
+        .expect("outer span captured");
+    assert!(snapshot.iter().all(|span| span.name != "invoke_agent"));
+    let chat_spans: Vec<_> = snapshot.iter().filter(|span| span.name == "chat").collect();
+    assert_eq!(chat_spans.len(), 1, "one model turn: {snapshot:?}");
+    assert_eq!(chat_spans[0].parent_id, Some(outer_id));
+}
+
+/// A typed run reaches the same rule through `IntoFuture`: the future is
+/// made inside `outer` and awaited from a spawned task.
+#[tokio::test]
+async fn a_typed_run_belongs_to_the_span_it_was_started_in() {
+    let _isolation = crate::test_utils::scoped_tracing_subscriber_guard().await;
+    let spans = CapturedSpans::default();
+    let subscriber = Registry::default().with(SpanCaptureLayer {
+        spans: spans.clone(),
+    });
+    let _default = tracing::subscriber::set_default(subscriber);
+
+    let warmup_agent = AgentBuilder::new(MockCompletionModel::text("{\"n\": 0}")).build();
+    warmup_agent
+        .prompt_typed::<serde_json::Value>("warmup")
+        .await
+        .expect("warmup");
+    tracing::callsite::rebuild_interest_cache();
+    spans.clear();
+
+    let agent = AgentBuilder::new(MockCompletionModel::text("{\"n\": 1}")).build();
+    let outer_span = tracing::info_span!("outer");
+    let run = outer_span.in_scope(|| {
+        std::future::IntoFuture::into_future(agent.prompt_typed::<serde_json::Value>("go"))
+    });
+    let response = tokio::spawn(run)
+        .await
+        .expect("join")
+        .expect("typed run succeeds");
+    assert_eq!(response.output["n"], 1);
+
+    let snapshot = spans.snapshot();
+    let outer_id = snapshot
+        .iter()
+        .find(|span| span.name == "outer")
+        .map(|span| span.id)
+        .expect("outer span captured");
+    assert!(snapshot.iter().all(|span| span.name != "invoke_agent"));
+    let chat_spans: Vec<_> = snapshot.iter().filter(|span| span.name == "chat").collect();
+    assert_eq!(chat_spans.len(), 1, "one model turn: {snapshot:?}");
+    assert_eq!(chat_spans[0].parent_id, Some(outer_id));
+}

--- a/crates/rig-agent/src/agent/streaming/tests.rs
+++ b/crates/rig-agent/src/agent/streaming/tests.rs
@@ -60,7 +60,7 @@ async fn public_streaming_request_constructor_preserves_agent_hooks() {
             .build(),
     );
 
-    let mut stream = agent.prompt("go").stream().await;
+    let mut stream = agent.prompt("go").stream();
     let error = stream
         .try_next()
         .await
@@ -80,7 +80,7 @@ async fn text_only_stream_without_terminal_record_is_rejected_as_truncated() {
     let model = MockCompletionModel::from_stream_turns([[MockStreamEvent::text("partial answer")]]);
     let agent = Arc::new(AgentBuilder::new(model.clone()).build());
 
-    let mut stream = agent.prompt("go").stream().await;
+    let mut stream = agent.prompt("go").stream();
     let mut saw_error = false;
     let mut saw_completion_call = false;
     while let Some(item) = stream.next().await {
@@ -124,7 +124,7 @@ async fn tool_call_stream_without_terminal_record_dispatches_no_tools() {
     )]]);
     let agent = AgentBuilder::new(model.clone()).tool(add_tool).build();
 
-    let mut stream = agent.prompt("go").max_turns(3).stream().await;
+    let mut stream = agent.prompt("go").max_turns(3).stream();
     let mut saw_error = false;
     while let Some(item) = stream.next().await {
         if item.is_err() {
@@ -860,7 +860,7 @@ async fn assert_stream_usage_recorded_on_chat_spans(
         MockStreamEvent::final_response(Usage::default()),
     ]]);
     let warmup_agent = crate::agent::AgentBuilder::new(warmup_model).build();
-    let mut warmup_stream = warmup_agent.prompt("warmup").max_turns(1).stream().await;
+    let mut warmup_stream = warmup_agent.prompt("warmup").max_turns(1).stream();
     while let Some(item) = warmup_stream
         .try_next()
         .await
@@ -883,8 +883,7 @@ async fn assert_stream_usage_recorded_on_chat_spans(
             .prompt(prompt)
             .history(empty_history)
             .max_turns(max_turns)
-            .stream()
-            .await;
+            .stream();
 
         while let Some(item) = stream.try_next().await.expect("stream should not error") {
             if matches!(item, MultiTurnStreamItem::FinalResponse(_)) {
@@ -982,7 +981,7 @@ async fn capture_stream_message_telemetry(
         MockStreamEvent::final_response(Usage::default()),
     ]]);
     let warmup_agent = crate::agent::AgentBuilder::new(warmup_model).build();
-    let mut warmup_stream = warmup_agent.prompt("warmup").max_turns(1).stream().await;
+    let mut warmup_stream = warmup_agent.prompt("warmup").max_turns(1).stream();
     while let Some(item) = warmup_stream
         .try_next()
         .await
@@ -1010,11 +1009,7 @@ async fn capture_stream_message_telemetry(
         builder.context("static stream context secret").build()
     };
 
-    let mut stream = agent
-        .prompt("stream prompt secret")
-        .max_turns(1)
-        .stream()
-        .await;
+    let mut stream = agent.prompt("stream prompt secret").max_turns(1).stream();
     while let Some(item) = stream.try_next().await.expect("stream should not error") {
         if matches!(item, MultiTurnStreamItem::FinalResponse(_)) {
             break;
@@ -1303,7 +1298,7 @@ async fn streaming_rejected_message_telemetry_does_not_record_output() {
         MockStreamEvent::final_response(Usage::default()),
     ]]);
     let warmup_agent = crate::agent::AgentBuilder::new(warmup_model).build();
-    let mut warmup_stream = warmup_agent.prompt("warmup").max_turns(1).stream().await;
+    let mut warmup_stream = warmup_agent.prompt("warmup").max_turns(1).stream();
     while let Some(item) = warmup_stream
         .try_next()
         .await
@@ -1332,8 +1327,7 @@ async fn streaming_rejected_message_telemetry_does_not_record_output() {
     let mut stream = agent
         .prompt("stream rejection prompt")
         .max_turns(1)
-        .stream()
-        .await;
+        .stream();
     let err = loop {
         match stream.try_next().await {
             Ok(Some(_)) => continue,
@@ -2007,8 +2001,7 @@ async fn stream_prompt_continues_after_tool_call_turn() {
         .prompt("do tool work")
         .history(empty_history)
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     let mut saw_tool_call = false;
     let mut saw_tool_result = false;
     let mut saw_final_response = false;
@@ -2090,8 +2083,7 @@ async fn streaming_prompt_request_tool_concurrency_runs_tools_concurrently() {
             .prompt("hit the barrier twice")
             .max_turns(3)
             .tool_concurrency(2)
-            .stream()
-            .await;
+            .stream();
         while let Some(item) = stream.next().await {
             item.unwrap_or_else(|err| panic!("unexpected streaming error: {err:?}"));
         }
@@ -2131,8 +2123,7 @@ async fn tool_context_reaches_tool_through_streaming_loop() {
         .tool_context(tool_context)
         .history(empty_history)
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
 
     while let Some(item) = stream.next().await {
         match item {
@@ -2169,8 +2160,7 @@ async fn streaming_tool_runs_with_empty_context_when_none_supplied() {
         .prompt("do tool work")
         .history(empty_history)
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
 
     while let Some(item) = stream.next().await {
         match item {
@@ -2206,8 +2196,7 @@ async fn unknown_tool_call_fails_before_streaming_second_request() {
         .prompt("use the tool")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     let mut saw_tool_call = false;
     let mut error = None;
 
@@ -2270,8 +2259,7 @@ async fn invalid_tool_call_hook_can_repair_streaming_tool_name() {
         .add_hook(RepairDefaultApiHook)
         .max_turns(3)
         .history(Vec::<Message>::new())
-        .stream()
-        .await;
+        .stream();
     let mut saw_repaired_tool_call = false;
     let mut saw_tool_result = false;
     let mut final_response_text = None;
@@ -2335,8 +2323,7 @@ async fn invalid_tool_call_context_uses_completed_streaming_tool_call_provider_i
         .prompt("use the tool")
         .add_hook(invalid_hook.clone())
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     let mut error = None;
 
     while let Some(item) = stream.next().await {
@@ -2393,8 +2380,7 @@ async fn invalid_tool_call_hook_skip_emits_streaming_tool_result() {
         .add_hook(SkipDefaultApiHook)
         .max_turns(3)
         .history(Vec::<Message>::new())
-        .stream()
-        .await;
+        .stream();
     let mut skipped_tool_result = None;
     let mut final_response_text = None;
 
@@ -2489,8 +2475,7 @@ async fn invalid_tool_call_hook_retries_mixed_streaming_turn_without_executing_v
         .max_turns(3)
         .history(Vec::<Message>::new())
         .max_invalid_tool_call_retries(1)
-        .stream()
-        .await;
+        .stream();
     let mut completion_call_events = Vec::new();
     let mut final_response_text = None;
     let mut final_response_usage = Usage::new();
@@ -2614,8 +2599,7 @@ async fn invalid_tool_call_hook_skips_mixed_streaming_turn_without_executing_val
         .add_hook(SkipDefaultApiHook)
         .max_turns(3)
         .history(Vec::<Message>::new())
-        .stream()
-        .await;
+        .stream();
     let mut skipped_tool_result = None;
     let mut final_response_text = None;
 
@@ -2739,8 +2723,7 @@ async fn invalid_completed_tool_call_skip_preserves_streaming_reasoning_history(
         .add_hook(SkipDefaultApiHook)
         .max_turns(3)
         .history(Vec::<Message>::new())
-        .stream()
-        .await;
+        .stream();
 
     while let Some(item) = stream.next().await {
         match item {
@@ -2793,8 +2776,7 @@ async fn invalid_name_delta_retry_preserves_streaming_reasoning_history() {
         .max_turns(3)
         .history(Vec::<Message>::new())
         .max_invalid_tool_call_retries(1)
-        .stream()
-        .await;
+        .stream();
 
     while let Some(item) = stream.next().await {
         match item {
@@ -2841,8 +2823,7 @@ async fn invalid_tool_call_hook_skip_resets_streaming_text_delta_state() {
         })
         .max_turns(3)
         .history(Vec::<Message>::new())
-        .stream()
-        .await;
+        .stream();
 
     while let Some(item) = stream.next().await {
         match item {
@@ -2895,8 +2876,7 @@ async fn invalid_tool_call_delta_retry_uses_structured_tool_feedback() {
         .max_turns(3)
         .history(Vec::<Message>::new())
         .max_invalid_tool_call_retries(1)
-        .stream()
-        .await;
+        .stream();
     let mut completion_call_events = Vec::new();
     let mut final_response_text = None;
     let mut final_response_usage = Usage::new();
@@ -3026,8 +3006,7 @@ async fn invalid_tool_call_delta_context_includes_same_turn_history_and_tool_cal
         .prompt("use the tool")
         .add_hook(invalid_hook.clone())
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     let mut error = None;
 
     while let Some(item) = stream.next().await {
@@ -3098,8 +3077,7 @@ async fn invalid_tool_call_delta_retry_resets_streaming_text_delta_state() {
         .max_turns(3)
         .history(Vec::<Message>::new())
         .max_invalid_tool_call_retries(1)
-        .stream()
-        .await;
+        .stream();
 
     while let Some(item) = stream.next().await {
         match item {
@@ -3150,8 +3128,7 @@ async fn invalid_tool_call_delta_skip_uses_structured_tool_feedback() {
         })
         .max_turns(3)
         .history(Vec::<Message>::new())
-        .stream()
-        .await;
+        .stream();
     let mut skipped_tool_result = None;
     let mut final_response_text = None;
 
@@ -3282,8 +3259,7 @@ async fn streaming_retry_budget_exhaustion_history_contains_invalid_tool_call() 
         .add_hook(RetryDefaultApiHook)
         .max_turns(3)
         .max_invalid_tool_call_retries(0)
-        .stream()
-        .await;
+        .stream();
     let mut error = None;
 
     while let Some(item) = stream.next().await {
@@ -3335,8 +3311,7 @@ async fn streaming_name_delta_retry_budget_exhaustion_history_includes_same_turn
         .add_hook(RetryDefaultApiHook)
         .max_turns(3)
         .max_invalid_tool_call_retries(0)
-        .stream()
-        .await;
+        .stream();
     let mut error = None;
 
     while let Some(item) = stream.next().await {
@@ -3395,8 +3370,7 @@ async fn completed_unknown_tool_call_after_text_fails_before_finish_hook_or_late
         .prompt("use the tool")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     let mut saw_text = false;
     let mut saw_completion_call = false;
     let mut saw_final_response = false;
@@ -3490,8 +3464,7 @@ async fn mixed_streaming_tool_calls_fail_before_any_tool_execution() {
         .prompt("use tools")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     let mut saw_completion_call = false;
     let mut saw_tool_call = false;
     let mut saw_tool_result = false;
@@ -3572,7 +3545,7 @@ async fn multiple_valid_streaming_tool_calls_execute_after_batch_validation() {
         })
         .build();
 
-    let mut stream = agent.prompt("use tools").max_turns(3).stream().await;
+    let mut stream = agent.prompt("use tools").max_turns(3).stream();
     let mut tool_call_names = Vec::new();
     let mut tool_result_ids = Vec::new();
     let mut final_response_text = None;
@@ -3647,8 +3620,7 @@ async fn disallowed_specific_tool_call_fails_before_streaming_second_request() {
         .prompt("use the allowed tool")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     let mut saw_tool_call = false;
     let mut error = None;
 
@@ -3723,8 +3695,7 @@ async fn mixed_specific_tool_calls_fail_before_any_tool_execution() {
         .prompt("use the allowed tool")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     let mut saw_tool_call = false;
     let mut saw_tool_result = false;
     let mut error = None;
@@ -3794,8 +3765,7 @@ async fn tool_choice_none_rejects_streaming_tool_call() {
         .prompt("do not use tools")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     let mut saw_tool_call = false;
     let mut error = None;
 
@@ -3857,8 +3827,7 @@ async fn tool_choice_none_rejects_streaming_tool_call_name_delta_before_hook_or_
         .prompt("do not use tools")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     let mut saw_delta = false;
     let mut error = None;
 
@@ -3920,8 +3889,7 @@ async fn unknown_tool_call_name_delta_fails_before_streaming_delta_hook_or_emit(
         .prompt("stream a bad tool call")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     let mut saw_delta = false;
     let mut error = None;
 
@@ -3983,8 +3951,7 @@ async fn tool_call_args_delta_before_unknown_name_fails_before_hook_or_emit() {
         .prompt("stream a bad tool call")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     let mut saw_delta = false;
     let mut error = None;
 
@@ -4040,8 +4007,7 @@ async fn tool_call_args_delta_before_valid_name_buffers_then_emits_in_safe_order
     let mut stream = agent
         .prompt("stream a tool call")
         .add_hook(hook.clone())
-        .stream()
-        .await;
+        .stream();
     let mut stream_deltas = Vec::new();
 
     while let Some(item) = stream.next().await {
@@ -4117,8 +4083,7 @@ async fn tool_call_args_delta_without_name_errors_at_stream_end() {
         .prompt("stream an incomplete tool call")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     let mut saw_delta = false;
     let mut saw_completion_call = false;
     let mut saw_final_response = false;
@@ -4188,8 +4153,7 @@ async fn tool_choice_none_buffers_args_then_rejects_name_without_emit() {
         .prompt("do not use tools")
         .add_hook(PanicOnUnknownToolHook)
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     let mut saw_delta = false;
     let mut error = None;
 
@@ -4246,8 +4210,7 @@ async fn stream_prompt_observes_interleaved_reasoning_deltas_before_unchanged_em
     let mut stream = agent
         .prompt("reason about this")
         .add_hook(hook.clone())
-        .stream()
-        .await;
+        .stream();
     let mut stream_deltas = Vec::new();
     let mut completed_reasoning = 0;
     // The durable provider id travels on the block start; a delta carries
@@ -4337,8 +4300,7 @@ async fn stream_prompt_reasoning_delta_stop_prevents_emit_and_later_hook_dispatc
         .prompt("reason about this")
         .add_hook(stopping.clone())
         .add_hook(later.clone())
-        .stream()
-        .await;
+        .stream();
     let mut saw_delta = false;
     let mut saw_final_response = false;
     let mut error_message = None;
@@ -4386,8 +4348,7 @@ async fn stream_prompt_skips_reasoning_delta_hook_without_observation_interest()
     let mut stream = agent
         .prompt("reason about this")
         .add_hook(hook.clone())
-        .stream()
-        .await;
+        .stream();
     let mut emitted = Vec::new();
 
     while let Some(item) = stream.next().await {
@@ -4425,8 +4386,7 @@ async fn stream_prompt_reasoning_delta_hook_observes_retried_turns_as_provisiona
         .prompt("reason about this")
         .add_hook(hook.clone())
         .max_turns(2)
-        .stream()
-        .await;
+        .stream();
     let mut order = Vec::new();
 
     while let Some(item) = stream.next().await {
@@ -4463,7 +4423,7 @@ async fn stream_prompt_emits_tool_call_deltas_without_hook() {
     ]]);
     let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
-    let mut stream = agent.prompt("stream a tool call").stream().await;
+    let mut stream = agent.prompt("stream a tool call").stream();
     let mut deltas = Vec::new();
 
     while let Some(item) = stream.next().await {
@@ -4526,8 +4486,7 @@ async fn stream_prompt_emits_tool_call_deltas_after_hook_continue() {
     let mut stream = agent
         .prompt("stream a tool call")
         .add_hook(hook.clone())
-        .stream()
-        .await;
+        .stream();
     let mut stream_deltas = Vec::new();
 
     while let Some(item) = stream.next().await {
@@ -4597,8 +4556,7 @@ async fn stream_prompt_tool_call_deltas_hook_termination_prevents_delta_emit() {
     let mut stream = agent
         .prompt("stream a tool call")
         .add_hook(hook.clone())
-        .stream()
-        .await;
+        .stream();
     let mut saw_delta = false;
     let mut saw_final_response = false;
     let mut error_message = None;
@@ -4662,8 +4620,7 @@ async fn stream_prompt_exposes_completion_calls() {
         .prompt("do tool work")
         .history(empty_history)
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     let mut completion_calls_events = Vec::new();
     let mut final_response = None;
 
@@ -4761,8 +4718,7 @@ async fn stream_prompt_emits_completion_call_before_finish_hook_termination() {
     let mut stream = agent
         .prompt("say done")
         .add_hook(TerminateOnCompletionOutcome)
-        .stream()
-        .await;
+        .stream();
     let mut completion_calls = Vec::new();
     let mut saw_error = false;
 
@@ -4810,8 +4766,7 @@ async fn stream_prompt_completion_calls_records_unreported_usage() {
         .prompt("do tool work")
         .history(empty_history)
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
     let mut completion_calls_events = Vec::new();
     let mut final_response = None;
 
@@ -4843,7 +4798,7 @@ async fn stream_prompt_completion_calls_records_unreported_usage() {
 async fn final_response_matches_streamed_text_when_provider_final_is_textless() {
     let agent = AgentBuilder::new(streaming_text_then_final_model()).build();
 
-    let mut stream = agent.prompt("say hello").stream().await;
+    let mut stream = agent.prompt("say hello").stream();
     let mut streamed_text = String::new();
     let mut final_response_text = None;
 
@@ -4870,7 +4825,7 @@ async fn final_response_matches_streamed_text_when_provider_final_is_textless() 
 async fn final_response_preserves_structured_text_metadata() {
     let agent = AgentBuilder::new(streaming_cited_text_then_final_model()).build();
 
-    let mut stream = agent.prompt("answer with citations").stream().await;
+    let mut stream = agent.prompt("answer with citations").stream();
     let mut final_response = None;
 
     while let Some(item) = stream.next().await {
@@ -4902,8 +4857,7 @@ async fn final_response_history_preserves_structured_text_metadata() {
     let mut stream = agent
         .prompt("answer with citations")
         .history(empty_history)
-        .stream()
-        .await;
+        .stream();
     let mut final_response = None;
 
     while let Some(item) = stream.next().await {
@@ -4947,8 +4901,7 @@ async fn tool_follow_up_history_preserves_structured_text_metadata() {
         .prompt("use a tool with citations")
         .history(empty_history)
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
 
     while let Some(item) = stream.next().await {
         match item {
@@ -4980,7 +4933,7 @@ async fn tool_follow_up_history_preserves_structured_text_metadata() {
 async fn final_response_can_remain_empty_for_truly_textless_turns() {
     let agent = AgentBuilder::new(streaming_final_only_model()).build();
 
-    let mut stream = agent.prompt("say nothing").stream().await;
+    let mut stream = agent.prompt("say nothing").stream();
     let mut streamed_text = String::new();
     let mut final_response_text = None;
 
@@ -5021,7 +4974,7 @@ async fn empty_turn_truncated_at_max_tokens_is_an_error_not_an_empty_answer() {
     )]]);
     let agent = AgentBuilder::new(model).build();
 
-    let mut stream = agent.prompt("write a long essay").stream().await;
+    let mut stream = agent.prompt("write a long essay").stream();
     let mut error = None;
     let mut final_response_text = None;
 
@@ -5072,7 +5025,7 @@ async fn partial_output_truncated_at_max_tokens_stays_a_valid_answer() {
     ]]);
     let agent = AgentBuilder::new(model).build();
 
-    let mut stream = agent.prompt("write a long essay").stream().await;
+    let mut stream = agent.prompt("write a long essay").stream();
     let mut final_response = None;
 
     while let Some(item) = stream.next().await {
@@ -5116,7 +5069,7 @@ async fn empty_content_filtered_turn_is_an_error_not_an_empty_answer() {
     )]]);
     let agent = AgentBuilder::new(model).build();
 
-    let mut stream = agent.prompt("something the filter rejects").stream().await;
+    let mut stream = agent.prompt("something the filter rejects").stream();
     let mut errored = None;
 
     while let Some(item) = stream.next().await {
@@ -5159,7 +5112,7 @@ async fn empty_turn_with_unmodeled_finish_reason_still_finalizes() {
     )]]);
     let agent = AgentBuilder::new(model).build();
 
-    let mut stream = agent.prompt("say nothing").stream().await;
+    let mut stream = agent.prompt("say nothing").stream();
     let mut final_response_text = None;
 
     while let Some(item) = stream.next().await {
@@ -5200,7 +5153,7 @@ async fn reasoning_only_turn_truncated_at_max_tokens_is_an_error() {
     ]]);
     let agent = AgentBuilder::new(model).build();
 
-    let mut stream = agent.prompt("solve this carefully").stream().await;
+    let mut stream = agent.prompt("solve this carefully").stream();
     let mut error = None;
 
     while let Some(item) = stream.next().await {
@@ -5239,7 +5192,7 @@ async fn reasoning_only_turn_content_filtered_is_an_error() {
     ]]);
     let agent = AgentBuilder::new(model).build();
 
-    let mut stream = agent.prompt("something borderline").stream().await;
+    let mut stream = agent.prompt("something borderline").stream();
     let mut errored = None;
 
     while let Some(item) = stream.next().await {
@@ -5284,7 +5237,7 @@ async fn reasoning_then_text_truncated_stays_a_valid_answer() {
     ]]);
     let agent = AgentBuilder::new(model).build();
 
-    let mut stream = agent.prompt("solve this").stream().await;
+    let mut stream = agent.prompt("solve this").stream();
     let mut final_response = None;
 
     while let Some(item) = stream.next().await {
@@ -5324,7 +5277,7 @@ async fn reasoning_only_turn_that_stopped_naturally_still_finalizes() {
     ]]);
     let agent = AgentBuilder::new(model).build();
 
-    let mut stream = agent.prompt("say nothing").stream().await;
+    let mut stream = agent.prompt("say nothing").stream();
     let mut final_response_text = None;
 
     while let Some(item) = stream.next().await {
@@ -5359,7 +5312,7 @@ async fn reasoning_survives_into_history_when_the_truncated_turn_errors() {
     ]]);
     let agent = AgentBuilder::new(model).build();
 
-    let mut stream = agent.prompt("solve this").stream().await;
+    let mut stream = agent.prompt("solve this").stream();
     let mut streamed_reasoning = String::new();
 
     while let Some(item) = stream.next().await {
@@ -5446,10 +5399,7 @@ async fn test_span_context_isolation() -> anyhow::Result<()> {
         .max_tokens(100)
         .build();
 
-    let mut stream = agent
-        .prompt("Say 'hello world' and nothing else.")
-        .stream()
-        .await;
+    let mut stream = agent.prompt("Say 'hello world' and nothing else.").stream();
 
     let mut full_content = String::new();
     while let Some(item) = stream.next().await {
@@ -5511,8 +5461,7 @@ async fn test_chat_history_in_final_response() -> anyhow::Result<()> {
     let mut stream = agent
         .prompt("Say 'hello' and nothing else.")
         .history(empty_history)
-        .stream()
-        .await;
+        .stream();
 
     // Consume the stream and collect FinalResponse
     let mut response_text = String::new();
@@ -5576,8 +5525,7 @@ async fn streaming_appends_to_memory_after_final_response() {
     let mut stream = agent
         .prompt("hi there")
         .conversation("stream-thread")
-        .stream()
-        .await;
+        .stream();
 
     let mut history_in_final = None;
     while let Some(item) = stream.next().await {
@@ -5617,8 +5565,7 @@ async fn streaming_reasoning_without_tools_does_not_duplicate_final_history() {
     let mut stream = agent
         .prompt("think before answering")
         .history(Vec::<Message>::new())
-        .stream()
-        .await;
+        .stream();
 
     let mut history_in_final = None;
     while let Some(item) = stream.next().await {
@@ -5711,8 +5658,7 @@ async fn streaming_with_history_overrides_memory() {
         .prompt("hi")
         .conversation("t1")
         .history(vec![Message::user("from-caller")])
-        .stream()
-        .await;
+        .stream();
 
     while let Some(item) = stream.next().await {
         if let Ok(MultiTurnStreamItem::FinalResponse(_)) = item {
@@ -5738,7 +5684,7 @@ async fn streaming_without_memory_disables_for_request() {
         .conversation("default")
         .build();
 
-    let mut stream = agent.prompt("hi").without_memory().stream().await;
+    let mut stream = agent.prompt("hi").without_memory().stream();
 
     while let Some(item) = stream.next().await {
         if let Ok(MultiTurnStreamItem::FinalResponse(_)) = item {
@@ -5756,7 +5702,7 @@ async fn streaming_load_error_yields_memory_error() {
         .memory(FailingMemory::default())
         .build();
 
-    let mut stream = agent.prompt("hi").conversation("t1").stream().await;
+    let mut stream = agent.prompt("hi").conversation("t1").stream();
 
     let first = stream.next().await.expect("at least one item");
     match first {
@@ -5796,7 +5742,7 @@ async fn streaming_with_filter_shapes_loaded_history() {
     let recorded = model.clone();
     let agent = AgentBuilder::new(model).memory(memory).build();
 
-    let mut stream = agent.prompt("ping").conversation("t1").stream().await;
+    let mut stream = agent.prompt("ping").conversation("t1").stream();
     while let Some(item) = stream.next().await {
         if let Ok(MultiTurnStreamItem::FinalResponse(_)) = item {
             break;
@@ -5817,7 +5763,7 @@ async fn streaming_append_error_does_not_suppress_final_response() {
         .memory(AppendFailingMemory::default())
         .build();
 
-    let mut stream = agent.prompt("hi").conversation("t1").stream().await;
+    let mut stream = agent.prompt("hi").conversation("t1").stream();
 
     let mut saw_final = false;
     while let Some(item) = stream.next().await {

--- a/crates/rig-agent/src/agent/streaming/tests.rs
+++ b/crates/rig-agent/src/agent/streaming/tests.rs
@@ -681,6 +681,7 @@ async fn execution_commit_items_are_not_emitted_when_run_commit_fails() {
 struct CapturedSpan {
     id: u64,
     name: String,
+    target: String,
     parent_id: Option<u64>,
     fields: HashMap<String, u64>,
     string_fields: HashMap<String, String>,
@@ -697,12 +698,13 @@ impl CapturedSpans {
         }
     }
 
-    fn insert(&self, id: &Id, name: &str, parent_id: Option<u64>) {
+    fn insert(&self, id: &Id, name: &str, target: &str, parent_id: Option<u64>) {
         let id = id.into_u64();
         if let Ok(mut spans) = self.0.lock() {
             spans.push(CapturedSpan {
                 id,
                 name: name.to_string(),
+                target: target.to_string(),
                 parent_id,
                 fields: HashMap::new(),
                 string_fields: HashMap::new(),
@@ -764,7 +766,12 @@ where
                 .map(Id::into_u64)
                 .or_else(|| ctx.current_span().id().map(Id::into_u64))
         };
-        self.spans.insert(id, attrs.metadata().name(), parent_id);
+        self.spans.insert(
+            id,
+            attrs.metadata().name(),
+            attrs.metadata().target(),
+            parent_id,
+        );
         let mut string_fields = Vec::new();
         attrs.record(&mut SpanStringCaptureVisitor {
             fields: &mut string_fields,
@@ -6052,7 +6059,9 @@ async fn a_stream_built_outside_a_span_stays_a_root_when_polled_inside_one() {
 
 /// The blocking terminal follows the same rule: `run()` called inside
 /// `outer` and awaited from a spawned task adopts `outer` — no
-/// `invoke_agent`, the chat span is `outer`'s child.
+/// `invoke_agent`, the chat span is `outer`'s child. (These tests rely on
+/// `#[tokio::test]`'s current-thread runtime: the spawned task polls on
+/// the thread holding the thread-local `set_default` subscriber.)
 #[tokio::test]
 async fn a_blocking_run_belongs_to_the_span_it_was_started_in() {
     let _isolation = crate::test_utils::scoped_tracing_subscriber_guard().await;
@@ -6128,4 +6137,47 @@ async fn a_typed_run_belongs_to_the_span_it_was_started_in() {
     let chat_spans: Vec<_> = snapshot.iter().filter(|span| span.name == "chat").collect();
     assert_eq!(chat_spans.len(), 1, "one model turn: {snapshot:?}");
     assert_eq!(chat_spans[0].parent_id, Some(outer_id));
+}
+
+/// The blocking counterpart of the stream root test: a run started outside
+/// any span creates a root `invoke_agent` when polled inside an unrelated
+/// span, and its chat span is the `invoke_agent`'s child, not the poller's.
+#[tokio::test]
+async fn a_blocking_run_started_outside_a_span_stays_a_root_when_polled_inside_one() {
+    let _isolation = crate::test_utils::scoped_tracing_subscriber_guard().await;
+    let spans = CapturedSpans::default();
+    let subscriber = Registry::default().with(SpanCaptureLayer {
+        spans: spans.clone(),
+    });
+    let _default = tracing::subscriber::set_default(subscriber);
+
+    let warmup_agent = AgentBuilder::new(MockCompletionModel::text("warmup")).build();
+    warmup_agent.prompt("warmup").await.expect("warmup");
+    tracing::callsite::rebuild_interest_cache();
+    spans.clear();
+
+    let agent = AgentBuilder::new(MockCompletionModel::text("done")).build();
+    let run = agent.prompt("go").run();
+    let poller_span = tracing::info_span!("poller");
+    let response = run.instrument(poller_span).await.expect("run succeeds");
+    assert_eq!(response.output(), "done");
+
+    let snapshot = spans.snapshot();
+    let poller_id = snapshot
+        .iter()
+        .find(|span| span.name == "poller")
+        .map(|span| span.id)
+        .expect("poller span captured");
+    let invoke = snapshot
+        .iter()
+        .find(|span| span.name == "invoke_agent")
+        .unwrap_or_else(|| panic!("a root invoke_agent is created: {snapshot:?}"));
+    assert_eq!(invoke.parent_id, None, "not the poller's child");
+    let chat_spans: Vec<_> = snapshot
+        .iter()
+        .filter(|span| span.name == "chat" && span.target == "rig::agent_chat")
+        .collect();
+    assert_eq!(chat_spans.len(), 1, "one model turn: {snapshot:?}");
+    assert_eq!(chat_spans[0].parent_id, Some(invoke.id));
+    assert_ne!(chat_spans[0].parent_id, Some(poller_id));
 }

--- a/crates/rig-agent/src/agent/streaming/tests.rs
+++ b/crates/rig-agent/src/agent/streaming/tests.rs
@@ -754,10 +754,16 @@ where
     S: for<'lookup> LookupSpan<'lookup>,
 {
     fn on_new_span(&self, attrs: &tracing::span::Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
-        let parent_id = attrs
-            .parent()
-            .map(Id::into_u64)
-            .or_else(|| ctx.current_span().id().map(Id::into_u64));
+        // An explicit root (`parent: None`) has no parent even when a span
+        // is current; only a contextual span inherits the current one.
+        let parent_id = if attrs.is_root() {
+            None
+        } else {
+            attrs
+                .parent()
+                .map(Id::into_u64)
+                .or_else(|| ctx.current_span().id().map(Id::into_u64))
+        };
         self.spans.insert(id, attrs.metadata().name(), parent_id);
         let mut string_fields = Vec::new();
         attrs.record(&mut SpanStringCaptureVisitor {
@@ -5930,5 +5936,116 @@ async fn a_stream_runs_under_the_span_it_was_built_in() {
     assert_eq!(chat_spans.len(), 2, "two model turns: {snapshot:?}");
     for chat_span in chat_spans {
         assert_eq!(chat_span.parent_id, Some(outer_id));
+    }
+}
+
+/// `run_channel` belongs to the span it was split in, like `stream()`: the
+/// future is spawned with no span of its own and the run still adopts
+/// `outer`.
+#[tokio::test]
+async fn run_channel_runs_under_the_span_it_was_split_in() {
+    let _isolation = crate::test_utils::scoped_tracing_subscriber_guard().await;
+    let spans = CapturedSpans::default();
+    let subscriber = Registry::default().with(SpanCaptureLayer {
+        spans: spans.clone(),
+    });
+    let _default = tracing::subscriber::set_default(subscriber);
+
+    let warmup_agent = AgentBuilder::new(streaming_tool_then_text_model()).build();
+    let mut warmup_stream = warmup_agent.prompt("warmup").max_turns(1).stream();
+    while warmup_stream.next().await.is_some() {}
+    tracing::callsite::rebuild_interest_cache();
+    spans.clear();
+
+    let agent = AgentBuilder::new(streaming_tool_then_text_model())
+        .tool(MockAddTool)
+        .build();
+    let outer_span = tracing::info_span!("outer");
+    let (run, events) =
+        outer_span.in_scope(|| agent.prompt("do tool work").max_turns(3).run_channel());
+    let (response, items) =
+        tokio::spawn(async move { futures::join!(run, events.collect::<Vec<_>>()) })
+            .await
+            .expect("join");
+    assert_eq!(response.expect("run succeeds").output(), "done");
+    assert!(matches!(
+        items.last(),
+        Some(MultiTurnStreamItem::FinalResponse(_))
+    ));
+
+    let snapshot = spans.snapshot();
+    let outer_id = snapshot
+        .iter()
+        .find(|span| span.name == "outer")
+        .map(|span| span.id)
+        .expect("outer span captured");
+    assert!(snapshot.iter().all(|span| span.name != "invoke_agent"));
+    let chat_spans: Vec<_> = snapshot
+        .iter()
+        .filter(|span| span.name == "chat_streaming")
+        .collect();
+    assert_eq!(chat_spans.len(), 2, "two model turns: {snapshot:?}");
+    for chat_span in chat_spans {
+        assert_eq!(chat_span.parent_id, Some(outer_id));
+    }
+}
+
+/// A stream built outside any span creates a root `invoke_agent` even when
+/// it is first polled inside an unrelated span: the poller's span is never
+/// adopted.
+#[tokio::test]
+async fn a_stream_built_outside_a_span_stays_a_root_when_polled_inside_one() {
+    let _isolation = crate::test_utils::scoped_tracing_subscriber_guard().await;
+    let spans = CapturedSpans::default();
+    let subscriber = Registry::default().with(SpanCaptureLayer {
+        spans: spans.clone(),
+    });
+    let _default = tracing::subscriber::set_default(subscriber);
+
+    let warmup_agent = AgentBuilder::new(streaming_tool_then_text_model()).build();
+    let mut warmup_stream = warmup_agent.prompt("warmup").max_turns(1).stream();
+    while warmup_stream.next().await.is_some() {}
+    tracing::callsite::rebuild_interest_cache();
+    spans.clear();
+
+    let agent = AgentBuilder::new(streaming_tool_then_text_model())
+        .tool(MockAddTool)
+        .build();
+    let stream = agent.prompt("do tool work").max_turns(3).stream();
+    let poller_span = tracing::info_span!("poller");
+    let items = async move {
+        let mut stream = stream;
+        let mut items = Vec::new();
+        while let Some(item) = stream.next().await {
+            items.push(item.expect("stream item"));
+        }
+        items
+    }
+    .instrument(poller_span)
+    .await;
+    assert!(matches!(
+        items.last(),
+        Some(MultiTurnStreamItem::FinalResponse(_))
+    ));
+
+    let snapshot = spans.snapshot();
+    let poller_id = snapshot
+        .iter()
+        .find(|span| span.name == "poller")
+        .map(|span| span.id)
+        .expect("poller span captured");
+    let invoke = snapshot
+        .iter()
+        .find(|span| span.name == "invoke_agent")
+        .expect("a root invoke_agent is created: {snapshot:?}");
+    assert_eq!(invoke.parent_id, None, "not the poller's child");
+    let chat_spans: Vec<_> = snapshot
+        .iter()
+        .filter(|span| span.name == "chat_streaming")
+        .collect();
+    assert_eq!(chat_spans.len(), 2);
+    for chat_span in chat_spans {
+        assert_eq!(chat_span.parent_id, Some(invoke.id));
+        assert_ne!(chat_span.parent_id, Some(poller_id));
     }
 }

--- a/crates/rig-agent/src/agent/streaming/tests.rs
+++ b/crates/rig-agent/src/agent/streaming/tests.rs
@@ -6037,7 +6037,7 @@ async fn a_stream_built_outside_a_span_stays_a_root_when_polled_inside_one() {
     let invoke = snapshot
         .iter()
         .find(|span| span.name == "invoke_agent")
-        .expect("a root invoke_agent is created: {snapshot:?}");
+        .unwrap_or_else(|| panic!("a root invoke_agent is created: {snapshot:?}"));
     assert_eq!(invoke.parent_id, None, "not the poller's child");
     let chat_spans: Vec<_> = snapshot
         .iter()

--- a/crates/rig-agent/src/agent/streaming/tests.rs
+++ b/crates/rig-agent/src/agent/streaming/tests.rs
@@ -1410,7 +1410,7 @@ async fn unary_repaired_message_telemetry_records_canonical_output() {
     let output_messages: Vec<String> = spans
         .snapshot()
         .into_iter()
-        .filter(|span| span.name == "chat")
+        .filter(|span| span.name == "chat" && span.target == "rig::agent_chat")
         .filter_map(|span| span.string_fields.get("gen_ai.output.messages").cloned())
         .collect();
     assert!(
@@ -6092,7 +6092,10 @@ async fn a_blocking_run_belongs_to_the_span_it_was_started_in() {
         .map(|span| span.id)
         .expect("outer span captured");
     assert!(snapshot.iter().all(|span| span.name != "invoke_agent"));
-    let chat_spans: Vec<_> = snapshot.iter().filter(|span| span.name == "chat").collect();
+    let chat_spans: Vec<_> = snapshot
+        .iter()
+        .filter(|span| span.name == "chat" && span.target == "rig::agent_chat")
+        .collect();
     assert_eq!(chat_spans.len(), 1, "one model turn: {snapshot:?}");
     assert_eq!(chat_spans[0].parent_id, Some(outer_id));
 }
@@ -6134,7 +6137,10 @@ async fn a_typed_run_belongs_to_the_span_it_was_started_in() {
         .map(|span| span.id)
         .expect("outer span captured");
     assert!(snapshot.iter().all(|span| span.name != "invoke_agent"));
-    let chat_spans: Vec<_> = snapshot.iter().filter(|span| span.name == "chat").collect();
+    let chat_spans: Vec<_> = snapshot
+        .iter()
+        .filter(|span| span.name == "chat" && span.target == "rig::agent_chat")
+        .collect();
     assert_eq!(chat_spans.len(), 1, "one model turn: {snapshot:?}");
     assert_eq!(chat_spans[0].parent_id, Some(outer_id));
 }
@@ -6178,6 +6184,9 @@ async fn a_blocking_run_started_outside_a_span_stays_a_root_when_polled_inside_o
         .filter(|span| span.name == "chat" && span.target == "rig::agent_chat")
         .collect();
     assert_eq!(chat_spans.len(), 1, "one model turn: {snapshot:?}");
-    assert_eq!(chat_spans[0].parent_id, Some(invoke.id));
-    assert_ne!(chat_spans[0].parent_id, Some(poller_id));
+    assert_eq!(
+        chat_spans[0].parent_id,
+        Some(invoke.id),
+        "not the poller {poller_id}"
+    );
 }

--- a/crates/rig-agent/src/agent/streaming/tests.rs
+++ b/crates/rig-agent/src/agent/streaming/tests.rs
@@ -5868,3 +5868,67 @@ async fn run_channel_reports_stream_errors_on_the_future() {
             .any(|item| matches!(item, MultiTurnStreamItem::FinalResponse(_)))
     );
 }
+
+/// A stream runs under the span it was built in, not the span that first
+/// polls it: built inside `outer` and drained from a spawned task (no span
+/// of its own), the run adopts `outer` — no `invoke_agent` is created and
+/// every chat span is `outer`'s child. Under a poll-site rule the spawned
+/// task's disabled span would have produced a root `invoke_agent`.
+#[tokio::test]
+async fn a_stream_runs_under_the_span_it_was_built_in() {
+    let _isolation = crate::test_utils::scoped_tracing_subscriber_guard().await;
+    let spans = CapturedSpans::default();
+    let subscriber = Registry::default().with(SpanCaptureLayer {
+        spans: spans.clone(),
+    });
+    let _default = tracing::subscriber::set_default(subscriber);
+
+    // Same callsite-interest warm-up as `assert_stream_usage_recorded_on_chat_spans`.
+    let warmup_agent = AgentBuilder::new(streaming_tool_then_text_model()).build();
+    let mut warmup_stream = warmup_agent.prompt("warmup").max_turns(1).stream();
+    while warmup_stream.next().await.is_some() {}
+    tracing::callsite::rebuild_interest_cache();
+    spans.clear();
+
+    let agent = AgentBuilder::new(streaming_tool_then_text_model())
+        .tool(MockAddTool)
+        .build();
+    let outer_span = tracing::info_span!("outer");
+    let stream = outer_span.in_scope(|| agent.prompt("do tool work").max_turns(3).stream());
+
+    // A current-thread runtime: the spawned task shares this thread's
+    // default subscriber but starts with no current span.
+    let items = tokio::spawn(async move {
+        let mut stream = stream;
+        let mut items = Vec::new();
+        while let Some(item) = stream.next().await {
+            items.push(item.expect("stream item"));
+        }
+        items
+    })
+    .await
+    .expect("join");
+    assert!(matches!(
+        items.last(),
+        Some(MultiTurnStreamItem::FinalResponse(_))
+    ));
+
+    let snapshot = spans.snapshot();
+    let outer_id = snapshot
+        .iter()
+        .find(|span| span.name == "outer")
+        .map(|span| span.id)
+        .expect("outer span captured");
+    assert!(
+        snapshot.iter().all(|span| span.name != "invoke_agent"),
+        "the build-site span is adopted; no invoke_agent is created"
+    );
+    let chat_spans: Vec<_> = snapshot
+        .iter()
+        .filter(|span| span.name == "chat_streaming")
+        .collect();
+    assert_eq!(chat_spans.len(), 2, "two model turns: {snapshot:?}");
+    for chat_span in chat_spans {
+        assert_eq!(chat_span.parent_id, Some(outer_id));
+    }
+}

--- a/crates/rig-agent/src/agent/telemetry.rs
+++ b/crates/rig-agent/src/agent/telemetry.rs
@@ -35,8 +35,9 @@ pub(crate) use build_chat_span;
 /// Build (or adopt) the top-level `invoke_agent` span for a run, shared by the
 /// blocking and streaming drivers so the run-level span shape is defined once.
 ///
-/// `ambient` is the span the run is invoked under — the current span when
-/// `run()` is first polled, the span `stream()` was built in. Returns the span
+/// `ambient` is the span the terminal (`run()`, `stream()`, `run_channel()`,
+/// a typed run's `into_future()`) was called in, whatever task later polls
+/// the future. Returns the span
 /// plus whether it was newly created. An enabled ambient span is adopted and
 /// reported as `false`, so the driver can avoid recording run-level usage onto
 /// a span it does not own (see the `created_agent_span` guard in both drivers'

--- a/crates/rig-agent/src/agent/telemetry.rs
+++ b/crates/rig-agent/src/agent/telemetry.rs
@@ -37,12 +37,11 @@ pub(crate) use build_chat_span;
 ///
 /// `ambient` is the span the terminal (`run()`, `stream()`, `run_channel()`,
 /// a typed run's `into_future()`) was called in, whatever task later polls
-/// the future. Returns the span
-/// plus whether it was newly created. An enabled ambient span is adopted and
-/// reported as `false`, so the driver can avoid recording run-level usage onto
-/// a span it does not own (see the `created_agent_span` guard in both drivers'
-/// `Done` handling); a disabled one yields a root `invoke_agent`, whatever span
-/// the poller happens to be in.
+/// the future. Returns the span plus whether it was newly created. An
+/// enabled ambient span is adopted and reported as `false`, so the driver
+/// can avoid recording run-level usage onto a span it does not own (see the
+/// `created_agent_span` guard in both drivers' `Done` handling); a disabled
+/// one yields a root `invoke_agent`, whatever span the poller happens to be in.
 pub(crate) fn acquire_agent_span(
     ambient: tracing::Span,
     agent_name: &str,

--- a/crates/rig-agent/src/agent/telemetry.rs
+++ b/crates/rig-agent/src/agent/telemetry.rs
@@ -35,19 +35,24 @@ pub(crate) use build_chat_span;
 /// Build (or adopt) the top-level `invoke_agent` span for a run, shared by the
 /// blocking and streaming drivers so the run-level span shape is defined once.
 ///
-/// Returns the span plus whether it was newly created. When the caller is
-/// already inside a span we adopt it and report `false`, so the driver can avoid
-/// recording run-level usage onto a span it does not own (see the
-/// `created_agent_span` guard in both drivers' `Done` handling).
+/// `ambient` is the span the run is invoked under — the current span when
+/// `run()` is first polled, the span `stream()` was built in. Returns the span
+/// plus whether it was newly created. An enabled ambient span is adopted and
+/// reported as `false`, so the driver can avoid recording run-level usage onto
+/// a span it does not own (see the `created_agent_span` guard in both drivers'
+/// `Done` handling); a disabled one yields a root `invoke_agent`, whatever span
+/// the poller happens to be in.
 pub(crate) fn acquire_agent_span(
+    ambient: tracing::Span,
     agent_name: &str,
     preamble: Option<&str>,
     record_content: bool,
 ) -> (tracing::Span, bool) {
-    if tracing::Span::current().is_disabled() {
+    if ambient.is_disabled() {
         let system_instructions =
             rig_core::telemetry::system_instructions_json(preamble, record_content);
         let span = info_span!(
+            parent: None,
             "invoke_agent",
             gen_ai.operation.name = "invoke_agent",
             gen_ai.agent.name = agent_name,
@@ -63,7 +68,7 @@ pub(crate) fn acquire_agent_span(
         );
         (span, true)
     } else {
-        (tracing::Span::current(), false)
+        (ambient, false)
     }
 }
 

--- a/crates/rig-agent/src/agent/typed.rs
+++ b/crates/rig-agent/src/agent/typed.rs
@@ -341,7 +341,10 @@ where
 
     forward_runner_setters!();
 
-    async fn send(self) -> Result<TypedPromptResponse<T>, StructuredOutputError> {
+    async fn send(
+        self,
+        ambient: tracing::Span,
+    ) -> Result<TypedPromptResponse<T>, StructuredOutputError> {
         let mut usage = Usage::new();
         let mut last_error = None;
 
@@ -352,7 +355,11 @@ where
                     self.retries - attempt
                 );
             }
-            let (result, error_usage) = self.runner.clone().run_with_error_usage().await;
+            let (result, error_usage) = self
+                .runner
+                .clone()
+                .run_with_error_usage(ambient.clone())
+                .await;
             let outcome = match result {
                 Ok(response) => {
                     usage += response.usage;
@@ -446,6 +453,10 @@ where
     type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
-        Box::pin(self.send())
+        // Captured in the synchronous part of the call, like `run()`: a
+        // typed run belongs to the span it was started in, not to the task
+        // that first polls it.
+        let ambient = tracing::Span::current();
+        Box::pin(self.send(ambient))
     }
 }

--- a/crates/rig-agent/src/agent/typed.rs
+++ b/crates/rig-agent/src/agent/typed.rs
@@ -15,6 +15,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 use rig_core::wasm_compat::{WasmBoxedFuture, WasmCompatSend};
+use tracing_futures::Instrument;
 
 use super::{
     Agent,
@@ -457,6 +458,7 @@ where
         // typed run belongs to the span it was started in, not to the task
         // that first polls it.
         let ambient = tracing::Span::current();
-        Box::pin(self.send(ambient))
+        let run_under = ambient.clone();
+        Box::pin(self.send(run_under).instrument(ambient))
     }
 }

--- a/crates/rig-agent/src/bus/tests.rs
+++ b/crates/rig-agent/src/bus/tests.rs
@@ -2072,7 +2072,7 @@ async fn concurrent_agent_wrappers_receive_distinct_recorder_contexts() {
         .build();
         let run = |agent: crate::agent::Agent| async move {
             if streamed {
-                let mut stream = agent.prompt("same prompt").stream().await;
+                let mut stream = agent.prompt("same prompt").stream();
                 let mut finished = false;
                 while let Some(event) = within(stream.next()).await {
                     if let crate::agent::MultiTurnStreamItem::FinalResponse(response) =

--- a/crates/rig-agent/src/bus/tests.rs
+++ b/crates/rig-agent/src/bus/tests.rs
@@ -2072,7 +2072,7 @@ async fn concurrent_agent_wrappers_receive_distinct_recorder_contexts() {
         .build();
         let run = |agent: crate::agent::Agent| async move {
             if streamed {
-                let mut stream = agent.runner("same prompt").stream().await;
+                let mut stream = agent.prompt("same prompt").stream().await;
                 let mut finished = false;
                 while let Some(event) = within(stream.next()).await {
                     if let crate::agent::MultiTurnStreamItem::FinalResponse(response) =
@@ -2085,7 +2085,7 @@ async fn concurrent_agent_wrappers_receive_distinct_recorder_contexts() {
                 assert!(finished);
             } else {
                 assert_eq!(
-                    within(agent.runner("same prompt").run())
+                    within(agent.prompt("same prompt").run())
                         .await
                         .unwrap()
                         .output,

--- a/crates/rig-agent/src/extractor.rs
+++ b/crates/rig-agent/src/extractor.rs
@@ -96,7 +96,7 @@ where
     /// billed response but failed extraction; attempts whose completion call
     /// itself errored contribute no usage.
     pub fn extract(&self, text: impl Into<Message>) -> TypedRun<T> {
-        let runner = self.agent.runner(text).max_turns(1).output_tool(
+        let runner = self.agent.prompt(text).max_turns(1).output_tool(
             SUBMIT_TOOL_NAME,
             "Submit the structured data you extracted from the provided text.",
             false,

--- a/crates/rig-agent/src/integrations/cli_chatbot.rs
+++ b/crates/rig-agent/src/integrations/cli_chatbot.rs
@@ -98,8 +98,7 @@ impl CliChat for AgentImpl {
             .prompt(prompt)
             .history(history.clone())
             .max_turns(self.max_turns)
-            .stream()
-            .await;
+            .stream();
 
         let mut acc = String::new();
         let mut messages = None;

--- a/crates/rig-agent/src/integrations/cli_chatbot.rs
+++ b/crates/rig-agent/src/integrations/cli_chatbot.rs
@@ -95,7 +95,7 @@ impl CliChat for AgentImpl {
     ) -> Result<String, PromptError> {
         let mut response_stream = self
             .agent
-            .stream_prompt(prompt)
+            .prompt(prompt)
             .history(history.clone())
             .max_turns(self.max_turns)
             .stream()

--- a/crates/rig-agent/src/run/mod.rs
+++ b/crates/rig-agent/src/run/mod.rs
@@ -30,11 +30,11 @@
 //! hook stack. Hand-driving it is a low-level provider integration: the caller
 //! owns all IO and any lifecycle policy. To execute a configured `Agent`
 //! with its hooks, tools, retrieval, and memory, use
-//! `Agent::runner`; constructing an `AgentRun`
+//! `Agent::prompt`; constructing an `AgentRun`
 //! directly is not an alternate way to execute an `Agent`.
 //!
 //! `Prompt::prompt` and
-//! `Agent::runner` drive this machine internally;
+//! `Agent::prompt` drive this machine internally;
 //! the same machine can be driven by hand for custom provider control flow.
 //! A host that does so (an ECS schedule, a job system) depends on `rig-agent`
 //! with default features off — that graph carries no async runtime, transport

--- a/crates/rig-agent/src/run/response.rs
+++ b/crates/rig-agent/src/run/response.rs
@@ -109,7 +109,7 @@ impl CompletionCall {
 
 /// The result of an agent run, returned by **both** the blocking
 /// (`AgentRunner::run`) and streaming (`AgentRunner::stream`) surfaces so a
-/// call site reads identically whether it used `.prompt()` or `.stream_prompt()`.
+/// call site reads identically whether it used `.prompt()` or `.prompt()`.
 ///
 /// On the streaming surface this is the payload of the terminal
 /// `MultiTurnStreamItem::FinalResponse` item.

--- a/crates/rig-agent/src/run/response.rs
+++ b/crates/rig-agent/src/run/response.rs
@@ -109,7 +109,7 @@ impl CompletionCall {
 
 /// The result of an agent run, returned by **both** the blocking
 /// (`AgentRunner::run`) and streaming (`AgentRunner::stream`) surfaces so a
-/// call site reads identically whether it used `.prompt()` or `.prompt()`.
+/// call site reads identically whether it awaited the runner or streamed it.
 ///
 /// On the streaming surface this is the payload of the terminal
 /// `MultiTurnStreamItem::FinalResponse` item.

--- a/crates/rig-agent/src/streaming.rs
+++ b/crates/rig-agent/src/streaming.rs
@@ -1,7 +1,7 @@
 //! Streaming values for the classic agent runtime.
 //!
 //! The streaming entry points are inherent on [`Agent`](crate::agent::Agent):
-//! [`stream_prompt`](crate::agent::Agent::stream_prompt) and
+//! [`stream_prompt`](crate::agent::Agent::prompt) and
 //! [`stream_chat`](crate::agent::Agent::stream_chat) return the runner, whose
 //! [`stream`](crate::agent::AgentRunner::stream) yields
 //! [`MultiTurnStreamItem`](crate::agent::MultiTurnStreamItem)s.

--- a/crates/rig-agent/src/streaming.rs
+++ b/crates/rig-agent/src/streaming.rs
@@ -1,9 +1,7 @@
 //! Streaming values for the classic agent runtime.
 //!
-//! The streaming entry points are inherent on [`Agent`](crate::agent::Agent):
-//! [`stream_prompt`](crate::agent::Agent::prompt) and
-//! [`stream_chat`](crate::agent::Agent::stream_chat) return the runner, whose
-//! [`stream`](crate::agent::AgentRunner::stream) yields
+//! Streaming is a terminal of the runner: [`Agent::prompt`](crate::agent::Agent::prompt)
+//! returns it, and its [`stream`](crate::agent::AgentRunner::stream) yields
 //! [`MultiTurnStreamItem`](crate::agent::MultiTurnStreamItem)s.
 
 pub use rig_core::streaming::*;

--- a/crates/rig-agent/src/test_utils/model_conformance.rs
+++ b/crates/rig-agent/src/test_utils/model_conformance.rs
@@ -1811,8 +1811,7 @@ where
     let mut stream = agent
         .prompt("Use add to calculate 17 + 25, then state the final number.")
         .max_turns(4)
-        .stream()
-        .await;
+        .stream();
     let mut final_response = None;
     let mut final_count = 0_usize;
     let mut completion_usage = crate::completion::Usage::new();
@@ -2051,8 +2050,7 @@ where
     let mut stream = agent
         .prompt("Use add to calculate 19 + 23. Return answer=42 and a short optional explanation.")
         .max_turns(5)
-        .stream()
-        .await;
+        .stream();
     let mut final_response = None;
     let mut final_count = 0_usize;
     while let Some(item) = stream.next().await {

--- a/crates/rig-agent/src/test_utils/model_conformance.rs
+++ b/crates/rig-agent/src/test_utils/model_conformance.rs
@@ -1422,7 +1422,7 @@ where
 
     let captured = Arc::new(Mutex::new(None));
     let stopped = agent
-        .runner(PROMPT)
+        .prompt(PROMPT)
         .add_hook(CaptureTurn(captured.clone()))
         .run()
         .await;
@@ -1809,7 +1809,7 @@ where
         .default_max_turns(4)
         .build();
     let mut stream = agent
-        .stream_prompt("Use add to calculate 17 + 25, then state the final number.")
+        .prompt("Use add to calculate 17 + 25, then state the final number.")
         .max_turns(4)
         .stream()
         .await;
@@ -2049,9 +2049,7 @@ where
         .default_max_turns(5)
         .build();
     let mut stream = agent
-        .stream_prompt(
-            "Use add to calculate 19 + 23. Return answer=42 and a short optional explanation.",
-        )
+        .prompt("Use add to calculate 19 + 23. Return answer=42 and a short optional explanation.")
         .max_turns(5)
         .stream()
         .await;

--- a/crates/rig-agent/tests/effect_bus.rs
+++ b/crates/rig-agent/tests/effect_bus.rs
@@ -382,7 +382,7 @@ async fn streaming_runs_drive_the_bus_too() {
         rig_core::test_utils::MockStreamEvent::final_response_with_total_tokens(3),
     ]]))
     .build();
-    let mut stream = agent.stream_prompt("go").stream().await;
+    let mut stream = agent.prompt("go").stream().await;
     let mut output = None;
     while let Some(item) = within(stream.next()).await {
         if let rig_agent::agent::MultiTurnStreamItem::FinalResponse(response) = item.expect("item")
@@ -422,7 +422,7 @@ async fn a_finished_stream_kept_in_scope_does_not_block_the_next_run() {
     )
     .model_route("unary", MockCompletionModel::text("second"))
     .build();
-    let mut stream = agent.stream_prompt("go").stream().await;
+    let mut stream = agent.prompt("go").stream().await;
     assert_eq!(drain(&mut stream).await.as_deref(), Some("first"));
     // `stream` is still alive here.
     let response = within(agent.prompt("again").using_model("unary").run())
@@ -439,8 +439,8 @@ async fn two_streams_polled_alternately_both_complete() {
         streamed_text("two"),
     ]))
     .build();
-    let mut first = agent.stream_prompt("a").stream().await;
-    let mut second = agent.stream_prompt("b").stream().await;
+    let mut first = agent.prompt("a").stream().await;
+    let mut second = agent.prompt("b").stream().await;
     let (mut out_first, mut out_second) = (None, None);
     let (mut done_first, mut done_second) = (false, false);
     while !(done_first && done_second) {
@@ -483,7 +483,7 @@ async fn a_prompt_awaited_inside_a_stream_loop_on_a_clone_resolves() {
     .model_route("unary", MockCompletionModel::text("inner"))
     .build();
     let clone = agent.clone();
-    let mut stream = agent.stream_prompt("go").stream().await;
+    let mut stream = agent.prompt("go").stream().await;
     let mut inner = None;
     let mut outer = None;
     while let Some(item) = within(stream.next()).await {
@@ -1032,7 +1032,7 @@ async fn hook_sequence_streaming_turn_with_one_tool_call() {
     .tool(Slow::default())
     .add_hook(sequence.clone())
     .build();
-    let mut stream = agent.stream_prompt("go").max_turns(3).stream().await;
+    let mut stream = agent.prompt("go").max_turns(3).stream().await;
     assert_eq!(drain(&mut stream).await.as_deref(), Some("done"));
     let recorded = sequence.take();
     // Deltas are provisional observations between a completion's dispatch
@@ -1212,7 +1212,7 @@ async fn a_cancelling_replacement_on_a_completion_outcome_stops_the_run_on_both_
     )]))
     .add_hook(StopOnAnswer)
     .build();
-    let mut stream = streaming.stream_prompt("go").stream().await;
+    let mut stream = streaming.prompt("go").stream().await;
     let mut cancelled = false;
     while let Some(item) = within(stream.next()).await {
         if let Err(rig_agent::agent::StreamingError::Prompt(err)) = item
@@ -1252,7 +1252,7 @@ async fn a_replacement_on_a_streamed_completion_is_what_the_run_keeps() {
     )]))
     .add_hook(ReplaceAnswer)
     .build();
-    let mut stream = agent.stream_prompt("go").stream().await;
+    let mut stream = agent.prompt("go").stream().await;
     assert_eq!(drain(&mut stream).await.as_deref(), Some("replaced"));
 }
 
@@ -1643,7 +1643,7 @@ async fn anonymous_models_are_scoped_to_the_values_that_selected_them() {
 
     for _ in 0..1_000 {
         let runner = agent
-            .runner("hello")
+            .prompt("hello")
             .using_model_value(MockCompletionModel::text("anonymous"));
         assert_eq!(
             anonymous(&dispatcher),
@@ -1848,7 +1848,7 @@ async fn a_model_registered_through_the_parts_registrar_serves_the_next_run() {
         dispatcher.descriptor(&key).is_some(),
         "the descriptor is visible at once"
     );
-    let response = within(agent.runner("hello").using_model("late").run())
+    let response = within(agent.prompt("hello").using_model("late").run())
         .await
         .expect("the next run selects it");
     assert_eq!(response.output, "late");
@@ -1957,7 +1957,7 @@ async fn a_hook_binds_a_run_scoped_view_and_dispatches_through_it() {
     )));
     let response = within(
         agent
-            .runner("hello")
+            .prompt("hello")
             .add_hook(AsksTheModel {
                 key,
                 seen: seen.clone(),

--- a/crates/rig-agent/tests/effect_bus.rs
+++ b/crates/rig-agent/tests/effect_bus.rs
@@ -382,7 +382,7 @@ async fn streaming_runs_drive_the_bus_too() {
         rig_core::test_utils::MockStreamEvent::final_response_with_total_tokens(3),
     ]]))
     .build();
-    let mut stream = agent.prompt("go").stream().await;
+    let mut stream = agent.prompt("go").stream();
     let mut output = None;
     while let Some(item) = within(stream.next()).await {
         if let rig_agent::agent::MultiTurnStreamItem::FinalResponse(response) = item.expect("item")
@@ -422,7 +422,7 @@ async fn a_finished_stream_kept_in_scope_does_not_block_the_next_run() {
     )
     .model_route("unary", MockCompletionModel::text("second"))
     .build();
-    let mut stream = agent.prompt("go").stream().await;
+    let mut stream = agent.prompt("go").stream();
     assert_eq!(drain(&mut stream).await.as_deref(), Some("first"));
     // `stream` is still alive here.
     let response = within(agent.prompt("again").using_model("unary").run())
@@ -439,8 +439,8 @@ async fn two_streams_polled_alternately_both_complete() {
         streamed_text("two"),
     ]))
     .build();
-    let mut first = agent.prompt("a").stream().await;
-    let mut second = agent.prompt("b").stream().await;
+    let mut first = agent.prompt("a").stream();
+    let mut second = agent.prompt("b").stream();
     let (mut out_first, mut out_second) = (None, None);
     let (mut done_first, mut done_second) = (false, false);
     while !(done_first && done_second) {
@@ -483,7 +483,7 @@ async fn a_prompt_awaited_inside_a_stream_loop_on_a_clone_resolves() {
     .model_route("unary", MockCompletionModel::text("inner"))
     .build();
     let clone = agent.clone();
-    let mut stream = agent.prompt("go").stream().await;
+    let mut stream = agent.prompt("go").stream();
     let mut inner = None;
     let mut outer = None;
     while let Some(item) = within(stream.next()).await {
@@ -1032,7 +1032,7 @@ async fn hook_sequence_streaming_turn_with_one_tool_call() {
     .tool(Slow::default())
     .add_hook(sequence.clone())
     .build();
-    let mut stream = agent.prompt("go").max_turns(3).stream().await;
+    let mut stream = agent.prompt("go").max_turns(3).stream();
     assert_eq!(drain(&mut stream).await.as_deref(), Some("done"));
     let recorded = sequence.take();
     // Deltas are provisional observations between a completion's dispatch
@@ -1212,7 +1212,7 @@ async fn a_cancelling_replacement_on_a_completion_outcome_stops_the_run_on_both_
     )]))
     .add_hook(StopOnAnswer)
     .build();
-    let mut stream = streaming.prompt("go").stream().await;
+    let mut stream = streaming.prompt("go").stream();
     let mut cancelled = false;
     while let Some(item) = within(stream.next()).await {
         if let Err(rig_agent::agent::StreamingError::Prompt(err)) = item
@@ -1252,7 +1252,7 @@ async fn a_replacement_on_a_streamed_completion_is_what_the_run_keeps() {
     )]))
     .add_hook(ReplaceAnswer)
     .build();
-    let mut stream = agent.prompt("go").stream().await;
+    let mut stream = agent.prompt("go").stream();
     assert_eq!(drain(&mut stream).await.as_deref(), Some("replaced"));
 }
 

--- a/crates/rig-agent/tests/runtime_model_swapping.rs
+++ b/crates/rig-agent/tests/runtime_model_swapping.rs
@@ -436,7 +436,7 @@ async fn downstream_models_keep_typed_low_level_apis_and_share_a_concrete_agent_
     assert_builder(AgentBuilder::new(alpha.clone()));
     assert_prompt_request(alpha_agent.prompt("typed request"));
     assert_extractor(ExtractorBuilder::<ExtractedValue>::new(alpha.clone()).build());
-    assert_agent_stream(alpha_agent.stream_prompt("stream type").stream().await);
+    assert_agent_stream(alpha_agent.prompt("stream type").stream().await);
 
     let unary = alpha
         .completion(request("low-level unary"))
@@ -499,7 +499,7 @@ async fn replacement_and_override_scopes_have_value_semantics() {
     let alpha = alpha_static("alpha");
     let beta = beta_static("beta");
     let mut agent = AgentBuilder::new(alpha.clone()).build();
-    let runner_before_replacement = agent.runner("runner snapshot");
+    let runner_before_replacement = agent.prompt("runner snapshot");
     agent.set_model(beta.clone());
 
     assert_eq!(
@@ -668,7 +668,7 @@ async fn model_selection_stop_cancels_before_provider_execution() {
     let streaming_completion_calls = Arc::new(AtomicUsize::new(0));
     let mut stream = AgentBuilder::new(streaming_model)
         .build()
-        .stream_prompt("stop before streaming")
+        .prompt("stop before streaming")
         .add_hook(StopSelection {
             completion_calls: streaming_completion_calls.clone(),
         })
@@ -999,7 +999,7 @@ async fn blocking_and_streaming_switch_after_tools_with_equivalent_semantics() {
             .add_hook(lifecycle.clone())
             .build();
         let mut stream = agent
-            .stream_prompt("research then synthesize")
+            .prompt("research then synthesize")
             .max_turns(3)
             .add_hook(SelectWith(
                 move |context: &HookContext, _event: ModelSelection<'_>| {
@@ -1231,7 +1231,7 @@ async fn normalized_stream_preserves_events_message_id_and_usage() {
     let rich = Turn::rich("final text", 13, "rich-message-id");
     let alpha = AlphaModel(Script::new("alpha", [rich.clone()], rich));
     let agent = AgentBuilder::new(alpha).build();
-    let mut stream = agent.stream_prompt("rich stream").stream().await;
+    let mut stream = agent.prompt("rich stream").stream().await;
     let mut saw_reasoning = false;
     let mut saw_reasoning_delta = false;
     let mut saw_unknown = false;
@@ -1544,7 +1544,7 @@ async fn dropping_pending_unary_and_streaming_attempts_cancels_by_drop() {
         dropped: stream_dropped.clone(),
     })
     .build();
-    let pending_stream = stream_agent.stream_prompt("pending stream").stream().await;
+    let pending_stream = stream_agent.prompt("pending stream").stream().await;
     let stream_task = tokio::spawn(async move {
         let mut pending_stream = pending_stream;
         pending_stream.next().await
@@ -1661,7 +1661,7 @@ async fn model_selection_hooks_observe_the_merged_request_patch_on_both_surfaces
             .build();
 
         if streaming {
-            drain_stream(agent.stream_prompt("merged patch").stream().await)
+            drain_stream(agent.prompt("merged patch").stream().await)
                 .await
                 .expect("streaming patched run");
         } else {
@@ -1710,7 +1710,7 @@ async fn a_request_patch_can_influence_the_selected_model_on_both_surfaces() {
             .build();
 
         if streaming {
-            drain_stream(agent.stream_prompt("route by patch").stream().await)
+            drain_stream(agent.prompt("route by patch").stream().await)
                 .await
                 .expect("streaming patch-routed run");
             assert_eq!(
@@ -1743,7 +1743,7 @@ async fn a_stopped_completion_call_hook_suppresses_selection_on_both_surfaces() 
             .build();
 
         if streaming {
-            let error = drain_stream(agent.stream_prompt("stopped").stream().await)
+            let error = drain_stream(agent.prompt("stopped").stream().await)
                 .await
                 .expect_err("streaming completion-call stop");
             assert!(matches!(
@@ -1793,15 +1793,9 @@ async fn failed_preparation_follows_selection_and_does_not_issue_an_attempt() {
             .build();
 
         let failed = if streaming {
-            drain_stream(
-                agent
-                    .stream_prompt("prepare fails")
-                    .max_turns(2)
-                    .stream()
-                    .await,
-            )
-            .await
-            .is_err()
+            drain_stream(agent.prompt("prepare fails").max_turns(2).stream().await)
+                .await
+                .is_err()
         } else {
             agent.prompt("prepare fails").max_turns(2).await.is_err()
         };
@@ -1873,7 +1867,7 @@ async fn an_errored_provider_attempt_still_counts_as_the_previous_model() {
         // provider-kind `ErrorReport` whose message is the provider's own.
         let failed_with_provider_error = if streaming {
             matches!(
-                drain_stream(agent.stream_prompt("boom").stream().await).await,
+                drain_stream(agent.prompt("boom").stream().await).await,
                 Err(StreamingError::Report(report))
                     if report.kind == ErrorKind::Provider
                         && report.message.ends_with("provider exploded")

--- a/crates/rig-agent/tests/runtime_model_swapping.rs
+++ b/crates/rig-agent/tests/runtime_model_swapping.rs
@@ -436,7 +436,7 @@ async fn downstream_models_keep_typed_low_level_apis_and_share_a_concrete_agent_
     assert_builder(AgentBuilder::new(alpha.clone()));
     assert_prompt_request(alpha_agent.prompt("typed request"));
     assert_extractor(ExtractorBuilder::<ExtractedValue>::new(alpha.clone()).build());
-    assert_agent_stream(alpha_agent.prompt("stream type").stream().await);
+    assert_agent_stream(alpha_agent.prompt("stream type").stream());
 
     let unary = alpha
         .completion(request("low-level unary"))
@@ -672,8 +672,7 @@ async fn model_selection_stop_cancels_before_provider_execution() {
         .add_hook(StopSelection {
             completion_calls: streaming_completion_calls.clone(),
         })
-        .stream()
-        .await;
+        .stream();
     let error = stream
         .next()
         .await
@@ -1010,8 +1009,7 @@ async fn blocking_and_streaming_switch_after_tools_with_equivalent_semantics() {
                     ModelSelectionAction::select(if context.turn() == 1 { "alpha" } else { "beta" })
                 },
             ))
-            .stream()
-            .await;
+            .stream();
         let mut final_response = None;
         let mut events = Vec::new();
         let mut block_ids = Vec::new();
@@ -1231,7 +1229,7 @@ async fn normalized_stream_preserves_events_message_id_and_usage() {
     let rich = Turn::rich("final text", 13, "rich-message-id");
     let alpha = AlphaModel(Script::new("alpha", [rich.clone()], rich));
     let agent = AgentBuilder::new(alpha).build();
-    let mut stream = agent.prompt("rich stream").stream().await;
+    let mut stream = agent.prompt("rich stream").stream();
     let mut saw_reasoning = false;
     let mut saw_reasoning_delta = false;
     let mut saw_unknown = false;
@@ -1544,7 +1542,7 @@ async fn dropping_pending_unary_and_streaming_attempts_cancels_by_drop() {
         dropped: stream_dropped.clone(),
     })
     .build();
-    let pending_stream = stream_agent.prompt("pending stream").stream().await;
+    let pending_stream = stream_agent.prompt("pending stream").stream();
     let stream_task = tokio::spawn(async move {
         let mut pending_stream = pending_stream;
         pending_stream.next().await
@@ -1661,7 +1659,7 @@ async fn model_selection_hooks_observe_the_merged_request_patch_on_both_surfaces
             .build();
 
         if streaming {
-            drain_stream(agent.prompt("merged patch").stream().await)
+            drain_stream(agent.prompt("merged patch").stream())
                 .await
                 .expect("streaming patched run");
         } else {
@@ -1710,7 +1708,7 @@ async fn a_request_patch_can_influence_the_selected_model_on_both_surfaces() {
             .build();
 
         if streaming {
-            drain_stream(agent.prompt("route by patch").stream().await)
+            drain_stream(agent.prompt("route by patch").stream())
                 .await
                 .expect("streaming patch-routed run");
             assert_eq!(
@@ -1743,7 +1741,7 @@ async fn a_stopped_completion_call_hook_suppresses_selection_on_both_surfaces() 
             .build();
 
         if streaming {
-            let error = drain_stream(agent.prompt("stopped").stream().await)
+            let error = drain_stream(agent.prompt("stopped").stream())
                 .await
                 .expect_err("streaming completion-call stop");
             assert!(matches!(
@@ -1793,7 +1791,7 @@ async fn failed_preparation_follows_selection_and_does_not_issue_an_attempt() {
             .build();
 
         let failed = if streaming {
-            drain_stream(agent.prompt("prepare fails").max_turns(2).stream().await)
+            drain_stream(agent.prompt("prepare fails").max_turns(2).stream())
                 .await
                 .is_err()
         } else {
@@ -1867,7 +1865,7 @@ async fn an_errored_provider_attempt_still_counts_as_the_previous_model() {
         // provider-kind `ErrorReport` whose message is the provider's own.
         let failed_with_provider_error = if streaming {
             matches!(
-                drain_stream(agent.prompt("boom").stream().await).await,
+                drain_stream(agent.prompt("boom").stream()).await,
                 Err(StreamingError::Report(report))
                     if report.kind == ErrorKind::Provider
                         && report.message.ends_with("provider exploded")

--- a/crates/rig-bedrock/examples/streaming_with_bedrock.rs
+++ b/crates/rig-bedrock/examples/streaming_with_bedrock.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Stream the response and print chunks as they arrive
     let mut stream = agent
-        .stream_prompt("When and where and what type is the next solar eclipse?")
+        .prompt("When and where and what type is the next solar eclipse?")
         .stream()
         .await;
 

--- a/crates/rig-bedrock/examples/streaming_with_bedrock.rs
+++ b/crates/rig-bedrock/examples/streaming_with_bedrock.rs
@@ -13,8 +13,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Stream the response and print chunks as they arrive
     let mut stream = agent
         .prompt("When and where and what type is the next solar eclipse?")
-        .stream()
-        .await;
+        .stream();
 
     let _ = stream_to_stdout(&mut stream).await?;
 

--- a/crates/rig-bedrock/examples/streaming_with_bedrock_and_tools.rs
+++ b/crates/rig-bedrock/examples/streaming_with_bedrock_and_tools.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .build();
 
     println!("Calculate 2 + 5");
-    let mut stream = agent.prompt("Calculate 2 + 5").stream().await;
+    let mut stream = agent.prompt("Calculate 2 + 5").stream();
     let _ = stream_to_stdout(&mut stream).await?;
     Ok(())
 }

--- a/crates/rig-bedrock/examples/streaming_with_bedrock_and_tools.rs
+++ b/crates/rig-bedrock/examples/streaming_with_bedrock_and_tools.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .build();
 
     println!("Calculate 2 + 5");
-    let mut stream = agent.stream_prompt("Calculate 2 + 5").stream().await;
+    let mut stream = agent.prompt("Calculate 2 + 5").stream().await;
     let _ = stream_to_stdout(&mut stream).await?;
     Ok(())
 }

--- a/crates/rig-verify/tests/corpus/mod.rs
+++ b/crates/rig-verify/tests/corpus/mod.rs
@@ -3157,7 +3157,7 @@ async fn resumed_tail(
     }
     let restored: AgentRun = serde_json::from_str(&state).expect("the run state restores");
     let agent = build_agent(replay, program, server, &tail_log);
-    let mut runner = agent.prompt("ignored").resume(restored);
+    let mut runner = agent.resume(restored);
     if let Some(max_turns) = program.max_turns {
         runner = runner.max_turns(max_turns);
     }

--- a/crates/rig-verify/tests/corpus/mod.rs
+++ b/crates/rig-verify/tests/corpus/mod.rs
@@ -2645,7 +2645,7 @@ pub async fn bus_engine_reproduces(program: &Program) {
     let mut output = None;
     for prompt in prompts {
         output = if program.streamed {
-            let mut runner = agent.stream_prompt(prompt);
+            let mut runner = agent.prompt(prompt);
             if let Some(history) = program.history {
                 runner = runner.history(history());
             }
@@ -3157,7 +3157,7 @@ async fn resumed_tail(
     }
     let restored: AgentRun = serde_json::from_str(&state).expect("the run state restores");
     let agent = build_agent(replay, program, server, &tail_log);
-    let mut runner = agent.runner("ignored").resume(restored);
+    let mut runner = agent.prompt("ignored").resume(restored);
     if let Some(max_turns) = program.max_turns {
         runner = runner.max_turns(max_turns);
     }

--- a/crates/rig-verify/tests/corpus/mod.rs
+++ b/crates/rig-verify/tests/corpus/mod.rs
@@ -326,7 +326,7 @@ pub struct Program {
     pub default_max_turns: Option<usize>,
     pub max_turns: Option<usize>,
     pub tool_concurrency: Option<usize>,
-    /// The producer ran `stream_prompt`: the model is asked for a stream.
+    /// The producer streamed (`prompt(..).stream()`): the model is asked for a stream.
     pub streamed: bool,
     /// The producer attached conversation memory under this id.
     pub conversation: Option<&'static str>,

--- a/crates/rig-verify/tests/corpus/mod.rs
+++ b/crates/rig-verify/tests/corpus/mod.rs
@@ -2658,7 +2658,7 @@ pub async fn bus_engine_reproduces(program: &Program) {
             runner = runner
                 .max_invalid_tool_call_retries(program.invalid_retries)
                 .unhandled_invalid_tool_call(unhandled_policy(program));
-            let mut stream = runner.stream().await;
+            let mut stream = runner.stream();
             let mut output = None;
             let mut failed_as_expected = false;
             while let Some(item) = within(stream.next()).await {
@@ -3168,7 +3168,7 @@ async fn resumed_tail(
         .max_invalid_tool_call_retries(program.invalid_retries)
         .unhandled_invalid_tool_call(unhandled_policy(program));
     let outcome = if program.streamed {
-        let mut stream = runner.stream().await;
+        let mut stream = runner.stream();
         let mut output = None;
         let mut failure = None;
         while let Some(item) = within(stream.next()).await {

--- a/crates/rig-verify/tests/durable_execution.rs
+++ b/crates/rig-verify/tests/durable_execution.rs
@@ -321,9 +321,8 @@ async fn resumes_identically(scenario: Scenario, tools_before_stop: usize) {
             .build();
     let response = within(
         resumed_agent
-            .prompt("ignored")
-            .tool_concurrency(scenario.tool_concurrency)
             .resume(restored)
+            .tool_concurrency(scenario.tool_concurrency)
             .run(),
     )
     .await
@@ -484,7 +483,7 @@ async fn a_hooks_decision_is_program_not_record() {
                 builder = builder.add_hook(PatchesTag);
             }
             let agent = builder.build();
-            let result = within(agent.prompt("ignored").resume(suspended).run()).await;
+            let result = within(agent.resume(suspended).run()).await;
             drop((agent, dispatcher, registrar));
             within(replay_task).await.expect("replay driver");
             result
@@ -545,7 +544,7 @@ async fn a_resumed_run_loads_nothing_from_memory() {
         ..RunSpec::new()
     };
     let state = AgentRun::from_spec(&spec, "go", None);
-    let response = within(agent.prompt("ignored").resume(state).run())
+    let response = within(agent.resume(state).run())
         .await
         .expect("the resumed run");
     assert_eq!(response.output, "done");
@@ -637,9 +636,8 @@ async fn resumes_from_a_checkpoint(
             .build();
     let response = within(
         resumed_agent
-            .prompt("ignored")
-            .tool_concurrency(scenario.tool_concurrency)
             .resume(restored)
+            .tool_concurrency(scenario.tool_concurrency)
             .run(),
     )
     .await

--- a/crates/rig-verify/tests/durable_execution.rs
+++ b/crates/rig-verify/tests/durable_execution.rs
@@ -9,7 +9,7 @@
 //!
 //! The interruption is a hand driver of `AgentRun` over the agent's own bus
 //! keys (the sans-IO machine is the only place a run can be suspended
-//! mid-flight today); the resumption goes through `Agent::prompt(..).resume`
+//! mid-flight today); the resumption goes through `Agent::resume(run)`
 //! — the bus-driven engine — so the property crosses the two interpreters.
 
 #![allow(clippy::expect_used, clippy::indexing_slicing, clippy::panic)]

--- a/crates/rig-verify/tests/durable_execution.rs
+++ b/crates/rig-verify/tests/durable_execution.rs
@@ -9,7 +9,7 @@
 //!
 //! The interruption is a hand driver of `AgentRun` over the agent's own bus
 //! keys (the sans-IO machine is the only place a run can be suspended
-//! mid-flight today); the resumption goes through `Agent::runner(..).resume`
+//! mid-flight today); the resumption goes through `Agent::prompt(..).resume`
 //! — the bus-driven engine — so the property crosses the two interpreters.
 
 #![allow(clippy::expect_used, clippy::indexing_slicing, clippy::panic)]
@@ -321,7 +321,7 @@ async fn resumes_identically(scenario: Scenario, tools_before_stop: usize) {
             .build();
     let response = within(
         resumed_agent
-            .runner("ignored")
+            .prompt("ignored")
             .tool_concurrency(scenario.tool_concurrency)
             .resume(restored)
             .run(),
@@ -484,7 +484,7 @@ async fn a_hooks_decision_is_program_not_record() {
                 builder = builder.add_hook(PatchesTag);
             }
             let agent = builder.build();
-            let result = within(agent.runner("ignored").resume(suspended).run()).await;
+            let result = within(agent.prompt("ignored").resume(suspended).run()).await;
             drop((agent, dispatcher, registrar));
             within(replay_task).await.expect("replay driver");
             result
@@ -545,7 +545,7 @@ async fn a_resumed_run_loads_nothing_from_memory() {
         ..RunSpec::new()
     };
     let state = AgentRun::from_spec(&spec, "go", None);
-    let response = within(agent.runner("ignored").resume(state).run())
+    let response = within(agent.prompt("ignored").resume(state).run())
         .await
         .expect("the resumed run");
     assert_eq!(response.output, "done");
@@ -637,7 +637,7 @@ async fn resumes_from_a_checkpoint(
             .build();
     let response = within(
         resumed_agent
-            .runner("ignored")
+            .prompt("ignored")
             .tool_concurrency(scenario.tool_concurrency)
             .resume(restored)
             .run(),

--- a/crates/rig-verify/tests/golden_replay.rs
+++ b/crates/rig-verify/tests/golden_replay.rs
@@ -7,8 +7,8 @@
 //!
 //! Both interpreters of the agent program reproduce every golden:
 //!
-//! - the bus-driven engine (`AgentBuilder::over_bus` … `prompt` /
-//!   `stream_prompt`), the program it was recorded with — same preamble,
+//! - the bus-driven engine (`AgentBuilder::over_bus` … `prompt(..)` awaited
+//!   or streamed), the program it was recorded with — same preamble,
 //!   prompt, tools, hooks, memory, bus policy and run options — hardcoded
 //!   here per fixture;
 //! - a hand driver of `AgentRun` that steps the run protocol itself and

--- a/crates/rig-verify/tests/interpreters_agree.rs
+++ b/crates/rig-verify/tests/interpreters_agree.rs
@@ -1,6 +1,6 @@
 //! Two interpreters of the agent program agree (Swierstra: any two
 //! interpreters of one syntax tree must). The bus-driven engine
-//! (`Agent::runner`) and a hand driver of `AgentRun::next_step` (the shape
+//! (`Agent::prompt`) and a hand driver of `AgentRun::next_step` (the shape
 //! of `tests/fixtures/agent_run_stepper`) run the same scripted model and
 //! the same tools **over the same bus keys**, and produce the same sequence
 //! of effects — every request and every outcome as data, in order, not

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,7 @@ Most examples expect provider API keys in the environment (e.g. `OPENAI_API_KEY`
 | `agent_prompt_chaining` | Demonstrates prompt chaining with two agents in sequence. |
 | `agent_routing` | Demonstrates routing one prompt into different follow-up prompts. |
 | `agent_run_stepping` | Drives the agent loop by hand with the sans-IO [`AgentRun`] state machine. |
-| `agent_stream_chat` | Demonstrates `stream_chat` with prior conversation history. |
+| `agent_stream_chat` | Demonstrates a streamed run over prior conversation history (`prompt(..).history(..).stream()`). |
 | `agent_with_agent_tool` | See source. |
 | `agent_with_approval_policy` | Demonstrates a non-interactive, policy-based HITL gate: an `AgentHook` auto-approves an allow-list, denies the rest (fail-closed), and applies an arg-based rule (mirrors `needs_approval`/`interrupt_on` predicates). |
 | `agent_with_context` | Demonstrates adding small context documents directly to an agent. |

--- a/examples/agent_no_tokio/README.md
+++ b/examples/agent_no_tokio/README.md
@@ -3,7 +3,7 @@
 Runs a rig agent on Bevy's `AsyncComputeTaskPool` with no tokio dependency in
 this crate's manifest.
 
-`Agent::run_channel` splits a run into a runtime-agnostic future and a bounded
+`AgentRunner::run_channel` splits a run into a runtime-agnostic future and a bounded
 `RunEvents` feed. The future is spawned on the pool; the main thread acts as a
 frame loop, draining events with the non-blocking `RunEvents::try_next` and
 checking the task with `bevy_tasks::futures::check_ready` — the shape a Bevy

--- a/examples/agent_no_tokio/src/main.rs
+++ b/examples/agent_no_tokio/src/main.rs
@@ -1,6 +1,6 @@
 //! An agent run driven by `bevy_tasks` instead of tokio.
 //!
-//! rig-agent has no runtime of its own: [`Agent::run_channel`] hands back a
+//! rig-agent has no runtime of its own: [`rig::agent::AgentRunner::run_channel`] hands back a
 //! plain future plus a bounded [`RunEvents`] feed, so the future can be spawned
 //! on any executor — here Bevy's `AsyncComputeTaskPool` — while a synchronous
 //! loop (think: a game frame, an ECS system) drains the events with
@@ -39,7 +39,7 @@ fn main() -> Result<()> {
         .build();
 
     // Split the run: a future for the pool, an event feed for the frame loop.
-    let (run, mut events) = agent.run_channel(PROMPT);
+    let (run, mut events) = agent.prompt(PROMPT).run_channel();
     let pool = AsyncComputeTaskPool::get_or_init(TaskPool::new);
     let mut task = pool.spawn(run);
 

--- a/examples/agent_run_stepping/src/main.rs
+++ b/examples/agent_run_stepping/src/main.rs
@@ -11,7 +11,7 @@
 //!
 //! For the common case you don't need that level of control: attach an
 //! [`AgentHook`] to observe tool calls (and every other event) without
-//! hand-driving the loop. Use `agent.runner(prompt).add_hook(h).run().await`.
+//! hand-driving the loop. Use `agent.prompt(prompt).add_hook(h).run().await`.
 //!
 //! Both approaches are demonstrated in `main` below.
 //!
@@ -196,7 +196,7 @@ async fn main() -> Result<()> {
     // -----------------------------------------------------------------------
     // Part 2 — high-level AgentRunner path with hooks
     //
-    // Most use-cases don't need the manual stepping above. `agent.runner(…)`
+    // Most use-cases don't need the manual stepping above. `agent.prompt(…)`
     // returns an `AgentRunner` that drives the same machine internally while
     // firing an `AgentHook` at every observable point. Attach hooks with
     // `.add_hook(h)`; each call appends another hook to the stack.
@@ -205,7 +205,7 @@ async fn main() -> Result<()> {
     println!("\n--- Part 2: AgentRunner with ToolLoggerHook ---");
 
     let resp = agent
-        .runner("What is 2 + 5?")
+        .prompt("What is 2 + 5?")
         .max_turns(2)
         .add_hook(ToolLoggerHook)
         .run()

--- a/examples/agent_stream_chat/src/main.rs
+++ b/examples/agent_stream_chat/src/main.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
         .build();
 
     let history = sample_history();
-    let mut stream = agent.prompt(PROMPT).history(&history).stream().await;
+    let mut stream = agent.prompt(PROMPT).history(&history).stream();
     let response = collect_stream_final_response(&mut stream).await?;
     println!("{response}");
 

--- a/examples/agent_stream_chat/src/main.rs
+++ b/examples/agent_stream_chat/src/main.rs
@@ -1,4 +1,4 @@
-//! Demonstrates `stream_chat` with prior conversation history.
+//! Demonstrates a streamed run over prior conversation history.
 //! Requires `OPENAI_API_KEY`.
 //! Run it to see a streamed continuation of an existing exchange.
 
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
         .build();
 
     let history = sample_history();
-    let mut stream = agent.stream_chat(PROMPT, &history).stream().await;
+    let mut stream = agent.prompt(PROMPT).history(&history).stream().await;
     let response = collect_stream_final_response(&mut stream).await?;
     println!("{response}");
 

--- a/examples/agent_with_human_in_the_loop/src/main.rs
+++ b/examples/agent_with_human_in_the_loop/src/main.rs
@@ -16,7 +16,7 @@
 //! Because `AgentHook::on_dispatch` is `async`, the hook can simply `.await` the
 //! human's input inline (here from stdin; in a real app this might be an HTTP
 //! request to an approval UI, a Slack round-trip, or a database poll). The same
-//! hook works unchanged on the streaming driver (`stream_prompt`).
+//! hook works unchanged on the streaming driver (`prompt(..).stream()`).
 //!
 //! Requires `OPENAI_API_KEY`. Run with: `cargo run -p agent_with_human_in_the_loop`
 

--- a/examples/agent_with_memory_streaming/src/main.rs
+++ b/examples/agent_with_memory_streaming/src/main.rs
@@ -35,16 +35,14 @@ async fn main() -> Result<()> {
     let mut first = agent
         .prompt("My name is Alice.")
         .conversation("user-123")
-        .stream()
-        .await;
+        .stream();
     let reply1 = collect_final(&mut first).await?;
     println!("turn 1: {reply1}");
 
     let mut second = agent
         .prompt("What's my name?")
         .conversation("user-123")
-        .stream()
-        .await;
+        .stream();
     let reply2 = collect_final(&mut second).await?;
     println!("turn 2: {reply2}");
 

--- a/examples/agent_with_memory_streaming/src/main.rs
+++ b/examples/agent_with_memory_streaming/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
         .build();
 
     let mut first = agent
-        .stream_prompt("My name is Alice.")
+        .prompt("My name is Alice.")
         .conversation("user-123")
         .stream()
         .await;
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
     println!("turn 1: {reply1}");
 
     let mut second = agent
-        .stream_prompt("What's my name?")
+        .prompt("What's my name?")
         .conversation("user-123")
         .stream()
         .await;

--- a/examples/agent_with_retry_hook/src/main.rs
+++ b/examples/agent_with_retry_hook/src/main.rs
@@ -109,7 +109,7 @@ async fn main() -> Result<()> {
         .build();
 
     let response = agent
-        .runner("Begin the retry-hook demonstration.")
+        .prompt("Begin the retry-hook demonstration.")
         .max_turns(2)
         .add_hook(RetryOnMarker::with_feedback(
             "RETRY:",

--- a/examples/gemini_default_api_recovery/src/main.rs
+++ b/examples/gemini_default_api_recovery/src/main.rs
@@ -355,8 +355,7 @@ async fn run_workspace_canary_attempt(
         .prompt(workspace_canary_prompt(attempt))
         .add_hook(repair_hook.clone())
         .history(Vec::<rig::message::Message>::new())
-        .stream()
-        .await;
+        .stream();
 
     let mut observation = consume_workspace_like_stream(stream).await?;
     observation.invalid_tool_names = repair_hook.invalid_tool_names();

--- a/examples/gemini_default_api_recovery/src/main.rs
+++ b/examples/gemini_default_api_recovery/src/main.rs
@@ -352,7 +352,7 @@ async fn run_workspace_canary_attempt(
     let repair_hook = DefaultApiRepairHook::default();
 
     let stream = agent
-        .stream_prompt(workspace_canary_prompt(attempt))
+        .prompt(workspace_canary_prompt(attempt))
         .add_hook(repair_hook.clone())
         .history(Vec::<rig::message::Message>::new())
         .stream()

--- a/examples/openai_streaming_per_call_usage/src/main.rs
+++ b/examples/openai_streaming_per_call_usage/src/main.rs
@@ -102,7 +102,7 @@ async fn main() -> Result<()> {
         .build();
 
     let mut stream = agent
-        .stream_prompt("Check ticket RIG-usage-42 and summarize the result in one sentence.")
+        .prompt("Check ticket RIG-usage-42 and summarize the result in one sentence.")
         .max_turns(4)
         .stream()
         .await;

--- a/examples/openai_streaming_per_call_usage/src/main.rs
+++ b/examples/openai_streaming_per_call_usage/src/main.rs
@@ -104,8 +104,7 @@ async fn main() -> Result<()> {
     let mut stream = agent
         .prompt("Check ticket RIG-usage-42 and summarize the result in one sentence.")
         .max_turns(4)
-        .stream()
-        .await;
+        .stream();
 
     let mut final_response = None;
     let mut printed_streamed_text = false;

--- a/examples/openai_streaming_with_tools_otel/src/main.rs
+++ b/examples/openai_streaming_with_tools_otel/src/main.rs
@@ -149,10 +149,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .name("Bob")
         .build();
 
-    let mut stream = calculator_agent
-        .stream_prompt("Calculate 2 - 5")
-        .stream()
-        .await;
+    let mut stream = calculator_agent.prompt("Calculate 2 - 5").stream().await;
 
     let res = stream_to_stdout(&mut stream).await?;
 

--- a/examples/openai_streaming_with_tools_otel/src/main.rs
+++ b/examples/openai_streaming_with_tools_otel/src/main.rs
@@ -149,7 +149,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .name("Bob")
         .build();
 
-    let mut stream = calculator_agent.prompt("Calculate 2 - 5").stream().await;
+    let mut stream = calculator_agent.prompt("Calculate 2 - 5").stream();
 
     let res = stream_to_stdout(&mut stream).await?;
 

--- a/tests/common/reasoning.rs
+++ b/tests/common/reasoning.rs
@@ -116,7 +116,7 @@ pub(crate) async fn run_reasoning_delta_hook_streaming<M>(
         .additional_params(additional_params)
         .build();
     let mut stream = agent
-        .stream_prompt(REASONING_DELTA_HOOK_PROMPT)
+        .prompt(REASONING_DELTA_HOOK_PROMPT)
         .add_hook(hook)
         .stream()
         .await;

--- a/tests/common/reasoning.rs
+++ b/tests/common/reasoning.rs
@@ -118,8 +118,7 @@ pub(crate) async fn run_reasoning_delta_hook_streaming<M>(
     let mut stream = agent
         .prompt(REASONING_DELTA_HOOK_PROMPT)
         .add_hook(hook)
-        .stream()
-        .await;
+        .stream();
     let mut final_text = None;
     // The provider reasoning id is announced once at the block's start; the
     // deltas carry only the block id.

--- a/tests/core/golden_delta.rs
+++ b/tests/core/golden_delta.rs
@@ -60,7 +60,7 @@ async fn streamed(
     retries: usize,
 ) -> Result<String, rig::agent::StreamingError> {
     let mut stream = agent
-        .stream_prompt(PROMPT)
+        .prompt(PROMPT)
         .max_turns(max_turns)
         .max_invalid_tool_call_retries(retries)
         .unhandled_invalid_tool_call(unhandled)
@@ -341,7 +341,7 @@ async fn delta_output_tool_effect_log_is_the_golden_fixture() {
     .record_effects_with_events()
     .build();
     let mut stream = agent
-        .stream_prompt("Return a concise event object for a local Rust meetup in Seattle.")
+        .prompt("Return a concise event object for a local Rust meetup in Seattle.")
         .stream()
         .await;
     let mut output = None;

--- a/tests/core/golden_delta.rs
+++ b/tests/core/golden_delta.rs
@@ -64,8 +64,7 @@ async fn streamed(
         .max_turns(max_turns)
         .max_invalid_tool_call_retries(retries)
         .unhandled_invalid_tool_call(unhandled)
-        .stream()
-        .await;
+        .stream();
     let mut output = None;
     let mut failure = None;
     while let Some(item) = stream.next().await {
@@ -342,8 +341,7 @@ async fn delta_output_tool_effect_log_is_the_golden_fixture() {
     .build();
     let mut stream = agent
         .prompt("Return a concise event object for a local Rust meetup in Seattle.")
-        .stream()
-        .await;
+        .stream();
     let mut output = None;
     while let Some(item) = stream.next().await {
         if let MultiTurnStreamItem::FinalResponse(response) = item.expect("the stream yields") {

--- a/tests/core/golden_invalid.rs
+++ b/tests/core/golden_invalid.rs
@@ -47,7 +47,7 @@ fn stream_turn(events: Vec<MockStreamEvent>) -> Vec<MockStreamEvent> {
 }
 
 async fn streamed_output(agent: &rig::agent::Agent, max_turns: usize) -> String {
-    let mut stream = agent.prompt(PROMPT).max_turns(max_turns).stream().await;
+    let mut stream = agent.prompt(PROMPT).max_turns(max_turns).stream();
     let mut output = None;
     while let Some(item) = stream.next().await {
         if let MultiTurnStreamItem::FinalResponse(response) = item.expect("the stream yields") {
@@ -111,8 +111,7 @@ async fn invalid_streamed_retry_once_effect_log_is_the_golden_fixture() {
         .prompt(PROMPT)
         .max_turns(4)
         .max_invalid_tool_call_retries(1)
-        .stream()
-        .await;
+        .stream();
     let mut output = None;
     while let Some(item) = stream.next().await {
         if let MultiTurnStreamItem::FinalResponse(response) = item.expect("the stream yields") {
@@ -158,8 +157,7 @@ async fn invalid_streamed_retry_twice_effect_log_is_the_golden_fixture() {
         .prompt(PROMPT)
         .max_turns(5)
         .max_invalid_tool_call_retries(2)
-        .stream()
-        .await;
+        .stream();
     let mut output = None;
     while let Some(item) = stream.next().await {
         if let MultiTurnStreamItem::FinalResponse(response) = item.expect("the stream yields") {
@@ -234,8 +232,7 @@ async fn invalid_ignore_streamed_effect_log_is_the_golden_fixture() {
         .prompt(PROMPT)
         .max_turns(3)
         .unhandled_invalid_tool_call(UnhandledInvalidToolCall::Ignore)
-        .stream()
-        .await;
+        .stream();
     let mut output = None;
     while let Some(item) = stream.next().await {
         if let MultiTurnStreamItem::FinalResponse(response) = item.expect("the stream yields") {
@@ -304,8 +301,7 @@ async fn invalid_mixed_ignore_streamed_effect_log_is_the_golden_fixture() {
         .prompt(PROMPT)
         .max_turns(3)
         .unhandled_invalid_tool_call(UnhandledInvalidToolCall::Ignore)
-        .stream()
-        .await;
+        .stream();
     let mut output = None;
     while let Some(item) = stream.next().await {
         if let MultiTurnStreamItem::FinalResponse(response) = item.expect("the stream yields") {

--- a/tests/core/golden_invalid.rs
+++ b/tests/core/golden_invalid.rs
@@ -47,11 +47,7 @@ fn stream_turn(events: Vec<MockStreamEvent>) -> Vec<MockStreamEvent> {
 }
 
 async fn streamed_output(agent: &rig::agent::Agent, max_turns: usize) -> String {
-    let mut stream = agent
-        .stream_prompt(PROMPT)
-        .max_turns(max_turns)
-        .stream()
-        .await;
+    let mut stream = agent.prompt(PROMPT).max_turns(max_turns).stream().await;
     let mut output = None;
     while let Some(item) = stream.next().await {
         if let MultiTurnStreamItem::FinalResponse(response) = item.expect("the stream yields") {
@@ -112,7 +108,7 @@ async fn invalid_streamed_retry_once_effect_log_is_the_golden_fixture() {
     .record_effects_with_events()
     .build();
     let mut stream = agent
-        .stream_prompt(PROMPT)
+        .prompt(PROMPT)
         .max_turns(4)
         .max_invalid_tool_call_retries(1)
         .stream()
@@ -159,7 +155,7 @@ async fn invalid_streamed_retry_twice_effect_log_is_the_golden_fixture() {
     .record_effects_with_events()
     .build();
     let mut stream = agent
-        .stream_prompt(PROMPT)
+        .prompt(PROMPT)
         .max_turns(5)
         .max_invalid_tool_call_retries(2)
         .stream()
@@ -235,7 +231,7 @@ async fn invalid_ignore_streamed_effect_log_is_the_golden_fixture() {
     .record_effects_with_events()
     .build();
     let mut stream = agent
-        .stream_prompt(PROMPT)
+        .prompt(PROMPT)
         .max_turns(3)
         .unhandled_invalid_tool_call(UnhandledInvalidToolCall::Ignore)
         .stream()
@@ -305,7 +301,7 @@ async fn invalid_mixed_ignore_streamed_effect_log_is_the_golden_fixture() {
     .record_effects_with_events()
     .build();
     let mut stream = agent
-        .stream_prompt(PROMPT)
+        .prompt(PROMPT)
         .max_turns(3)
         .unhandled_invalid_tool_call(UnhandledInvalidToolCall::Ignore)
         .stream()

--- a/tests/core/golden_layers.rs
+++ b/tests/core/golden_layers.rs
@@ -207,10 +207,7 @@ async fn replace_streamed_cancelled_effect_log_is_the_golden_fixture() {
         .preamble(BASIC_PREAMBLE)
         .temperature(0.0)
         .build();
-    let mut stream = agent
-        .prompt("Reply with the single word: ready.")
-        .stream()
-        .await;
+    let mut stream = agent.prompt("Reply with the single word: ready.").stream();
     let mut ending = None;
     let mut texts = String::new();
     while let Some(item) = stream.next().await {

--- a/tests/core/golden_layers.rs
+++ b/tests/core/golden_layers.rs
@@ -208,7 +208,7 @@ async fn replace_streamed_cancelled_effect_log_is_the_golden_fixture() {
         .temperature(0.0)
         .build();
     let mut stream = agent
-        .stream_prompt("Reply with the single word: ready.")
+        .prompt("Reply with the single word: ready.")
         .stream()
         .await;
     let mut ending = None;

--- a/tests/core/golden_leftovers.rs
+++ b/tests/core/golden_leftovers.rs
@@ -234,7 +234,7 @@ async fn over_host(
     let agent = agent(builder);
     let output = if streamed {
         use futures::StreamExt;
-        let mut stream = agent.stream_prompt(prompt).max_turns(200).stream().await;
+        let mut stream = agent.prompt(prompt).max_turns(200).stream().await;
         let mut output = None;
         while let Some(item) = stream.next().await {
             if let rig::agent::MultiTurnStreamItem::FinalResponse(response) =

--- a/tests/core/golden_leftovers.rs
+++ b/tests/core/golden_leftovers.rs
@@ -234,7 +234,7 @@ async fn over_host(
     let agent = agent(builder);
     let output = if streamed {
         use futures::StreamExt;
-        let mut stream = agent.prompt(prompt).max_turns(200).stream().await;
+        let mut stream = agent.prompt(prompt).max_turns(200).stream();
         let mut output = None;
         while let Some(item) = stream.next().await {
             if let rig::agent::MultiTurnStreamItem::FinalResponse(response) =

--- a/tests/integrations/bedrock/streaming.rs
+++ b/tests/integrations/bedrock/streaming.rs
@@ -23,7 +23,7 @@ async fn streaming_smoke() {
         .preamble(STREAMING_PREAMBLE)
         .build();
 
-    let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");
@@ -42,7 +42,7 @@ async fn streaming_tools_smoke() {
         .tool(Subtract)
         .build();
 
-    let mut stream = agent.stream_prompt(STREAMING_TOOLS_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming tool prompt should succeed");

--- a/tests/integrations/bedrock/streaming.rs
+++ b/tests/integrations/bedrock/streaming.rs
@@ -23,7 +23,7 @@ async fn streaming_smoke() {
         .preamble(STREAMING_PREAMBLE)
         .build();
 
-    let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_PROMPT).stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");
@@ -42,7 +42,7 @@ async fn streaming_tools_smoke() {
         .tool(Subtract)
         .build();
 
-    let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming tool prompt should succeed");

--- a/tests/providers/anthropic/cassette/boxed_transport.rs
+++ b/tests/providers/anthropic/cassette/boxed_transport.rs
@@ -42,7 +42,7 @@ async fn streaming_smoke_through_boxed_transport() {
             .preamble(STREAMING_PREAMBLE)
             .build();
 
-        let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
         let (response, provider_final): (_, rig::streaming::StreamFinal) =
             collect_stream_final_response_and_provider_final(&mut stream)
                 .await

--- a/tests/providers/anthropic/cassette/boxed_transport.rs
+++ b/tests/providers/anthropic/cassette/boxed_transport.rs
@@ -42,7 +42,7 @@ async fn streaming_smoke_through_boxed_transport() {
             .preamble(STREAMING_PREAMBLE)
             .build();
 
-        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream();
         let (response, provider_final): (_, rig::streaming::StreamFinal) =
             collect_stream_final_response_and_provider_final(&mut stream)
                 .await

--- a/tests/providers/anthropic/cassette/corpus_causal.rs
+++ b/tests/providers/anthropic/cassette/corpus_causal.rs
@@ -86,7 +86,7 @@ async fn over_host(
         .tool_server_handle(server)
         .build();
     let output = if host.streamed {
-        let mut stream = agent.stream_prompt(PROMPT).max_turns(3).stream().await;
+        let mut stream = agent.prompt(PROMPT).max_turns(3).stream().await;
         let output = final_output(&mut stream).await;
         drop(stream);
         output

--- a/tests/providers/anthropic/cassette/corpus_causal.rs
+++ b/tests/providers/anthropic/cassette/corpus_causal.rs
@@ -86,7 +86,7 @@ async fn over_host(
         .tool_server_handle(server)
         .build();
     let output = if host.streamed {
-        let mut stream = agent.prompt(PROMPT).max_turns(3).stream().await;
+        let mut stream = agent.prompt(PROMPT).max_turns(3).stream();
         let output = final_output(&mut stream).await;
         drop(stream);
         output

--- a/tests/providers/anthropic/cassette/corpus_endings.rs
+++ b/tests/providers/anthropic/cassette/corpus_endings.rs
@@ -160,7 +160,7 @@ async fn streamed_run(
         Streamed::Note => NOTE_PROMPT,
     };
     {
-        let mut stream = agent.prompt(prompt).max_turns(3).stream().await;
+        let mut stream = agent.prompt(prompt).max_turns(3).stream();
         assert_eq!(streamed_cancel(&mut stream).await, reason);
     }
     for _ in 0..64 {

--- a/tests/providers/anthropic/cassette/corpus_endings.rs
+++ b/tests/providers/anthropic/cassette/corpus_endings.rs
@@ -160,7 +160,7 @@ async fn streamed_run(
         Streamed::Note => NOTE_PROMPT,
     };
     {
-        let mut stream = agent.stream_prompt(prompt).max_turns(3).stream().await;
+        let mut stream = agent.prompt(prompt).max_turns(3).stream().await;
         assert_eq!(streamed_cancel(&mut stream).await, reason);
     }
     for _ in 0..64 {

--- a/tests/providers/anthropic/cassette/corpus_hooks.rs
+++ b/tests/providers/anthropic/cassette/corpus_hooks.rs
@@ -198,7 +198,7 @@ async fn patch_tool_args_streamed_effect_log_is_the_golden_fixture() {
                 .add_hook(PatchAddArgs)
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.stream_prompt(ADD_PROMPT).max_turns(3).stream().await;
+            let mut stream = agent.prompt(ADD_PROMPT).max_turns(3).stream().await;
             let output = final_output(&mut stream).await;
             drop(stream);
             assert!(output.contains("42"), "{output}");
@@ -263,7 +263,7 @@ async fn deny_tool_streamed_effect_log_is_the_golden_fixture() {
             .add_hook(DenyAdd)
             .record_effects_with_events()
             .build();
-        let mut stream = agent.stream_prompt(ADD_PROMPT).max_turns(3).stream().await;
+        let mut stream = agent.prompt(ADD_PROMPT).max_turns(3).stream().await;
         let output = final_output(&mut stream).await;
         drop(stream);
         assert!(!output.is_empty());

--- a/tests/providers/anthropic/cassette/corpus_hooks.rs
+++ b/tests/providers/anthropic/cassette/corpus_hooks.rs
@@ -198,7 +198,7 @@ async fn patch_tool_args_streamed_effect_log_is_the_golden_fixture() {
                 .add_hook(PatchAddArgs)
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.prompt(ADD_PROMPT).max_turns(3).stream().await;
+            let mut stream = agent.prompt(ADD_PROMPT).max_turns(3).stream();
             let output = final_output(&mut stream).await;
             drop(stream);
             assert!(output.contains("42"), "{output}");
@@ -263,7 +263,7 @@ async fn deny_tool_streamed_effect_log_is_the_golden_fixture() {
             .add_hook(DenyAdd)
             .record_effects_with_events()
             .build();
-        let mut stream = agent.prompt(ADD_PROMPT).max_turns(3).stream().await;
+        let mut stream = agent.prompt(ADD_PROMPT).max_turns(3).stream();
         let output = final_output(&mut stream).await;
         drop(stream);
         assert!(!output.is_empty());

--- a/tests/providers/anthropic/cassette/corpus_host.rs
+++ b/tests/providers/anthropic/cassette/corpus_host.rs
@@ -126,7 +126,7 @@ async fn over_host(
     };
     let prompt = if host.with_tool { ADD_PROMPT } else { PROMPT };
     let output = if host.streamed {
-        let mut stream = agent.prompt(prompt).max_turns(3).stream().await;
+        let mut stream = agent.prompt(prompt).max_turns(3).stream();
         let output = final_output(&mut stream).await;
         drop(stream);
         output

--- a/tests/providers/anthropic/cassette/corpus_host.rs
+++ b/tests/providers/anthropic/cassette/corpus_host.rs
@@ -126,7 +126,7 @@ async fn over_host(
     };
     let prompt = if host.with_tool { ADD_PROMPT } else { PROMPT };
     let output = if host.streamed {
-        let mut stream = agent.stream_prompt(prompt).max_turns(3).stream().await;
+        let mut stream = agent.prompt(prompt).max_turns(3).stream().await;
         let output = final_output(&mut stream).await;
         drop(stream);
         output

--- a/tests/providers/anthropic/cassette/corpus_memory.rs
+++ b/tests/providers/anthropic/cassette/corpus_memory.rs
@@ -82,7 +82,7 @@ async fn run_prompts(agent: &rig::agent::Agent, prompts: &[&str], streamed: bool
     let mut outputs = Vec::new();
     for prompt in prompts {
         let output = if streamed {
-            let mut stream = agent.prompt(*prompt).max_turns(8).stream().await;
+            let mut stream = agent.prompt(*prompt).max_turns(8).stream();
             let output = final_output(&mut stream).await;
             drop(stream);
             output

--- a/tests/providers/anthropic/cassette/corpus_memory.rs
+++ b/tests/providers/anthropic/cassette/corpus_memory.rs
@@ -82,7 +82,7 @@ async fn run_prompts(agent: &rig::agent::Agent, prompts: &[&str], streamed: bool
     let mut outputs = Vec::new();
     for prompt in prompts {
         let output = if streamed {
-            let mut stream = agent.stream_prompt(*prompt).max_turns(8).stream().await;
+            let mut stream = agent.prompt(*prompt).max_turns(8).stream().await;
             let output = final_output(&mut stream).await;
             drop(stream);
             output

--- a/tests/providers/anthropic/cassette/corpus_outcome.rs
+++ b/tests/providers/anthropic/cassette/corpus_outcome.rs
@@ -70,7 +70,7 @@ async fn cancel_after_tool_call_delta_effect_log_is_the_golden_fixture() {
                 .record_effects_with_events()
                 .build();
             {
-                let mut stream = agent.stream_prompt(NOTE_PROMPT).max_turns(3).stream().await;
+                let mut stream = agent.prompt(NOTE_PROMPT).max_turns(3).stream().await;
                 while let Some(item) = stream.next().await {
                     if let Ok(MultiTurnStreamItem::StreamAssistantItem(StreamEvent::BlockDelta {
                         delta: Delta::ToolName { .. } | Delta::ToolArguments { .. },
@@ -148,7 +148,7 @@ async fn tool_error_streamed_effect_log_is_the_golden_fixture() {
                 .tool(FailingAdd)
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.stream_prompt(ADD_PROMPT).max_turns(3).stream().await;
+            let mut stream = agent.prompt(ADD_PROMPT).max_turns(3).stream().await;
             let output = final_output(&mut stream).await;
             drop(stream);
             assert!(!output.is_empty());
@@ -214,7 +214,7 @@ async fn model_error_streamed_effect_log_is_the_golden_fixture() {
             .temperature(0.0)
             .record_effects_with_events()
             .build();
-        let mut stream = agent.stream_prompt(BASIC_PROMPT).stream().await;
+        let mut stream = agent.prompt(BASIC_PROMPT).stream().await;
         let mut kinds = Vec::new();
         while let Some(item) = stream.next().await {
             if let Err(error) = item {

--- a/tests/providers/anthropic/cassette/corpus_outcome.rs
+++ b/tests/providers/anthropic/cassette/corpus_outcome.rs
@@ -70,7 +70,7 @@ async fn cancel_after_tool_call_delta_effect_log_is_the_golden_fixture() {
                 .record_effects_with_events()
                 .build();
             {
-                let mut stream = agent.prompt(NOTE_PROMPT).max_turns(3).stream().await;
+                let mut stream = agent.prompt(NOTE_PROMPT).max_turns(3).stream();
                 while let Some(item) = stream.next().await {
                     if let Ok(MultiTurnStreamItem::StreamAssistantItem(StreamEvent::BlockDelta {
                         delta: Delta::ToolName { .. } | Delta::ToolArguments { .. },
@@ -148,7 +148,7 @@ async fn tool_error_streamed_effect_log_is_the_golden_fixture() {
                 .tool(FailingAdd)
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.prompt(ADD_PROMPT).max_turns(3).stream().await;
+            let mut stream = agent.prompt(ADD_PROMPT).max_turns(3).stream();
             let output = final_output(&mut stream).await;
             drop(stream);
             assert!(!output.is_empty());
@@ -214,7 +214,7 @@ async fn model_error_streamed_effect_log_is_the_golden_fixture() {
             .temperature(0.0)
             .record_effects_with_events()
             .build();
-        let mut stream = agent.prompt(BASIC_PROMPT).stream().await;
+        let mut stream = agent.prompt(BASIC_PROMPT).stream();
         let mut kinds = Vec::new();
         while let Some(item) = stream.next().await {
             if let Err(error) = item {

--- a/tests/providers/anthropic/cassette/corpus_output.rs
+++ b/tests/providers/anthropic/cassette/corpus_output.rs
@@ -109,7 +109,7 @@ async fn tool_streamed_effect_log_is_the_golden_fixture() {
             .output_mode(OutputMode::Tool)
             .record_effects_with_events()
             .build();
-        let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
+        let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream();
         let output = final_output(&mut stream).await;
         drop(stream);
         assert_event(&output);
@@ -170,7 +170,7 @@ async fn prompted_streamed_effect_log_is_the_golden_fixture() {
             .output_mode(OutputMode::Prompted)
             .record_effects_with_events()
             .build();
-        let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
+        let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream();
         let output = final_output(&mut stream).await;
         drop(stream);
         assert_event(&output);

--- a/tests/providers/anthropic/cassette/corpus_output.rs
+++ b/tests/providers/anthropic/cassette/corpus_output.rs
@@ -109,7 +109,7 @@ async fn tool_streamed_effect_log_is_the_golden_fixture() {
             .output_mode(OutputMode::Tool)
             .record_effects_with_events()
             .build();
-        let mut stream = agent.stream_prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
+        let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
         let output = final_output(&mut stream).await;
         drop(stream);
         assert_event(&output);
@@ -170,7 +170,7 @@ async fn prompted_streamed_effect_log_is_the_golden_fixture() {
             .output_mode(OutputMode::Prompted)
             .record_effects_with_events()
             .build();
-        let mut stream = agent.stream_prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
+        let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
         let output = final_output(&mut stream).await;
         drop(stream);
         assert_event(&output);

--- a/tests/providers/anthropic/cassette/corpus_request_shape.rs
+++ b/tests/providers/anthropic/cassette/corpus_request_shape.rs
@@ -320,7 +320,7 @@ async fn thinking_streamed_effect_log_is_the_golden_fixture() {
                 .additional_params(thinking_params())
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.stream_prompt(THINKING_PROMPT).stream().await;
+            let mut stream = agent.prompt(THINKING_PROMPT).stream().await;
             let mut output = None;
             while let Some(item) = stream.next().await {
                 if let MultiTurnStreamItem::FinalResponse(response) =
@@ -476,7 +476,7 @@ async fn output_schema_streamed_effect_log_is_the_golden_fixture() {
                 .output_schema_raw(event_schema())
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.stream_prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
+            let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
             let mut output = None;
             while let Some(item) = stream.next().await {
                 if let MultiTurnStreamItem::FinalResponse(response) =

--- a/tests/providers/anthropic/cassette/corpus_request_shape.rs
+++ b/tests/providers/anthropic/cassette/corpus_request_shape.rs
@@ -320,7 +320,7 @@ async fn thinking_streamed_effect_log_is_the_golden_fixture() {
                 .additional_params(thinking_params())
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.prompt(THINKING_PROMPT).stream().await;
+            let mut stream = agent.prompt(THINKING_PROMPT).stream();
             let mut output = None;
             while let Some(item) = stream.next().await {
                 if let MultiTurnStreamItem::FinalResponse(response) =
@@ -476,7 +476,7 @@ async fn output_schema_streamed_effect_log_is_the_golden_fixture() {
                 .output_schema_raw(event_schema())
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
+            let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream();
             let mut output = None;
             while let Some(item) = stream.next().await {
                 if let MultiTurnStreamItem::FinalResponse(response) =

--- a/tests/providers/anthropic/cassette/corpus_serving.rs
+++ b/tests/providers/anthropic/cassette/corpus_serving.rs
@@ -63,7 +63,7 @@ async fn two_tools(
     };
     let agent = builder.build();
     let mut stream = agent
-        .stream_prompt(TWO_TOOL_STREAM_PROMPT)
+        .prompt(TWO_TOOL_STREAM_PROMPT)
         .max_turns(8)
         .tool_concurrency(concurrency)
         .stream()
@@ -341,7 +341,7 @@ async fn over_host_bus(
         .build();
     assert_eq!(agent.bus_config(), None, "the policy is the host's");
     let output = if streamed {
-        let mut stream = agent.stream_prompt(ADD_PROMPT).max_turns(3).stream().await;
+        let mut stream = agent.prompt(ADD_PROMPT).max_turns(3).stream().await;
         let output = final_output(&mut stream).await;
         drop(stream);
         output

--- a/tests/providers/anthropic/cassette/corpus_serving.rs
+++ b/tests/providers/anthropic/cassette/corpus_serving.rs
@@ -66,8 +66,7 @@ async fn two_tools(
         .prompt(TWO_TOOL_STREAM_PROMPT)
         .max_turns(8)
         .tool_concurrency(concurrency)
-        .stream()
-        .await;
+        .stream();
     let output = tokio::time::timeout(std::time::Duration::from_secs(5), final_output(&mut stream))
         .await
         .expect("two tools never wait on each other");
@@ -341,7 +340,7 @@ async fn over_host_bus(
         .build();
     assert_eq!(agent.bus_config(), None, "the policy is the host's");
     let output = if streamed {
-        let mut stream = agent.prompt(ADD_PROMPT).max_turns(3).stream().await;
+        let mut stream = agent.prompt(ADD_PROMPT).max_turns(3).stream();
         let output = final_output(&mut stream).await;
         drop(stream);
         output

--- a/tests/providers/anthropic/cassette/corpus_shaping.rs
+++ b/tests/providers/anthropic/cassette/corpus_shaping.rs
@@ -167,7 +167,7 @@ async fn extra_context_streamed_effect_log_is_the_golden_fixture() {
                 .add_hook(PatchExtraContext)
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.stream_prompt(CONTEXT_PROMPT).stream().await;
+            let mut stream = agent.prompt(CONTEXT_PROMPT).stream().await;
             let mut output = None;
             while let Some(item) = stream.next().await {
                 if let MultiTurnStreamItem::FinalResponse(response) =

--- a/tests/providers/anthropic/cassette/corpus_shaping.rs
+++ b/tests/providers/anthropic/cassette/corpus_shaping.rs
@@ -167,7 +167,7 @@ async fn extra_context_streamed_effect_log_is_the_golden_fixture() {
                 .add_hook(PatchExtraContext)
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.prompt(CONTEXT_PROMPT).stream().await;
+            let mut stream = agent.prompt(CONTEXT_PROMPT).stream();
             let mut output = None;
             while let Some(item) = stream.next().await {
                 if let MultiTurnStreamItem::FinalResponse(response) =

--- a/tests/providers/anthropic/cassette/document_file_id.rs
+++ b/tests/providers/anthropic/cassette/document_file_id.rs
@@ -463,7 +463,7 @@ async fn streaming_document_file_id_roundtrip_live() {
                 assert_no_verifier_leaked_into_prompt(&stream_prompt);
                 assert_anthropic_wire_file_source(stream_prompt.clone(), &file_id);
 
-                let mut stream = agent.prompt(stream_prompt).stream().await;
+                let mut stream = agent.prompt(stream_prompt).stream();
                 let response = collect_stream_final_response(&mut stream)
                     .await
                     .expect("streaming Messages API should read uploaded PDF by file_id");

--- a/tests/providers/anthropic/cassette/document_file_id.rs
+++ b/tests/providers/anthropic/cassette/document_file_id.rs
@@ -463,7 +463,7 @@ async fn streaming_document_file_id_roundtrip_live() {
                 assert_no_verifier_leaked_into_prompt(&stream_prompt);
                 assert_anthropic_wire_file_source(stream_prompt.clone(), &file_id);
 
-                let mut stream = agent.stream_prompt(stream_prompt).stream().await;
+                let mut stream = agent.prompt(stream_prompt).stream().await;
                 let response = collect_stream_final_response(&mut stream)
                     .await
                     .expect("streaming Messages API should read uploaded PDF by file_id");

--- a/tests/providers/anthropic/cassette/effect_corpus.rs
+++ b/tests/providers/anthropic/cassette/effect_corpus.rs
@@ -67,9 +67,7 @@ async fn cancelled_stream_effect_log_is_the_golden_fixture() {
             .build();
         {
             let mut stream = agent
-                .stream_prompt(
-                    "Write a 600-word essay on the history of the Rust programming language.",
-                )
+                .prompt("Write a 600-word essay on the history of the Rust programming language.")
                 .stream()
                 .await;
             while let Some(item) = stream.next().await {

--- a/tests/providers/anthropic/cassette/effect_corpus.rs
+++ b/tests/providers/anthropic/cassette/effect_corpus.rs
@@ -68,8 +68,7 @@ async fn cancelled_stream_effect_log_is_the_golden_fixture() {
         {
             let mut stream = agent
                 .prompt("Write a 600-word essay on the history of the Rust programming language.")
-                .stream()
-                .await;
+                .stream();
             while let Some(item) = stream.next().await {
                 if let Ok(MultiTurnStreamItem::StreamAssistantItem(StreamEvent::BlockDelta {
                     delta: Delta::Text { .. },

--- a/tests/providers/anthropic/cassette/empty_stop_sequence_matrix.rs
+++ b/tests/providers/anthropic/cassette/empty_stop_sequence_matrix.rs
@@ -305,7 +305,7 @@ async fn agent_stream_empty_stop_sequence() {
                 .additional_params(json!({ "stop_sequences": ["alpha"] }))
                 .build();
 
-            let mut stream = agent.prompt(IMMEDIATE_PROMPT).stream().await;
+            let mut stream = agent.prompt(IMMEDIATE_PROMPT).stream();
             let mut errors = Vec::new();
             let mut final_output = None;
             let mut completion_finish = None;

--- a/tests/providers/anthropic/cassette/empty_stop_sequence_matrix.rs
+++ b/tests/providers/anthropic/cassette/empty_stop_sequence_matrix.rs
@@ -305,7 +305,7 @@ async fn agent_stream_empty_stop_sequence() {
                 .additional_params(json!({ "stop_sequences": ["alpha"] }))
                 .build();
 
-            let mut stream = agent.stream_prompt(IMMEDIATE_PROMPT).stream().await;
+            let mut stream = agent.prompt(IMMEDIATE_PROMPT).stream().await;
             let mut errors = Vec::new();
             let mut final_output = None;
             let mut completion_finish = None;

--- a/tests/providers/anthropic/cassette/error_identity_edge.rs
+++ b/tests/providers/anthropic/cassette/error_identity_edge.rs
@@ -195,8 +195,7 @@ async fn streamed_agent_run_failure_exposes_error_identity_accessors() {
 
             let mut stream = agent
                 .prompt(rig::completion::Message::user("Never authenticated"))
-                .stream()
-                .await;
+                .stream();
             let mut surfaced = None;
             while let Some(item) = stream.next().await {
                 if let Err(error) = item {

--- a/tests/providers/anthropic/cassette/error_identity_edge.rs
+++ b/tests/providers/anthropic/cassette/error_identity_edge.rs
@@ -194,7 +194,7 @@ async fn streamed_agent_run_failure_exposes_error_identity_accessors() {
                 .build();
 
             let mut stream = agent
-                .runner(rig::completion::Message::user("Never authenticated"))
+                .prompt(rig::completion::Message::user("Never authenticated"))
                 .stream()
                 .await;
             let mut surfaced = None;

--- a/tests/providers/anthropic/cassette/lifecycle_matrix.rs
+++ b/tests/providers/anthropic/cassette/lifecycle_matrix.rs
@@ -53,7 +53,7 @@ async fn middleware_response_phase_precedes_stream_consumption() {
                 .preamble(STREAMING_PREAMBLE)
                 .add_hook(settle_hook)
                 .build();
-            let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_PROMPT).stream();
             let (response, provider_final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await
@@ -119,8 +119,7 @@ async fn entry_log_orders_and_turn_stamps_across_a_streamed_tool_run() {
             let mut stream = agent
                 .prompt("What is 9 + 16? Use the add tool, then reply with just the number.")
                 .max_turns(3)
-                .stream()
-                .await;
+                .stream();
             let (response, _final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await

--- a/tests/providers/anthropic/cassette/lifecycle_matrix.rs
+++ b/tests/providers/anthropic/cassette/lifecycle_matrix.rs
@@ -53,7 +53,7 @@ async fn middleware_response_phase_precedes_stream_consumption() {
                 .preamble(STREAMING_PREAMBLE)
                 .add_hook(settle_hook)
                 .build();
-            let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
             let (response, provider_final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await
@@ -117,7 +117,7 @@ async fn entry_log_orders_and_turn_stamps_across_a_streamed_tool_run() {
                 .add_hook(agent_hook)
                 .build();
             let mut stream = agent
-                .stream_prompt("What is 9 + 16? Use the add tool, then reply with just the number.")
+                .prompt("What is 9 + 16? Use the add tool, then reply with just the number.")
                 .max_turns(3)
                 .stream()
                 .await;

--- a/tests/providers/anthropic/cassette/messages_sessions.rs
+++ b/tests/providers/anthropic/cassette/messages_sessions.rs
@@ -157,7 +157,8 @@ async fn sequential_tool_calls_streaming() {
                 .build();
 
             let mut stream = agent
-                .stream_chat(SEQUENTIAL_TOOLS_PROMPT, Vec::<Message>::new())
+                .prompt(SEQUENTIAL_TOOLS_PROMPT)
+                .history(Vec::<Message>::new())
                 .max_turns(6)
                 .stream()
                 .await;
@@ -388,7 +389,7 @@ async fn usage_accumulates_across_streaming_multi_turn() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(ORDERED_TOOL_STREAM_PROMPT)
+                .prompt(ORDERED_TOOL_STREAM_PROMPT)
                 .max_turns(5)
                 .stream()
                 .await;

--- a/tests/providers/anthropic/cassette/messages_sessions.rs
+++ b/tests/providers/anthropic/cassette/messages_sessions.rs
@@ -160,8 +160,7 @@ async fn sequential_tool_calls_streaming() {
                 .prompt(SEQUENTIAL_TOOLS_PROMPT)
                 .history(Vec::<Message>::new())
                 .max_turns(6)
-                .stream()
-                .await;
+                .stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert!(
@@ -391,8 +390,7 @@ async fn usage_accumulates_across_streaming_multi_turn() {
             let mut stream = agent
                 .prompt(ORDERED_TOOL_STREAM_PROMPT)
                 .max_turns(5)
-                .stream()
-                .await;
+                .stream();
 
             let mut saw_tool_result = false;
             let mut final_usage = None;

--- a/tests/providers/anthropic/cassette/multi_turn_streaming.rs
+++ b/tests/providers/anthropic/cassette/multi_turn_streaming.rs
@@ -182,8 +182,7 @@ async fn multi_turn_streaming_tools() {
             let mut stream = agent
                 .prompt(MULTI_TURN_STREAMING_PROMPT)
                 .max_turns(10)
-                .stream()
-                .await;
+                .stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert!(

--- a/tests/providers/anthropic/cassette/multi_turn_streaming.rs
+++ b/tests/providers/anthropic/cassette/multi_turn_streaming.rs
@@ -180,7 +180,7 @@ async fn multi_turn_streaming_tools() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(MULTI_TURN_STREAMING_PROMPT)
+                .prompt(MULTI_TURN_STREAMING_PROMPT)
                 .max_turns(10)
                 .stream()
                 .await;

--- a/tests/providers/anthropic/cassette/opus_4_7.rs
+++ b/tests/providers/anthropic/cassette/opus_4_7.rs
@@ -55,7 +55,7 @@ async fn messages_streaming_prompt_smoke() {
                 .preamble(STREAMING_PREAMBLE)
                 .build();
 
-            let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming prompt should succeed");
@@ -104,7 +104,7 @@ async fn messages_streaming_tools_smoke() {
                 .default_max_turns(2)
                 .build();
 
-            let mut stream = agent.stream_prompt(STREAMING_TOOLS_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");
@@ -332,7 +332,8 @@ async fn messages_adaptive_thinking_streaming_tool_roundtrip_smoke() {
                 .build();
 
             let stream = agent
-                .stream_chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+                .prompt(reasoning::TOOL_USER_PROMPT)
+                .history(Vec::<Message>::new())
                 .max_turns(3)
                 .stream()
                 .await;

--- a/tests/providers/anthropic/cassette/opus_4_7.rs
+++ b/tests/providers/anthropic/cassette/opus_4_7.rs
@@ -55,7 +55,7 @@ async fn messages_streaming_prompt_smoke() {
                 .preamble(STREAMING_PREAMBLE)
                 .build();
 
-            let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_PROMPT).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming prompt should succeed");
@@ -104,7 +104,7 @@ async fn messages_streaming_tools_smoke() {
                 .default_max_turns(2)
                 .build();
 
-            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");
@@ -335,8 +335,7 @@ async fn messages_adaptive_thinking_streaming_tool_roundtrip_smoke() {
                 .prompt(reasoning::TOOL_USER_PROMPT)
                 .history(Vec::<Message>::new())
                 .max_turns(3)
-                .stream()
-                .await;
+                .stream();
 
             let stats = reasoning::collect_stream_stats(stream, "anthropic").await;
             reasoning::assert_universal(&stats, &call_count, "anthropic");

--- a/tests/providers/anthropic/cassette/plaintext_document.rs
+++ b/tests/providers/anthropic/cassette/plaintext_document.rs
@@ -151,7 +151,7 @@ async fn streaming_document_citations_accepts_null_citation_start() {
                 .temperature(0.0)
                 .build();
 
-            let mut stream = agent.prompt(citation_prompt()).stream().await;
+            let mut stream = agent.prompt(citation_prompt()).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming document citations should accept null citations on text start");

--- a/tests/providers/anthropic/cassette/plaintext_document.rs
+++ b/tests/providers/anthropic/cassette/plaintext_document.rs
@@ -151,7 +151,7 @@ async fn streaming_document_citations_accepts_null_citation_start() {
                 .temperature(0.0)
                 .build();
 
-            let mut stream = agent.stream_prompt(citation_prompt()).stream().await;
+            let mut stream = agent.prompt(citation_prompt()).stream().await;
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming document citations should accept null citations on text start");

--- a/tests/providers/anthropic/cassette/raw_capture_agent_matrix.rs
+++ b/tests/providers/anthropic/cassette/raw_capture_agent_matrix.rs
@@ -316,13 +316,7 @@ async fn hooks_observe_raw_streamed() {
                 .max_tokens(32)
                 .add_hook(hook)
                 .build();
-            let run = drain(
-                agent
-                    .stream_prompt(Message::user(TEXT_PROMPT))
-                    .stream()
-                    .await,
-            )
-            .await;
+            let run = drain(agent.prompt(Message::user(TEXT_PROMPT)).stream().await).await;
             assert!(run.output.is_some(), "the run finished");
             assert_eq!(run.finals.len(), 1, "one text turn, one terminal record");
             assert!(
@@ -431,7 +425,7 @@ async fn multi_turn_tool_run_records_distinct_raw_streamed() {
                 .build();
             let run = drain(
                 agent
-                    .stream_prompt(Message::user(TOOL_PROMPT))
+                    .prompt(Message::user(TOOL_PROMPT))
                     .max_turns(3)
                     .stream()
                     .await,
@@ -487,7 +481,7 @@ async fn streamed_final_carries_final_turn_raw() {
                 .build();
             let run = drain(
                 agent
-                    .stream_prompt(Message::user(TOOL_PROMPT))
+                    .prompt(Message::user(TOOL_PROMPT))
                     .max_turns(3)
                     .stream()
                     .await,
@@ -593,7 +587,7 @@ async fn retried_turn_records_retried_attempt_raw_streamed() {
                 .build();
             let run = drain(
                 agent
-                    .stream_prompt(Message::user(TEXT_PROMPT))
+                    .prompt(Message::user(TEXT_PROMPT))
                     .max_turns(3)
                     .stream()
                     .await,

--- a/tests/providers/anthropic/cassette/raw_capture_agent_matrix.rs
+++ b/tests/providers/anthropic/cassette/raw_capture_agent_matrix.rs
@@ -18,12 +18,12 @@
 //! | # | Cell | Dimension | expected | Status |
 //! |---|------|-----------|----------|--------|
 //! | 1 | `hooks_observe_raw_blocking` | `agent.prompt` | `CompletionResponse` and `ModelTurnFinished` see `raw`; `id` matches fixture | recorded |
-//! | 2 | `hooks_observe_raw_streamed` | `agent.stream_prompt` | `CompletionResponse` and `ModelTurnFinished` see `raw`; `message_id` matches fixture | recorded |
+//! | 2 | `hooks_observe_raw_streamed` | `agent.prompt(..).stream()` | `CompletionResponse` and `ModelTurnFinished` see `raw`; `message_id` matches fixture | recorded |
 //! | 3 | `multi_turn_tool_run_records_distinct_raw_blocking` | tool run, `agent.prompt` | two `completion_calls`, two different `raw["id"]`s equal to the interactions' ids in order | recorded |
-//! | 4 | `multi_turn_tool_run_records_distinct_raw_streamed` | tool run, `agent.stream_prompt` | two `CompletionCall` items, two different `raw["message_id"]`s equal to the interactions' ids in order | recorded |
-//! | 5 | `streamed_final_carries_final_turn_raw` | tool run, `agent.stream_prompt` | the last `StreamEvent::Final.raw["message_id"]` is the last interaction's id | recorded |
+//! | 4 | `multi_turn_tool_run_records_distinct_raw_streamed` | tool run, `agent.prompt(..).stream()` | two `CompletionCall` items, two different `raw["message_id"]`s equal to the interactions' ids in order | recorded |
+//! | 5 | `streamed_final_carries_final_turn_raw` | tool run, `agent.prompt(..).stream()` | the last `StreamEvent::Final.raw["message_id"]` is the last interaction's id | recorded |
 //! | 6 | `retried_turn_records_retried_attempt_raw_blocking` | `ModelTurnFinished` → `Retry` once, `agent.prompt` | second recorded call / second event carry the second interaction's `id` | recorded |
-//! | 7 | `retried_turn_records_retried_attempt_raw_streamed` | same, `agent.stream_prompt` | same, by `message_id` | recorded |
+//! | 7 | `retried_turn_records_retried_attempt_raw_streamed` | same, `agent.prompt(..).stream()` | same, by `message_id` | recorded |
 //!
 //! Both surfaces fire the same two events per accepted model turn:
 //! `CompletionResponse` — after the unary call returns on the blocking

--- a/tests/providers/anthropic/cassette/raw_capture_agent_matrix.rs
+++ b/tests/providers/anthropic/cassette/raw_capture_agent_matrix.rs
@@ -316,7 +316,7 @@ async fn hooks_observe_raw_streamed() {
                 .max_tokens(32)
                 .add_hook(hook)
                 .build();
-            let run = drain(agent.prompt(Message::user(TEXT_PROMPT)).stream().await).await;
+            let run = drain(agent.prompt(Message::user(TEXT_PROMPT)).stream()).await;
             assert!(run.output.is_some(), "the run finished");
             assert_eq!(run.finals.len(), 1, "one text turn, one terminal record");
             assert!(
@@ -427,8 +427,7 @@ async fn multi_turn_tool_run_records_distinct_raw_streamed() {
                 agent
                     .prompt(Message::user(TOOL_PROMPT))
                     .max_turns(3)
-                    .stream()
-                    .await,
+                    .stream(),
             )
             .await;
             assert!(run.output.is_some(), "the run finished");
@@ -483,8 +482,7 @@ async fn streamed_final_carries_final_turn_raw() {
                 agent
                     .prompt(Message::user(TOOL_PROMPT))
                     .max_turns(3)
-                    .stream()
-                    .await,
+                    .stream(),
             )
             .await;
             assert_eq!(
@@ -589,8 +587,7 @@ async fn retried_turn_records_retried_attempt_raw_streamed() {
                 agent
                     .prompt(Message::user(TEXT_PROMPT))
                     .max_turns(3)
-                    .stream()
-                    .await,
+                    .stream(),
             )
             .await;
             assert!(run.output.is_some());

--- a/tests/providers/anthropic/cassette/reasoning_tool_roundtrip.rs
+++ b/tests/providers/anthropic/cassette/reasoning_tool_roundtrip.rs
@@ -31,8 +31,7 @@ async fn streaming() {
             .prompt(reasoning::TOOL_USER_PROMPT)
             .history(Vec::<Message>::new())
             .max_turns(3)
-            .stream()
-            .await;
+            .stream();
 
         let stats = reasoning::collect_stream_stats(stream, "anthropic").await;
         reasoning::assert_universal(&stats, &call_count, "anthropic");

--- a/tests/providers/anthropic/cassette/reasoning_tool_roundtrip.rs
+++ b/tests/providers/anthropic/cassette/reasoning_tool_roundtrip.rs
@@ -28,7 +28,8 @@ async fn streaming() {
             .build();
 
         let stream = agent
-            .stream_chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+            .prompt(reasoning::TOOL_USER_PROMPT)
+            .history(Vec::<Message>::new())
             .max_turns(3)
             .stream()
             .await;

--- a/tests/providers/anthropic/cassette/regression_suite.rs
+++ b/tests/providers/anthropic/cassette/regression_suite.rs
@@ -34,7 +34,7 @@ async fn max_tokens_truncation_surfaces_as_length() {
             .build();
 
         let mut stream = agent
-            .stream_prompt("Write a detailed five paragraph essay about the ocean.")
+            .prompt("Write a detailed five paragraph essay about the ocean.")
             .stream()
             .await;
         let (_response, provider_final): (_, rig::streaming::StreamFinal) =
@@ -65,7 +65,7 @@ async fn natural_stop_surfaces_as_stop() {
             .max_tokens(512)
             .build();
 
-        let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
         let (_response, provider_final): (_, rig::streaming::StreamFinal) =
             collect_stream_final_response_and_provider_final(&mut stream)
                 .await
@@ -122,7 +122,7 @@ async fn cache_hit_turn_reports_uncached_remainder_not_prompt_size() {
                     .max_tokens(32)
                     .build();
                 let mut stream = agent
-                    .stream_prompt("Reply with exactly: cache probe ready")
+                    .prompt("Reply with exactly: cache probe ready")
                     .stream()
                     .await;
                 let (_text, provider_final): (_, rig::streaming::StreamFinal) =

--- a/tests/providers/anthropic/cassette/regression_suite.rs
+++ b/tests/providers/anthropic/cassette/regression_suite.rs
@@ -35,8 +35,7 @@ async fn max_tokens_truncation_surfaces_as_length() {
 
         let mut stream = agent
             .prompt("Write a detailed five paragraph essay about the ocean.")
-            .stream()
-            .await;
+            .stream();
         let (_response, provider_final): (_, rig::streaming::StreamFinal) =
             collect_stream_final_response_and_provider_final(&mut stream)
                 .await
@@ -65,7 +64,7 @@ async fn natural_stop_surfaces_as_stop() {
             .max_tokens(512)
             .build();
 
-        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream();
         let (_response, provider_final): (_, rig::streaming::StreamFinal) =
             collect_stream_final_response_and_provider_final(&mut stream)
                 .await
@@ -123,8 +122,7 @@ async fn cache_hit_turn_reports_uncached_remainder_not_prompt_size() {
                     .build();
                 let mut stream = agent
                     .prompt("Reply with exactly: cache probe ready")
-                    .stream()
-                    .await;
+                    .stream();
                 let (_text, provider_final): (_, rig::streaming::StreamFinal) =
                     collect_stream_final_response_and_provider_final(&mut stream)
                         .await

--- a/tests/providers/anthropic/cassette/request_override.rs
+++ b/tests/providers/anthropic/cassette/request_override.rs
@@ -241,7 +241,7 @@ async fn request_overridden_by_hook_streaming() {
                 .add_hook(ForceWeatherOnlyOnFirstTurn)
                 .build();
 
-            let mut stream = agent.stream_prompt(PROMPT).max_turns(5).stream().await;
+            let mut stream = agent.prompt(PROMPT).max_turns(5).stream().await;
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming prompt should succeed");

--- a/tests/providers/anthropic/cassette/request_override.rs
+++ b/tests/providers/anthropic/cassette/request_override.rs
@@ -241,7 +241,7 @@ async fn request_overridden_by_hook_streaming() {
                 .add_hook(ForceWeatherOnlyOnFirstTurn)
                 .build();
 
-            let mut stream = agent.prompt(PROMPT).max_turns(5).stream().await;
+            let mut stream = agent.prompt(PROMPT).max_turns(5).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming prompt should succeed");

--- a/tests/providers/anthropic/cassette/response_identity.rs
+++ b/tests/providers/anthropic/cassette/response_identity.rs
@@ -211,8 +211,7 @@ async fn streamed_agent_run_hook_observes_identity() {
                 .prompt(Message::user(
                     "Reply with exactly: streamed hook identity probe",
                 ))
-                .stream()
-                .await;
+                .stream();
             while let Some(item) = stream.next().await {
                 item.expect("stream item should succeed");
             }
@@ -268,8 +267,7 @@ async fn streamed_agent_tool_run_reports_per_attempt_identity() {
                     "What is 2 + 3? Use the tool, then state the result.",
                 ))
                 .max_turns(3)
-                .stream()
-                .await;
+                .stream();
             let mut completion_calls = Vec::new();
             while let Some(item) = stream.next().await {
                 if let rig::agent::MultiTurnStreamItem::CompletionCall(call) =

--- a/tests/providers/anthropic/cassette/response_identity.rs
+++ b/tests/providers/anthropic/cassette/response_identity.rs
@@ -208,7 +208,7 @@ async fn streamed_agent_run_hook_observes_identity() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(Message::user(
+                .prompt(Message::user(
                     "Reply with exactly: streamed hook identity probe",
                 ))
                 .stream()
@@ -264,7 +264,7 @@ async fn streamed_agent_tool_run_reports_per_attempt_identity() {
                 .build();
 
             let mut stream = agent
-                .runner(Message::user(
+                .prompt(Message::user(
                     "What is 2 + 3? Use the tool, then state the result.",
                 ))
                 .max_turns(3)

--- a/tests/providers/anthropic/cassette/response_identity_edge.rs
+++ b/tests/providers/anthropic/cassette/response_identity_edge.rs
@@ -322,8 +322,7 @@ async fn tool_error_retry_reports_distinct_ids_streamed() {
             let mut stream = agent
                 .prompt(Message::user("What is 2 + 3? Use the tool."))
                 .max_turns(5)
-                .stream()
-                .await;
+                .stream();
             while let Some(item) = stream.next().await {
                 item.expect("stream item should succeed");
             }
@@ -393,8 +392,7 @@ async fn streamed_hook_retry_uses_second_connections_id() {
             let mut stream = agent
                 .prompt(Message::user("Reply with exactly: first probe"))
                 .max_turns(3)
-                .stream()
-                .await;
+                .stream();
             while let Some(item) = stream.next().await {
                 item.expect("stream item should succeed");
             }

--- a/tests/providers/anthropic/cassette/response_identity_edge.rs
+++ b/tests/providers/anthropic/cassette/response_identity_edge.rs
@@ -320,7 +320,7 @@ async fn tool_error_retry_reports_distinct_ids_streamed() {
                 .build();
 
             let mut stream = agent
-                .runner(Message::user("What is 2 + 3? Use the tool."))
+                .prompt(Message::user("What is 2 + 3? Use the tool."))
                 .max_turns(5)
                 .stream()
                 .await;
@@ -391,7 +391,7 @@ async fn streamed_hook_retry_uses_second_connections_id() {
                 .build();
 
             let mut stream = agent
-                .runner(Message::user("Reply with exactly: first probe"))
+                .prompt(Message::user("Reply with exactly: first probe"))
                 .max_turns(3)
                 .stream()
                 .await;
@@ -615,7 +615,7 @@ async fn history_replay_does_not_leak_prior_run_identity() {
             let run_a_identity = probe.turn_identities()[0].clone();
 
             let second = agent
-                .runner(Message::user("Reply with exactly: run B probe"))
+                .prompt(Message::user("Reply with exactly: run B probe"))
                 .history(history)
                 .run()
                 .await

--- a/tests/providers/anthropic/cassette/stop_sequence_terminal_matrix.rs
+++ b/tests/providers/anthropic/cassette/stop_sequence_terminal_matrix.rs
@@ -836,7 +836,7 @@ async fn agent_stream_single_sequence() {
                 .additional_params(json!({ "stop_sequences": ["charlie"] }))
                 .build();
 
-            let mut stream = agent.stream_prompt(LIST_PROMPT).stream().await;
+            let mut stream = agent.prompt(LIST_PROMPT).stream().await;
             let (_response, provider_final): (_, rig::streaming::StreamFinal) =
                 crate::support::collect_stream_final_response_and_provider_final(&mut stream)
                     .await

--- a/tests/providers/anthropic/cassette/stop_sequence_terminal_matrix.rs
+++ b/tests/providers/anthropic/cassette/stop_sequence_terminal_matrix.rs
@@ -836,7 +836,7 @@ async fn agent_stream_single_sequence() {
                 .additional_params(json!({ "stop_sequences": ["charlie"] }))
                 .build();
 
-            let mut stream = agent.prompt(LIST_PROMPT).stream().await;
+            let mut stream = agent.prompt(LIST_PROMPT).stream();
             let (_response, provider_final): (_, rig::streaming::StreamFinal) =
                 crate::support::collect_stream_final_response_and_provider_final(&mut stream)
                     .await

--- a/tests/providers/anthropic/cassette/streaming.rs
+++ b/tests/providers/anthropic/cassette/streaming.rs
@@ -17,7 +17,7 @@ async fn streaming_smoke() {
             .preamble(STREAMING_PREAMBLE)
             .build();
 
-        let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
         let (response, provider_final): (_, rig::streaming::StreamFinal) =
             collect_stream_final_response_and_provider_final(&mut stream)
                 .await
@@ -69,7 +69,7 @@ async fn gateway_reports_input_tokens_on_message_delta() {
                 .max_tokens(16)
                 .build();
 
-            let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
             let (_response, provider_final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await
@@ -129,7 +129,7 @@ async fn anthropic_proper_agrees_on_input_tokens_across_both_frames() {
                 .max_tokens(64)
                 .build();
 
-            let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
             let (_response, provider_final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await

--- a/tests/providers/anthropic/cassette/streaming.rs
+++ b/tests/providers/anthropic/cassette/streaming.rs
@@ -17,7 +17,7 @@ async fn streaming_smoke() {
             .preamble(STREAMING_PREAMBLE)
             .build();
 
-        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream();
         let (response, provider_final): (_, rig::streaming::StreamFinal) =
             collect_stream_final_response_and_provider_final(&mut stream)
                 .await
@@ -69,7 +69,7 @@ async fn gateway_reports_input_tokens_on_message_delta() {
                 .max_tokens(16)
                 .build();
 
-            let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_PROMPT).stream();
             let (_response, provider_final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await
@@ -129,7 +129,7 @@ async fn anthropic_proper_agrees_on_input_tokens_across_both_frames() {
                 .max_tokens(64)
                 .build();
 
-            let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_PROMPT).stream();
             let (_response, provider_final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await

--- a/tests/providers/anthropic/cassette/streaming_tools.rs
+++ b/tests/providers/anthropic/cassette/streaming_tools.rs
@@ -36,7 +36,7 @@ async fn streaming_tools_smoke() {
                 .default_max_turns(2)
                 .build();
 
-            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");
@@ -59,11 +59,7 @@ async fn streaming_tools_batches_multiple_tool_results_in_one_followup_message()
                 .tool(BetaSignal)
                 .build();
 
-            let mut stream = agent
-                .prompt(TWO_TOOL_STREAM_PROMPT)
-                .max_turns(8)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(TWO_TOOL_STREAM_PROMPT).max_turns(8).stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert!(
@@ -134,8 +130,7 @@ async fn serial_serving_reproduces_the_recorded_request_order() {
                 .prompt(TWO_TOOL_STREAM_PROMPT)
                 .max_turns(8)
                 .tool_concurrency(2)
-                .stream()
-                .await;
+                .stream();
             let observation = tokio::time::timeout(
                 std::time::Duration::from_secs(5),
                 collect_concurrent_tool_observation(&mut stream),
@@ -179,8 +174,7 @@ async fn streaming_tool_concurrency_surfaces_results_in_call_order_after_batch_s
             .prompt(TWO_TOOL_STREAM_PROMPT)
             .max_turns(8)
             .tool_concurrency(2)
-            .stream()
-            .await;
+            .stream();
         let observation = tokio::time::timeout(
             std::time::Duration::from_secs(5),
             collect_concurrent_tool_observation(&mut stream),
@@ -665,7 +659,7 @@ async fn streaming_tools_effect_log_is_the_golden_fixture() {
                 .default_max_turns(2)
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");
@@ -709,8 +703,7 @@ async fn concurrent_tools_serial_effect_log_is_the_golden_fixture() {
                 .prompt(TWO_TOOL_STREAM_PROMPT)
                 .max_turns(8)
                 .tool_concurrency(2)
-                .stream()
-                .await;
+                .stream();
             let observation = tokio::time::timeout(
                 std::time::Duration::from_secs(5),
                 collect_concurrent_tool_observation(&mut stream),

--- a/tests/providers/anthropic/cassette/streaming_tools.rs
+++ b/tests/providers/anthropic/cassette/streaming_tools.rs
@@ -36,7 +36,7 @@ async fn streaming_tools_smoke() {
                 .default_max_turns(2)
                 .build();
 
-            let mut stream = agent.stream_prompt(STREAMING_TOOLS_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");
@@ -60,7 +60,7 @@ async fn streaming_tools_batches_multiple_tool_results_in_one_followup_message()
                 .build();
 
             let mut stream = agent
-                .stream_prompt(TWO_TOOL_STREAM_PROMPT)
+                .prompt(TWO_TOOL_STREAM_PROMPT)
                 .max_turns(8)
                 .stream()
                 .await;
@@ -131,7 +131,7 @@ async fn serial_serving_reproduces_the_recorded_request_order() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(TWO_TOOL_STREAM_PROMPT)
+                .prompt(TWO_TOOL_STREAM_PROMPT)
                 .max_turns(8)
                 .tool_concurrency(2)
                 .stream()
@@ -176,7 +176,7 @@ async fn streaming_tool_concurrency_surfaces_results_in_call_order_after_batch_s
             .build();
 
         let mut stream = agent
-            .stream_prompt(TWO_TOOL_STREAM_PROMPT)
+            .prompt(TWO_TOOL_STREAM_PROMPT)
             .max_turns(8)
             .tool_concurrency(2)
             .stream()
@@ -665,7 +665,7 @@ async fn streaming_tools_effect_log_is_the_golden_fixture() {
                 .default_max_turns(2)
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.stream_prompt(STREAMING_TOOLS_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");
@@ -706,7 +706,7 @@ async fn concurrent_tools_serial_effect_log_is_the_golden_fixture() {
                 .record_effects()
                 .build();
             let mut stream = agent
-                .stream_prompt(TWO_TOOL_STREAM_PROMPT)
+                .prompt(TWO_TOOL_STREAM_PROMPT)
                 .max_turns(8)
                 .tool_concurrency(2)
                 .stream()

--- a/tests/providers/anthropic/cassette/tool_call_rewrite_args.rs
+++ b/tests/providers/anthropic/cassette/tool_call_rewrite_args.rs
@@ -184,11 +184,7 @@ async fn tool_call_args_rewritten_by_hook_streaming() {
                 .add_hook(PinUnitsToCelsius)
                 .build();
 
-            let mut stream = agent
-                .stream_prompt(WEATHER_PROMPT)
-                .max_turns(5)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(WEATHER_PROMPT).max_turns(5).stream().await;
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming weather prompt should succeed");

--- a/tests/providers/anthropic/cassette/tool_call_rewrite_args.rs
+++ b/tests/providers/anthropic/cassette/tool_call_rewrite_args.rs
@@ -184,7 +184,7 @@ async fn tool_call_args_rewritten_by_hook_streaming() {
                 .add_hook(PinUnitsToCelsius)
                 .build();
 
-            let mut stream = agent.prompt(WEATHER_PROMPT).max_turns(5).stream().await;
+            let mut stream = agent.prompt(WEATHER_PROMPT).max_turns(5).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming weather prompt should succeed");

--- a/tests/providers/anthropic/cassette/tool_result_rewrite.rs
+++ b/tests/providers/anthropic/cassette/tool_result_rewrite.rs
@@ -186,11 +186,7 @@ async fn tool_result_redacted_by_hook_streaming() {
                 .add_hook(RedactSsnFromResult)
                 .build();
 
-            let mut stream = agent
-                .stream_prompt(LOOKUP_PROMPT)
-                .max_turns(5)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(LOOKUP_PROMPT).max_turns(5).stream().await;
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming lookup should succeed");

--- a/tests/providers/anthropic/cassette/tool_result_rewrite.rs
+++ b/tests/providers/anthropic/cassette/tool_result_rewrite.rs
@@ -186,7 +186,7 @@ async fn tool_result_redacted_by_hook_streaming() {
                 .add_hook(RedactSsnFromResult)
                 .build();
 
-            let mut stream = agent.prompt(LOOKUP_PROMPT).max_turns(5).stream().await;
+            let mut stream = agent.prompt(LOOKUP_PROMPT).max_turns(5).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming lookup should succeed");

--- a/tests/providers/anthropic/cassette/turn_termination_matrix.rs
+++ b/tests/providers/anthropic/cassette/turn_termination_matrix.rs
@@ -155,11 +155,7 @@ async fn streaming_truncated_turn_reports_length_and_cap() {
                         .max_tokens(TINY_CAP)
                         .build();
 
-                    let mut stream = agent
-                        .prompt(TRUNCATING_PROMPT)
-                        .add_hook(probe)
-                        .stream()
-                        .await;
+                    let mut stream = agent.prompt(TRUNCATING_PROMPT).add_hook(probe).stream();
                     let _ = collect_stream_final_response(&mut stream).await;
                 }
             },
@@ -240,7 +236,7 @@ async fn streaming_completed_turn_reports_stop_and_cap() {
                         .max_tokens(ROOMY_CAP)
                         .build();
 
-                    let mut stream = agent.prompt(SHORT_PROMPT).add_hook(probe).stream().await;
+                    let mut stream = agent.prompt(SHORT_PROMPT).add_hook(probe).stream();
                     let _ = collect_stream_final_response(&mut stream).await;
                 }
             },
@@ -327,8 +323,7 @@ async fn streaming_tool_turn_reports_tool_calls() {
                         .prompt(TOOL_PROMPT)
                         .add_hook(probe)
                         .max_turns(3)
-                        .stream()
-                        .await;
+                        .stream();
                     let _ = collect_stream_final_response(&mut stream).await;
                 }
             },
@@ -435,8 +430,7 @@ async fn streaming_escalating_retry_reports_each_attempts_own_cap() {
                         .add_hook(probe)
                         .add_hook(escalate)
                         .max_turns(2)
-                        .stream()
-                        .await;
+                        .stream();
                     let _ = collect_stream_final_response(&mut stream).await;
                 }
             },

--- a/tests/providers/anthropic/cassette/turn_termination_matrix.rs
+++ b/tests/providers/anthropic/cassette/turn_termination_matrix.rs
@@ -106,7 +106,7 @@ async fn blocking_truncated_turn_reports_length_and_cap() {
                         .max_tokens(TINY_CAP)
                         .add_hook(probe)
                         .build()
-                        .runner(TRUNCATING_PROMPT)
+                        .prompt(TRUNCATING_PROMPT)
                         .run()
                         .await
                         .expect("a partially truncated turn still carries an answer");
@@ -156,7 +156,7 @@ async fn streaming_truncated_turn_reports_length_and_cap() {
                         .build();
 
                     let mut stream = agent
-                        .stream_prompt(TRUNCATING_PROMPT)
+                        .prompt(TRUNCATING_PROMPT)
                         .add_hook(probe)
                         .stream()
                         .await;
@@ -200,7 +200,7 @@ async fn blocking_completed_turn_reports_stop_and_cap() {
                         .max_tokens(ROOMY_CAP)
                         .add_hook(probe)
                         .build()
-                        .runner(SHORT_PROMPT)
+                        .prompt(SHORT_PROMPT)
                         .run()
                         .await
                         .expect("a short answer under a roomy cap");
@@ -240,11 +240,7 @@ async fn streaming_completed_turn_reports_stop_and_cap() {
                         .max_tokens(ROOMY_CAP)
                         .build();
 
-                    let mut stream = agent
-                        .stream_prompt(SHORT_PROMPT)
-                        .add_hook(probe)
-                        .stream()
-                        .await;
+                    let mut stream = agent.prompt(SHORT_PROMPT).add_hook(probe).stream().await;
                     let _ = collect_stream_final_response(&mut stream).await;
                 }
             },
@@ -282,7 +278,7 @@ async fn blocking_tool_turn_reports_tool_calls() {
                         .tool(Adder)
                         .add_hook(probe)
                         .build()
-                        .runner(TOOL_PROMPT)
+                        .prompt(TOOL_PROMPT)
                         .max_turns(3)
                         .run()
                         .await
@@ -328,7 +324,7 @@ async fn streaming_tool_turn_reports_tool_calls() {
                         .build();
 
                     let mut stream = agent
-                        .stream_prompt(TOOL_PROMPT)
+                        .prompt(TOOL_PROMPT)
                         .add_hook(probe)
                         .max_turns(3)
                         .stream()
@@ -380,7 +376,7 @@ async fn blocking_escalating_retry_reports_each_attempts_own_cap() {
                         .add_hook(probe)
                         .add_hook(escalate)
                         .build()
-                        .runner(RETRY_PROMPT)
+                        .prompt(RETRY_PROMPT)
                         .max_turns(2)
                         .run()
                         .await
@@ -435,7 +431,7 @@ async fn streaming_escalating_retry_reports_each_attempts_own_cap() {
                         .build();
 
                     let mut stream = agent
-                        .stream_prompt(RETRY_PROMPT)
+                        .prompt(RETRY_PROMPT)
                         .add_hook(probe)
                         .add_hook(escalate)
                         .max_turns(2)

--- a/tests/providers/bedrock/cassette/streaming.rs
+++ b/tests/providers/bedrock/cassette/streaming.rs
@@ -18,7 +18,7 @@ async fn streaming_smoke() {
             .preamble(STREAMING_PREAMBLE)
             .build();
 
-        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream();
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");
@@ -39,7 +39,7 @@ async fn streaming_tools_smoke() {
             .default_max_turns(2)
             .build();
 
-        let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream();
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming tool prompt should succeed");

--- a/tests/providers/bedrock/cassette/streaming.rs
+++ b/tests/providers/bedrock/cassette/streaming.rs
@@ -18,7 +18,7 @@ async fn streaming_smoke() {
             .preamble(STREAMING_PREAMBLE)
             .build();
 
-        let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");
@@ -39,7 +39,7 @@ async fn streaming_tools_smoke() {
             .default_max_turns(2)
             .build();
 
-        let mut stream = agent.stream_prompt(STREAMING_TOOLS_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming tool prompt should succeed");

--- a/tests/providers/bedrock/cassette/tool_choice.rs
+++ b/tests/providers/bedrock/cassette/tool_choice.rs
@@ -235,7 +235,7 @@ async fn none_streaming_does_not_emit_tool_calls() {
             .build();
 
         let mut stream = agent
-            .stream_prompt("Calculate 20 + 22 directly in text. Do not call tools.")
+            .prompt("Calculate 20 + 22 directly in text. Do not call tools.")
             .stream()
             .await;
         let observation = collect_stream_observation(&mut stream).await;

--- a/tests/providers/bedrock/cassette/tool_choice.rs
+++ b/tests/providers/bedrock/cassette/tool_choice.rs
@@ -236,8 +236,7 @@ async fn none_streaming_does_not_emit_tool_calls() {
 
         let mut stream = agent
             .prompt("Calculate 20 + 22 directly in text. Do not call tools.")
-            .stream()
-            .await;
+            .stream();
         let observation = collect_stream_observation(&mut stream).await;
 
         assert!(

--- a/tests/providers/chatgpt/auth.rs
+++ b/tests/providers/chatgpt/auth.rs
@@ -66,7 +66,7 @@ async fn oauth_device_flow_authorize_and_cached_completion_smoke() {
     );
 
     let agent = client.agent(LIVE_MODEL).preamble(BASIC_PREAMBLE).build();
-    let mut stream = agent.stream_prompt(BASIC_PROMPT).stream().await;
+    let mut stream = agent.prompt(BASIC_PROMPT).stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("authorized streaming completion should succeed");
@@ -79,7 +79,7 @@ async fn oauth_device_flow_authorize_and_cached_completion_smoke() {
 
     let cached_agent = cached_client.agent(LIVE_MODEL).build();
     let mut cached_stream = cached_agent
-        .stream_prompt("Reply with the single word cached.")
+        .prompt("Reply with the single word cached.")
         .stream()
         .await;
     let cached_response = collect_stream_final_response(&mut cached_stream)
@@ -125,7 +125,7 @@ async fn refresh_token_cache_authorize_and_completion_smoke() {
 
     let agent = client.agent(LIVE_MODEL).build();
     let mut stream = agent
-        .stream_prompt("Reply with the single word refreshed.")
+        .prompt("Reply with the single word refreshed.")
         .stream()
         .await;
     let response = collect_stream_final_response(&mut stream)

--- a/tests/providers/chatgpt/auth.rs
+++ b/tests/providers/chatgpt/auth.rs
@@ -66,7 +66,7 @@ async fn oauth_device_flow_authorize_and_cached_completion_smoke() {
     );
 
     let agent = client.agent(LIVE_MODEL).preamble(BASIC_PREAMBLE).build();
-    let mut stream = agent.prompt(BASIC_PROMPT).stream().await;
+    let mut stream = agent.prompt(BASIC_PROMPT).stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("authorized streaming completion should succeed");
@@ -80,8 +80,7 @@ async fn oauth_device_flow_authorize_and_cached_completion_smoke() {
     let cached_agent = cached_client.agent(LIVE_MODEL).build();
     let mut cached_stream = cached_agent
         .prompt("Reply with the single word cached.")
-        .stream()
-        .await;
+        .stream();
     let cached_response = collect_stream_final_response(&mut cached_stream)
         .await
         .expect("cached streaming completion should succeed");
@@ -126,8 +125,7 @@ async fn refresh_token_cache_authorize_and_completion_smoke() {
     let agent = client.agent(LIVE_MODEL).build();
     let mut stream = agent
         .prompt("Reply with the single word refreshed.")
-        .stream()
-        .await;
+        .stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("refreshed streaming completion should succeed");

--- a/tests/providers/chatgpt/cassette/codex_sessions.rs
+++ b/tests/providers/chatgpt/cassette/codex_sessions.rs
@@ -178,7 +178,8 @@ async fn sequential_tool_calls_streaming() {
                 .build();
 
             let mut stream = agent
-                .stream_chat(SEQUENTIAL_TOOLS_PROMPT, Vec::<Message>::new())
+                .prompt(SEQUENTIAL_TOOLS_PROMPT)
+                .history(Vec::<Message>::new())
                 .max_turns(6)
                 .stream()
                 .await;
@@ -286,7 +287,7 @@ async fn parallel_tool_calls_single_turn_streaming() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(TWO_TOOL_STREAM_PROMPT)
+                .prompt(TWO_TOOL_STREAM_PROMPT)
                 .max_turns(5)
                 .stream()
                 .await;
@@ -417,12 +418,12 @@ async fn reasoning_session_two_tool_calls_streaming() {
                 .build();
 
             let stream = agent
-                .stream_chat(
+                .prompt(
                     "I need the current weather in Tokyo and in Paris. Use the get_weather \
                      tool once per city, then compare the two cities in one short paragraph \
                      that mentions both city names.",
-                    Vec::<Message>::new(),
                 )
+                .history(Vec::<Message>::new())
                 .max_turns(5)
                 .stream()
                 .await;
@@ -485,7 +486,7 @@ async fn usage_accumulates_across_streaming_multi_turn() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(ORDERED_TOOL_STREAM_PROMPT)
+                .prompt(ORDERED_TOOL_STREAM_PROMPT)
                 .max_turns(5)
                 .stream()
                 .await;

--- a/tests/providers/chatgpt/cassette/codex_sessions.rs
+++ b/tests/providers/chatgpt/cassette/codex_sessions.rs
@@ -181,8 +181,7 @@ async fn sequential_tool_calls_streaming() {
                 .prompt(SEQUENTIAL_TOOLS_PROMPT)
                 .history(Vec::<Message>::new())
                 .max_turns(6)
-                .stream()
-                .await;
+                .stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert!(
@@ -286,11 +285,7 @@ async fn parallel_tool_calls_single_turn_streaming() {
                 .tool(BetaSignal)
                 .build();
 
-            let mut stream = agent
-                .prompt(TWO_TOOL_STREAM_PROMPT)
-                .max_turns(5)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(TWO_TOOL_STREAM_PROMPT).max_turns(5).stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert_two_tool_roundtrip_contract(
@@ -425,8 +420,7 @@ async fn reasoning_session_two_tool_calls_streaming() {
                 )
                 .history(Vec::<Message>::new())
                 .max_turns(5)
-                .stream()
-                .await;
+                .stream();
 
             let stats = reasoning::collect_stream_stats(stream, "chatgpt").await;
 
@@ -488,8 +482,7 @@ async fn usage_accumulates_across_streaming_multi_turn() {
             let mut stream = agent
                 .prompt(ORDERED_TOOL_STREAM_PROMPT)
                 .max_turns(5)
-                .stream()
-                .await;
+                .stream();
 
             let mut saw_tool_result = false;
             let mut final_usage = None;

--- a/tests/providers/chatgpt/cassette/noninteractive_oauth.rs
+++ b/tests/providers/chatgpt/cassette/noninteractive_oauth.rs
@@ -22,7 +22,7 @@ async fn cached_oauth_allows_noninteractive_streaming_completion() {
                 .agent(chatgpt::GPT_5_4)
                 .preamble(BASIC_PREAMBLE)
                 .build();
-            let mut stream = agent.prompt(BASIC_PROMPT).stream().await;
+            let mut stream = agent.prompt(BASIC_PROMPT).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("non-interactive OAuth streaming completion should succeed");

--- a/tests/providers/chatgpt/cassette/noninteractive_oauth.rs
+++ b/tests/providers/chatgpt/cassette/noninteractive_oauth.rs
@@ -22,7 +22,7 @@ async fn cached_oauth_allows_noninteractive_streaming_completion() {
                 .agent(chatgpt::GPT_5_4)
                 .preamble(BASIC_PREAMBLE)
                 .build();
-            let mut stream = agent.stream_prompt(BASIC_PROMPT).stream().await;
+            let mut stream = agent.prompt(BASIC_PROMPT).stream().await;
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("non-interactive OAuth streaming completion should succeed");

--- a/tests/providers/chatgpt/completion.rs
+++ b/tests/providers/chatgpt/completion.rs
@@ -32,7 +32,7 @@ async fn default_instructions_fill_required_instructions() {
 
     let agent = client.agent(LIVE_MODEL).build();
     let mut stream = agent
-        .stream_prompt("Reply with the exact word from the instructions.")
+        .prompt("Reply with the exact word from the instructions.")
         .stream()
         .await;
     let response = collect_stream_final_response(&mut stream)

--- a/tests/providers/chatgpt/completion.rs
+++ b/tests/providers/chatgpt/completion.rs
@@ -33,8 +33,7 @@ async fn default_instructions_fill_required_instructions() {
     let agent = client.agent(LIVE_MODEL).build();
     let mut stream = agent
         .prompt("Reply with the exact word from the instructions.")
-        .stream()
-        .await;
+        .stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("default-instructions streaming completion should succeed");

--- a/tests/providers/chatgpt/permission_control.rs
+++ b/tests/providers/chatgpt/permission_control.rs
@@ -209,8 +209,7 @@ async fn permission_control_streaming_example() -> Result<()> {
         )
         .max_turns(5)
         .add_hook(hook)
-        .stream()
-        .await;
+        .stream();
 
     let final_response = stream_to_stdout(&mut stream).await?;
     let last = last_result.lock().expect("lock last_result").clone();

--- a/tests/providers/chatgpt/permission_control.rs
+++ b/tests/providers/chatgpt/permission_control.rs
@@ -203,7 +203,7 @@ async fn permission_control_streaming_example() -> Result<()> {
     };
 
     let mut stream = agent
-        .stream_prompt(
+        .prompt(
             "Use the available tools to read test.txt now. \
              Do not ask any follow-up questions; just read the file and report its content.",
         )

--- a/tests/providers/chatgpt/reasoning_tool_roundtrip.rs
+++ b/tests/providers/chatgpt/reasoning_tool_roundtrip.rs
@@ -24,7 +24,8 @@ async fn streaming() {
         .build();
 
     let stream = agent
-        .stream_chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .prompt(reasoning::TOOL_USER_PROMPT)
+        .history(Vec::<Message>::new())
         .max_turns(3)
         .stream()
         .await;

--- a/tests/providers/chatgpt/reasoning_tool_roundtrip.rs
+++ b/tests/providers/chatgpt/reasoning_tool_roundtrip.rs
@@ -27,8 +27,7 @@ async fn streaming() {
         .prompt(reasoning::TOOL_USER_PROMPT)
         .history(Vec::<Message>::new())
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
 
     let stats = reasoning::collect_stream_stats(stream, "chatgpt").await;
     reasoning::assert_universal(&stats, &call_count, "chatgpt");

--- a/tests/providers/chatgpt/streaming.rs
+++ b/tests/providers/chatgpt/streaming.rs
@@ -15,7 +15,7 @@ async fn streaming_smoke() {
         .preamble(STREAMING_PREAMBLE)
         .build();
 
-    let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_PROMPT).stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("ChatGPT stream should succeed");
@@ -34,8 +34,7 @@ async fn example_streaming_prompt() {
 
     let mut stream = agent
         .prompt("When and where and what type is the next solar eclipse?")
-        .stream()
-        .await;
+        .stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");

--- a/tests/providers/chatgpt/streaming.rs
+++ b/tests/providers/chatgpt/streaming.rs
@@ -15,7 +15,7 @@ async fn streaming_smoke() {
         .preamble(STREAMING_PREAMBLE)
         .build();
 
-    let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("ChatGPT stream should succeed");
@@ -33,7 +33,7 @@ async fn example_streaming_prompt() {
         .build();
 
     let mut stream = agent
-        .stream_prompt("When and where and what type is the next solar eclipse?")
+        .prompt("When and where and what type is the next solar eclipse?")
         .stream()
         .await;
     let response = collect_stream_final_response(&mut stream)

--- a/tests/providers/chatgpt/streaming_tools.rs
+++ b/tests/providers/chatgpt/streaming_tools.rs
@@ -18,7 +18,7 @@ async fn streaming_tools_smoke() {
         .tool(Subtract)
         .build();
 
-    let mut stream = agent.stream_prompt(STREAMING_TOOLS_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming tool prompt should succeed");
@@ -40,7 +40,7 @@ async fn example_streaming_with_tools() {
         .tool(Subtract)
         .build();
 
-    let mut stream = agent.stream_prompt("Calculate 2 - 5").stream().await;
+    let mut stream = agent.prompt("Calculate 2 - 5").stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming tools prompt should succeed");

--- a/tests/providers/chatgpt/streaming_tools.rs
+++ b/tests/providers/chatgpt/streaming_tools.rs
@@ -18,7 +18,7 @@ async fn streaming_tools_smoke() {
         .tool(Subtract)
         .build();
 
-    let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming tool prompt should succeed");
@@ -40,7 +40,7 @@ async fn example_streaming_with_tools() {
         .tool(Subtract)
         .build();
 
-    let mut stream = agent.prompt("Calculate 2 - 5").stream().await;
+    let mut stream = agent.prompt("Calculate 2 - 5").stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming tools prompt should succeed");

--- a/tests/providers/cohere/cassette/streaming.rs
+++ b/tests/providers/cohere/cassette/streaming.rs
@@ -19,7 +19,7 @@ async fn streaming_smoke() {
             .max_tokens(64)
             .build();
 
-        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream();
         let (response, provider_final) =
             collect_stream_final_response_and_provider_final(&mut stream)
                 .await

--- a/tests/providers/cohere/cassette/streaming.rs
+++ b/tests/providers/cohere/cassette/streaming.rs
@@ -19,7 +19,7 @@ async fn streaming_smoke() {
             .max_tokens(64)
             .build();
 
-        let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
         let (response, provider_final) =
             collect_stream_final_response_and_provider_final(&mut stream)
                 .await

--- a/tests/providers/cohere/cassette/streaming_tools.rs
+++ b/tests/providers/cohere/cassette/streaming_tools.rs
@@ -24,7 +24,7 @@ async fn streaming_tool_call_roundtrip() {
                 .default_max_turns(2)
                 .build();
 
-            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert!(

--- a/tests/providers/cohere/cassette/streaming_tools.rs
+++ b/tests/providers/cohere/cassette/streaming_tools.rs
@@ -24,7 +24,7 @@ async fn streaming_tool_call_roundtrip() {
                 .default_max_turns(2)
                 .build();
 
-            let mut stream = agent.stream_prompt(STREAMING_TOOLS_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
             let observation = collect_stream_observation(&mut stream).await;
 
             assert!(

--- a/tests/providers/cohere/streaming.rs
+++ b/tests/providers/cohere/streaming.rs
@@ -16,7 +16,7 @@ async fn streaming_smoke() {
         .preamble(STREAMING_PREAMBLE)
         .build();
 
-    let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_PROMPT).stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");

--- a/tests/providers/cohere/streaming.rs
+++ b/tests/providers/cohere/streaming.rs
@@ -16,7 +16,7 @@ async fn streaming_smoke() {
         .preamble(STREAMING_PREAMBLE)
         .build();
 
-    let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");

--- a/tests/providers/cohere/streaming_tools.rs
+++ b/tests/providers/cohere/streaming_tools.rs
@@ -19,7 +19,7 @@ async fn streaming_tools_smoke() {
         .tool(Subtract)
         .build();
 
-    let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming tool prompt should succeed");

--- a/tests/providers/cohere/streaming_tools.rs
+++ b/tests/providers/cohere/streaming_tools.rs
@@ -19,7 +19,7 @@ async fn streaming_tools_smoke() {
         .tool(Subtract)
         .build();
 
-    let mut stream = agent.stream_prompt(STREAMING_TOOLS_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming tool prompt should succeed");

--- a/tests/providers/copilot/permission_control.rs
+++ b/tests/providers/copilot/permission_control.rs
@@ -213,7 +213,7 @@ async fn permission_control_streaming_example() -> Result<()> {
     };
 
     let mut stream = agent
-        .stream_prompt(
+        .prompt(
             "Use the available tools to read test.txt now. \
              Do not ask any follow-up questions; just read the file and report its content.",
         )

--- a/tests/providers/copilot/permission_control.rs
+++ b/tests/providers/copilot/permission_control.rs
@@ -219,8 +219,7 @@ async fn permission_control_streaming_example() -> Result<()> {
         )
         .max_turns(5)
         .add_hook(hook)
-        .stream()
-        .await;
+        .stream();
 
     let final_response = stream_to_stdout(&mut stream).await?;
     let last = last_result.lock().expect("lock last_result").clone();

--- a/tests/providers/copilot/reasoning_tool_roundtrip.rs
+++ b/tests/providers/copilot/reasoning_tool_roundtrip.rs
@@ -27,8 +27,7 @@ async fn streaming() {
         .prompt(reasoning::TOOL_USER_PROMPT)
         .history(Vec::<Message>::new())
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
 
     let stats = reasoning::collect_stream_stats(stream, "copilot").await;
     reasoning::assert_universal(&stats, &call_count, "copilot");

--- a/tests/providers/copilot/reasoning_tool_roundtrip.rs
+++ b/tests/providers/copilot/reasoning_tool_roundtrip.rs
@@ -24,7 +24,8 @@ async fn streaming() {
         .build();
 
     let stream = agent
-        .stream_chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .prompt(reasoning::TOOL_USER_PROMPT)
+        .history(Vec::<Message>::new())
         .max_turns(3)
         .stream()
         .await;

--- a/tests/providers/copilot/streaming.rs
+++ b/tests/providers/copilot/streaming.rs
@@ -15,7 +15,7 @@ async fn streaming_smoke() {
             .preamble(STREAMING_PREAMBLE)
             .build();
 
-        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream();
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");
@@ -36,8 +36,7 @@ async fn example_streaming_prompt() {
 
         let mut stream = agent
             .prompt("When and where and what type is the next solar eclipse?")
-            .stream()
-            .await;
+            .stream();
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");

--- a/tests/providers/copilot/streaming.rs
+++ b/tests/providers/copilot/streaming.rs
@@ -15,7 +15,7 @@ async fn streaming_smoke() {
             .preamble(STREAMING_PREAMBLE)
             .build();
 
-        let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");
@@ -35,7 +35,7 @@ async fn example_streaming_prompt() {
             .build();
 
         let mut stream = agent
-            .stream_prompt("When and where and what type is the next solar eclipse?")
+            .prompt("When and where and what type is the next solar eclipse?")
             .stream()
             .await;
         let response = collect_stream_final_response(&mut stream)

--- a/tests/providers/copilot/streaming_tools.rs
+++ b/tests/providers/copilot/streaming_tools.rs
@@ -28,7 +28,7 @@ async fn streaming_tools_smoke() {
                 .default_max_turns(2)
                 .build();
 
-            let mut stream = agent.stream_prompt(STREAMING_TOOLS_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");
@@ -54,7 +54,7 @@ async fn example_streaming_with_tools() {
             .default_max_turns(2)
             .build();
 
-        let mut stream = agent.stream_prompt("Calculate 2 - 5").stream().await;
+        let mut stream = agent.prompt("Calculate 2 - 5").stream().await;
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming tools prompt should succeed");
@@ -126,7 +126,7 @@ async fn streaming_tools_surface_two_distinct_tool_calls_before_final_answer() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(TWO_TOOL_STREAM_PROMPT)
+                .prompt(TWO_TOOL_STREAM_PROMPT)
                 .max_turns(8)
                 .stream()
                 .await;

--- a/tests/providers/copilot/streaming_tools.rs
+++ b/tests/providers/copilot/streaming_tools.rs
@@ -28,7 +28,7 @@ async fn streaming_tools_smoke() {
                 .default_max_turns(2)
                 .build();
 
-            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");
@@ -54,7 +54,7 @@ async fn example_streaming_with_tools() {
             .default_max_turns(2)
             .build();
 
-        let mut stream = agent.prompt("Calculate 2 - 5").stream().await;
+        let mut stream = agent.prompt("Calculate 2 - 5").stream();
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming tools prompt should succeed");
@@ -125,11 +125,7 @@ async fn streaming_tools_surface_two_distinct_tool_calls_before_final_answer() {
                 .tool(BetaSignal)
                 .build();
 
-            let mut stream = agent
-                .prompt(TWO_TOOL_STREAM_PROMPT)
-                .max_turns(8)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(TWO_TOOL_STREAM_PROMPT).max_turns(8).stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert_two_tool_roundtrip_contract(

--- a/tests/providers/deepseek/agent_tool_sessions.rs
+++ b/tests/providers/deepseek/agent_tool_sessions.rs
@@ -522,8 +522,7 @@ async fn sequential_complex_tool_calls_streaming() -> Result<()> {
                 .prompt(COMPLEX_SESSION_PROMPT)
                 .history(Vec::<Message>::new())
                 .max_turns(10)
-                .stream()
-                .await;
+                .stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             anyhow::ensure!(
@@ -629,11 +628,7 @@ async fn parallel_tool_calls_single_turn_streaming() -> Result<()> {
                 ))
                 .build();
 
-            let mut stream = agent
-                .prompt(TWO_TOOL_STREAM_PROMPT)
-                .max_turns(5)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(TWO_TOOL_STREAM_PROMPT).max_turns(5).stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert_two_tool_roundtrip_contract(

--- a/tests/providers/deepseek/agent_tool_sessions.rs
+++ b/tests/providers/deepseek/agent_tool_sessions.rs
@@ -519,7 +519,8 @@ async fn sequential_complex_tool_calls_streaming() -> Result<()> {
                 .build();
 
             let mut stream = agent
-                .stream_chat(COMPLEX_SESSION_PROMPT, Vec::<Message>::new())
+                .prompt(COMPLEX_SESSION_PROMPT)
+                .history(Vec::<Message>::new())
                 .max_turns(10)
                 .stream()
                 .await;
@@ -629,7 +630,7 @@ async fn parallel_tool_calls_single_turn_streaming() -> Result<()> {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(TWO_TOOL_STREAM_PROMPT)
+                .prompt(TWO_TOOL_STREAM_PROMPT)
                 .max_turns(5)
                 .stream()
                 .await;

--- a/tests/providers/deepseek/permission_control.rs
+++ b/tests/providers/deepseek/permission_control.rs
@@ -247,7 +247,7 @@ async fn permission_control_streaming_example() -> Result<()> {
                 )
                 .max_turns(5)
                 .add_hook(hook)
-                .stream().await;
+                .stream();
 
             let final_response = stream_to_stdout(&mut stream).await?;
             let last = last_result.lock().expect("lock last_result").clone();

--- a/tests/providers/deepseek/permission_control.rs
+++ b/tests/providers/deepseek/permission_control.rs
@@ -241,7 +241,7 @@ async fn permission_control_streaming_example() -> Result<()> {
             };
 
             let mut stream = agent
-                .stream_prompt(
+                .prompt(
                     "Use the available tools to read test.txt now. \
                      Do not ask any follow-up questions; just read the file and report its content.",
                 )

--- a/tests/providers/deepseek/reasoning_block_order.rs
+++ b/tests/providers/deepseek/reasoning_block_order.rs
@@ -480,7 +480,7 @@ async fn agent_streaming_reasoner_roundtrip_streams_reasoning_first() {
             let mut stream = agent
                 .prompt(reasoning::TOOL_USER_PROMPT).history(Vec::<Message>::new())
                 .max_turns(3)
-                .stream().await;
+                .stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             let reasoning_at = observation

--- a/tests/providers/deepseek/reasoning_block_order.rs
+++ b/tests/providers/deepseek/reasoning_block_order.rs
@@ -478,7 +478,7 @@ async fn agent_streaming_reasoner_roundtrip_streams_reasoning_first() {
                 .build();
 
             let mut stream = agent
-                .stream_chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+                .prompt(reasoning::TOOL_USER_PROMPT).history(Vec::<Message>::new())
                 .max_turns(3)
                 .stream().await;
             let observation = collect_stream_observation(&mut stream).await;

--- a/tests/providers/deepseek/reasoning_tool_roundtrip.rs
+++ b/tests/providers/deepseek/reasoning_tool_roundtrip.rs
@@ -32,8 +32,7 @@ async fn streaming() {
             .prompt(reasoning::TOOL_USER_PROMPT)
             .history(Vec::<Message>::new())
             .max_turns(3)
-            .stream()
-            .await;
+            .stream();
 
         let stats = reasoning::collect_stream_stats(stream, "deepseek").await;
         reasoning::assert_universal(&stats, &call_count, "deepseek");

--- a/tests/providers/deepseek/reasoning_tool_roundtrip.rs
+++ b/tests/providers/deepseek/reasoning_tool_roundtrip.rs
@@ -29,7 +29,8 @@ async fn streaming() {
             .build();
 
         let stream = agent
-            .stream_chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+            .prompt(reasoning::TOOL_USER_PROMPT)
+            .history(Vec::<Message>::new())
             .max_turns(3)
             .stream()
             .await;

--- a/tests/providers/deepseek/streaming.rs
+++ b/tests/providers/deepseek/streaming.rs
@@ -14,7 +14,7 @@ async fn streaming_prompt_smoke() {
             .preamble("You are a helpful assistant.")
             .build();
 
-        let mut stream = agent.stream_prompt("Tell me a joke").stream().await;
+        let mut stream = agent.prompt("Tell me a joke").stream().await;
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");

--- a/tests/providers/deepseek/streaming.rs
+++ b/tests/providers/deepseek/streaming.rs
@@ -14,7 +14,7 @@ async fn streaming_prompt_smoke() {
             .preamble("You are a helpful assistant.")
             .build();
 
-        let mut stream = agent.prompt("Tell me a joke").stream().await;
+        let mut stream = agent.prompt("Tell me a joke").stream();
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");

--- a/tests/providers/deepseek/streaming_tools.rs
+++ b/tests/providers/deepseek/streaming_tools.rs
@@ -40,11 +40,7 @@ async fn streaming_chat_with_tools() {
                 .build();
 
             let history: &[Message] = &[];
-            let mut stream = agent
-                .prompt("Calculate 2 - 5")
-                .history(history)
-                .stream()
-                .await;
+            let mut stream = agent.prompt("Calculate 2 - 5").history(history).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming chat should succeed");
@@ -162,8 +158,7 @@ async fn streaming_chat_surfaces_two_distinct_tool_calls_before_final_answer() {
                 .prompt(TWO_TOOL_STREAM_PROMPT)
                 .history(history)
                 .max_turns(8)
-                .stream()
-                .await;
+                .stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert_two_tool_roundtrip_contract(
@@ -193,8 +188,7 @@ async fn streaming_chat_emits_tool_call_before_later_text() {
                 .prompt(ORDERED_TOOL_STREAM_PROMPT)
                 .history(history)
                 .max_turns(5)
-                .stream()
-                .await;
+                .stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert_tool_call_precedes_later_text(

--- a/tests/providers/deepseek/streaming_tools.rs
+++ b/tests/providers/deepseek/streaming_tools.rs
@@ -40,7 +40,11 @@ async fn streaming_chat_with_tools() {
                 .build();
 
             let history: &[Message] = &[];
-            let mut stream = agent.stream_chat("Calculate 2 - 5", history).stream().await;
+            let mut stream = agent
+                .prompt("Calculate 2 - 5")
+                .history(history)
+                .stream()
+                .await;
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming chat should succeed");
@@ -155,7 +159,8 @@ async fn streaming_chat_surfaces_two_distinct_tool_calls_before_final_answer() {
 
             let history: &[Message] = &[];
             let mut stream = agent
-                .stream_chat(TWO_TOOL_STREAM_PROMPT, history)
+                .prompt(TWO_TOOL_STREAM_PROMPT)
+                .history(history)
                 .max_turns(8)
                 .stream()
                 .await;
@@ -185,7 +190,8 @@ async fn streaming_chat_emits_tool_call_before_later_text() {
 
             let history: &[Message] = &[];
             let mut stream = agent
-                .stream_chat(ORDERED_TOOL_STREAM_PROMPT, history)
+                .prompt(ORDERED_TOOL_STREAM_PROMPT)
+                .history(history)
                 .max_turns(5)
                 .stream()
                 .await;

--- a/tests/providers/deepseek/truncation_matrix.rs
+++ b/tests/providers/deepseek/truncation_matrix.rs
@@ -1132,7 +1132,8 @@ async fn agent_streaming_truncated_call_is_not_invoked() {
                 .build();
 
             let mut stream = agent
-                .stream_chat(INCIDENT_PROMPT, Vec::<rig::completion::Message>::new())
+                .prompt(INCIDENT_PROMPT)
+                .history(Vec::<rig::completion::Message>::new())
                 .max_turns(1)
                 .stream()
                 .await;
@@ -1221,7 +1222,8 @@ async fn agent_streaming_empty_arguments_on_length_are_not_invoked() {
                 .build();
 
             let mut stream = agent
-                .stream_chat(INCIDENT_PROMPT, Vec::<rig::completion::Message>::new())
+                .prompt(INCIDENT_PROMPT)
+                .history(Vec::<rig::completion::Message>::new())
                 .max_turns(1)
                 .stream()
                 .await;

--- a/tests/providers/deepseek/truncation_matrix.rs
+++ b/tests/providers/deepseek/truncation_matrix.rs
@@ -1135,8 +1135,7 @@ async fn agent_streaming_truncated_call_is_not_invoked() {
                 .prompt(INCIDENT_PROMPT)
                 .history(Vec::<rig::completion::Message>::new())
                 .max_turns(1)
-                .stream()
-                .await;
+                .stream();
             let observation = crate::support::collect_stream_observation(&mut stream).await;
 
             assert!(
@@ -1225,8 +1224,7 @@ async fn agent_streaming_empty_arguments_on_length_are_not_invoked() {
                 .prompt(INCIDENT_PROMPT)
                 .history(Vec::<rig::completion::Message>::new())
                 .max_turns(1)
-                .stream()
-                .await;
+                .stream();
             let observation = crate::support::collect_stream_observation(&mut stream).await;
             assert!(observation.tool_calls.is_empty());
             assert_eq!(

--- a/tests/providers/doubleword/cassette/streaming.rs
+++ b/tests/providers/doubleword/cassette/streaming.rs
@@ -14,7 +14,7 @@ async fn streaming_smoke() {
             .agent(DEFAULT_MODEL)
             .preamble(STREAMING_PREAMBLE)
             .build();
-        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream();
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");

--- a/tests/providers/doubleword/cassette/streaming.rs
+++ b/tests/providers/doubleword/cassette/streaming.rs
@@ -14,7 +14,7 @@ async fn streaming_smoke() {
             .agent(DEFAULT_MODEL)
             .preamble(STREAMING_PREAMBLE)
             .build();
-        let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");

--- a/tests/providers/doubleword/cassette/streaming_tools.rs
+++ b/tests/providers/doubleword/cassette/streaming_tools.rs
@@ -20,7 +20,7 @@ async fn streaming_tools_smoke() {
                 .tool(Subtract)
                 .default_max_turns(2)
                 .build();
-            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");

--- a/tests/providers/doubleword/cassette/streaming_tools.rs
+++ b/tests/providers/doubleword/cassette/streaming_tools.rs
@@ -20,7 +20,7 @@ async fn streaming_tools_smoke() {
                 .tool(Subtract)
                 .default_max_turns(2)
                 .build();
-            let mut stream = agent.stream_prompt(STREAMING_TOOLS_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");

--- a/tests/providers/gemini/cassette/agent_run_streamed.rs
+++ b/tests/providers/gemini/cassette/agent_run_streamed.rs
@@ -503,7 +503,7 @@ async fn builtin_streaming_max_turns_error_carries_pending_message() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt("What is 21 + 21? Use the add tool.")
+                .prompt("What is 21 + 21? Use the add tool.")
                 .max_turns(2)
                 .stream()
                 .await;
@@ -577,7 +577,7 @@ async fn builtin_streaming_cancellation_history_includes_assistant_turn() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt("What is 21 + 21? Use the add tool.")
+                .prompt("What is 21 + 21? Use the add tool.")
                 .add_hook(CancelOnToolCall)
                 .max_turns(2)
                 .stream()

--- a/tests/providers/gemini/cassette/agent_run_streamed.rs
+++ b/tests/providers/gemini/cassette/agent_run_streamed.rs
@@ -505,8 +505,7 @@ async fn builtin_streaming_max_turns_error_carries_pending_message() {
             let mut stream = agent
                 .prompt("What is 21 + 21? Use the add tool.")
                 .max_turns(2)
-                .stream()
-                .await;
+                .stream();
 
             let mut prompt_error = None;
             while let Some(item) = stream.next().await {
@@ -580,8 +579,7 @@ async fn builtin_streaming_cancellation_history_includes_assistant_turn() {
                 .prompt("What is 21 + 21? Use the add tool.")
                 .add_hook(CancelOnToolCall)
                 .max_turns(2)
-                .stream()
-                .await;
+                .stream();
 
             let mut prompt_error = None;
             let mut saw_final = false;

--- a/tests/providers/gemini/cassette/agent_tools_e2e.rs
+++ b/tests/providers/gemini/cassette/agent_tools_e2e.rs
@@ -86,7 +86,7 @@ async fn streaming_multi_turn_executes_tools_via_builtin_driver() {
                 .tool(subtract)
                 .build();
 
-            let mut stream = agent.prompt(CHAINED_PROMPT).max_turns(5).stream().await;
+            let mut stream = agent.prompt(CHAINED_PROMPT).max_turns(5).stream();
             let observation = crate::support::collect_stream_observation(&mut stream).await;
 
             assert!(

--- a/tests/providers/gemini/cassette/agent_tools_e2e.rs
+++ b/tests/providers/gemini/cassette/agent_tools_e2e.rs
@@ -1,6 +1,6 @@
 //! End-to-end tool execution through the built-in agent drivers: real
 //! `ToolSet` execution behind `agent.prompt()` / `agent.chat()` /
-//! `agent.stream_prompt()`, pinning the wire contract of the handrolled tool
+//! `agent.prompt()`, pinning the wire contract of the handrolled tool
 //! pipeline ahead of the rmcp migration.
 
 use rig::prelude::*;
@@ -86,11 +86,7 @@ async fn streaming_multi_turn_executes_tools_via_builtin_driver() {
                 .tool(subtract)
                 .build();
 
-            let mut stream = agent
-                .stream_prompt(CHAINED_PROMPT)
-                .max_turns(5)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(CHAINED_PROMPT).max_turns(5).stream().await;
             let observation = crate::support::collect_stream_observation(&mut stream).await;
 
             assert!(

--- a/tests/providers/gemini/cassette/code_execution_matrix.rs
+++ b/tests/providers/gemini/cassette/code_execution_matrix.rs
@@ -334,8 +334,7 @@ async fn streaming_agent_prompt_answers_after_code_execution() {
 
             let mut stream = agent
                 .prompt("Use the code execution tool to compute 2 to the power of 20. State the number in your answer.")
-                .stream()
-                .await;
+                .stream();
 
             let mut answer = String::new();
             while let Some(item) = stream.next().await {

--- a/tests/providers/gemini/cassette/code_execution_matrix.rs
+++ b/tests/providers/gemini/cassette/code_execution_matrix.rs
@@ -27,7 +27,7 @@
 //! | 1 | `blocking_raw_model_answers_after_code_execution` | blocking | `CompletionModel::completion` | baseline: code parts skipped, text survives |
 //! | 2 | `streaming_raw_model_answers_after_code_execution` | streaming | `CompletionModel::stream` | parity twin of 1 |
 //! | 3 | `blocking_agent_prompt_answers_after_code_execution` | blocking | `Agent::prompt` | agent surface |
-//! | 4 | `streaming_agent_prompt_answers_after_code_execution` | streaming | `Agent::stream_prompt` | parity twin of 3 |
+//! | 4 | `streaming_agent_prompt_answers_after_code_execution` | streaming | `Agent::prompt` | parity twin of 3 |
 //! | 5 | `blocking_raw_completion_keeps_native_code_parts` | blocking | `CompletionModel::raw_completion` | escape hatch still exposes the parts |
 //! | 6 | `blocking_failed_code_execution_outcome` | blocking | `completion` | `OUTCOME_FAILED` result part |
 //! | 7 | `streaming_failed_code_execution_outcome` | streaming | `stream` | parity twin of 6 |
@@ -333,7 +333,7 @@ async fn streaming_agent_prompt_answers_after_code_execution() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt("Use the code execution tool to compute 2 to the power of 20. State the number in your answer.")
+                .prompt("Use the code execution tool to compute 2 to the power of 20. State the number in your answer.")
                 .stream()
                 .await;
 

--- a/tests/providers/gemini/cassette/corpus_breadth.rs
+++ b/tests/providers/gemini/cassette/corpus_breadth.rs
@@ -113,7 +113,7 @@ async fn output_tool_streamed_effect_log_is_the_golden_fixture() {
                 .output_mode(OutputMode::Tool)
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
+            let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream();
             let output = final_output(&mut stream).await.expect("the run answers");
             drop(stream);
             assert_event(&output);
@@ -139,7 +139,7 @@ async fn text_delta_stop_effect_log_is_the_golden_fixture() {
             .add_hook(StopOnTextDelta)
             .record_effects_with_events()
             .build();
-        let mut stream = agent.prompt(ESSAY_PROMPT).stream().await;
+        let mut stream = agent.prompt(ESSAY_PROMPT).stream();
         let reason = final_output(&mut stream)
             .await
             .expect_err("the hook stops the run");

--- a/tests/providers/gemini/cassette/corpus_breadth.rs
+++ b/tests/providers/gemini/cassette/corpus_breadth.rs
@@ -113,7 +113,7 @@ async fn output_tool_streamed_effect_log_is_the_golden_fixture() {
                 .output_mode(OutputMode::Tool)
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.stream_prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
+            let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
             let output = final_output(&mut stream).await.expect("the run answers");
             drop(stream);
             assert_event(&output);
@@ -139,7 +139,7 @@ async fn text_delta_stop_effect_log_is_the_golden_fixture() {
             .add_hook(StopOnTextDelta)
             .record_effects_with_events()
             .build();
-        let mut stream = agent.stream_prompt(ESSAY_PROMPT).stream().await;
+        let mut stream = agent.prompt(ESSAY_PROMPT).stream().await;
         let reason = final_output(&mut stream)
             .await
             .expect_err("the hook stops the run");

--- a/tests/providers/gemini/cassette/corpus_delta.rs
+++ b/tests/providers/gemini/cassette/corpus_delta.rs
@@ -29,7 +29,7 @@ async fn interactions_baseline_effect_log_is_the_golden_fixture() {
             .tool(Adder)
             .record_effects_with_events()
             .build();
-        let mut stream = agent.prompt(ADD_PROMPT).max_turns(3).stream().await;
+        let mut stream = agent.prompt(ADD_PROMPT).max_turns(3).stream();
         let mut output = None;
         while let Some(item) = stream.next().await {
             if let MultiTurnStreamItem::FinalResponse(response) = item.expect("the stream yields") {

--- a/tests/providers/gemini/cassette/corpus_delta.rs
+++ b/tests/providers/gemini/cassette/corpus_delta.rs
@@ -29,7 +29,7 @@ async fn interactions_baseline_effect_log_is_the_golden_fixture() {
             .tool(Adder)
             .record_effects_with_events()
             .build();
-        let mut stream = agent.stream_prompt(ADD_PROMPT).max_turns(3).stream().await;
+        let mut stream = agent.prompt(ADD_PROMPT).max_turns(3).stream().await;
         let mut output = None;
         while let Some(item) = stream.next().await {
             if let MultiTurnStreamItem::FinalResponse(response) = item.expect("the stream yields") {

--- a/tests/providers/gemini/cassette/corpus_retrieval.rs
+++ b/tests/providers/gemini/cassette/corpus_retrieval.rs
@@ -140,7 +140,7 @@ async fn dynamic_context_two_streamed_effect_log_is_the_golden_fixture() {
                 .dynamic_context(2, index)
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.stream_prompt(FACT_PROMPT).stream().await;
+            let mut stream = agent.prompt(FACT_PROMPT).stream().await;
             let output = final_output(&mut stream).await;
             drop(stream);
             assert!(!output.is_empty());

--- a/tests/providers/gemini/cassette/corpus_retrieval.rs
+++ b/tests/providers/gemini/cassette/corpus_retrieval.rs
@@ -140,7 +140,7 @@ async fn dynamic_context_two_streamed_effect_log_is_the_golden_fixture() {
                 .dynamic_context(2, index)
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.prompt(FACT_PROMPT).stream().await;
+            let mut stream = agent.prompt(FACT_PROMPT).stream();
             let output = final_output(&mut stream).await;
             drop(stream);
             assert!(!output.is_empty());

--- a/tests/providers/gemini/cassette/corpus_serving.rs
+++ b/tests/providers/gemini/cassette/corpus_serving.rs
@@ -38,8 +38,7 @@ async fn two_turns_serial_effect_log_is_the_golden_fixture() {
                      subtract tool. Report the final number.",
                 )
                 .max_turns(6)
-                .stream()
-                .await;
+                .stream();
             let mut saw_final = false;
             while let Some(item) = stream.next().await {
                 if let Ok(MultiTurnStreamItem::FinalResponse(_)) = item {

--- a/tests/providers/gemini/cassette/corpus_serving.rs
+++ b/tests/providers/gemini/cassette/corpus_serving.rs
@@ -33,7 +33,7 @@ async fn two_turns_serial_effect_log_is_the_golden_fixture() {
                 .record_effects()
                 .build();
             let mut stream = agent
-                .stream_prompt(
+                .prompt(
                     "First add 20 and 5 with the add tool. Then subtract 4 from that sum with the \
                      subtract tool. Report the final number.",
                 )

--- a/tests/providers/gemini/cassette/generate_sessions.rs
+++ b/tests/providers/gemini/cassette/generate_sessions.rs
@@ -155,7 +155,8 @@ async fn sequential_tool_calls_ordering_streaming() {
                 .build();
 
             let mut stream = agent
-                .stream_chat(SEQUENTIAL_TOOLS_PROMPT, Vec::<Message>::new())
+                .prompt(SEQUENTIAL_TOOLS_PROMPT)
+                .history(Vec::<Message>::new())
                 .max_turns(6)
                 .stream()
                 .await;

--- a/tests/providers/gemini/cassette/generate_sessions.rs
+++ b/tests/providers/gemini/cassette/generate_sessions.rs
@@ -158,8 +158,7 @@ async fn sequential_tool_calls_ordering_streaming() {
                 .prompt(SEQUENTIAL_TOOLS_PROMPT)
                 .history(Vec::<Message>::new())
                 .max_turns(6)
-                .stream()
-                .await;
+                .stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert!(

--- a/tests/providers/gemini/cassette/hook_stress.rs
+++ b/tests/providers/gemini/cassette/hook_stress.rs
@@ -532,7 +532,7 @@ async fn streaming_lifecycle_ordering_and_context_streaming_flag() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(
+                .prompt(
                     "First add 20 and 5 with the add tool. Then subtract 4 from that sum with the \
                      subtract tool. Report the final number.",
                 )
@@ -806,7 +806,7 @@ async fn tool_call_turns_effect_log_is_the_golden_fixture() {
                 .record_effects()
                 .build();
             let mut stream = agent
-                .stream_prompt(
+                .prompt(
                     "First add 20 and 5 with the add tool. Then subtract 4 from that sum with the \
                      subtract tool. Report the final number.",
                 )

--- a/tests/providers/gemini/cassette/hook_stress.rs
+++ b/tests/providers/gemini/cassette/hook_stress.rs
@@ -538,8 +538,7 @@ async fn streaming_lifecycle_ordering_and_context_streaming_flag() {
                 )
                 .add_hook(recorder)
                 .max_turns(6)
-                .stream()
-                .await;
+                .stream();
 
             // Ordered stream-item taxonomy tags, so we can assert lifecycle order.
             let mut events: Vec<&'static str> = Vec::new();
@@ -811,8 +810,7 @@ async fn tool_call_turns_effect_log_is_the_golden_fixture() {
                      subtract tool. Report the final number.",
                 )
                 .max_turns(6)
-                .stream()
-                .await;
+                .stream();
             let mut saw_final = false;
             while let Some(item) = stream.next().await {
                 if let Ok(MultiTurnStreamItem::FinalResponse(_)) = item {

--- a/tests/providers/gemini/cassette/hook_stress_streaming.rs
+++ b/tests/providers/gemini/cassette/hook_stress_streaming.rs
@@ -36,7 +36,7 @@ async fn streaming_text_only_emits_text_deltas_and_stream_finish() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt("In one short sentence, describe the color of a clear daytime sky.")
+                .prompt("In one short sentence, describe the color of a clear daytime sky.")
                 .add_hook(tap)
                 .max_turns(2)
                 .stream()
@@ -90,7 +90,7 @@ async fn streaming_tool_turns_fire_model_turn_finished() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(
+                .prompt(
                     "First add 40 and 2 with the add tool. Then subtract 10 from that sum with the \
                      subtract tool. Report the final number.",
                 )
@@ -144,9 +144,7 @@ async fn streaming_result_redaction_reaches_final_response() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(
-                    "Use the add tool to add 5 and 5, then report the exact tool result.",
-                )
+                .prompt("Use the add tool to add 5 and 5, then report the exact tool result.")
                 .add_hook(RewriteToolResult {
                     tool: "add",
                     rewrite: ResultRewrite::Replace("STREAM-REDACTED-Q3"),
@@ -193,7 +191,7 @@ async fn streaming_active_tools_narrowing_filters_a_tool() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt("Compute 12 + 8, then compute 30 - 7. Report whichever you can.")
+                .prompt("Compute 12 + 8, then compute 30 - 7. Report whichever you can.")
                 .add_hook(ApplyPatch(
                     RequestPatch::new().active_tools(["add"]).temperature(0.0),
                 ))
@@ -241,7 +239,7 @@ async fn streaming_skip_leaves_tool_unexecuted() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt("Add 14 and 6, and subtract 9 from 40. Report what you can.")
+                .prompt("Add 14 and 6, and subtract 9 from 40. Report what you can.")
                 .add_hook(SkipToolHook {
                     tool_name: "subtract",
                     reason: "the subtract tool is offline; continue without it",
@@ -308,7 +306,7 @@ async fn blocking_and_streaming_produce_same_final_answer() {
                 .tool(add_s)
                 .tool(sub_s)
                 .build();
-            let mut stream = agent.stream_prompt(PROMPT).max_turns(6).stream().await;
+            let mut stream = agent.prompt(PROMPT).max_turns(6).stream().await;
             let final_text = collect_stream_final_response(&mut stream)
                 .await
                 .expect("a final response");

--- a/tests/providers/gemini/cassette/hook_stress_streaming.rs
+++ b/tests/providers/gemini/cassette/hook_stress_streaming.rs
@@ -39,8 +39,7 @@ async fn streaming_text_only_emits_text_deltas_and_stream_finish() {
                 .prompt("In one short sentence, describe the color of a clear daytime sky.")
                 .add_hook(tap)
                 .max_turns(2)
-                .stream()
-                .await;
+                .stream();
 
             let final_text = collect_stream_final_response(&mut stream)
                 .await
@@ -96,8 +95,7 @@ async fn streaming_tool_turns_fire_model_turn_finished() {
                 )
                 .add_hook(tap)
                 .max_turns(6)
-                .stream()
-                .await;
+                .stream();
 
             let final_text = collect_stream_final_response(&mut stream)
                 .await
@@ -150,8 +148,7 @@ async fn streaming_result_redaction_reaches_final_response() {
                     rewrite: ResultRewrite::Replace("STREAM-REDACTED-Q3"),
                 })
                 .max_turns(4)
-                .stream()
-                .await;
+                .stream();
 
             let final_text = collect_stream_final_response(&mut stream)
                 .await
@@ -196,8 +193,7 @@ async fn streaming_active_tools_narrowing_filters_a_tool() {
                     RequestPatch::new().active_tools(["add"]).temperature(0.0),
                 ))
                 .max_turns(5)
-                .stream()
-                .await;
+                .stream();
 
             let final_text = collect_stream_final_response(&mut stream)
                 .await
@@ -245,8 +241,7 @@ async fn streaming_skip_leaves_tool_unexecuted() {
                     reason: "the subtract tool is offline; continue without it",
                 })
                 .max_turns(5)
-                .stream()
-                .await;
+                .stream();
 
             let final_text = collect_stream_final_response(&mut stream)
                 .await
@@ -306,7 +301,7 @@ async fn blocking_and_streaming_produce_same_final_answer() {
                 .tool(add_s)
                 .tool(sub_s)
                 .build();
-            let mut stream = agent.prompt(PROMPT).max_turns(6).stream().await;
+            let mut stream = agent.prompt(PROMPT).max_turns(6).stream();
             let final_text = collect_stream_final_response(&mut stream)
                 .await
                 .expect("a final response");

--- a/tests/providers/gemini/cassette/lifecycle_matrix.rs
+++ b/tests/providers/gemini/cassette/lifecycle_matrix.rs
@@ -52,7 +52,7 @@ async fn middleware_response_phase_precedes_stream_consumption() {
                 .preamble(STREAMING_PREAMBLE)
                 .add_hook(settle_hook)
                 .build();
-            let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
             let (response, provider_final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await
@@ -115,7 +115,7 @@ async fn entry_log_orders_and_turn_stamps_across_a_streamed_tool_run() {
                 .add_hook(agent_hook)
                 .build();
             let mut stream = agent
-                .stream_prompt("What is 9 + 16? Use the add tool, then reply with just the number.")
+                .prompt("What is 9 + 16? Use the add tool, then reply with just the number.")
                 .max_turns(3)
                 .stream()
                 .await;

--- a/tests/providers/gemini/cassette/lifecycle_matrix.rs
+++ b/tests/providers/gemini/cassette/lifecycle_matrix.rs
@@ -52,7 +52,7 @@ async fn middleware_response_phase_precedes_stream_consumption() {
                 .preamble(STREAMING_PREAMBLE)
                 .add_hook(settle_hook)
                 .build();
-            let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_PROMPT).stream();
             let (response, provider_final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await
@@ -117,8 +117,7 @@ async fn entry_log_orders_and_turn_stamps_across_a_streamed_tool_run() {
             let mut stream = agent
                 .prompt("What is 9 + 16? Use the add tool, then reply with just the number.")
                 .max_turns(3)
-                .stream()
-                .await;
+                .stream();
             let (response, _final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await

--- a/tests/providers/gemini/cassette/multi_turn_streaming.rs
+++ b/tests/providers/gemini/cassette/multi_turn_streaming.rs
@@ -36,7 +36,7 @@ async fn runner_driven_multi_turn_streaming_loop() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(MULTI_TURN_STREAMING_PROMPT)
+                .prompt(MULTI_TURN_STREAMING_PROMPT)
                 .max_turns(10)
                 .stream()
                 .await;

--- a/tests/providers/gemini/cassette/multi_turn_streaming.rs
+++ b/tests/providers/gemini/cassette/multi_turn_streaming.rs
@@ -38,8 +38,7 @@ async fn runner_driven_multi_turn_streaming_loop() {
             let mut stream = agent
                 .prompt(MULTI_TURN_STREAMING_PROMPT)
                 .max_turns(10)
-                .stream()
-                .await;
+                .stream();
             let mut response = None;
             while let Some(item) = stream.next().await {
                 if let MultiTurnStreamItem::FinalResponse(final_response) =

--- a/tests/providers/gemini/cassette/raw_capture_agent_matrix.rs
+++ b/tests/providers/gemini/cassette/raw_capture_agent_matrix.rs
@@ -388,13 +388,7 @@ async fn hooks_observe_raw_streamed() {
         "raw_capture_agent_matrix/hooks_observe_raw_streamed",
         move |client| async move {
             let agent = client.agent(MODEL).temperature(0.0).add_hook(hook).build();
-            let run = drain(
-                agent
-                    .stream_prompt(Message::user(TEXT_PROMPT))
-                    .stream()
-                    .await,
-            )
-            .await;
+            let run = drain(agent.prompt(Message::user(TEXT_PROMPT)).stream().await).await;
             assert!(run.output.is_some(), "the run finished");
             assert_eq!(run.finals.len(), 1, "one text turn, one terminal record");
             assert!(
@@ -535,7 +529,7 @@ async fn multi_turn_tool_run_records_distinct_raw_streamed() {
                 .build();
             let run = drain(
                 agent
-                    .stream_prompt(Message::user(TOOL_PROMPT))
+                    .prompt(Message::user(TOOL_PROMPT))
                     .max_turns(3)
                     .stream()
                     .await,

--- a/tests/providers/gemini/cassette/raw_capture_agent_matrix.rs
+++ b/tests/providers/gemini/cassette/raw_capture_agent_matrix.rs
@@ -18,9 +18,9 @@
 //! | # | Cell | Dimension | expected | Status |
 //! |---|------|-----------|----------|--------|
 //! | 1 | `hooks_observe_raw_blocking` | `agent.prompt` | `CompletionResponse` and `ModelTurnFinished` see `raw`; `responseId` matches fixture | recorded |
-//! | 2 | `hooks_observe_raw_streamed` | `agent.stream_prompt` | `CompletionResponse` and `ModelTurnFinished` see `raw`; `response_id` matches fixture | recorded |
+//! | 2 | `hooks_observe_raw_streamed` | `agent.prompt(..).stream()` | `CompletionResponse` and `ModelTurnFinished` see `raw`; `response_id` matches fixture | recorded |
 //! | 3 | `multi_turn_tool_run_records_distinct_raw_blocking` | tool run, `agent.prompt` | two `completion_calls`, two different `raw["responseId"]`s equal to the interactions' ids in order; the first carries the `functionCall` | recorded |
-//! | 4 | `multi_turn_tool_run_records_distinct_raw_streamed` | tool run, `agent.stream_prompt` | two `CompletionCall` items, two different `raw["response_id"]`s equal to the interactions' ids in order; the forwarded last `Final.raw` is the final turn's | recorded |
+//! | 4 | `multi_turn_tool_run_records_distinct_raw_streamed` | tool run, `agent.prompt(..).stream()` | two `CompletionCall` items, two different `raw["response_id"]`s equal to the interactions' ids in order; the forwarded last `Final.raw` is the final turn's | recorded |
 //!
 //! Both surfaces fire the same two events per accepted model turn:
 //! `CompletionResponse` — after the unary call returns on the blocking

--- a/tests/providers/gemini/cassette/raw_capture_agent_matrix.rs
+++ b/tests/providers/gemini/cassette/raw_capture_agent_matrix.rs
@@ -388,7 +388,7 @@ async fn hooks_observe_raw_streamed() {
         "raw_capture_agent_matrix/hooks_observe_raw_streamed",
         move |client| async move {
             let agent = client.agent(MODEL).temperature(0.0).add_hook(hook).build();
-            let run = drain(agent.prompt(Message::user(TEXT_PROMPT)).stream().await).await;
+            let run = drain(agent.prompt(Message::user(TEXT_PROMPT)).stream()).await;
             assert!(run.output.is_some(), "the run finished");
             assert_eq!(run.finals.len(), 1, "one text turn, one terminal record");
             assert!(
@@ -531,8 +531,7 @@ async fn multi_turn_tool_run_records_distinct_raw_streamed() {
                 agent
                     .prompt(Message::user(TOOL_PROMPT))
                     .max_turns(3)
-                    .stream()
-                    .await,
+                    .stream(),
             )
             .await;
             assert!(run.output.is_some(), "the run finished");

--- a/tests/providers/gemini/cassette/reasoning_tool_roundtrip.rs
+++ b/tests/providers/gemini/cassette/reasoning_tool_roundtrip.rs
@@ -30,7 +30,8 @@ async fn streaming() {
                 .build();
 
             let stream = agent
-                .stream_chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+                .prompt(reasoning::TOOL_USER_PROMPT)
+                .history(Vec::<Message>::new())
                 .max_turns(3)
                 .stream()
                 .await;

--- a/tests/providers/gemini/cassette/reasoning_tool_roundtrip.rs
+++ b/tests/providers/gemini/cassette/reasoning_tool_roundtrip.rs
@@ -33,8 +33,7 @@ async fn streaming() {
                 .prompt(reasoning::TOOL_USER_PROMPT)
                 .history(Vec::<Message>::new())
                 .max_turns(3)
-                .stream()
-                .await;
+                .stream();
 
             let stats = reasoning::collect_stream_stats(stream, "gemini").await;
             reasoning::assert_universal(&stats, &call_count, "gemini");

--- a/tests/providers/gemini/cassette/regression_suite.rs
+++ b/tests/providers/gemini/cassette/regression_suite.rs
@@ -50,7 +50,7 @@ async fn agent_max_tokens_reaches_generation_config_without_additional_params() 
                 .max_tokens(512)
                 .build();
 
-            let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_PROMPT).stream();
             let (_response, provider_final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await
@@ -269,7 +269,7 @@ async fn streaming_structured_output_without_max_tokens_sends_no_sampling_fields
                 .output_mode(OutputMode::Native)
                 .build();
 
-            let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
+            let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream();
             let (_response, provider_final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await

--- a/tests/providers/gemini/cassette/regression_suite.rs
+++ b/tests/providers/gemini/cassette/regression_suite.rs
@@ -50,7 +50,7 @@ async fn agent_max_tokens_reaches_generation_config_without_additional_params() 
                 .max_tokens(512)
                 .build();
 
-            let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
             let (_response, provider_final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await
@@ -269,7 +269,7 @@ async fn streaming_structured_output_without_max_tokens_sends_no_sampling_fields
                 .output_mode(OutputMode::Native)
                 .build();
 
-            let mut stream = agent.stream_prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
+            let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
             let (_response, provider_final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await

--- a/tests/providers/gemini/cassette/response_identity.rs
+++ b/tests/providers/gemini/cassette/response_identity.rs
@@ -115,8 +115,7 @@ async fn streamed_agent_run_reports_none_identity() {
                 .prompt(rig::completion::Message::user(
                     "Reply with exactly: streamed identity probe",
                 ))
-                .stream()
-                .await;
+                .stream();
             while let Some(item) = stream.next().await {
                 item.expect("stream item should succeed");
             }

--- a/tests/providers/gemini/cassette/response_identity.rs
+++ b/tests/providers/gemini/cassette/response_identity.rs
@@ -112,7 +112,7 @@ async fn streamed_agent_run_reports_none_identity() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(rig::completion::Message::user(
+                .prompt(rig::completion::Message::user(
                     "Reply with exactly: streamed identity probe",
                 ))
                 .stream()

--- a/tests/providers/gemini/cassette/stream_terminal_matrix.rs
+++ b/tests/providers/gemini/cassette/stream_terminal_matrix.rs
@@ -35,7 +35,7 @@
 //! |---|------|------|------------------|
 //! | 1 | `two_terminal_stream_keeps_the_text_after_the_first_finish` | recorded | the bug itself |
 //! | 2 | `two_terminal_stream_blocking_twin_has_the_same_answer` | recorded | the blocking yardstick cell 1 is measured against |
-//! | 3 | `two_terminal_stream_agent_prompt_keeps_the_answer` | recorded | `Agent::stream_prompt` |
+//! | 3 | `two_terminal_stream_agent_prompt_keeps_the_answer` | recorded | `Agent::prompt` |
 //! | 4 | `two_terminal_stream_terminal_carries_the_last_usage` | recorded | terminal metadata comes from the last chunk |
 //! | 5 | `two_terminal_stream_with_visible_thoughts` | recorded | reasoning spanning the boundary |
 //! | 6 | `gemini_3_flash_does_not_emit_the_intermediate_finish` | recorded | second model family: control, shape absent |
@@ -285,7 +285,7 @@ async fn two_terminal_stream_agent_prompt_keeps_the_answer() {
                 .additional_params(code_execution_params())
                 .build();
 
-            let mut stream = agent.stream_prompt(TWO_ROUND_PROMPT).stream().await;
+            let mut stream = agent.prompt(TWO_ROUND_PROMPT).stream().await;
             let mut answer = String::new();
             while let Some(item) = stream.next().await {
                 if let rig::agent::MultiTurnStreamItem::StreamAssistantItem(

--- a/tests/providers/gemini/cassette/stream_terminal_matrix.rs
+++ b/tests/providers/gemini/cassette/stream_terminal_matrix.rs
@@ -285,7 +285,7 @@ async fn two_terminal_stream_agent_prompt_keeps_the_answer() {
                 .additional_params(code_execution_params())
                 .build();
 
-            let mut stream = agent.prompt(TWO_ROUND_PROMPT).stream().await;
+            let mut stream = agent.prompt(TWO_ROUND_PROMPT).stream();
             let mut answer = String::new();
             while let Some(item) = stream.next().await {
                 if let rig::agent::MultiTurnStreamItem::StreamAssistantItem(

--- a/tests/providers/gemini/cassette/streaming.rs
+++ b/tests/providers/gemini/cassette/streaming.rs
@@ -37,7 +37,7 @@ async fn streaming_smoke() {
             )
             .build();
 
-        let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
         let (response, provider_final): (_, StreamFinal) =
             collect_stream_final_response_and_provider_final(&mut stream)
                 .await
@@ -71,7 +71,7 @@ async fn example_streaming_prompt() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt("When and where and what type is the next solar eclipse?")
+                .prompt("When and where and what type is the next solar eclipse?")
                 .stream()
                 .await;
             let response = collect_stream_final_response(&mut stream)

--- a/tests/providers/gemini/cassette/streaming.rs
+++ b/tests/providers/gemini/cassette/streaming.rs
@@ -37,7 +37,7 @@ async fn streaming_smoke() {
             )
             .build();
 
-        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream();
         let (response, provider_final): (_, StreamFinal) =
             collect_stream_final_response_and_provider_final(&mut stream)
                 .await
@@ -72,8 +72,7 @@ async fn example_streaming_prompt() {
 
             let mut stream = agent
                 .prompt("When and where and what type is the next solar eclipse?")
-                .stream()
-                .await;
+                .stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming prompt should succeed");

--- a/tests/providers/gemini/cassette/streaming_multimodal_tool_results.rs
+++ b/tests/providers/gemini/cassette/streaming_multimodal_tool_results.rs
@@ -86,8 +86,7 @@ async fn streaming_history_preserves_hybrid_tool_result_image_parts() {
         )
         .history(empty_history)
         .max_turns(4)
-        .stream()
-        .await;
+        .stream();
 
     let mut final_response = None;
     let mut final_history = None;

--- a/tests/providers/gemini/cassette/streaming_multimodal_tool_results.rs
+++ b/tests/providers/gemini/cassette/streaming_multimodal_tool_results.rs
@@ -81,7 +81,7 @@ async fn streaming_history_preserves_hybrid_tool_result_image_parts() {
 
     let empty_history: &[Message] = &[];
     let mut stream = agent
-        .stream_prompt(
+        .prompt(
             "Use the tool once, then answer with the dominant color in the returned image.",
         )
         .history(empty_history)

--- a/tests/providers/gemini/cassette/streaming_tools.rs
+++ b/tests/providers/gemini/cassette/streaming_tools.rs
@@ -37,7 +37,7 @@ async fn streaming_tools_smoke() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(STREAMING_TOOLS_PROMPT)
+                .prompt(STREAMING_TOOLS_PROMPT)
                 .max_turns(3)
                 .stream()
                 .await;
@@ -85,7 +85,7 @@ async fn streaming_tools_surface_two_distinct_tool_calls_before_final_answer() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(TWO_TOOL_STREAM_PROMPT)
+                .prompt(TWO_TOOL_STREAM_PROMPT)
                 .max_turns(8)
                 .stream()
                 .await;
@@ -114,7 +114,7 @@ async fn streaming_tools_emit_tool_call_before_later_text() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(ORDERED_TOOL_STREAM_PROMPT)
+                .prompt(ORDERED_TOOL_STREAM_PROMPT)
                 .max_turns(5)
                 .stream()
                 .await;
@@ -147,11 +147,7 @@ async fn example_streaming_with_tools() {
                 .additional_params(streaming_tool_params())
                 .build();
 
-            let mut stream = agent
-                .stream_prompt("Calculate 2 - 5")
-                .max_turns(3)
-                .stream()
-                .await;
+            let mut stream = agent.prompt("Calculate 2 - 5").max_turns(3).stream().await;
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming prompt should succeed");

--- a/tests/providers/gemini/cassette/streaming_tools.rs
+++ b/tests/providers/gemini/cassette/streaming_tools.rs
@@ -36,11 +36,7 @@ async fn streaming_tools_smoke() {
                 .additional_params(streaming_tool_params())
                 .build();
 
-            let mut stream = agent
-                .prompt(STREAMING_TOOLS_PROMPT)
-                .max_turns(3)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).max_turns(3).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");
@@ -84,11 +80,7 @@ async fn streaming_tools_surface_two_distinct_tool_calls_before_final_answer() {
                 .additional_params(streaming_tool_params())
                 .build();
 
-            let mut stream = agent
-                .prompt(TWO_TOOL_STREAM_PROMPT)
-                .max_turns(8)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(TWO_TOOL_STREAM_PROMPT).max_turns(8).stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert_two_tool_roundtrip_contract(
@@ -116,8 +108,7 @@ async fn streaming_tools_emit_tool_call_before_later_text() {
             let mut stream = agent
                 .prompt(ORDERED_TOOL_STREAM_PROMPT)
                 .max_turns(5)
-                .stream()
-                .await;
+                .stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert_tool_call_precedes_later_text(
@@ -147,7 +138,7 @@ async fn example_streaming_with_tools() {
                 .additional_params(streaming_tool_params())
                 .build();
 
-            let mut stream = agent.prompt("Calculate 2 - 5").max_turns(3).stream().await;
+            let mut stream = agent.prompt("Calculate 2 - 5").max_turns(3).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming prompt should succeed");

--- a/tests/providers/gemini/cassette/tool_choice.rs
+++ b/tests/providers/gemini/cassette/tool_choice.rs
@@ -166,7 +166,7 @@ async fn none_streaming_does_not_emit_tool_calls() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt("Calculate 20 + 22 directly in text. Do not call tools.")
+                .prompt("Calculate 20 + 22 directly in text. Do not call tools.")
                 .stream()
                 .await;
             let observation = collect_stream_observation(&mut stream).await;

--- a/tests/providers/gemini/cassette/tool_choice.rs
+++ b/tests/providers/gemini/cassette/tool_choice.rs
@@ -167,8 +167,7 @@ async fn none_streaming_does_not_emit_tool_calls() {
 
             let mut stream = agent
                 .prompt("Calculate 20 + 22 directly in text. Do not call tools.")
-                .stream()
-                .await;
+                .stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert!(

--- a/tests/providers/gemini/cassette/turn_termination_matrix.rs
+++ b/tests/providers/gemini/cassette/turn_termination_matrix.rs
@@ -162,11 +162,7 @@ async fn streaming_truncated_turn_reports_length_and_cap() {
                         .additional_params(no_thinking())
                         .build();
 
-                    let mut stream = agent
-                        .prompt(TRUNCATING_PROMPT)
-                        .add_hook(probe)
-                        .stream()
-                        .await;
+                    let mut stream = agent.prompt(TRUNCATING_PROMPT).add_hook(probe).stream();
                     let _ = collect_stream_final_response(&mut stream).await;
                 }
             },
@@ -249,7 +245,7 @@ async fn streaming_completed_turn_reports_stop_and_cap() {
                         .additional_params(no_thinking())
                         .build();
 
-                    let mut stream = agent.prompt(SHORT_PROMPT).add_hook(probe).stream().await;
+                    let mut stream = agent.prompt(SHORT_PROMPT).add_hook(probe).stream();
                     let _ = collect_stream_final_response(&mut stream).await;
                 }
             },
@@ -341,8 +337,7 @@ async fn streaming_tool_turn_reports_tool_calls() {
                         .prompt(TOOL_PROMPT)
                         .add_hook(probe)
                         .max_turns(3)
-                        .stream()
-                        .await;
+                        .stream();
                     let _ = collect_stream_final_response(&mut stream).await;
                 }
             },
@@ -451,8 +446,7 @@ async fn streaming_escalating_retry_reports_each_attempts_own_cap() {
                         .add_hook(probe)
                         .add_hook(escalate)
                         .max_turns(2)
-                        .stream()
-                        .await;
+                        .stream();
                     let _ = collect_stream_final_response(&mut stream).await;
                 }
             },

--- a/tests/providers/gemini/cassette/turn_termination_matrix.rs
+++ b/tests/providers/gemini/cassette/turn_termination_matrix.rs
@@ -112,7 +112,7 @@ async fn blocking_truncated_turn_reports_length_and_cap() {
                         .additional_params(no_thinking())
                         .add_hook(probe)
                         .build()
-                        .runner(TRUNCATING_PROMPT)
+                        .prompt(TRUNCATING_PROMPT)
                         .run()
                         .await
                         .expect("a partially truncated turn still carries an answer");
@@ -163,7 +163,7 @@ async fn streaming_truncated_turn_reports_length_and_cap() {
                         .build();
 
                     let mut stream = agent
-                        .stream_prompt(TRUNCATING_PROMPT)
+                        .prompt(TRUNCATING_PROMPT)
                         .add_hook(probe)
                         .stream()
                         .await;
@@ -208,7 +208,7 @@ async fn blocking_completed_turn_reports_stop_and_cap() {
                         .additional_params(no_thinking())
                         .add_hook(probe)
                         .build()
-                        .runner(SHORT_PROMPT)
+                        .prompt(SHORT_PROMPT)
                         .run()
                         .await
                         .expect("a short answer under a roomy cap");
@@ -249,11 +249,7 @@ async fn streaming_completed_turn_reports_stop_and_cap() {
                         .additional_params(no_thinking())
                         .build();
 
-                    let mut stream = agent
-                        .stream_prompt(SHORT_PROMPT)
-                        .add_hook(probe)
-                        .stream()
-                        .await;
+                    let mut stream = agent.prompt(SHORT_PROMPT).add_hook(probe).stream().await;
                     let _ = collect_stream_final_response(&mut stream).await;
                 }
             },
@@ -295,7 +291,7 @@ async fn blocking_tool_turn_reports_tool_calls() {
                         .tool(Adder)
                         .add_hook(probe)
                         .build()
-                        .runner(TOOL_PROMPT)
+                        .prompt(TOOL_PROMPT)
                         .max_turns(3)
                         .run()
                         .await
@@ -342,7 +338,7 @@ async fn streaming_tool_turn_reports_tool_calls() {
                         .build();
 
                     let mut stream = agent
-                        .stream_prompt(TOOL_PROMPT)
+                        .prompt(TOOL_PROMPT)
                         .add_hook(probe)
                         .max_turns(3)
                         .stream()
@@ -395,7 +391,7 @@ async fn blocking_escalating_retry_reports_each_attempts_own_cap() {
                         .add_hook(probe)
                         .add_hook(escalate)
                         .build()
-                        .runner(RETRY_PROMPT)
+                        .prompt(RETRY_PROMPT)
                         .max_turns(2)
                         .run()
                         .await
@@ -451,7 +447,7 @@ async fn streaming_escalating_retry_reports_each_attempts_own_cap() {
                         .build();
 
                     let mut stream = agent
-                        .stream_prompt(RETRY_PROMPT)
+                        .prompt(RETRY_PROMPT)
                         .add_hook(probe)
                         .add_hook(escalate)
                         .max_turns(2)

--- a/tests/providers/groq/agent_tool_sessions.rs
+++ b/tests/providers/groq/agent_tool_sessions.rs
@@ -598,7 +598,8 @@ async fn sequential_complex_tool_calls_streaming() -> Result<()> {
                 .build();
 
             let mut stream = agent
-                .stream_chat(COMPLEX_SESSION_PROMPT, Vec::<Message>::new())
+                .prompt(COMPLEX_SESSION_PROMPT)
+                .history(Vec::<Message>::new())
                 .max_turns(10)
                 .stream()
                 .await;
@@ -708,7 +709,7 @@ async fn parallel_tool_calls_single_turn_streaming() -> Result<()> {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(TWO_TOOL_STREAM_PROMPT)
+                .prompt(TWO_TOOL_STREAM_PROMPT)
                 .max_turns(5)
                 .stream()
                 .await;

--- a/tests/providers/groq/agent_tool_sessions.rs
+++ b/tests/providers/groq/agent_tool_sessions.rs
@@ -601,8 +601,7 @@ async fn sequential_complex_tool_calls_streaming() -> Result<()> {
                 .prompt(COMPLEX_SESSION_PROMPT)
                 .history(Vec::<Message>::new())
                 .max_turns(10)
-                .stream()
-                .await;
+                .stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             anyhow::ensure!(
@@ -708,11 +707,7 @@ async fn parallel_tool_calls_single_turn_streaming() -> Result<()> {
                 .additional_params(json!({"parallel_tool_calls": true}))
                 .build();
 
-            let mut stream = agent
-                .prompt(TWO_TOOL_STREAM_PROMPT)
-                .max_turns(5)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(TWO_TOOL_STREAM_PROMPT).max_turns(5).stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert_two_tool_roundtrip_contract(

--- a/tests/providers/groq/permission_control.rs
+++ b/tests/providers/groq/permission_control.rs
@@ -213,7 +213,7 @@ async fn permission_control_streaming_example() -> Result<()> {
     };
 
     let mut stream = agent
-        .stream_prompt(
+        .prompt(
             "Use the available tools to read test.txt now. \
              Call `read_file_head` first. If it is unavailable, immediately call `read_file_tail` instead. \
              Both tools take zero arguments and return the file content. \

--- a/tests/providers/groq/permission_control.rs
+++ b/tests/providers/groq/permission_control.rs
@@ -221,7 +221,7 @@ async fn permission_control_streaming_example() -> Result<()> {
         )
         .max_turns(5)
         .add_hook(hook)
-        .stream().await;
+        .stream();
 
     let final_response = stream_to_stdout(&mut stream).await?;
     let last = last_result.lock().expect("lock last_result").clone();

--- a/tests/providers/groq/streaming.rs
+++ b/tests/providers/groq/streaming.rs
@@ -18,7 +18,7 @@ async fn streaming_smoke() {
         .preamble(STREAMING_PREAMBLE)
         .build();
 
-    let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");

--- a/tests/providers/groq/streaming.rs
+++ b/tests/providers/groq/streaming.rs
@@ -18,7 +18,7 @@ async fn streaming_smoke() {
         .preamble(STREAMING_PREAMBLE)
         .build();
 
-    let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_PROMPT).stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");

--- a/tests/providers/groq/streaming_reasoning.rs
+++ b/tests/providers/groq/streaming_reasoning.rs
@@ -17,7 +17,7 @@ async fn parsed_reasoning_stream() {
         .additional_params(serde_json::json!({ "reasoning_format": "parsed" }))
         .build();
 
-    let mut stream = agent.stream_prompt("Entertain me!").stream().await;
+    let mut stream = agent.prompt("Entertain me!").stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");

--- a/tests/providers/groq/streaming_reasoning.rs
+++ b/tests/providers/groq/streaming_reasoning.rs
@@ -17,7 +17,7 @@ async fn parsed_reasoning_stream() {
         .additional_params(serde_json::json!({ "reasoning_format": "parsed" }))
         .build();
 
-    let mut stream = agent.prompt("Entertain me!").stream().await;
+    let mut stream = agent.prompt("Entertain me!").stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");

--- a/tests/providers/groq/streaming_tools.rs
+++ b/tests/providers/groq/streaming_tools.rs
@@ -71,7 +71,7 @@ async fn streaming_tools_surface_two_distinct_tool_calls_before_final_answer() {
         .build();
 
     let mut stream = agent
-        .stream_prompt(TWO_TOOL_STREAM_PROMPT)
+        .prompt(TWO_TOOL_STREAM_PROMPT)
         .max_turns(8)
         .stream()
         .await;
@@ -95,7 +95,7 @@ async fn streaming_tools_emit_tool_call_before_later_text() {
         .build();
 
     let mut stream = agent
-        .stream_prompt(ORDERED_TOOL_STREAM_PROMPT)
+        .prompt(ORDERED_TOOL_STREAM_PROMPT)
         .max_turns(5)
         .stream()
         .await;

--- a/tests/providers/groq/streaming_tools.rs
+++ b/tests/providers/groq/streaming_tools.rs
@@ -70,11 +70,7 @@ async fn streaming_tools_surface_two_distinct_tool_calls_before_final_answer() {
         .tool(BetaSignal)
         .build();
 
-    let mut stream = agent
-        .prompt(TWO_TOOL_STREAM_PROMPT)
-        .max_turns(8)
-        .stream()
-        .await;
+    let mut stream = agent.prompt(TWO_TOOL_STREAM_PROMPT).max_turns(8).stream();
     let observation = collect_stream_observation(&mut stream).await;
 
     assert_two_tool_roundtrip_contract(
@@ -97,8 +93,7 @@ async fn streaming_tools_emit_tool_call_before_later_text() {
     let mut stream = agent
         .prompt(ORDERED_TOOL_STREAM_PROMPT)
         .max_turns(5)
-        .stream()
-        .await;
+        .stream();
     let observation = collect_stream_observation(&mut stream).await;
 
     assert_tool_call_precedes_later_text(

--- a/tests/providers/huggingface/streaming.rs
+++ b/tests/providers/huggingface/streaming.rs
@@ -16,7 +16,7 @@ async fn streaming_smoke() {
         .preamble(STREAMING_PREAMBLE)
         .build();
 
-    let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");
@@ -39,7 +39,7 @@ async fn together_subprovider_streaming() {
         .build();
 
     let mut stream = agent
-        .stream_prompt("When and where and what type is the next solar eclipse?")
+        .prompt("When and where and what type is the next solar eclipse?")
         .stream()
         .await;
     let response = collect_stream_final_response(&mut stream)

--- a/tests/providers/huggingface/streaming.rs
+++ b/tests/providers/huggingface/streaming.rs
@@ -16,7 +16,7 @@ async fn streaming_smoke() {
         .preamble(STREAMING_PREAMBLE)
         .build();
 
-    let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_PROMPT).stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");
@@ -40,8 +40,7 @@ async fn together_subprovider_streaming() {
 
     let mut stream = agent
         .prompt("When and where and what type is the next solar eclipse?")
-        .stream()
-        .await;
+        .stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");

--- a/tests/providers/llamacpp/cassette/bare_openai_client.rs
+++ b/tests/providers/llamacpp/cassette/bare_openai_client.rs
@@ -215,7 +215,7 @@ async fn a_fragmented_tool_call_stream_reassembles_without_the_provider_consts()
                 .build();
 
             let mut stream = agent
-                .stream_prompt(STREAMING_TOOLS_PROMPT)
+                .prompt(STREAMING_TOOLS_PROMPT)
                 .max_turns(4)
                 .stream()
                 .await;

--- a/tests/providers/llamacpp/cassette/bare_openai_client.rs
+++ b/tests/providers/llamacpp/cassette/bare_openai_client.rs
@@ -214,11 +214,7 @@ async fn a_fragmented_tool_call_stream_reassembles_without_the_provider_consts()
                 .tool(Subtract)
                 .build();
 
-            let mut stream = agent
-                .prompt(STREAMING_TOOLS_PROMPT)
-                .max_turns(4)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).max_turns(4).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");

--- a/tests/providers/llamacpp/cassette/content_matrix.rs
+++ b/tests/providers/llamacpp/cassette/content_matrix.rs
@@ -200,8 +200,7 @@ async fn unicode_split_across_stream_chunks_reassembles() {
                     "{NO_THINK}Write exactly this line and nothing else: \
                  🌍こんにちは世界🎉안녕하세요🚀Здравствуйте🌸"
                 ))
-                .stream()
-                .await;
+                .stream();
             let answer = collect_stream_final_response(&mut stream)
                 .await
                 .expect("a unicode stream should complete");

--- a/tests/providers/llamacpp/cassette/content_matrix.rs
+++ b/tests/providers/llamacpp/cassette/content_matrix.rs
@@ -196,7 +196,7 @@ async fn unicode_split_across_stream_chunks_reassembles() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(format!(
+                .prompt(format!(
                     "{NO_THINK}Write exactly this line and nothing else: \
                  🌍こんにちは世界🎉안녕하세요🚀Здравствуйте🌸"
                 ))

--- a/tests/providers/llamacpp/cassette/permission_control.rs
+++ b/tests/providers/llamacpp/cassette/permission_control.rs
@@ -253,8 +253,7 @@ async fn permission_control_streaming_example() -> Result<()> {
                 )
                 .max_turns(5)
                 .add_hook(hook)
-                .stream()
-                .await;
+                .stream();
 
             let observation = collect_stream_observation(&mut stream).await;
             anyhow::ensure!(

--- a/tests/providers/llamacpp/cassette/permission_control.rs
+++ b/tests/providers/llamacpp/cassette/permission_control.rs
@@ -247,7 +247,7 @@ async fn permission_control_streaming_example() -> Result<()> {
             };
 
             let mut stream = agent
-                .stream_prompt(
+                .prompt(
                     "Use the available tools to read test.txt now. \
                  Do not ask any follow-up questions; just read the file and report its content.",
                 )

--- a/tests/providers/llamacpp/cassette/streaming.rs
+++ b/tests/providers/llamacpp/cassette/streaming.rs
@@ -16,7 +16,7 @@ async fn streaming_smoke() {
             .preamble(STREAMING_PREAMBLE)
             .build();
 
-        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream();
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");
@@ -37,8 +37,7 @@ async fn example_streaming_prompt() {
 
         let mut stream = agent
             .prompt("When and where and what type is the next solar eclipse?")
-            .stream()
-            .await;
+            .stream();
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");

--- a/tests/providers/llamacpp/cassette/streaming.rs
+++ b/tests/providers/llamacpp/cassette/streaming.rs
@@ -16,7 +16,7 @@ async fn streaming_smoke() {
             .preamble(STREAMING_PREAMBLE)
             .build();
 
-        let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");
@@ -36,7 +36,7 @@ async fn example_streaming_prompt() {
             .build();
 
         let mut stream = agent
-            .stream_prompt("When and where and what type is the next solar eclipse?")
+            .prompt("When and where and what type is the next solar eclipse?")
             .stream()
             .await;
         let response = collect_stream_final_response(&mut stream)

--- a/tests/providers/llamacpp/cassette/streaming_tools.rs
+++ b/tests/providers/llamacpp/cassette/streaming_tools.rs
@@ -42,11 +42,7 @@ async fn streaming_tools_smoke() {
                 .tool(Subtract)
                 .build();
 
-            let mut stream = agent
-                .prompt(STREAMING_TOOLS_PROMPT)
-                .max_turns(4)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).max_turns(4).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");
@@ -73,7 +69,7 @@ async fn example_streaming_with_tools() {
             .tool(Subtract)
             .build();
 
-        let mut stream = agent.prompt("Calculate 2 - 5").max_turns(4).stream().await;
+        let mut stream = agent.prompt("Calculate 2 - 5").max_turns(4).stream();
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming tools prompt should succeed");
@@ -144,11 +140,7 @@ async fn streaming_tools_surface_two_distinct_tool_calls_before_final_answer() {
                 .tool(BetaSignal)
                 .build();
 
-            let mut stream = agent
-                .prompt(TWO_TOOL_STREAM_PROMPT)
-                .max_turns(8)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(TWO_TOOL_STREAM_PROMPT).max_turns(8).stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert_two_tool_roundtrip_contract(
@@ -175,8 +167,7 @@ async fn streaming_tools_emit_tool_call_before_later_text() {
             let mut stream = agent
                 .prompt(ORDERED_TOOL_STREAM_PROMPT)
                 .max_turns(5)
-                .stream()
-                .await;
+                .stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert_tool_call_precedes_later_text(

--- a/tests/providers/llamacpp/cassette/streaming_tools.rs
+++ b/tests/providers/llamacpp/cassette/streaming_tools.rs
@@ -43,7 +43,7 @@ async fn streaming_tools_smoke() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(STREAMING_TOOLS_PROMPT)
+                .prompt(STREAMING_TOOLS_PROMPT)
                 .max_turns(4)
                 .stream()
                 .await;
@@ -73,7 +73,7 @@ async fn example_streaming_with_tools() {
             .tool(Subtract)
             .build();
 
-        let mut stream = agent.stream_prompt("Calculate 2 - 5").max_turns(4).stream().await;
+        let mut stream = agent.prompt("Calculate 2 - 5").max_turns(4).stream().await;
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming tools prompt should succeed");
@@ -145,7 +145,7 @@ async fn streaming_tools_surface_two_distinct_tool_calls_before_final_answer() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(TWO_TOOL_STREAM_PROMPT)
+                .prompt(TWO_TOOL_STREAM_PROMPT)
                 .max_turns(8)
                 .stream()
                 .await;
@@ -173,7 +173,7 @@ async fn streaming_tools_emit_tool_call_before_later_text() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(ORDERED_TOOL_STREAM_PROMPT)
+                .prompt(ORDERED_TOOL_STREAM_PROMPT)
                 .max_turns(5)
                 .stream()
                 .await;

--- a/tests/providers/llamacpp/cassette/turn_termination_matrix.rs
+++ b/tests/providers/llamacpp/cassette/turn_termination_matrix.rs
@@ -127,7 +127,7 @@ async fn blocking_truncated_turn_reports_length_and_cap() {
                 .max_tokens(TINY_CAP)
                 .add_hook(probe)
                 .build()
-                .runner(TRUNCATING_PROMPT)
+                .prompt(TRUNCATING_PROMPT)
                 .run()
                 .await
                 .expect("a partially truncated turn still carries an answer");
@@ -174,7 +174,7 @@ async fn streaming_truncated_turn_reports_length_and_cap() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(TRUNCATING_PROMPT)
+                .prompt(TRUNCATING_PROMPT)
                 .add_hook(probe)
                 .stream()
                 .await;
@@ -211,7 +211,7 @@ async fn blocking_completed_turn_reports_stop() {
                 .max_tokens(ROOMY_CAP)
                 .add_hook(probe)
                 .build()
-                .runner(SHORT_PROMPT)
+                .prompt(SHORT_PROMPT)
                 .run()
                 .await
                 .expect("a short prompt under a roomy cap should finish");
@@ -251,7 +251,7 @@ async fn blocking_tool_turn_reports_tool_calls() {
                 .tool(Adder)
                 .add_hook(probe)
                 .build()
-                .runner(TOOL_PROMPT)
+                .prompt(TOOL_PROMPT)
                 .max_turns(4)
                 .run()
                 .await
@@ -296,7 +296,7 @@ async fn blocking_escalating_retry_reports_each_attempts_own_cap() {
                 .add_hook(probe)
                 .add_hook(escalate)
                 .build()
-                .runner(TRUNCATING_PROMPT)
+                .prompt(TRUNCATING_PROMPT)
                 .max_turns(2)
                 .run()
                 .await

--- a/tests/providers/llamacpp/cassette/turn_termination_matrix.rs
+++ b/tests/providers/llamacpp/cassette/turn_termination_matrix.rs
@@ -173,11 +173,7 @@ async fn streaming_truncated_turn_reports_length_and_cap() {
                 .max_tokens(TINY_CAP)
                 .build();
 
-            let mut stream = agent
-                .prompt(TRUNCATING_PROMPT)
-                .add_hook(probe)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(TRUNCATING_PROMPT).add_hook(probe).stream();
             let _ = collect_stream_final_response(&mut stream).await;
         },
     )

--- a/tests/providers/mistral/agent_tool_sessions.rs
+++ b/tests/providers/mistral/agent_tool_sessions.rs
@@ -562,7 +562,8 @@ async fn sequential_complex_tool_calls_streaming() -> Result<()> {
                 .build();
 
             let mut stream = agent
-                .stream_chat(COMPLEX_SESSION_PROMPT, Vec::<Message>::new())
+                .prompt(COMPLEX_SESSION_PROMPT)
+                .history(Vec::<Message>::new())
                 .max_turns(10)
                 .stream()
                 .await;
@@ -672,7 +673,7 @@ async fn parallel_tool_calls_single_turn_streaming() -> Result<()> {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(TWO_TOOL_STREAM_PROMPT)
+                .prompt(TWO_TOOL_STREAM_PROMPT)
                 .max_turns(5)
                 .stream()
                 .await;

--- a/tests/providers/mistral/agent_tool_sessions.rs
+++ b/tests/providers/mistral/agent_tool_sessions.rs
@@ -565,8 +565,7 @@ async fn sequential_complex_tool_calls_streaming() -> Result<()> {
                 .prompt(COMPLEX_SESSION_PROMPT)
                 .history(Vec::<Message>::new())
                 .max_turns(10)
-                .stream()
-                .await;
+                .stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             anyhow::ensure!(
@@ -672,11 +671,7 @@ async fn parallel_tool_calls_single_turn_streaming() -> Result<()> {
                 .additional_params(json!({"parallel_tool_calls": true}))
                 .build();
 
-            let mut stream = agent
-                .prompt(TWO_TOOL_STREAM_PROMPT)
-                .max_turns(5)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(TWO_TOOL_STREAM_PROMPT).max_turns(5).stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert_two_tool_roundtrip_contract(

--- a/tests/providers/mistral/multimodal_content.rs
+++ b/tests/providers/mistral/multimodal_content.rs
@@ -214,7 +214,7 @@ async fn streaming_raw_model_sends_a_base64_image() -> Result<()> {
         |client| async move {
             let agent = client.agent(VISION_MODEL).temperature(0.0).build();
             let mut stream = agent
-                .stream_prompt(user_message(vec![
+                .prompt(user_message(vec![
                     UserContent::text(COLOUR_PROMPT),
                     red_png(),
                 ]))
@@ -438,7 +438,8 @@ async fn streaming_image_survives_a_replayed_history() -> Result<()> {
                 Message::assistant("Red."),
             ];
             let mut stream = agent
-                .stream_chat("Repeat the colour you just named.", history)
+                .prompt("Repeat the colour you just named.")
+                .history(history)
                 .stream()
                 .await;
             let response = collect_stream_final_response(&mut stream).await?;
@@ -534,7 +535,7 @@ async fn streaming_agent_reads_an_attached_pdf() -> Result<()> {
         |client| async move {
             let agent = client.agent(VISION_MODEL).temperature(0.0).build();
             let mut stream = agent
-                .stream_prompt(user_message(vec![
+                .prompt(user_message(vec![
                     UserContent::text(DOCUMENT_PROMPT),
                     pdf_document(),
                 ]))
@@ -723,7 +724,7 @@ async fn streaming_agent_sends_audio() -> Result<()> {
         |client| async move {
             let agent = client.agent(AUDIO_MODEL).temperature(0.0).build();
             let mut stream = agent
-                .stream_prompt(user_message(vec![
+                .prompt(user_message(vec![
                     UserContent::text(AUDIO_PROMPT),
                     speech_audio(),
                 ]))
@@ -823,7 +824,7 @@ async fn streaming_text_only_content_still_flattens_to_a_string() -> Result<()> 
                 .temperature(0.0)
                 .build();
             let mut stream = agent
-                .stream_prompt(user_message(vec![
+                .prompt(user_message(vec![
                     UserContent::text("Name the capital of France."),
                     UserContent::text(" Answer with one word."),
                 ]))
@@ -975,7 +976,7 @@ async fn streaming_image_with_a_tool_configured() -> Result<()> {
                 .default_max_turns(3)
                 .build();
             let mut stream = agent
-                .stream_prompt(user_message(vec![
+                .prompt(user_message(vec![
                     UserContent::text("Record this image's colour."),
                     red_png(),
                 ]))

--- a/tests/providers/mistral/multimodal_content.rs
+++ b/tests/providers/mistral/multimodal_content.rs
@@ -218,8 +218,7 @@ async fn streaming_raw_model_sends_a_base64_image() -> Result<()> {
                     UserContent::text(COLOUR_PROMPT),
                     red_png(),
                 ]))
-                .stream()
-                .await;
+                .stream();
             let response = collect_stream_final_response(&mut stream).await?;
             assert_mentions(&response, "red");
             Ok::<_, anyhow::Error>(())
@@ -440,8 +439,7 @@ async fn streaming_image_survives_a_replayed_history() -> Result<()> {
             let mut stream = agent
                 .prompt("Repeat the colour you just named.")
                 .history(history)
-                .stream()
-                .await;
+                .stream();
             let response = collect_stream_final_response(&mut stream).await?;
             assert_mentions(&response, "red");
             Ok::<_, anyhow::Error>(())
@@ -539,8 +537,7 @@ async fn streaming_agent_reads_an_attached_pdf() -> Result<()> {
                     UserContent::text(DOCUMENT_PROMPT),
                     pdf_document(),
                 ]))
-                .stream()
-                .await;
+                .stream();
             let response = collect_stream_final_response(&mut stream).await?;
             assert_mentions(&response, PDF_TOKEN);
             Ok::<_, anyhow::Error>(())
@@ -728,8 +725,7 @@ async fn streaming_agent_sends_audio() -> Result<()> {
                     UserContent::text(AUDIO_PROMPT),
                     speech_audio(),
                 ]))
-                .stream()
-                .await;
+                .stream();
             let response = collect_stream_final_response(&mut stream).await?;
             assert_mentions(&response, AUDIO_KEYWORD);
             Ok::<_, anyhow::Error>(())
@@ -828,8 +824,7 @@ async fn streaming_text_only_content_still_flattens_to_a_string() -> Result<()> 
                     UserContent::text("Name the capital of France."),
                     UserContent::text(" Answer with one word."),
                 ]))
-                .stream()
-                .await;
+                .stream();
             let response = collect_stream_final_response(&mut stream).await?;
             assert_mentions(&response, "paris");
             Ok::<_, anyhow::Error>(())
@@ -980,8 +975,7 @@ async fn streaming_image_with_a_tool_configured() -> Result<()> {
                     UserContent::text("Record this image's colour."),
                     red_png(),
                 ]))
-                .stream()
-                .await;
+                .stream();
             let response = collect_stream_final_response(&mut stream).await?;
             assert_mentions(&response, "red");
             Ok::<_, anyhow::Error>(())

--- a/tests/providers/mistral/permission_control.rs
+++ b/tests/providers/mistral/permission_control.rs
@@ -214,8 +214,7 @@ async fn permission_control_streaming_example() -> Result<()> {
         )
         .max_turns(5)
         .add_hook(hook)
-        .stream()
-        .await;
+        .stream();
 
     let final_response = stream_to_stdout(&mut stream).await?;
     let last = last_result.lock().expect("lock last_result").clone();

--- a/tests/providers/mistral/permission_control.rs
+++ b/tests/providers/mistral/permission_control.rs
@@ -208,7 +208,7 @@ async fn permission_control_streaming_example() -> Result<()> {
     };
 
     let mut stream = agent
-        .stream_prompt(
+        .prompt(
             "Use the available tools to read test.txt now. \
              Do not ask any follow-up questions; just read the file and report its content.",
         )

--- a/tests/providers/mistral/response_identity_edge.rs
+++ b/tests/providers/mistral/response_identity_edge.rs
@@ -76,7 +76,7 @@ async fn streaming_terminal_carries_the_correlation_id() -> Result<()> {
         |client| async move {
             let agent = client.agent(mistral::MISTRAL_SMALL).build();
             let mut stream = agent
-                .stream_prompt("Reply with exactly: identity probe")
+                .prompt("Reply with exactly: identity probe")
                 .stream()
                 .await;
             let (_text, provider_final) =

--- a/tests/providers/mistral/response_identity_edge.rs
+++ b/tests/providers/mistral/response_identity_edge.rs
@@ -75,10 +75,7 @@ async fn streaming_terminal_carries_the_correlation_id() -> Result<()> {
         "response_identity_edge/streaming_terminal_carries_the_correlation_id",
         |client| async move {
             let agent = client.agent(mistral::MISTRAL_SMALL).build();
-            let mut stream = agent
-                .prompt("Reply with exactly: identity probe")
-                .stream()
-                .await;
+            let mut stream = agent.prompt("Reply with exactly: identity probe").stream();
             let (_text, provider_final) =
                 collect_stream_final_response_and_provider_final(&mut stream).await?;
             assert_is_request_id(provider_final.provider_request_id.as_deref());

--- a/tests/providers/mistral/streaming.rs
+++ b/tests/providers/mistral/streaming.rs
@@ -18,7 +18,7 @@ async fn streaming_smoke() {
         .preamble(STREAMING_PREAMBLE)
         .build();
 
-    let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_PROMPT).stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");
@@ -38,8 +38,7 @@ async fn example_streaming_prompt() {
 
     let mut stream = agent
         .prompt("When and where and what type is the next solar eclipse?")
-        .stream()
-        .await;
+        .stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");

--- a/tests/providers/mistral/streaming.rs
+++ b/tests/providers/mistral/streaming.rs
@@ -18,7 +18,7 @@ async fn streaming_smoke() {
         .preamble(STREAMING_PREAMBLE)
         .build();
 
-    let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");
@@ -37,7 +37,7 @@ async fn example_streaming_prompt() {
         .build();
 
     let mut stream = agent
-        .stream_prompt("When and where and what type is the next solar eclipse?")
+        .prompt("When and where and what type is the next solar eclipse?")
         .stream()
         .await;
     let response = collect_stream_final_response(&mut stream)

--- a/tests/providers/mistral/streaming_tools.rs
+++ b/tests/providers/mistral/streaming_tools.rs
@@ -25,7 +25,7 @@ async fn streaming_tools_smoke() {
         .tool(Subtract)
         .build();
 
-    let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming tool prompt should succeed");
@@ -48,7 +48,7 @@ async fn example_streaming_with_tools() {
         .tool(Subtract)
         .build();
 
-    let mut stream = agent.prompt("Calculate 2 - 5").stream().await;
+    let mut stream = agent.prompt("Calculate 2 - 5").stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming tools prompt should succeed");
@@ -70,8 +70,7 @@ async fn stream_prompt_tool_roundtrip_preserves_streaming_contract() {
     let mut stream = agent
         .prompt(ORDERED_TOOL_STREAM_PROMPT)
         .max_turns(5)
-        .stream()
-        .await;
+        .stream();
     let observation = collect_stream_observation(&mut stream).await;
 
     assert_tool_call_precedes_later_text(
@@ -96,8 +95,7 @@ async fn stream_chat_tool_roundtrip_preserves_streaming_contract() {
         .prompt(ORDERED_TOOL_STREAM_PROMPT)
         .history(Vec::<Message>::new())
         .max_turns(5)
-        .stream()
-        .await;
+        .stream();
     let observation = collect_stream_observation(&mut stream).await;
 
     assert_tool_call_precedes_later_text(

--- a/tests/providers/mistral/streaming_tools.rs
+++ b/tests/providers/mistral/streaming_tools.rs
@@ -25,7 +25,7 @@ async fn streaming_tools_smoke() {
         .tool(Subtract)
         .build();
 
-    let mut stream = agent.stream_prompt(STREAMING_TOOLS_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming tool prompt should succeed");
@@ -48,7 +48,7 @@ async fn example_streaming_with_tools() {
         .tool(Subtract)
         .build();
 
-    let mut stream = agent.stream_prompt("Calculate 2 - 5").stream().await;
+    let mut stream = agent.prompt("Calculate 2 - 5").stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming tools prompt should succeed");
@@ -68,7 +68,7 @@ async fn stream_prompt_tool_roundtrip_preserves_streaming_contract() {
         .build();
 
     let mut stream = agent
-        .stream_prompt(ORDERED_TOOL_STREAM_PROMPT)
+        .prompt(ORDERED_TOOL_STREAM_PROMPT)
         .max_turns(5)
         .stream()
         .await;
@@ -93,7 +93,8 @@ async fn stream_chat_tool_roundtrip_preserves_streaming_contract() {
         .build();
 
     let mut stream = agent
-        .stream_chat(ORDERED_TOOL_STREAM_PROMPT, Vec::<Message>::new())
+        .prompt(ORDERED_TOOL_STREAM_PROMPT)
+        .history(Vec::<Message>::new())
         .max_turns(5)
         .stream()
         .await;

--- a/tests/providers/mistral/tool_lifecycle_matrix.rs
+++ b/tests/providers/mistral/tool_lifecycle_matrix.rs
@@ -360,8 +360,7 @@ async fn run_agent(client: mistral::Client, cell: Cell) -> Observation {
                 .prompt(prompt(cell.shape))
                 .history(Vec::<rig::completion::Message>::new())
                 .max_turns(1)
-                .stream()
-                .await;
+                .stream();
             errors = crate::support::collect_stream_observation(&mut stream)
                 .await
                 .errors;

--- a/tests/providers/mistral/tool_lifecycle_matrix.rs
+++ b/tests/providers/mistral/tool_lifecycle_matrix.rs
@@ -357,7 +357,8 @@ async fn run_agent(client: mistral::Client, cell: Cell) -> Observation {
         }
         Transport::Streaming => {
             let mut stream = agent
-                .stream_chat(prompt(cell.shape), Vec::<rig::completion::Message>::new())
+                .prompt(prompt(cell.shape))
+                .history(Vec::<rig::completion::Message>::new())
                 .max_turns(1)
                 .stream()
                 .await;

--- a/tests/providers/mistral/tool_truncation_matrix.rs
+++ b/tests/providers/mistral/tool_truncation_matrix.rs
@@ -266,7 +266,8 @@ async fn run_agent(client: mistral::Client, cell: Cell) -> Observation {
         }
         Transport::Streaming => {
             let mut stream = agent
-                .stream_chat(PROMPT, Vec::<rig::completion::Message>::new())
+                .prompt(PROMPT)
+                .history(Vec::<rig::completion::Message>::new())
                 .max_turns(1)
                 .stream()
                 .await;

--- a/tests/providers/mistral/tool_truncation_matrix.rs
+++ b/tests/providers/mistral/tool_truncation_matrix.rs
@@ -269,8 +269,7 @@ async fn run_agent(client: mistral::Client, cell: Cell) -> Observation {
                 .prompt(PROMPT)
                 .history(Vec::<rig::completion::Message>::new())
                 .max_turns(1)
-                .stream()
-                .await;
+                .stream();
             errors = crate::support::collect_stream_observation(&mut stream)
                 .await
                 .errors;

--- a/tests/providers/mistralrs/cassette/streaming.rs
+++ b/tests/providers/mistralrs/cassette/streaming.rs
@@ -20,8 +20,7 @@ async fn chat_completions_stream_emits_reasoning_and_text_incrementally() {
                 .prompt(
                     "Think briefly, then answer with three short bullet points about token usage reporting.",
                 )
-                .stream()
-                .await;
+                .stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert!(

--- a/tests/providers/mistralrs/cassette/streaming.rs
+++ b/tests/providers/mistralrs/cassette/streaming.rs
@@ -17,7 +17,7 @@ async fn chat_completions_stream_emits_reasoning_and_text_incrementally() {
                 .max_tokens(512)
                 .build();
             let mut stream = agent
-                .stream_prompt(
+                .prompt(
                     "Think briefly, then answer with three short bullet points about token usage reporting.",
                 )
                 .stream()

--- a/tests/providers/ollama/cassette/agentic.rs
+++ b/tests/providers/ollama/cassette/agentic.rs
@@ -188,7 +188,7 @@ async fn streaming_structured_output_with_tools() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(
+                .prompt(
                     "What is the current weather in Tokyo? Use the get_weather tool, then return \
                      the city and a one-sentence summary of the conditions.",
                 )

--- a/tests/providers/ollama/cassette/agentic.rs
+++ b/tests/providers/ollama/cassette/agentic.rs
@@ -193,8 +193,7 @@ async fn streaming_structured_output_with_tools() {
                      the city and a one-sentence summary of the conditions.",
                 )
                 .max_turns(5)
-                .stream()
-                .await;
+                .stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming agentic structured output should succeed");

--- a/tests/providers/ollama/cassette/raw_capture_agent_matrix.rs
+++ b/tests/providers/ollama/cassette/raw_capture_agent_matrix.rs
@@ -18,9 +18,9 @@
 //! | # | Cell | Dimension | expected | Status |
 //! |---|------|-----------|----------|--------|
 //! | 1 | `hooks_observe_raw_blocking` | `agent.prompt` | `CompletionResponse` and `ModelTurnFinished` see `raw`; `eval_count`/`done_reason`/durations match the fixture body | recorded |
-//! | 2 | `hooks_observe_raw_streamed` | `agent.stream_prompt` | `CompletionResponse` and `ModelTurnFinished` see `raw`; `eval_count`/`done_reason`/durations match the fixture's `done: true` line | recorded |
+//! | 2 | `hooks_observe_raw_streamed` | `agent.prompt(..).stream()` | `CompletionResponse` and `ModelTurnFinished` see `raw`; `eval_count`/`done_reason`/durations match the fixture's `done: true` line | recorded |
 //! | 3 | `multi_turn_tool_run_records_distinct_raw_blocking` | tool run, `agent.prompt` | two `completion_calls`, two different payloads whose fingerprints equal the interactions' in order; the first carries `message.tool_calls` | recorded |
-//! | 4 | `multi_turn_tool_run_records_distinct_raw_streamed` | tool run, `agent.stream_prompt` | two `CompletionCall` items, two different terminal payloads whose fingerprints equal the interactions' in order; the forwarded last `Final.raw` is the final turn's | recorded |
+//! | 4 | `multi_turn_tool_run_records_distinct_raw_streamed` | tool run, `agent.prompt(..).stream()` | two `CompletionCall` items, two different terminal payloads whose fingerprints equal the interactions' in order; the forwarded last `Final.raw` is the final turn's | recorded |
 //!
 //! Both surfaces fire the same two events per accepted model turn:
 //! `CompletionResponse` — after the unary call returns on the blocking

--- a/tests/providers/ollama/cassette/raw_capture_agent_matrix.rs
+++ b/tests/providers/ollama/cassette/raw_capture_agent_matrix.rs
@@ -365,7 +365,7 @@ async fn hooks_observe_raw_streamed() {
                 .additional_params(json!({ "think": false }))
                 .add_hook(hook)
                 .build();
-            let run = drain(agent.prompt(Message::user(TEXT_PROMPT)).stream().await).await;
+            let run = drain(agent.prompt(Message::user(TEXT_PROMPT)).stream()).await;
             assert!(run.output.is_some(), "the run finished");
             assert_eq!(run.finals.len(), 1, "one text turn, one terminal record");
             assert!(
@@ -498,8 +498,7 @@ async fn multi_turn_tool_run_records_distinct_raw_streamed() {
                 agent
                     .prompt(Message::user(TOOL_PROMPT))
                     .max_turns(3)
-                    .stream()
-                    .await,
+                    .stream(),
             )
             .await;
             assert!(run.output.is_some(), "the run finished");

--- a/tests/providers/ollama/cassette/raw_capture_agent_matrix.rs
+++ b/tests/providers/ollama/cassette/raw_capture_agent_matrix.rs
@@ -365,13 +365,7 @@ async fn hooks_observe_raw_streamed() {
                 .additional_params(json!({ "think": false }))
                 .add_hook(hook)
                 .build();
-            let run = drain(
-                agent
-                    .stream_prompt(Message::user(TEXT_PROMPT))
-                    .stream()
-                    .await,
-            )
-            .await;
+            let run = drain(agent.prompt(Message::user(TEXT_PROMPT)).stream().await).await;
             assert!(run.output.is_some(), "the run finished");
             assert_eq!(run.finals.len(), 1, "one text turn, one terminal record");
             assert!(
@@ -502,7 +496,7 @@ async fn multi_turn_tool_run_records_distinct_raw_streamed() {
                 .build();
             let run = drain(
                 agent
-                    .stream_prompt(Message::user(TOOL_PROMPT))
+                    .prompt(Message::user(TOOL_PROMPT))
                     .max_turns(3)
                     .stream()
                     .await,

--- a/tests/providers/ollama/cassette/reasoning_tool_roundtrip.rs
+++ b/tests/providers/ollama/cassette/reasoning_tool_roundtrip.rs
@@ -79,7 +79,8 @@ async fn streaming() {
             .build();
 
         let stream = agent
-            .stream_chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+            .prompt(reasoning::TOOL_USER_PROMPT)
+            .history(Vec::<Message>::new())
             .max_turns(3)
             .stream()
             .await;

--- a/tests/providers/ollama/cassette/reasoning_tool_roundtrip.rs
+++ b/tests/providers/ollama/cassette/reasoning_tool_roundtrip.rs
@@ -82,8 +82,7 @@ async fn streaming() {
             .prompt(reasoning::TOOL_USER_PROMPT)
             .history(Vec::<Message>::new())
             .max_turns(3)
-            .stream()
-            .await;
+            .stream();
 
         let stats = reasoning::collect_stream_stats(stream, "ollama").await;
         reasoning::assert_universal(&stats, &call_count, "ollama");

--- a/tests/providers/ollama/cassette/streaming.rs
+++ b/tests/providers/ollama/cassette/streaming.rs
@@ -21,7 +21,7 @@ async fn streaming_smoke() {
             .additional_params(serde_json::json!({ "think": false }))
             .build();
 
-        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream();
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");

--- a/tests/providers/ollama/cassette/streaming.rs
+++ b/tests/providers/ollama/cassette/streaming.rs
@@ -21,7 +21,7 @@ async fn streaming_smoke() {
             .additional_params(serde_json::json!({ "think": false }))
             .build();
 
-        let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");

--- a/tests/providers/ollama/cassette/streaming_tools.rs
+++ b/tests/providers/ollama/cassette/streaming_tools.rs
@@ -26,11 +26,7 @@ async fn streaming_tools_smoke() {
                 .additional_params(serde_json::json!({ "think": false }))
                 .build();
 
-            let mut stream = agent
-                .prompt(STREAMING_TOOLS_PROMPT)
-                .max_turns(3)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).max_turns(3).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");

--- a/tests/providers/ollama/cassette/streaming_tools.rs
+++ b/tests/providers/ollama/cassette/streaming_tools.rs
@@ -27,7 +27,7 @@ async fn streaming_tools_smoke() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(STREAMING_TOOLS_PROMPT)
+                .prompt(STREAMING_TOOLS_PROMPT)
                 .max_turns(3)
                 .stream()
                 .await;

--- a/tests/providers/ollama/streaming.rs
+++ b/tests/providers/ollama/streaming.rs
@@ -17,8 +17,7 @@ async fn example_streaming_prompt() {
 
     let mut stream = agent
         .prompt("When and where and what type is the next solar eclipse?")
-        .stream()
-        .await;
+        .stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");

--- a/tests/providers/ollama/streaming.rs
+++ b/tests/providers/ollama/streaming.rs
@@ -16,7 +16,7 @@ async fn example_streaming_prompt() {
         .build();
 
     let mut stream = agent
-        .stream_prompt("When and where and what type is the next solar eclipse?")
+        .prompt("When and where and what type is the next solar eclipse?")
         .stream()
         .await;
     let response = collect_stream_final_response(&mut stream)

--- a/tests/providers/ollama/streaming_tools.rs
+++ b/tests/providers/ollama/streaming_tools.rs
@@ -22,7 +22,7 @@ async fn example_streaming_with_tools() {
         .tool(Subtract)
         .build();
 
-    let mut stream = agent.stream_prompt("Calculate 2 - 5").stream().await;
+    let mut stream = agent.prompt("Calculate 2 - 5").stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");

--- a/tests/providers/ollama/streaming_tools.rs
+++ b/tests/providers/ollama/streaming_tools.rs
@@ -22,7 +22,7 @@ async fn example_streaming_with_tools() {
         .tool(Subtract)
         .build();
 
-    let mut stream = agent.prompt("Calculate 2 - 5").stream().await;
+    let mut stream = agent.prompt("Calculate 2 - 5").stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");

--- a/tests/providers/openai/cassette/boxed_transport.rs
+++ b/tests/providers/openai/cassette/boxed_transport.rs
@@ -42,7 +42,7 @@ async fn streaming_smoke_through_boxed_transport() {
             .preamble(STREAMING_PREAMBLE)
             .build();
 
-        let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
         let (response, provider_final): (_, rig::streaming::StreamFinal) =
             collect_stream_final_response_and_provider_final(&mut stream)
                 .await

--- a/tests/providers/openai/cassette/boxed_transport.rs
+++ b/tests/providers/openai/cassette/boxed_transport.rs
@@ -42,7 +42,7 @@ async fn streaming_smoke_through_boxed_transport() {
             .preamble(STREAMING_PREAMBLE)
             .build();
 
-        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream();
         let (response, provider_final): (_, rig::streaming::StreamFinal) =
             collect_stream_final_response_and_provider_final(&mut stream)
                 .await

--- a/tests/providers/openai/cassette/chat_tool_lifecycle_matrix.rs
+++ b/tests/providers/openai/cassette/chat_tool_lifecycle_matrix.rs
@@ -356,7 +356,8 @@ async fn run_agent(client: openai::Client, cell: Cell) -> Observation {
         }
         Transport::Streaming => {
             let mut stream = agent
-                .stream_chat(prompt(cell.shape), Vec::<rig::completion::Message>::new())
+                .prompt(prompt(cell.shape))
+                .history(Vec::<rig::completion::Message>::new())
                 .max_turns(1)
                 .stream()
                 .await;

--- a/tests/providers/openai/cassette/chat_tool_lifecycle_matrix.rs
+++ b/tests/providers/openai/cassette/chat_tool_lifecycle_matrix.rs
@@ -359,8 +359,7 @@ async fn run_agent(client: openai::Client, cell: Cell) -> Observation {
                 .prompt(prompt(cell.shape))
                 .history(Vec::<rig::completion::Message>::new())
                 .max_turns(1)
-                .stream()
-                .await;
+                .stream();
             errors = crate::support::collect_stream_observation(&mut stream)
                 .await
                 .errors;

--- a/tests/providers/openai/cassette/chat_tool_truncation_matrix.rs
+++ b/tests/providers/openai/cassette/chat_tool_truncation_matrix.rs
@@ -269,7 +269,8 @@ async fn run_agent(client: openai::Client, cell: Cell) -> Observation {
         }
         Transport::Streaming => {
             let mut stream = agent
-                .stream_chat(PROMPT, Vec::<rig::completion::Message>::new())
+                .prompt(PROMPT)
+                .history(Vec::<rig::completion::Message>::new())
                 .max_turns(1)
                 .stream()
                 .await;

--- a/tests/providers/openai/cassette/chat_tool_truncation_matrix.rs
+++ b/tests/providers/openai/cassette/chat_tool_truncation_matrix.rs
@@ -272,8 +272,7 @@ async fn run_agent(client: openai::Client, cell: Cell) -> Observation {
                 .prompt(PROMPT)
                 .history(Vec::<rig::completion::Message>::new())
                 .max_turns(1)
-                .stream()
-                .await;
+                .stream();
             errors = crate::support::collect_stream_observation(&mut stream)
                 .await
                 .errors;

--- a/tests/providers/openai/cassette/completions_api.rs
+++ b/tests/providers/openai/cassette/completions_api.rs
@@ -92,7 +92,7 @@ async fn completions_api_streams_two_tool_calls_before_final_answer() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(TWO_TOOL_STREAM_PROMPT)
+                .prompt(TWO_TOOL_STREAM_PROMPT)
                 .max_turns(8)
                 .stream()
                 .await;
@@ -198,7 +198,7 @@ async fn completions_api_stream_emits_tool_call_before_later_text() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(ORDERED_TOOL_STREAM_PROMPT)
+                .prompt(ORDERED_TOOL_STREAM_PROMPT)
                 .max_turns(5)
                 .stream()
                 .await;

--- a/tests/providers/openai/cassette/completions_api.rs
+++ b/tests/providers/openai/cassette/completions_api.rs
@@ -91,11 +91,7 @@ async fn completions_api_streams_two_tool_calls_before_final_answer() {
                 .tool(BetaSignal)
                 .build();
 
-            let mut stream = agent
-                .prompt(TWO_TOOL_STREAM_PROMPT)
-                .max_turns(8)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(TWO_TOOL_STREAM_PROMPT).max_turns(8).stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert_two_tool_roundtrip_contract(
@@ -200,8 +196,7 @@ async fn completions_api_stream_emits_tool_call_before_later_text() {
             let mut stream = agent
                 .prompt(ORDERED_TOOL_STREAM_PROMPT)
                 .max_turns(5)
-                .stream()
-                .await;
+                .stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert_tool_call_precedes_later_text(

--- a/tests/providers/openai/cassette/corpus_breadth.rs
+++ b/tests/providers/openai/cassette/corpus_breadth.rs
@@ -114,7 +114,7 @@ async fn output_tool_streamed_effect_log_is_the_golden_fixture() {
                 .output_mode(OutputMode::Tool)
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.stream_prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
+            let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
             let output = final_output(&mut stream).await.expect("the run answers");
             drop(stream);
             assert_event(&output);
@@ -140,7 +140,7 @@ async fn text_delta_stop_effect_log_is_the_golden_fixture() {
             .add_hook(StopOnTextDelta)
             .record_effects_with_events()
             .build();
-        let mut stream = agent.stream_prompt(ESSAY_PROMPT).stream().await;
+        let mut stream = agent.prompt(ESSAY_PROMPT).stream().await;
         let reason = final_output(&mut stream)
             .await
             .expect_err("the hook stops the run");
@@ -253,7 +253,7 @@ async fn prompted_streamed_effect_log_is_the_golden_fixture() {
             .output_mode(OutputMode::Prompted)
             .record_effects_with_events()
             .build();
-        let mut stream = agent.stream_prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
+        let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
         let output = final_output(&mut stream).await.expect("the run answers");
         drop(stream);
         assert_event(&output);

--- a/tests/providers/openai/cassette/corpus_breadth.rs
+++ b/tests/providers/openai/cassette/corpus_breadth.rs
@@ -114,7 +114,7 @@ async fn output_tool_streamed_effect_log_is_the_golden_fixture() {
                 .output_mode(OutputMode::Tool)
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
+            let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream();
             let output = final_output(&mut stream).await.expect("the run answers");
             drop(stream);
             assert_event(&output);
@@ -140,7 +140,7 @@ async fn text_delta_stop_effect_log_is_the_golden_fixture() {
             .add_hook(StopOnTextDelta)
             .record_effects_with_events()
             .build();
-        let mut stream = agent.prompt(ESSAY_PROMPT).stream().await;
+        let mut stream = agent.prompt(ESSAY_PROMPT).stream();
         let reason = final_output(&mut stream)
             .await
             .expect_err("the hook stops the run");
@@ -253,7 +253,7 @@ async fn prompted_streamed_effect_log_is_the_golden_fixture() {
             .output_mode(OutputMode::Prompted)
             .record_effects_with_events()
             .build();
-        let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream().await;
+        let mut stream = agent.prompt(STRUCTURED_OUTPUT_PROMPT).stream();
         let output = final_output(&mut stream).await.expect("the run answers");
         drop(stream);
         assert_event(&output);

--- a/tests/providers/openai/cassette/corpus_delta.rs
+++ b/tests/providers/openai/cassette/corpus_delta.rs
@@ -29,7 +29,7 @@ async fn chat_baseline_effect_log_is_the_golden_fixture() {
             .tool(Adder)
             .record_effects_with_events()
             .build();
-        let mut stream = agent.stream_prompt(ADD_PROMPT).max_turns(3).stream().await;
+        let mut stream = agent.prompt(ADD_PROMPT).max_turns(3).stream().await;
         let mut output = None;
         while let Some(item) = stream.next().await {
             if let MultiTurnStreamItem::FinalResponse(response) = item.expect("the stream yields") {

--- a/tests/providers/openai/cassette/corpus_delta.rs
+++ b/tests/providers/openai/cassette/corpus_delta.rs
@@ -29,7 +29,7 @@ async fn chat_baseline_effect_log_is_the_golden_fixture() {
             .tool(Adder)
             .record_effects_with_events()
             .build();
-        let mut stream = agent.prompt(ADD_PROMPT).max_turns(3).stream().await;
+        let mut stream = agent.prompt(ADD_PROMPT).max_turns(3).stream();
         let mut output = None;
         while let Some(item) = stream.next().await {
             if let MultiTurnStreamItem::FinalResponse(response) = item.expect("the stream yields") {

--- a/tests/providers/openai/cassette/corpus_host.rs
+++ b/tests/providers/openai/cassette/corpus_host.rs
@@ -61,7 +61,7 @@ async fn embeds_over_host(client: openai::Client, streamed: bool) -> rig::effect
         .add_hook(EmbedPrompt)
         .build();
     let output = if streamed {
-        let mut stream = agent.stream_prompt(PROMPT).stream().await;
+        let mut stream = agent.prompt(PROMPT).stream().await;
         let output = final_output(&mut stream).await;
         drop(stream);
         output

--- a/tests/providers/openai/cassette/corpus_host.rs
+++ b/tests/providers/openai/cassette/corpus_host.rs
@@ -61,7 +61,7 @@ async fn embeds_over_host(client: openai::Client, streamed: bool) -> rig::effect
         .add_hook(EmbedPrompt)
         .build();
     let output = if streamed {
-        let mut stream = agent.prompt(PROMPT).stream().await;
+        let mut stream = agent.prompt(PROMPT).stream();
         let output = final_output(&mut stream).await;
         drop(stream);
         output

--- a/tests/providers/openai/cassette/corpus_retrieval.rs
+++ b/tests/providers/openai/cassette/corpus_retrieval.rs
@@ -88,7 +88,7 @@ async fn dynamic_context_one_streamed_effect_log_is_the_golden_fixture() {
                 .dynamic_context(1, index)
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.stream_prompt(FACT_PROMPT).stream().await;
+            let mut stream = agent.prompt(FACT_PROMPT).stream().await;
             let output = final_output(&mut stream).await;
             drop(stream);
             assert!(!output.is_empty());
@@ -158,11 +158,7 @@ async fn retrieved_tools_one_streamed_effect_log_is_the_golden_fixture() {
                 .retrieved_tools(1, index, toolset)
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent
-                .stream_prompt(SUBTRACT_PROMPT)
-                .max_turns(3)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(SUBTRACT_PROMPT).max_turns(3).stream().await;
             let output = final_output(&mut stream).await;
             drop(stream);
             assert!(output.contains("42"), "{output}");

--- a/tests/providers/openai/cassette/corpus_retrieval.rs
+++ b/tests/providers/openai/cassette/corpus_retrieval.rs
@@ -88,7 +88,7 @@ async fn dynamic_context_one_streamed_effect_log_is_the_golden_fixture() {
                 .dynamic_context(1, index)
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.prompt(FACT_PROMPT).stream().await;
+            let mut stream = agent.prompt(FACT_PROMPT).stream();
             let output = final_output(&mut stream).await;
             drop(stream);
             assert!(!output.is_empty());
@@ -158,7 +158,7 @@ async fn retrieved_tools_one_streamed_effect_log_is_the_golden_fixture() {
                 .retrieved_tools(1, index, toolset)
                 .record_effects_with_events()
                 .build();
-            let mut stream = agent.prompt(SUBTRACT_PROMPT).max_turns(3).stream().await;
+            let mut stream = agent.prompt(SUBTRACT_PROMPT).max_turns(3).stream();
             let output = final_output(&mut stream).await;
             drop(stream);
             assert!(output.contains("42"), "{output}");

--- a/tests/providers/openai/cassette/effect_corpus.rs
+++ b/tests/providers/openai/cassette/effect_corpus.rs
@@ -70,7 +70,7 @@ async fn streaming_with_events_effect_log_is_the_golden_fixture() {
             .record_effects_with_events()
             .build();
         let mut stream = agent
-            .stream_prompt(STREAMING_TOOLS_PROMPT)
+            .prompt(STREAMING_TOOLS_PROMPT)
             .max_turns(3)
             .stream()
             .await;

--- a/tests/providers/openai/cassette/effect_corpus.rs
+++ b/tests/providers/openai/cassette/effect_corpus.rs
@@ -69,11 +69,7 @@ async fn streaming_with_events_effect_log_is_the_golden_fixture() {
             .tool(Subtract)
             .record_effects_with_events()
             .build();
-        let mut stream = agent
-            .prompt(STREAMING_TOOLS_PROMPT)
-            .max_turns(3)
-            .stream()
-            .await;
+        let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).max_turns(3).stream();
         let mut saw_final = false;
         while let Some(item) = stream.next().await {
             if let Ok(MultiTurnStreamItem::FinalResponse(_)) = item {

--- a/tests/providers/openai/cassette/lifecycle_matrix.rs
+++ b/tests/providers/openai/cassette/lifecycle_matrix.rs
@@ -53,7 +53,7 @@ async fn middleware_response_phase_precedes_stream_consumption() {
                 .preamble(STREAMING_PREAMBLE)
                 .add_hook(settle_hook)
                 .build();
-            let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_PROMPT).stream();
             let (response, provider_final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await
@@ -119,8 +119,7 @@ async fn entry_log_orders_and_turn_stamps_across_a_streamed_tool_run() {
             let mut stream = agent
                 .prompt("What is 9 + 16? Use the add tool, then reply with just the number.")
                 .max_turns(3)
-                .stream()
-                .await;
+                .stream();
             let (response, _final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await

--- a/tests/providers/openai/cassette/lifecycle_matrix.rs
+++ b/tests/providers/openai/cassette/lifecycle_matrix.rs
@@ -53,7 +53,7 @@ async fn middleware_response_phase_precedes_stream_consumption() {
                 .preamble(STREAMING_PREAMBLE)
                 .add_hook(settle_hook)
                 .build();
-            let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
             let (response, provider_final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await
@@ -117,7 +117,7 @@ async fn entry_log_orders_and_turn_stamps_across_a_streamed_tool_run() {
                 .add_hook(agent_hook)
                 .build();
             let mut stream = agent
-                .stream_prompt("What is 9 + 16? Use the add tool, then reply with just the number.")
+                .prompt("What is 9 + 16? Use the add tool, then reply with just the number.")
                 .max_turns(3)
                 .stream()
                 .await;

--- a/tests/providers/openai/cassette/max_completion_tokens_matrix.rs
+++ b/tests/providers/openai/cassette/max_completion_tokens_matrix.rs
@@ -207,7 +207,7 @@ async fn reasoning_gpt5_nano_agent_streaming_cap() {
                 .max_tokens(CAP)
                 .build();
 
-            let mut stream = agent.prompt(PROMPT).stream().await;
+            let mut stream = agent.prompt(PROMPT).stream();
             let observed = collect_stream_observation(&mut stream).await;
 
             assert!(observed.errors.is_empty(), "{:?}", observed.errors);
@@ -256,7 +256,7 @@ async fn reasoning_gpt5_nano_tool_turn_streaming_cap() {
                 .tool(Adder)
                 .build();
 
-            let mut stream = agent.prompt("What is 3 + 4?").max_turns(3).stream().await;
+            let mut stream = agent.prompt("What is 3 + 4?").max_turns(3).stream();
             let observed = collect_stream_observation(&mut stream).await;
 
             assert!(observed.errors.is_empty(), "{:?}", observed.errors);

--- a/tests/providers/openai/cassette/max_completion_tokens_matrix.rs
+++ b/tests/providers/openai/cassette/max_completion_tokens_matrix.rs
@@ -207,7 +207,7 @@ async fn reasoning_gpt5_nano_agent_streaming_cap() {
                 .max_tokens(CAP)
                 .build();
 
-            let mut stream = agent.stream_prompt(PROMPT).stream().await;
+            let mut stream = agent.prompt(PROMPT).stream().await;
             let observed = collect_stream_observation(&mut stream).await;
 
             assert!(observed.errors.is_empty(), "{:?}", observed.errors);
@@ -256,11 +256,7 @@ async fn reasoning_gpt5_nano_tool_turn_streaming_cap() {
                 .tool(Adder)
                 .build();
 
-            let mut stream = agent
-                .stream_prompt("What is 3 + 4?")
-                .max_turns(3)
-                .stream()
-                .await;
+            let mut stream = agent.prompt("What is 3 + 4?").max_turns(3).stream().await;
             let observed = collect_stream_observation(&mut stream).await;
 
             assert!(observed.errors.is_empty(), "{:?}", observed.errors);

--- a/tests/providers/openai/cassette/permission_control.rs
+++ b/tests/providers/openai/cassette/permission_control.rs
@@ -247,8 +247,7 @@ async fn permission_control_streaming_example() -> Result<()> {
                 )
                 .max_turns(5)
                 .add_hook(hook)
-                .stream()
-                .await;
+                .stream();
 
             let final_response = stream_to_stdout(&mut stream).await?;
             let last = last_result.lock().expect("lock last_result").clone();

--- a/tests/providers/openai/cassette/permission_control.rs
+++ b/tests/providers/openai/cassette/permission_control.rs
@@ -241,7 +241,7 @@ async fn permission_control_streaming_example() -> Result<()> {
             };
 
             let mut stream = agent
-                .stream_prompt(
+                .prompt(
                     "Use the available tools to read test.txt now. \
                  Do not ask any follow-up questions; just read the file and report its content.",
                 )

--- a/tests/providers/openai/cassette/raw_capture_agent_matrix.rs
+++ b/tests/providers/openai/cassette/raw_capture_agent_matrix.rs
@@ -304,12 +304,12 @@ fn blocking_body(sink: Observed, route: Route, tools: bool, probe: RawProbe) -> 
     })
 }
 
-/// A streamed `stream_prompt(..)` run, drained to its `FinalResponse`.
+/// A streamed `prompt(..).stream()` run, drained to its `FinalResponse`.
 fn streamed_body(sink: Observed, route: Route, tools: bool, probe: RawProbe) -> Body {
     Box::new(move |client| {
         Box::pin(async move {
             let (agent, prompt) = build_agent(route, client, tools, probe);
-            let mut stream = agent.stream_prompt(prompt).max_turns(3).stream().await;
+            let mut stream = agent.prompt(prompt).max_turns(3).stream().await;
             let mut observation = RunObservation::default();
             let mut final_response = None;
             while let Some(item) = stream.next().await {
@@ -677,7 +677,7 @@ async fn chat_retried_turn_records_retried_attempt_raw() {
                 )
                 .temperature(0.0)
                 .build()
-                .runner("Begin the retry-hook demonstration.")
+                .prompt("Begin the retry-hook demonstration.")
                 .max_turns(2)
                 .add_hook(hook_probe)
                 .add_hook(RetryOnceOnMarker)

--- a/tests/providers/openai/cassette/raw_capture_agent_matrix.rs
+++ b/tests/providers/openai/cassette/raw_capture_agent_matrix.rs
@@ -309,7 +309,7 @@ fn streamed_body(sink: Observed, route: Route, tools: bool, probe: RawProbe) -> 
     Box::new(move |client| {
         Box::pin(async move {
             let (agent, prompt) = build_agent(route, client, tools, probe);
-            let mut stream = agent.prompt(prompt).max_turns(3).stream().await;
+            let mut stream = agent.prompt(prompt).max_turns(3).stream();
             let mut observation = RunObservation::default();
             let mut final_response = None;
             while let Some(item) = stream.next().await {

--- a/tests/providers/openai/cassette/reasoning_tool_roundtrip.rs
+++ b/tests/providers/openai/cassette/reasoning_tool_roundtrip.rs
@@ -30,8 +30,7 @@ async fn streaming() {
             .prompt(reasoning::TOOL_USER_PROMPT)
             .history(Vec::<Message>::new())
             .max_turns(3)
-            .stream()
-            .await;
+            .stream();
 
         let stats = reasoning::collect_stream_stats(stream, "openai").await;
         reasoning::assert_universal(&stats, &call_count, "openai");

--- a/tests/providers/openai/cassette/reasoning_tool_roundtrip.rs
+++ b/tests/providers/openai/cassette/reasoning_tool_roundtrip.rs
@@ -27,7 +27,8 @@ async fn streaming() {
             .build();
 
         let stream = agent
-            .stream_chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+            .prompt(reasoning::TOOL_USER_PROMPT)
+            .history(Vec::<Message>::new())
             .max_turns(3)
             .stream()
             .await;

--- a/tests/providers/openai/cassette/refusal_matrix.rs
+++ b/tests/providers/openai/cassette/refusal_matrix.rs
@@ -305,7 +305,7 @@ async fn chat_streaming_agent_surfaces_refusal() {
                 .additional_params(chat_response_format())
                 .build();
 
-            let mut stream = agent.stream_prompt(REFUSED_PROMPT).stream().await;
+            let mut stream = agent.prompt(REFUSED_PROMPT).stream().await;
             let observed = collect_stream_observation(&mut stream).await;
 
             assert!(observed.errors.is_empty(), "{:?}", observed.errors);
@@ -666,7 +666,7 @@ async fn responses_agent_streaming_refusal_surfaces() {
                 .additional_params(responses_text_format())
                 .build();
 
-            let mut stream = agent.stream_prompt(REFUSED_PROMPT).stream().await;
+            let mut stream = agent.prompt(REFUSED_PROMPT).stream().await;
             let observed = collect_stream_observation(&mut stream).await;
 
             assert!(observed.errors.is_empty(), "{:?}", observed.errors);

--- a/tests/providers/openai/cassette/refusal_matrix.rs
+++ b/tests/providers/openai/cassette/refusal_matrix.rs
@@ -305,7 +305,7 @@ async fn chat_streaming_agent_surfaces_refusal() {
                 .additional_params(chat_response_format())
                 .build();
 
-            let mut stream = agent.prompt(REFUSED_PROMPT).stream().await;
+            let mut stream = agent.prompt(REFUSED_PROMPT).stream();
             let observed = collect_stream_observation(&mut stream).await;
 
             assert!(observed.errors.is_empty(), "{:?}", observed.errors);
@@ -666,7 +666,7 @@ async fn responses_agent_streaming_refusal_surfaces() {
                 .additional_params(responses_text_format())
                 .build();
 
-            let mut stream = agent.prompt(REFUSED_PROMPT).stream().await;
+            let mut stream = agent.prompt(REFUSED_PROMPT).stream();
             let observed = collect_stream_observation(&mut stream).await;
 
             assert!(observed.errors.is_empty(), "{:?}", observed.errors);

--- a/tests/providers/openai/cassette/regression_suite.rs
+++ b/tests/providers/openai/cassette/regression_suite.rs
@@ -36,7 +36,7 @@ async fn chat_completions_streaming_surfaces_finish_reason() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt("Write a detailed five paragraph essay about the ocean.")
+                .prompt("Write a detailed five paragraph essay about the ocean.")
                 .stream()
                 .await;
             let (_response, provider_final): (_, rig::streaming::StreamFinal) =
@@ -66,7 +66,7 @@ async fn chat_completions_streaming_surfaces_finish_reason() {
                 .max_tokens(512)
                 .build();
 
-            let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
             let (_response, provider_final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await

--- a/tests/providers/openai/cassette/regression_suite.rs
+++ b/tests/providers/openai/cassette/regression_suite.rs
@@ -37,8 +37,7 @@ async fn chat_completions_streaming_surfaces_finish_reason() {
 
             let mut stream = agent
                 .prompt("Write a detailed five paragraph essay about the ocean.")
-                .stream()
-                .await;
+                .stream();
             let (_response, provider_final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await
@@ -66,7 +65,7 @@ async fn chat_completions_streaming_surfaces_finish_reason() {
                 .max_tokens(512)
                 .build();
 
-            let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_PROMPT).stream();
             let (_response, provider_final): (_, rig::streaming::StreamFinal) =
                 collect_stream_final_response_and_provider_final(&mut stream)
                     .await

--- a/tests/providers/openai/cassette/response_identity.rs
+++ b/tests/providers/openai/cassette/response_identity.rs
@@ -192,8 +192,7 @@ async fn streamed_agent_run_reports_identity() {
                 .prompt(rig::completion::Message::user(
                     "Reply with exactly: streamed identity probe",
                 ))
-                .stream()
-                .await;
+                .stream();
             while let Some(item) = stream.next().await {
                 item.expect("stream item should succeed");
             }

--- a/tests/providers/openai/cassette/response_identity.rs
+++ b/tests/providers/openai/cassette/response_identity.rs
@@ -189,7 +189,7 @@ async fn streamed_agent_run_reports_identity() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(rig::completion::Message::user(
+                .prompt(rig::completion::Message::user(
                     "Reply with exactly: streamed identity probe",
                 ))
                 .stream()

--- a/tests/providers/openai/cassette/response_retry.rs
+++ b/tests/providers/openai/cassette/response_retry.rs
@@ -54,7 +54,7 @@ async fn rejected_response_is_retried_with_feedback() {
                 )
                 .temperature(0.0)
                 .build()
-                .runner("Begin the retry-hook demonstration.")
+                .prompt("Begin the retry-hook demonstration.")
                 .max_turns(2)
                 .add_hook(RetryOnceOnMarker)
                 .run()

--- a/tests/providers/openai/cassette/responses_sessions.rs
+++ b/tests/providers/openai/cassette/responses_sessions.rs
@@ -182,8 +182,7 @@ async fn sequential_tool_calls_streaming() {
                 .prompt(SEQUENTIAL_TOOLS_PROMPT)
                 .history(Vec::<Message>::new())
                 .max_turns(6)
-                .stream()
-                .await;
+                .stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert!(
@@ -288,11 +287,7 @@ async fn parallel_tool_calls_single_turn_streaming() {
                 .tool(BetaSignal)
                 .build();
 
-            let mut stream = agent
-                .prompt(TWO_TOOL_STREAM_PROMPT)
-                .max_turns(5)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(TWO_TOOL_STREAM_PROMPT).max_turns(5).stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert_two_tool_roundtrip_contract(
@@ -427,8 +422,7 @@ async fn reasoning_session_two_tool_calls_streaming() {
                 )
                 .history(Vec::<Message>::new())
                 .max_turns(5)
-                .stream()
-                .await;
+                .stream();
 
             let stats = reasoning::collect_stream_stats(stream, "openai").await;
 
@@ -490,8 +484,7 @@ async fn usage_accumulates_across_streaming_multi_turn() {
             let mut stream = agent
                 .prompt(ORDERED_TOOL_STREAM_PROMPT)
                 .max_turns(5)
-                .stream()
-                .await;
+                .stream();
 
             let mut saw_tool_result = false;
             let mut final_usage = None;

--- a/tests/providers/openai/cassette/responses_sessions.rs
+++ b/tests/providers/openai/cassette/responses_sessions.rs
@@ -179,7 +179,8 @@ async fn sequential_tool_calls_streaming() {
                 .build();
 
             let mut stream = agent
-                .stream_chat(SEQUENTIAL_TOOLS_PROMPT, Vec::<Message>::new())
+                .prompt(SEQUENTIAL_TOOLS_PROMPT)
+                .history(Vec::<Message>::new())
                 .max_turns(6)
                 .stream()
                 .await;
@@ -288,7 +289,7 @@ async fn parallel_tool_calls_single_turn_streaming() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(TWO_TOOL_STREAM_PROMPT)
+                .prompt(TWO_TOOL_STREAM_PROMPT)
                 .max_turns(5)
                 .stream()
                 .await;
@@ -419,12 +420,12 @@ async fn reasoning_session_two_tool_calls_streaming() {
                 .build();
 
             let stream = agent
-                .stream_chat(
+                .prompt(
                     "I need the current weather in Tokyo and in Paris. Use the get_weather \
                      tool once per city, then compare the two cities in one short paragraph \
                      that mentions both city names.",
-                    Vec::<Message>::new(),
                 )
+                .history(Vec::<Message>::new())
                 .max_turns(5)
                 .stream()
                 .await;
@@ -487,7 +488,7 @@ async fn usage_accumulates_across_streaming_multi_turn() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(ORDERED_TOOL_STREAM_PROMPT)
+                .prompt(ORDERED_TOOL_STREAM_PROMPT)
                 .max_turns(5)
                 .stream()
                 .await;

--- a/tests/providers/openai/cassette/streaming.rs
+++ b/tests/providers/openai/cassette/streaming.rs
@@ -17,7 +17,7 @@ async fn streaming_smoke() {
             .preamble(STREAMING_PREAMBLE)
             .build();
 
-        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream();
         let (response, provider_final) =
             collect_stream_final_response_and_provider_final(&mut stream)
                 .await
@@ -44,8 +44,7 @@ async fn example_streaming_prompt() {
 
         let mut stream = agent
             .prompt("When and where and what type is the next solar eclipse?")
-            .stream()
-            .await;
+            .stream();
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");

--- a/tests/providers/openai/cassette/streaming.rs
+++ b/tests/providers/openai/cassette/streaming.rs
@@ -17,7 +17,7 @@ async fn streaming_smoke() {
             .preamble(STREAMING_PREAMBLE)
             .build();
 
-        let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
         let (response, provider_final) =
             collect_stream_final_response_and_provider_final(&mut stream)
                 .await
@@ -43,7 +43,7 @@ async fn example_streaming_prompt() {
             .build();
 
         let mut stream = agent
-            .stream_prompt("When and where and what type is the next solar eclipse?")
+            .prompt("When and where and what type is the next solar eclipse?")
             .stream()
             .await;
         let response = collect_stream_final_response(&mut stream)

--- a/tests/providers/openai/cassette/streaming_tools.rs
+++ b/tests/providers/openai/cassette/streaming_tools.rs
@@ -95,7 +95,7 @@ async fn streaming_tools_smoke() {
                 .default_max_turns(2)
                 .build();
 
-            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");
@@ -121,7 +121,7 @@ async fn example_streaming_with_tools() {
             .default_max_turns(2)
             .build();
 
-        let mut stream = agent.prompt("Calculate 2 - 5").stream().await;
+        let mut stream = agent.prompt("Calculate 2 - 5").stream();
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming tools prompt should succeed");
@@ -144,8 +144,7 @@ async fn responses_stream_preserves_tool_result_flow() {
             let mut stream = agent
                 .prompt(ORDERED_TOOL_STREAM_PROMPT)
                 .max_turns(5)
-                .stream()
-                .await;
+                .stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert_tool_call_precedes_later_text(

--- a/tests/providers/openai/cassette/streaming_tools.rs
+++ b/tests/providers/openai/cassette/streaming_tools.rs
@@ -95,7 +95,7 @@ async fn streaming_tools_smoke() {
                 .default_max_turns(2)
                 .build();
 
-            let mut stream = agent.stream_prompt(STREAMING_TOOLS_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");
@@ -121,7 +121,7 @@ async fn example_streaming_with_tools() {
             .default_max_turns(2)
             .build();
 
-        let mut stream = agent.stream_prompt("Calculate 2 - 5").stream().await;
+        let mut stream = agent.prompt("Calculate 2 - 5").stream().await;
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming tools prompt should succeed");
@@ -142,7 +142,7 @@ async fn responses_stream_preserves_tool_result_flow() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(ORDERED_TOOL_STREAM_PROMPT)
+                .prompt(ORDERED_TOOL_STREAM_PROMPT)
                 .max_turns(5)
                 .stream()
                 .await;

--- a/tests/providers/openai/cassette/turn_termination_matrix.rs
+++ b/tests/providers/openai/cassette/turn_termination_matrix.rs
@@ -108,7 +108,7 @@ async fn blocking_truncated_turn_reports_length_and_cap() {
                         .max_tokens(TINY_CAP)
                         .add_hook(probe)
                         .build()
-                        .runner(TRUNCATING_PROMPT)
+                        .prompt(TRUNCATING_PROMPT)
                         .run()
                         .await
                         .expect("a partially truncated turn still carries an answer");
@@ -159,7 +159,7 @@ async fn streaming_truncated_turn_reports_length_and_cap() {
                         .build();
 
                     let mut stream = agent
-                        .stream_prompt(TRUNCATING_PROMPT)
+                        .prompt(TRUNCATING_PROMPT)
                         .add_hook(probe)
                         .stream()
                         .await;
@@ -204,7 +204,7 @@ async fn blocking_completed_turn_reports_stop_and_cap() {
                         .max_tokens(ROOMY_CAP)
                         .add_hook(probe)
                         .build()
-                        .runner(SHORT_PROMPT)
+                        .prompt(SHORT_PROMPT)
                         .run()
                         .await
                         .expect("a short answer under a roomy cap");
@@ -245,11 +245,7 @@ async fn streaming_completed_turn_reports_stop_and_cap() {
                         .max_tokens(ROOMY_CAP)
                         .build();
 
-                    let mut stream = agent
-                        .stream_prompt(SHORT_PROMPT)
-                        .add_hook(probe)
-                        .stream()
-                        .await;
+                    let mut stream = agent.prompt(SHORT_PROMPT).add_hook(probe).stream().await;
                     let _ = collect_stream_final_response(&mut stream).await;
                 }
             },
@@ -288,7 +284,7 @@ async fn blocking_tool_turn_reports_tool_calls() {
                         .tool(Adder)
                         .add_hook(probe)
                         .build()
-                        .runner(TOOL_PROMPT)
+                        .prompt(TOOL_PROMPT)
                         .max_turns(3)
                         .run()
                         .await
@@ -335,7 +331,7 @@ async fn streaming_tool_turn_reports_tool_calls() {
                         .build();
 
                     let mut stream = agent
-                        .stream_prompt(TOOL_PROMPT)
+                        .prompt(TOOL_PROMPT)
                         .add_hook(probe)
                         .max_turns(3)
                         .stream()
@@ -388,7 +384,7 @@ async fn blocking_escalating_retry_reports_each_attempts_own_cap() {
                         .add_hook(probe)
                         .add_hook(escalate)
                         .build()
-                        .runner(RETRY_PROMPT)
+                        .prompt(RETRY_PROMPT)
                         .max_turns(2)
                         .run()
                         .await
@@ -444,7 +440,7 @@ async fn streaming_escalating_retry_reports_each_attempts_own_cap() {
                         .build();
 
                     let mut stream = agent
-                        .stream_prompt(RETRY_PROMPT)
+                        .prompt(RETRY_PROMPT)
                         .add_hook(probe)
                         .add_hook(escalate)
                         .max_turns(2)

--- a/tests/providers/openai/cassette/turn_termination_matrix.rs
+++ b/tests/providers/openai/cassette/turn_termination_matrix.rs
@@ -158,11 +158,7 @@ async fn streaming_truncated_turn_reports_length_and_cap() {
                         .max_tokens(TINY_CAP)
                         .build();
 
-                    let mut stream = agent
-                        .prompt(TRUNCATING_PROMPT)
-                        .add_hook(probe)
-                        .stream()
-                        .await;
+                    let mut stream = agent.prompt(TRUNCATING_PROMPT).add_hook(probe).stream();
                     let _ = collect_stream_final_response(&mut stream).await;
                 }
             },
@@ -245,7 +241,7 @@ async fn streaming_completed_turn_reports_stop_and_cap() {
                         .max_tokens(ROOMY_CAP)
                         .build();
 
-                    let mut stream = agent.prompt(SHORT_PROMPT).add_hook(probe).stream().await;
+                    let mut stream = agent.prompt(SHORT_PROMPT).add_hook(probe).stream();
                     let _ = collect_stream_final_response(&mut stream).await;
                 }
             },
@@ -334,8 +330,7 @@ async fn streaming_tool_turn_reports_tool_calls() {
                         .prompt(TOOL_PROMPT)
                         .add_hook(probe)
                         .max_turns(3)
-                        .stream()
-                        .await;
+                        .stream();
                     let _ = collect_stream_final_response(&mut stream).await;
                 }
             },
@@ -444,8 +439,7 @@ async fn streaming_escalating_retry_reports_each_attempts_own_cap() {
                         .add_hook(probe)
                         .add_hook(escalate)
                         .max_turns(2)
-                        .stream()
-                        .await;
+                        .stream();
                     let _ = collect_stream_final_response(&mut stream).await;
                 }
             },

--- a/tests/providers/openai/live/gpt_5_5.rs
+++ b/tests/providers/openai/live/gpt_5_5.rs
@@ -63,7 +63,7 @@ async fn responses_streaming_prompt_smoke() {
         .preamble(STREAMING_PREAMBLE)
         .build();
 
-    let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_PROMPT).stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");
@@ -102,11 +102,7 @@ async fn responses_streaming_tools_smoke() {
         .tool(Subtract)
         .build();
 
-    let mut stream = agent
-        .prompt(STREAMING_TOOLS_PROMPT)
-        .max_turns(3)
-        .stream()
-        .await;
+    let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).max_turns(3).stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming tool prompt should succeed");
@@ -259,8 +255,7 @@ async fn responses_reasoning_streaming_tool_roundtrip_smoke() {
         .prompt(reasoning::TOOL_USER_PROMPT)
         .history(Vec::<Message>::new())
         .max_turns(3)
-        .stream()
-        .await;
+        .stream();
 
     let stats = reasoning::collect_stream_stats(stream, "openai").await;
     reasoning::assert_universal(&stats, &call_count, "openai");
@@ -297,7 +292,7 @@ async fn chat_completions_streaming_prompt_smoke() {
         .preamble(STREAMING_PREAMBLE)
         .build();
 
-    let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_PROMPT).stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("chat completions streaming prompt should succeed");
@@ -340,7 +335,7 @@ async fn chat_completions_streaming_tools_smoke() {
         .tool(Subtract)
         .build();
 
-    let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("chat completions streaming tool prompt should succeed");

--- a/tests/providers/openai/live/gpt_5_5.rs
+++ b/tests/providers/openai/live/gpt_5_5.rs
@@ -63,7 +63,7 @@ async fn responses_streaming_prompt_smoke() {
         .preamble(STREAMING_PREAMBLE)
         .build();
 
-    let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");
@@ -103,7 +103,7 @@ async fn responses_streaming_tools_smoke() {
         .build();
 
     let mut stream = agent
-        .stream_prompt(STREAMING_TOOLS_PROMPT)
+        .prompt(STREAMING_TOOLS_PROMPT)
         .max_turns(3)
         .stream()
         .await;
@@ -256,7 +256,8 @@ async fn responses_reasoning_streaming_tool_roundtrip_smoke() {
         .build();
 
     let stream = agent
-        .stream_chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .prompt(reasoning::TOOL_USER_PROMPT)
+        .history(Vec::<Message>::new())
         .max_turns(3)
         .stream()
         .await;
@@ -296,7 +297,7 @@ async fn chat_completions_streaming_prompt_smoke() {
         .preamble(STREAMING_PREAMBLE)
         .build();
 
-    let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("chat completions streaming prompt should succeed");
@@ -339,7 +340,7 @@ async fn chat_completions_streaming_tools_smoke() {
         .tool(Subtract)
         .build();
 
-    let mut stream = agent.stream_prompt(STREAMING_TOOLS_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("chat completions streaming tool prompt should succeed");

--- a/tests/providers/openai/live/streaming_tools_reasoning.rs
+++ b/tests/providers/openai/live/streaming_tools_reasoning.rs
@@ -19,7 +19,8 @@ async fn test_openai_streaming_tools_reasoning() {
 
     let chat_history: Vec<Message> = Vec::new();
     let mut stream = agent
-        .stream_chat("Call my example tool", &chat_history)
+        .prompt("Call my example tool")
+        .history(&chat_history)
         .max_turns(5)
         .stream()
         .await;

--- a/tests/providers/openai/live/streaming_tools_reasoning.rs
+++ b/tests/providers/openai/live/streaming_tools_reasoning.rs
@@ -22,8 +22,7 @@ async fn test_openai_streaming_tools_reasoning() {
         .prompt("Call my example tool")
         .history(&chat_history)
         .max_turns(5)
-        .stream()
-        .await;
+        .stream();
 
     while let Some(item) = stream.next().await {
         println!("Got item: {item:?}");

--- a/tests/providers/openrouter/cassette/agent_tool_sessions.rs
+++ b/tests/providers/openrouter/cassette/agent_tool_sessions.rs
@@ -457,8 +457,7 @@ async fn sequential_complex_tool_calls_streaming() -> Result<()> {
                 .prompt(COMPLEX_SESSION_PROMPT)
                 .history(Vec::<Message>::new())
                 .max_turns(10)
-                .stream()
-                .await;
+                .stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             anyhow::ensure!(
@@ -561,11 +560,7 @@ async fn parallel_tool_calls_single_turn_streaming() -> Result<()> {
                 .tool(BetaSignal)
                 .build();
 
-            let mut stream = agent
-                .prompt(TWO_TOOL_STREAM_PROMPT)
-                .max_turns(5)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(TWO_TOOL_STREAM_PROMPT).max_turns(5).stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert_two_tool_roundtrip_contract(

--- a/tests/providers/openrouter/cassette/agent_tool_sessions.rs
+++ b/tests/providers/openrouter/cassette/agent_tool_sessions.rs
@@ -454,7 +454,8 @@ async fn sequential_complex_tool_calls_streaming() -> Result<()> {
                 .build();
 
             let mut stream = agent
-                .stream_chat(COMPLEX_SESSION_PROMPT, Vec::<Message>::new())
+                .prompt(COMPLEX_SESSION_PROMPT)
+                .history(Vec::<Message>::new())
                 .max_turns(10)
                 .stream()
                 .await;
@@ -561,7 +562,7 @@ async fn parallel_tool_calls_single_turn_streaming() -> Result<()> {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(TWO_TOOL_STREAM_PROMPT)
+                .prompt(TWO_TOOL_STREAM_PROMPT)
                 .max_turns(5)
                 .stream()
                 .await;

--- a/tests/providers/openrouter/cassette/document_file_data.rs
+++ b/tests/providers/openrouter/cassette/document_file_data.rs
@@ -251,7 +251,7 @@ async fn streaming_document_file_data_roundtrip_live() {
             assert_no_verifier_leaked_into_prompt(&stream_prompt);
             assert_openrouter_wire_file_data(stream_prompt.clone());
 
-            let mut stream = agent.stream_prompt(stream_prompt).stream().await;
+            let mut stream = agent.prompt(stream_prompt).stream().await;
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("OpenRouter streaming should read PDF file_data document");

--- a/tests/providers/openrouter/cassette/document_file_data.rs
+++ b/tests/providers/openrouter/cassette/document_file_data.rs
@@ -251,7 +251,7 @@ async fn streaming_document_file_data_roundtrip_live() {
             assert_no_verifier_leaked_into_prompt(&stream_prompt);
             assert_openrouter_wire_file_data(stream_prompt.clone());
 
-            let mut stream = agent.prompt(stream_prompt).stream().await;
+            let mut stream = agent.prompt(stream_prompt).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("OpenRouter streaming should read PDF file_data document");

--- a/tests/providers/openrouter/cassette/openai_responses_compat.rs
+++ b/tests/providers/openrouter/cassette/openai_responses_compat.rs
@@ -83,8 +83,7 @@ async fn openai_responses_stream_against_openrouter_completes() {
 
             let mut stream = agent
                 .prompt("In one sentence, confirm this streaming response works.")
-                .stream()
-                .await;
+                .stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming prompt should not fail on OpenRouter service_tier metadata");

--- a/tests/providers/openrouter/cassette/openai_responses_compat.rs
+++ b/tests/providers/openrouter/cassette/openai_responses_compat.rs
@@ -82,7 +82,7 @@ async fn openai_responses_stream_against_openrouter_completes() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt("In one sentence, confirm this streaming response works.")
+                .prompt("In one sentence, confirm this streaming response works.")
                 .stream()
                 .await;
             let response = collect_stream_final_response(&mut stream)

--- a/tests/providers/openrouter/cassette/permission_control.rs
+++ b/tests/providers/openrouter/cassette/permission_control.rs
@@ -240,7 +240,7 @@ async fn permission_control_streaming_example() -> Result<()> {
             };
 
             let mut stream = agent
-                .stream_prompt(
+                .prompt(
                     "Use the available tools to read test.txt now. \
                      Do not ask any follow-up questions; just read the file and report its content.",
                 )

--- a/tests/providers/openrouter/cassette/permission_control.rs
+++ b/tests/providers/openrouter/cassette/permission_control.rs
@@ -246,8 +246,7 @@ async fn permission_control_streaming_example() -> Result<()> {
                 )
                 .max_turns(5)
                 .add_hook(hook)
-                .stream()
-                .await;
+                .stream();
 
             let final_response = stream_to_stdout(&mut stream).await?;
             let last = last_result.lock().expect("lock last_result").clone();

--- a/tests/providers/openrouter/cassette/reasoning_tool_order_matrix.rs
+++ b/tests/providers/openrouter/cassette/reasoning_tool_order_matrix.rs
@@ -207,10 +207,8 @@ async fn run_signed_agent(
         }
         Transport::Streaming => {
             let mut stream = agent
-                .stream_chat(
-                    prompt(Shape::Single),
-                    Vec::<rig::completion::Message>::new(),
-                )
+                .prompt(prompt(Shape::Single))
+                .history(Vec::<rig::completion::Message>::new())
                 .max_turns(2)
                 .stream()
                 .await;

--- a/tests/providers/openrouter/cassette/reasoning_tool_order_matrix.rs
+++ b/tests/providers/openrouter/cassette/reasoning_tool_order_matrix.rs
@@ -210,8 +210,7 @@ async fn run_signed_agent(
                 .prompt(prompt(Shape::Single))
                 .history(Vec::<rig::completion::Message>::new())
                 .max_turns(2)
-                .stream()
-                .await;
+                .stream();
             while let Some(item) = stream.next().await {
                 item?;
             }

--- a/tests/providers/openrouter/cassette/reasoning_tool_roundtrip.rs
+++ b/tests/providers/openrouter/cassette/reasoning_tool_roundtrip.rs
@@ -29,8 +29,7 @@ async fn streaming() {
             .prompt(reasoning::TOOL_USER_PROMPT)
             .history(Vec::<Message>::new())
             .max_turns(3)
-            .stream()
-            .await;
+            .stream();
 
         let stats = reasoning::collect_stream_stats(stream, "openrouter").await;
         reasoning::assert_universal(&stats, &call_count, "openrouter");

--- a/tests/providers/openrouter/cassette/reasoning_tool_roundtrip.rs
+++ b/tests/providers/openrouter/cassette/reasoning_tool_roundtrip.rs
@@ -26,7 +26,8 @@ async fn streaming() {
             .build();
 
         let stream = agent
-            .stream_chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+            .prompt(reasoning::TOOL_USER_PROMPT)
+            .history(Vec::<Message>::new())
             .max_turns(3)
             .stream()
             .await;

--- a/tests/providers/openrouter/cassette/reasoning_usage_matrix.rs
+++ b/tests/providers/openrouter/cassette/reasoning_usage_matrix.rs
@@ -251,7 +251,7 @@ async fn streaming_agent_reports_reasoning_tokens() {
                 .additional_params(openai_reasoning("medium"))
                 .build();
 
-            let mut stream = agent.stream_prompt(REASONING_PROMPT).stream().await;
+            let mut stream = agent.prompt(REASONING_PROMPT).stream().await;
             let (_, provider_final) = collect_stream_final_response_and_provider_final(&mut stream)
                 .await
                 .expect("agent stream should succeed");

--- a/tests/providers/openrouter/cassette/reasoning_usage_matrix.rs
+++ b/tests/providers/openrouter/cassette/reasoning_usage_matrix.rs
@@ -251,7 +251,7 @@ async fn streaming_agent_reports_reasoning_tokens() {
                 .additional_params(openai_reasoning("medium"))
                 .build();
 
-            let mut stream = agent.prompt(REASONING_PROMPT).stream().await;
+            let mut stream = agent.prompt(REASONING_PROMPT).stream();
             let (_, provider_final) = collect_stream_final_response_and_provider_final(&mut stream)
                 .await
                 .expect("agent stream should succeed");

--- a/tests/providers/openrouter/cassette/refusal_matrix.rs
+++ b/tests/providers/openrouter/cassette/refusal_matrix.rs
@@ -507,7 +507,7 @@ async fn streaming_agent_surfaces_refusal() {
                 .additional_params(refusal_request_params("OpenAI"))
                 .build();
 
-            let mut stream = agent.prompt(REFUSED_PROMPT).stream().await;
+            let mut stream = agent.prompt(REFUSED_PROMPT).stream();
             let observed = collect_stream_observation(&mut stream).await;
 
             assert!(observed.errors.is_empty(), "{:?}", observed.errors);

--- a/tests/providers/openrouter/cassette/refusal_matrix.rs
+++ b/tests/providers/openrouter/cassette/refusal_matrix.rs
@@ -507,7 +507,7 @@ async fn streaming_agent_surfaces_refusal() {
                 .additional_params(refusal_request_params("OpenAI"))
                 .build();
 
-            let mut stream = agent.stream_prompt(REFUSED_PROMPT).stream().await;
+            let mut stream = agent.prompt(REFUSED_PROMPT).stream().await;
             let observed = collect_stream_observation(&mut stream).await;
 
             assert!(observed.errors.is_empty(), "{:?}", observed.errors);

--- a/tests/providers/openrouter/cassette/streaming.rs
+++ b/tests/providers/openrouter/cassette/streaming.rs
@@ -16,7 +16,7 @@ async fn streaming_smoke() {
             .preamble(STREAMING_PREAMBLE)
             .build();
 
-        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream();
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");
@@ -37,8 +37,7 @@ async fn example_streaming_prompt() {
 
         let mut stream = agent
             .prompt("When and where and what type is the next solar eclipse?")
-            .stream()
-            .await;
+            .stream();
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");

--- a/tests/providers/openrouter/cassette/streaming.rs
+++ b/tests/providers/openrouter/cassette/streaming.rs
@@ -16,7 +16,7 @@ async fn streaming_smoke() {
             .preamble(STREAMING_PREAMBLE)
             .build();
 
-        let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");
@@ -36,7 +36,7 @@ async fn example_streaming_prompt() {
             .build();
 
         let mut stream = agent
-            .stream_prompt("When and where and what type is the next solar eclipse?")
+            .prompt("When and where and what type is the next solar eclipse?")
             .stream()
             .await;
         let response = collect_stream_final_response(&mut stream)

--- a/tests/providers/openrouter/cassette/streaming_tools.rs
+++ b/tests/providers/openrouter/cassette/streaming_tools.rs
@@ -35,7 +35,7 @@ async fn streaming_tools_smoke() {
                 .default_max_turns(2)
                 .build();
 
-            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");

--- a/tests/providers/openrouter/cassette/streaming_tools.rs
+++ b/tests/providers/openrouter/cassette/streaming_tools.rs
@@ -35,7 +35,7 @@ async fn streaming_tools_smoke() {
                 .default_max_turns(2)
                 .build();
 
-            let mut stream = agent.stream_prompt(STREAMING_TOOLS_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");

--- a/tests/providers/openrouter/cassette/tool_lifecycle_matrix.rs
+++ b/tests/providers/openrouter/cassette/tool_lifecycle_matrix.rs
@@ -361,7 +361,8 @@ async fn run_agent(client: openrouter::Client, cell: Cell) -> Observation {
         }
         Transport::Streaming => {
             let mut stream = agent
-                .stream_chat(prompt(cell.shape), Vec::<rig::completion::Message>::new())
+                .prompt(prompt(cell.shape))
+                .history(Vec::<rig::completion::Message>::new())
                 .max_turns(1)
                 .stream()
                 .await;

--- a/tests/providers/openrouter/cassette/tool_lifecycle_matrix.rs
+++ b/tests/providers/openrouter/cassette/tool_lifecycle_matrix.rs
@@ -364,8 +364,7 @@ async fn run_agent(client: openrouter::Client, cell: Cell) -> Observation {
                 .prompt(prompt(cell.shape))
                 .history(Vec::<rig::completion::Message>::new())
                 .max_turns(1)
-                .stream()
-                .await;
+                .stream();
             errors = crate::support::collect_stream_observation(&mut stream)
                 .await
                 .errors;

--- a/tests/providers/openrouter/cassette/tool_truncation_contract_matrix.rs
+++ b/tests/providers/openrouter/cassette/tool_truncation_contract_matrix.rs
@@ -272,7 +272,8 @@ async fn run_agent(client: openrouter::Client, cell: Cell) -> Observation {
         }
         Transport::Streaming => {
             let mut stream = agent
-                .stream_chat(PROMPT, Vec::<rig::completion::Message>::new())
+                .prompt(PROMPT)
+                .history(Vec::<rig::completion::Message>::new())
                 .max_turns(1)
                 .stream()
                 .await;

--- a/tests/providers/openrouter/cassette/tool_truncation_contract_matrix.rs
+++ b/tests/providers/openrouter/cassette/tool_truncation_contract_matrix.rs
@@ -275,8 +275,7 @@ async fn run_agent(client: openrouter::Client, cell: Cell) -> Observation {
                 .prompt(PROMPT)
                 .history(Vec::<rig::completion::Message>::new())
                 .max_turns(1)
-                .stream()
-                .await;
+                .stream();
             errors = crate::support::collect_stream_observation(&mut stream)
                 .await
                 .errors;

--- a/tests/providers/perplexity/cassette/streaming.rs
+++ b/tests/providers/perplexity/cassette/streaming.rs
@@ -18,7 +18,7 @@ async fn streaming_smoke() {
             .max_tokens(16)
             .build();
 
-        let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");

--- a/tests/providers/perplexity/cassette/streaming.rs
+++ b/tests/providers/perplexity/cassette/streaming.rs
@@ -18,7 +18,7 @@ async fn streaming_smoke() {
             .max_tokens(16)
             .build();
 
-        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream();
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");

--- a/tests/providers/together/streaming.rs
+++ b/tests/providers/together/streaming.rs
@@ -16,7 +16,7 @@ async fn streaming_smoke() {
         .preamble(STREAMING_PREAMBLE)
         .build();
 
-    let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_PROMPT).stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");

--- a/tests/providers/together/streaming.rs
+++ b/tests/providers/together/streaming.rs
@@ -16,7 +16,7 @@ async fn streaming_smoke() {
         .preamble(STREAMING_PREAMBLE)
         .build();
 
-    let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming prompt should succeed");

--- a/tests/providers/together/streaming_tools.rs
+++ b/tests/providers/together/streaming_tools.rs
@@ -19,7 +19,7 @@ async fn streaming_tools_smoke() {
         .tool(Subtract)
         .build();
 
-    let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream();
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming tool prompt should succeed");

--- a/tests/providers/together/streaming_tools.rs
+++ b/tests/providers/together/streaming_tools.rs
@@ -19,7 +19,7 @@ async fn streaming_tools_smoke() {
         .tool(Subtract)
         .build();
 
-    let mut stream = agent.stream_prompt(STREAMING_TOOLS_PROMPT).stream().await;
+    let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
     let response = collect_stream_final_response(&mut stream)
         .await
         .expect("streaming tool prompt should succeed");

--- a/tests/providers/venice/cassette/streaming.rs
+++ b/tests/providers/venice/cassette/streaming.rs
@@ -14,7 +14,7 @@ async fn streaming_smoke() {
             .agent(DEFAULT_MODEL)
             .preamble(STREAMING_PREAMBLE)
             .build();
-        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream();
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");

--- a/tests/providers/venice/cassette/streaming.rs
+++ b/tests/providers/venice/cassette/streaming.rs
@@ -14,7 +14,7 @@ async fn streaming_smoke() {
             .agent(DEFAULT_MODEL)
             .preamble(STREAMING_PREAMBLE)
             .build();
-        let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");

--- a/tests/providers/venice/cassette/streaming_tools.rs
+++ b/tests/providers/venice/cassette/streaming_tools.rs
@@ -20,7 +20,7 @@ async fn streaming_tools_smoke() {
                 .tool(Subtract)
                 .default_max_turns(2)
                 .build();
-            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream();
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");

--- a/tests/providers/venice/cassette/streaming_tools.rs
+++ b/tests/providers/venice/cassette/streaming_tools.rs
@@ -20,7 +20,7 @@ async fn streaming_tools_smoke() {
                 .tool(Subtract)
                 .default_max_turns(2)
                 .build();
-            let mut stream = agent.stream_prompt(STREAMING_TOOLS_PROMPT).stream().await;
+            let mut stream = agent.prompt(STREAMING_TOOLS_PROMPT).stream().await;
             let response = collect_stream_final_response(&mut stream)
                 .await
                 .expect("streaming tool prompt should succeed");

--- a/tests/providers/xai/agent_tool_sessions.rs
+++ b/tests/providers/xai/agent_tool_sessions.rs
@@ -510,8 +510,7 @@ async fn sequential_complex_tool_calls_streaming() -> Result<()> {
                 .prompt(COMPLEX_SESSION_PROMPT)
                 .history(Vec::<Message>::new())
                 .max_turns(10)
-                .stream()
-                .await;
+                .stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             anyhow::ensure!(
@@ -611,11 +610,7 @@ async fn parallel_tool_calls_single_turn_streaming() -> Result<()> {
                 .additional_params(json!({"parallel_tool_calls": true}))
                 .build();
 
-            let mut stream = agent
-                .prompt(TWO_TOOL_STREAM_PROMPT)
-                .max_turns(5)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(TWO_TOOL_STREAM_PROMPT).max_turns(5).stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert_two_tool_roundtrip_contract(

--- a/tests/providers/xai/agent_tool_sessions.rs
+++ b/tests/providers/xai/agent_tool_sessions.rs
@@ -507,7 +507,8 @@ async fn sequential_complex_tool_calls_streaming() -> Result<()> {
                 .build();
 
             let mut stream = agent
-                .stream_chat(COMPLEX_SESSION_PROMPT, Vec::<Message>::new())
+                .prompt(COMPLEX_SESSION_PROMPT)
+                .history(Vec::<Message>::new())
                 .max_turns(10)
                 .stream()
                 .await;
@@ -611,7 +612,7 @@ async fn parallel_tool_calls_single_turn_streaming() -> Result<()> {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(TWO_TOOL_STREAM_PROMPT)
+                .prompt(TWO_TOOL_STREAM_PROMPT)
                 .max_turns(5)
                 .stream()
                 .await;

--- a/tests/providers/xai/permission_control.rs
+++ b/tests/providers/xai/permission_control.rs
@@ -248,8 +248,7 @@ async fn permission_control_streaming_example() -> Result<()> {
                 )
                 .max_turns(5)
                 .add_hook(hook)
-                .stream()
-                .await;
+                .stream();
 
             let final_response = stream_to_stdout(&mut stream).await?;
             let last = last_result.lock().expect("lock last_result").clone();

--- a/tests/providers/xai/permission_control.rs
+++ b/tests/providers/xai/permission_control.rs
@@ -242,7 +242,7 @@ async fn permission_control_streaming_example() -> Result<()> {
             };
 
             let mut stream = agent
-                .stream_prompt(
+                .prompt(
                     "Use the available tools to read test.txt now. \
                      Do not ask any follow-up questions; just read the file and report its content.",
                 )

--- a/tests/providers/xai/reasoning_tool_roundtrip.rs
+++ b/tests/providers/xai/reasoning_tool_roundtrip.rs
@@ -25,7 +25,8 @@ async fn streaming() {
             .build();
 
         let stream = agent
-            .stream_chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+            .prompt(reasoning::TOOL_USER_PROMPT)
+            .history(Vec::<Message>::new())
             .max_turns(3)
             .stream()
             .await;

--- a/tests/providers/xai/reasoning_tool_roundtrip.rs
+++ b/tests/providers/xai/reasoning_tool_roundtrip.rs
@@ -28,8 +28,7 @@ async fn streaming() {
             .prompt(reasoning::TOOL_USER_PROMPT)
             .history(Vec::<Message>::new())
             .max_turns(3)
-            .stream()
-            .await;
+            .stream();
 
         let stats = reasoning::collect_stream_stats(stream, "xai").await;
         reasoning::assert_universal(&stats, &call_count, "xai");

--- a/tests/providers/xai/response_identity.rs
+++ b/tests/providers/xai/response_identity.rs
@@ -89,7 +89,7 @@ async fn streamed_agent_run_reports_identity() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(rig::completion::Message::user(
+                .prompt(rig::completion::Message::user(
                     "Reply with exactly: streamed identity probe",
                 ))
                 .stream()

--- a/tests/providers/xai/response_identity.rs
+++ b/tests/providers/xai/response_identity.rs
@@ -92,8 +92,7 @@ async fn streamed_agent_run_reports_identity() {
                 .prompt(rig::completion::Message::user(
                     "Reply with exactly: streamed identity probe",
                 ))
-                .stream()
-                .await;
+                .stream();
             while let Some(item) = stream.next().await {
                 item.expect("stream item should succeed");
             }

--- a/tests/providers/xai/streaming.rs
+++ b/tests/providers/xai/streaming.rs
@@ -16,7 +16,7 @@ async fn streaming_smoke() {
             .preamble(STREAMING_PREAMBLE)
             .build();
 
-        let mut stream = agent.stream_prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");

--- a/tests/providers/xai/streaming.rs
+++ b/tests/providers/xai/streaming.rs
@@ -16,7 +16,7 @@ async fn streaming_smoke() {
             .preamble(STREAMING_PREAMBLE)
             .build();
 
-        let mut stream = agent.prompt(STREAMING_PROMPT).stream().await;
+        let mut stream = agent.prompt(STREAMING_PROMPT).stream();
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming prompt should succeed");

--- a/tests/providers/xai/streaming_tools.rs
+++ b/tests/providers/xai/streaming_tools.rs
@@ -91,7 +91,7 @@ async fn responses_stream_preserves_tool_result_flow() {
                 .build();
 
             let mut stream = agent
-                .stream_prompt(XAI_STATUS_TOOL_PROMPT)
+                .prompt(XAI_STATUS_TOOL_PROMPT)
                 .max_turns(5)
                 .stream()
                 .await;

--- a/tests/providers/xai/streaming_tools.rs
+++ b/tests/providers/xai/streaming_tools.rs
@@ -90,11 +90,7 @@ async fn responses_stream_preserves_tool_result_flow() {
                 .tool(StatusWordTool)
                 .build();
 
-            let mut stream = agent
-                .prompt(XAI_STATUS_TOOL_PROMPT)
-                .max_turns(5)
-                .stream()
-                .await;
+            let mut stream = agent.prompt(XAI_STATUS_TOOL_PROMPT).max_turns(5).stream();
             let observation = collect_stream_observation(&mut stream).await;
 
             assert_tool_call_precedes_later_text(


### PR DESCRIPTION
# refactor(agent)!: one way to a runner, and a lazy stream

## Description

Child of #2443 (base `feat/effect-bus`), the second of the merge-readiness series: the
`AgentRunner` entry points, streaming and history configuration, made coherent before the
parent merges.

The audit (all of `crates/rig-agent/src/agent/{completion,runner,streaming}.rs`, their tests
and docs, the facade, every owned example and consumer) found that the streamed-versus-
collected choice was made **only** by the terminal call — `.await`/`run()` runs the provider's
unary operation, `stream()` its stream, `run_channel()` wraps `stream()` — while the agent
offered three constructors that built the identical runner (`runner`, `prompt`, `stream_prompt`)
plus two sugars (`stream_chat`, `Agent::run_channel`). `stream_prompt(..).await` therefore ran a
unary call under a name that said otherwise, and `runner(..).stream()` was used 81 times.
Continuing a persisted run needed a placeholder prompt (`agent.runner("ignored").resume(run)`,
five call sites). And `stream()` was an eager `async fn`: the memory load — a hook-visible bus
dispatch, recorded in the effect log — ran at `.stream().await` even if the stream was never
polled, while `run()` and `run_channel()` were lazy.

Three changes, one commit each (plus tests, docs and the review follow-up):

1. **One way to a runner.** `Agent::prompt(p)` is the only constructor. `runner`, `stream_prompt`,
   `stream_chat` and `Agent::run_channel` are removed; `AgentRunner::from_agent` is crate-private.
   `chat(p, &mut history)` stays (it is the write-back convenience; its doc no longer claims "one
   turn"), as do `prompt_typed` and `Extractor`. Every owned call site, doctest, example and
   README uses `prompt(..)` and chooses `.await`, `.stream()` or `.run_channel()`.
2. **`Agent::resume(run)`** replaces `AgentRunner::resume`. The runner carries one `RunOrigin`
   (a prompt or the persisted run) that both drivers match on, so the two fields that could
   disagree are gone along with the ignored prompt.
3. **`AgentRunner::stream` is synchronous and lazy.** It returns the `StreamingResult` directly;
   the memory load, the agent span and the first provider call happen on the first poll, exactly
   as `run()` does on its first poll. A stream dropped unpolled does nothing. A memory-load
   failure is still the stream's first and only item. Streams can now be built from
   synchronous host code and handed to whatever polls them. Every terminal — `run()`/`.await`,
   `stream()`, `run_channel()` — belongs to the span it was called in (an enabled ambient span is
   adopted, otherwise a root `invoke_agent` is created), never to whichever task first polls it.
   On the base this was decided at first poll; it coincided with the call site only because every
   caller wrote `.stream().await` inline. `stream()` and `run_channel()` are `#[must_use]`.
   `run()` is now `fn run(self) -> impl Future + WasmCompatSend` (call sites unchanged); typed runs
   (`prompt_typed`, `Extractor`) follow the same rule through `IntoFuture`.

Not changed on purpose: `run()` beside `IntoFuture` (the explicit verb reads better in long
chains); the bus/ECS surfaces; `TypedRun`'s setter mirror. Handed to prompt 03
(history/context): `history(h)` silently disabling memory load *and* save when `conversation(id)`
is also set; the streamed `FinalResponse.messages` always `Some` versus the blocking response's
documented `None`; no runner-level write-back for caller-owned history; the pre-existing
streamed/blocking asymmetry of `unhandled_invalid_tool_call` on a resumed run (documented on
`Agent::resume`, not changed).

## Changelog

- *(rig-agent)* [**breaking**] `Agent::prompt` is the one constructor of an `AgentRunner`; `Agent::{runner, stream_prompt, stream_chat, run_channel}` are removed and `AgentRunner::from_agent` is crate-private. The terminal call (`.await`/`run()`, `stream()`, `run_channel()`) alone chooses the medium.
- *(rig-agent)* [**breaking**] `Agent::resume(run)` continues a persisted run; `AgentRunner::resume` is removed, so no placeholder prompt is needed.
- *(rig-agent)* [**breaking**] `AgentRunner::stream` is a synchronous, lazy method: `agent.prompt(p).stream()` returns the stream; nothing (memory load included) runs until it is polled.

## Migration

`agent.runner(p)`, `agent.stream_prompt(p)` → `agent.prompt(p)`. `agent.stream_chat(p, h)` →
`agent.prompt(p).history(h)`. `agent.run_channel(p)` → `agent.prompt(p).run_channel()`.
`AgentRunner::from_agent(&agent, p)` → `agent.prompt(p)`.

```rust
// before
let mut stream = agent.stream_chat("hi", &history).max_turns(5).stream().await;
let (run, events) = agent.run_channel("hi");
let response = agent.runner("ignored").tool_concurrency(4).resume(restored).run().await?;

// after
let mut stream = agent.prompt("hi").history(&history).max_turns(5).stream();
let (run, events) = agent.prompt("hi").run_channel();
let response = agent.resume(restored).tool_concurrency(4).await?;
```

`stream()` no longer takes `.await`. Behavioral consequence: the conversation-memory load and
the agent span now happen on the stream's first poll rather than when `stream()` is called; a
stream that is never polled loads nothing and writes no effect-log record. Error surfacing is
unchanged (a load failure is the first stream item); hook order, provider streaming mode and
cancellation on drop are unchanged.

All four sibling children (#2487, #2488, #2489, #2490) merged first; this branch merges `feat/effect-bus` at `b24e2103c` and applies the rule above to their new call sites (ten in #2490's `stream_faults.rs` files, one in #2487's streaming tests). #2487's `resume` documentation now lives on `Agent::resume`.

## Type of change

- [x] Breaking change
- [x] Documentation update

## Testing

- `crates/rig-agent/src/agent/runner/entry_tests.rs` (new): an awaited prompt runs unary and a
  streamed one streams (observed through `HookContext::is_streaming` and a mock scripted for
  one medium only); the terminal alone chooses the medium; `stream()` performs no load and fires
  no hook until polled, and an unpolled stream does nothing; `Agent::resume` continues a run
  without a prompt on either medium, its hooks apply, and it neither loads nor saves memory; both media fire
  run-start once.
- Span tests (streaming tests): a stream or `run_channel` split inside a span and drained from a
  spawned task adopts that span (no `invoke_agent`; every chat span is its child); a stream built
  outside any span stays a root `invoke_agent` when polled inside one.
- Existing coverage migrated, none deleted: 330 streamed cassette sites, `run_channel` tests,
  rig-verify durable-execution/corpus resume sites.
- `RIG_PROVIDER_TEST_MODE=replay cargo xtask verify --pr --base origin/feat/effect-bus --no-reuse` on head `b909546d6`: 31/31 checks passed; on the merged head `e0f24d413` against base `b24e2103c`: 30/30 (16 executed fresh after a disk-full interruption, 14 reused with matching inputs; `full-tests`, `dependency-floors` and `doctests` executed fresh) (the full lane, since `tests/core/*.rs` changed: fmt, source-guards, tooling, clippy, default-check, default-tests, scenario-registrations, core-all, bus-verification, macro-hygiene, conformance, derive, doctests, docs, loom, full-tests, workspace-check, dependency-floors, nine wasm lanes, two native-only guards). `wasm-bindgen-test-runner` 0.2.118 matching the lockfile.
- `full-tests` (`--workspace`) compiles every example package, so every public example uses the chosen path. GitHub CI on `e0f24d413`: 24/24.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated READMEs and Rust docs affected by this change
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did not edit `CHANGELOG.md` or `MIGRATING.md` (they are generated at release)

## Notes

Independent reviews: seven (full diff, each fix delta, and the merge resolution), by subagents with no implementation context; all findings fixed or justified in the ledger (`reviews/rig-2443-02-agentrunner-api/`). This child certifies the entry-point surface only, not the
whole #2443 architecture.
