### PR TITLE
ci: warm caches save only on success; read-only workflow tokens

### DIFF
--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -92,8 +92,12 @@ runs:
           echo "CARGO_INCREMENTAL=0"
         } >> "$GITHUB_ENV"
 
+    # Pinned to a commit: this action's nested rust-cache version decides the
+    # cache key layout, and cache-warm.yaml invokes the same rust-cache commit
+    # directly. A floating tag could move the nested version and silently
+    # split the two keys; a bump must change both pins in one diff.
     - name: Install Rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
       with:
         toolchain: ${{ env.RIG_CI_TOOLCHAIN }}
         components: ${{ inputs.components }}

--- a/.github/workflows/cache-warm.yaml
+++ b/.github/workflows/cache-warm.yaml
@@ -7,26 +7,72 @@ on:
 permissions:
   contents: read
 
+# rust-cache hashes every CARGO*/RUST* variable into its key. ci.yaml and
+# nightly.yaml set this at workflow level; state it here too rather than
+# relying on setup-rust-toolchain's identical default.
+env:
+  CARGO_TERM_COLOR: always
+
+# Never cancel a warm in progress. rust-cache's post step runs even when the
+# job is cancelled or fails and saves whatever `target/` holds under the
+# exact key, and a later complete warm then restores that entry as a full
+# match and skips its own save ("Cache up-to-date."). That happened on the
+# first push after this workflow gained the all-features job: a superseding
+# push cancelled it at three minutes, an 831 MB partial entry was published,
+# and the superseding run's own 12-minute build was thrown away. Queuing the
+# newer push behind a started warm removes the cancellation trigger; the
+# all-features job below removes the failure trigger too.
 concurrency:
   group: cache-warm-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   # Two configurations, not every matrix leg. PR merge refs can restore
   # their base's cache but cannot warm other PRs themselves. The default
   # graph is warmed for the development base only: on main, cd.yaml's own
-  # `test` job already saves it. Match ci.yaml's test job ID and setup so
-  # rust-cache keys stay compatible.
+  # `test` job already saves it.
+  #
+  # Both jobs invoke rust-cache at job level rather than through the
+  # composite. The runner registers an embedded action's post step with the
+  # embedded step's own `if:` and discards its `post-if`, so nested
+  # rust-cache saves after a cancellation (the 831 MB incident); the
+  # composite's nested call also fixes `cache-on-failure: true`, which
+  # saves after a failed compile. At job level rust-cache's
+  # `post-if: success()` is honoured and a cancelled or failed warm saves
+  # nothing. `save-if` restates the composite's trusted-push gate, which a
+  # job-level call cannot reach. Every other saving job still uses the
+  # nested cache; a failed push to main can therefore still publish a
+  # partial entry under its own job key, and a later warm that restores it
+  # as an exact match will not replace it. That is a known gap, not closed
+  # here.
+  #
+  # This job's key must equal ci.yaml's `test` job's, whose nested rust-cache
+  # runs before the composite exports RUSTC_WRAPPER for sccache. So the
+  # composite runs twice: once without sccache so rust-cache computes the key
+  # from the same environment (job id `test` is the automatic key), then
+  # again to enable sccache for the build. Neither the toolchain install nor
+  # nextest exports a CARGO*/RUST* variable, so the order is otherwise moot.
   test:
     if: github.repository == '0xPlaygrounds/rig' && github.event_name == 'push' && github.ref == 'refs/heads/feat/effect-bus'
     runs-on: ubuntu-latest
+    # A warm is never cancelled, so a hung build must not hold this ref's
+    # concurrency group for the runner's six-hour default (queue time is not
+    # counted; only the running job is bounded).
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/rust-setup
         with:
           nextest: "true"
           components: rustfmt
+          cache: "false"
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.repository == '0xPlaygrounds/rig' && github.event_name == 'push' && github.ref == 'refs/heads/feat/effect-bus' }}
+      - uses: ./.github/actions/rust-setup
+        with:
           sccache: "true"
+          cache: "false"
           cache-development: "true"
       # Populate the same artifacts without repeating the required CI test run.
       - run: cargo xtask verify --check default-test-build
@@ -48,13 +94,27 @@ jobs:
   all-features:
     if: github.repository == '0xPlaygrounds/rig' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    # Actions cache entries are branch-scoped, so the main and feat/effect-bus
+    # warms write separate entries under this one key and need no
+    # cross-ref serialization; the per-ref workflow group above suffices.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
+      # Job-level rust-cache, see the note above `test`. This job uses no
+      # sccache, so the key matches the two restoring jobs (ci.yaml doctest,
+      # nightly.yaml test-all-features), which have no RUSTC_WRAPPER either;
+      # the protoc install exports nothing rust-cache hashes.
       - uses: ./.github/actions/rust-setup
         with:
           nextest: "true"
           protoc: "true"
-          cache-development: "true"
-          cache-shared-key: all-features
+          cache: "false"
+      # Same pinned rust-cache the composite reaches through its pinned
+      # setup-rust-toolchain, so the key layout is identical. This job is the
+      # key's only writer; both restorers pass `cache-save-if: "false"`.
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: all-features
+          save-if: ${{ github.repository == '0xPlaygrounds/rig' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feat/effect-bus') }}
       # Compile the all-features test artifacts; execute nothing.
       - run: cargo xtask verify --check full-test-build

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -17,14 +17,18 @@ concurrency:
   group: release-plz-${{ github.ref }}
   cancel-in-progress: false
 
+# Read-only by default; a called workflow may hold no more than its caller
+# job, and all three gates declare exactly `contents: read`. release-plz
+# raises `contents`/`pull-requests: write` at job level.
+permissions:
+  contents: read
+
 jobs:
-  # No `secrets: inherit` on either gate call: the test lanes are hermetic
+  # No `secrets: inherit` on any gate call: the test lanes are hermetic
   # (cassette replay, dummy keys, `#[ignore]`-gated live tests) and reference
   # no secrets, so inheriting them into jobs that execute the whole test
   # suite would be pure exfiltration surface.
   run-ci:
-    permissions:
-      checks: write
     uses: ./.github/workflows/ci.yaml
 
   # ci.yaml is the fast PR gate; the `--all-features` suite (Docker-backed

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,11 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Read-only token for every job: nothing here writes checks, artifacts or
+# comments (cargo's own diagnostics become annotations without any scope).
+permissions:
+  contents: read
+
 # Ensure the workflow runs once per PR: a newer push cancels and restarts the
 # in-flight run. Keyed on the PR number rather than `head_ref` because two
 # forks PRing from identically-named branches share a head_ref — under the
@@ -310,8 +315,6 @@ jobs:
   clippy:
     name: stable / clippy
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -110,6 +110,11 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Read-only token: this lane builds and runs third-party code with every
+# feature enabled and needs nothing from the repository but its contents.
+permissions:
+  contents: read
+
 # The `full-` prefix keeps this group disjoint from ci.yaml's when both are
 # invoked from the same cd.yaml run (inside a called workflow,
 # `github.workflow` resolves to the CALLER's name). Keyed on the PR number

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -173,9 +173,11 @@ verification. rust-cache keeps dependency artifacts only, so workspace crates
 still compile in every run. Conformance passes explicit Cargo test-target
 selectors matching its existing nextest filter, preserving the four executed
 binaries and their package/feature graph while avoiding compilation of unused
-harnesses. Cache warming still consumes runner time and quota; its benefit can
-only be measured after the workflow lands and trusted pushes populate that
-base cache.
+harnesses. Cache warming still consumes runner time and quota: a started
+warm is never cancelled (a cancelled warm once published a partial entry that
+later complete warms treated as an exact match), so a warm is never
+superseded mid-build; newer pushes queue behind it, a queued warm may be
+replaced by a newer one, and only a warm that succeeds saves.
 
 The all-features run starts its two nested-Cargo tests first (a nextest
 priority override): the facade feature-forwarding guard alone runs four


### PR DESCRIPTION
## Description

Follow-up to #2488, driven by what the first trusted push after it showed.

**The defect.** The `all-features` warm on the #2488 merge push was cancelled three minutes in when #2490 pushed (`cancel-in-progress: true`). rust-cache's post step still ran and saved an 831 MB partial entry under the exact key. The superseding warm restored that entry as a full match, built the complete graph for 12½ minutes, and logged "Cache up-to-date." without saving (run 34699063518). #2491's doctest job then restored the partial entry. The lock hash had not changed, so nothing would ever have replaced it. I deleted the entry by hand.

**Root cause and fix.** The runner registers an embedded action's post step with the embedded step's own `if:` and discards its `post-if`, and the composite's nested rust-cache call fixes `cache-on-failure: true`, so a nested rust-cache saves after a cancellation and after a failed compile. Both warm jobs now invoke rust-cache at job level (composite with `cache: "false"`, then the same pinned rust-cache with the composite's trusted-push `save-if`), where `post-if: success()` is honoured: a cancelled or failed warm saves nothing. The default/bedrock job runs the composite twice so rust-cache computes its key before sccache exports `RUSTC_WRAPPER`, keeping the key identical to ci.yaml's `test` job (checked component by component against rust-cache's key code in review). The warmer also keeps `cancel-in-progress: false` with 60-minute job timeouts, and states `CARGO_TERM_COLOR` at workflow level like the restoring workflows. The composite's `setup-rust-toolchain` is pinned to a commit because its nested rust-cache version decides the key layout that cache-warm.yaml now reproduces directly.

**Tokens.** ci.yaml, nightly.yaml and cd.yaml get a top-level `permissions: contents: read`, matching cache-warm.yaml and dependency-floors.yaml. The clippy job's `checks: write` was unused (a plain `cargo` run; annotations come from the problem matcher) and is removed, and cd.yaml's `run-ci` caller job dropped its matching grant so the called workflow's `contents: read` is within what the caller holds.

**Measurements from the prompt's follow-up list**
- Doctest with the partial entry (#2491 run 34699540673): restore 10 s, 560 crates compiled instead of 973, job 444 s versus 575 s cold. The complete entry will exist after the first trusted push with this change; the full-warm doctest number is still to be read from the first child PR after that.
- With even the partial entry, `stable / test` (512 s) is the gate's longest job, as #2488 projected. Its sccache statistics show 174 requests, 12 hits, 3 misses: dependencies come from rust-cache and sccache only sees the workspace units, so it is not the lever. The link phase of 120 root test binaries is the next candidate and is deferred to a measured follow-up.
- Nightly on #2488's own run: the facade guard started first and finished 40 s before the last test (620 s test phase versus 648 s before), so the priority took effect.

**Known gap, stated not fixed.** Every other saving job (ci.yaml jobs on pushes to main via cd.yaml, the floors lane) still uses the composite's nested cache; a failed main run can publish a partial entry under its job key that a later restore treats as an exact match. Moving every job to job-level rust-cache is its own change.

## Changelog

None (CI only).

## Migration

None.

## Testing

- Four independent full-diff reviews (subagents that did not implement the change): one P0 (caller permissions narrower than the called workflow) and one P1 (the default warm still nested) found and fixed; the last pass found nothing at P0–P2 and one accepted correction (branch-scoped cache entries), applied.
- `cargo test --locked -p xtask` (65 passed), `check-toolchain-pin.sh`, YAML parse of all workflows and the composite.
- Final plan on the committed head 8d7b66784: `RIG_PROVIDER_TEST_MODE=replay cargo xtask verify --pr --base origin/feat/effect-bus` — **30/30 passed, exit 0**, 2602 s wall on a lightly loaded machine (nextest 0.9.144, Docker via OrbStack). full-tests 7430 passed, 213 skipped, one flaky retry; dependency-floors passed. (Two earlier attempts on this head were lost to a full disk and to Docker having stopped; neither ran a check to failure.)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated READMEs and Rust docs affected by this change
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did not edit `CHANGELOG.md` or `MIGRATING.md` (they are generated at release)

## Notes

- Ledger and evidence: `many_rigs/reviews/rig-ci-06-ledger.md`, `reviews/rig-ci-05-evidence/` (outside the repository).
- This review certifies the CI change against `feat/effect-bus`; it does not certify the #2443 architecture.
