### PR TITLE
refactor(core)!: one error funnel for every provider reply, and adapter facts on every HTTP wire

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ expectations:
   `with_response_headers` when the call site has them, so retry/status logic
   can inspect `provider_response_status()`, the raw provider body, the
   request id and `Retry-After`. `HttpError` is only a transport failure that
-  produced no provider reply.
+  produced no provider reply, and never carries a status.
 - `ProviderResponseExt`, telemetry spans, and GenAI fields are populated
   consistently with nearby providers where applicable.
 - Tests cover the smallest reliable scope: unit tests, cassette-backed provider

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,9 +78,13 @@ expectations:
   streaming normalization patterns.
 - Provider error responses preserve status/body details through the relevant Rig
   error helpers, so callers can inspect provider response details.
-- Non-2xx completion responses surface through the capability error's
-  `from_http_response(status, body)` helper so retry/status logic can inspect
-  `provider_response_status()` and the raw provider body.
+- Non-2xx completion responses surface through the capability error's one
+  funnel, `from_http_response(status, body)` (or `?` on the transport error,
+  which routes through it), stamped with `with_provider_request_id` and
+  `with_response_headers` when the call site has them, so retry/status logic
+  can inspect `provider_response_status()`, the raw provider body, the
+  request id and `Retry-After`. `HttpError` is only a transport failure that
+  produced no provider reply.
 - `ProviderResponseExt`, telemetry spans, and GenAI fields are populated
   consistently with nearby providers where applicable.
 - Tests cover the smallest reliable scope: unit tests, cassette-backed provider

--- a/crates/rig-agent/src/agent/mod.rs
+++ b/crates/rig-agent/src/agent/mod.rs
@@ -105,6 +105,7 @@ mod builder;
 mod completion;
 pub(crate) mod drive;
 mod engine;
+pub(crate) use engine::streaming_error_into_prompt;
 pub mod hook;
 pub mod run;
 pub mod runner;

--- a/crates/rig-agent/src/agent/runner.rs
+++ b/crates/rig-agent/src/agent/runner.rs
@@ -654,7 +654,7 @@ pub(crate) fn memory_error_from_report(
         // A layer on the memory key denied the load: policy, and the run
         // fails at the record.
         rig_core::error::ErrorKind::Denied => rig_core::memory::MemoryError::Policy(report.message),
-        rig_core::error::ErrorKind::Http { .. }
+        rig_core::error::ErrorKind::Http
         | rig_core::error::ErrorKind::Json
         | rig_core::error::ErrorKind::Url
         | rig_core::error::ErrorKind::Request

--- a/crates/rig-agent/src/completion/provider_response_tests.rs
+++ b/crates/rig-agent/src/completion/provider_response_tests.rs
@@ -81,16 +81,19 @@ fn prompt_error_forwards_captured_response_headers() {
     let body = r#"{"error":{"message":"rate limited"}}"#;
 
     for completion_error in [
-        // Contract provider: headers live on the ProviderResponse.
-        CompletionError::from_http_response_with_request_id(
-            http::StatusCode::TOO_MANY_REQUESTS,
-            body,
-            Some("req_abc".to_string()),
-        )
-        .with_response_headers(Some(Box::new(headers.clone()))),
-        // Contract-less provider: headers live on the transport error.
+        // A preserved response, with and without a request id.
+        CompletionError::from_http_response(http::StatusCode::TOO_MANY_REQUESTS, body)
+            .with_provider_request_id(Some("req_abc".to_string()))
+            .with_response_headers(Some(Box::new(headers.clone()))),
         CompletionError::from_http_response(http::StatusCode::TOO_MANY_REQUESTS, body)
             .with_response_headers(Some(Box::new(headers.clone()))),
+        // A transport that reported the reply as an error routes through
+        // the same funnel, headers included.
+        CompletionError::from_transport_error(http_client::Error::InvalidStatusCodeWithDetails {
+            status: http::StatusCode::TOO_MANY_REQUESTS,
+            body: body.to_string(),
+            headers: Box::new(headers.clone()),
+        }),
     ] {
         let prompt_error = PromptError::CompletionError(completion_error);
         assert_eq!(

--- a/crates/rig-agent/src/completion/provider_response_tests.rs
+++ b/crates/rig-agent/src/completion/provider_response_tests.rs
@@ -25,9 +25,10 @@ fn prompt_error_forwards_provider_response_to_completion_error() {
 #[test]
 fn prompt_error_provider_response_helpers_forward_http_status_and_body() {
     let body = r#"{"error":{"message":"unauthorized"}}"#;
-    let error = PromptError::CompletionError(CompletionError::HttpError(
-        http_client::Error::InvalidStatusCodeWithMessage(
+    let error = PromptError::CompletionError(CompletionError::from_transport_error(
+        http_client::Error::non_success_with_details(
             http::StatusCode::UNAUTHORIZED,
+            http::HeaderMap::new(),
             body.to_string(),
         ),
     ));

--- a/crates/rig-agent/src/integrations/cli_chatbot.rs
+++ b/crates/rig-agent/src/integrations/cli_chatbot.rs
@@ -124,9 +124,9 @@ impl CliChat for AgentImpl {
                         .map(<[rig_core::completion::Message]>::to_vec);
                 }
                 Err(e) => {
-                    break Err(PromptError::CompletionError(
-                        CompletionError::ResponseError(e.to_string()),
-                    ));
+                    // The stream's error is the run's error: the provider's
+                    // report, a cancel, a memory failure — not its `Display`.
+                    break Err(crate::agent::streaming_error_into_prompt(e));
                 }
                 _ => continue,
             }

--- a/crates/rig-core/src/audio_generation/provider_response_tests.rs
+++ b/crates/rig-core/src/audio_generation/provider_response_tests.rs
@@ -20,10 +20,12 @@ fn audio_generation_error_provider_response_helpers_with_preserved_json_body() {
 #[test]
 fn audio_generation_error_provider_response_helpers_with_http_non_success() {
     let body = r#"{"error":{"message":"bad request"}}"#;
-    let error = AudioGenerationError::HttpError(http_client::Error::InvalidStatusCodeWithMessage(
-        StatusCode::BAD_REQUEST,
-        body.to_string(),
-    ));
+    let error =
+        AudioGenerationError::from_transport_error(http_client::Error::non_success_with_details(
+            StatusCode::BAD_REQUEST,
+            http::HeaderMap::new(),
+            body.to_string(),
+        ));
 
     assert_eq!(error.provider_response_body(), Some(body));
     assert_eq!(

--- a/crates/rig-core/src/client/mod.rs
+++ b/crates/rig-core/src/client/mod.rs
@@ -609,14 +609,14 @@ where
         // 401/403 arms below were dead and every bogus key surfaced as a raw
         // HttpError). Recover the status from the transport error so the
         // documented VerifyError classification actually fires.
-        let response = match self.http_client.send(req).await {
+        let response = match self.http_client.send::<_, Vec<u8>>(req).await {
             Ok(response) => response,
             Err(error) => {
                 return Err(match error.non_success_status() {
                     Some(StatusCode::UNAUTHORIZED) | Some(StatusCode::FORBIDDEN) => {
                         VerifyError::InvalidAuthentication
                     }
-                    _ => VerifyError::HttpError(error),
+                    _ => VerifyError::from_transport_error(error),
                 });
             }
         };
@@ -629,44 +629,12 @@ where
             // The failed response's headers are preserved on every branch, so
             // a caller can read rate-limit metadata such as `Retry-After` off
             // a rejected verification (rig#2210).
-            StatusCode::INTERNAL_SERVER_ERROR => {
+            status if status.is_success() => Ok(()),
+            status => {
                 let headers = Box::new(response.headers().clone());
-                let body = http_client::text(response).await?;
-                Err(VerifyError::HttpError(
-                    http_client::Error::InvalidStatusCodeWithDetails {
-                        status: StatusCode::INTERNAL_SERVER_ERROR,
-                        body,
-                        headers,
-                    },
-                ))
-            }
-            status if status.as_u16() == 529 => {
-                let headers = Box::new(response.headers().clone());
-                let body = http_client::text(response).await?;
-                Err(VerifyError::HttpError(
-                    http_client::Error::InvalidStatusCodeWithDetails {
-                        status,
-                        body,
-                        headers,
-                    },
-                ))
-            }
-            _ => {
-                let status = response.status();
-
-                if status.is_success() {
-                    Ok(())
-                } else {
-                    let headers = Box::new(response.headers().clone());
-                    let body: String = String::from_utf8_lossy(&response.into_body().await?).into();
-                    Err(VerifyError::HttpError(
-                        http_client::Error::InvalidStatusCodeWithDetails {
-                            status,
-                            body,
-                            headers,
-                        },
-                    ))
-                }
+                let body: String = String::from_utf8_lossy(&response.into_body().await?).into();
+                Err(VerifyError::from_http_response(status, body)
+                    .with_response_headers(Some(headers)))
             }
         }
     }

--- a/crates/rig-core/src/client/verify.rs
+++ b/crates/rig-core/src/client/verify.rs
@@ -6,10 +6,6 @@ use thiserror::Error;
 /// Inspect provider failures with [`Self::provider_response_body`],
 /// [`Self::provider_response_json`], and [`Self::provider_response_status`].
 ///
-/// Note: no provider path currently constructs [`Self::ProviderResponse`] for
-/// verification; real verify failures surface as [`Self::HttpError`], which
-/// the helpers read. The variant is kept for symmetry with the other capability
-/// errors and for future provider paths that preserve a 2xx error envelope.
 #[derive(Debug, Error)]
 pub enum VerifyError {
     #[error("invalid authentication")]
@@ -19,15 +15,19 @@ pub enum VerifyError {
     /// Raw error response preserved from the provider
     #[error("provider response error: {0}")]
     ProviderResponse(provider_response::ProviderResponseError),
+    /// A transport failure that produced no provider reply; a rejected
+    /// verification with a body is [`Self::ProviderResponse`].
     #[error("http error: {0}")]
-    HttpError(
-        #[from]
-        #[source]
-        http_client::Error,
-    ),
+    HttpError(#[source] http_client::Error),
 }
 
 crate::provider_response::impl_provider_response_helpers!(VerifyError);
+
+impl From<http_client::Error> for VerifyError {
+    fn from(error: http_client::Error) -> Self {
+        Self::from_transport_error(error)
+    }
+}
 
 /// A provider client that can verify the configuration.
 /// Clone is required for conversions between client types.

--- a/crates/rig-core/src/client/verify/provider_response_tests.rs
+++ b/crates/rig-core/src/client/verify/provider_response_tests.rs
@@ -19,8 +19,9 @@ fn verify_error_provider_response_helpers_with_preserved_json_body() {
 #[test]
 fn verify_error_provider_response_helpers_with_http_non_success() {
     let body = r#"{"error":{"message":"bad request"}}"#;
-    let error = VerifyError::HttpError(http_client::Error::InvalidStatusCodeWithMessage(
+    let error = VerifyError::from_transport_error(http_client::Error::non_success_with_details(
         StatusCode::BAD_REQUEST,
+        http::HeaderMap::new(),
         body.to_string(),
     ));
 

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -81,8 +81,8 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum CompletionError {
     /// A transport failure that produced no provider reply (a connection
-    /// error, a timeout, a status reported without a body); a reply with a
-    /// body is [`Self::ProviderResponse`].
+    /// error, a timeout, an unreadable response); it never carries a
+    /// status. A reply the server made is [`Self::ProviderResponse`].
     #[error("HttpError: {0}")]
     HttpError(http_client::Error),
 

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -80,9 +80,11 @@ use thiserror::Error;
 /// ```
 #[derive(Debug, Error)]
 pub enum CompletionError {
-    /// Http error (e.g.: connection error, timeout, etc.)
+    /// A transport failure that produced no provider reply (a connection
+    /// error, a timeout, a status reported without a body); a reply with a
+    /// body is [`Self::ProviderResponse`].
     #[error("HttpError: {0}")]
-    HttpError(#[from] http_client::Error),
+    HttpError(http_client::Error),
 
     /// Json error (e.g.: serialization, deserialization)
     #[error("JsonError: {0}")]
@@ -117,18 +119,18 @@ pub enum CompletionError {
 
 crate::provider_response::impl_provider_response_helpers!(CompletionError);
 
+impl From<http_client::Error> for CompletionError {
+    fn from(error: http_client::Error) -> Self {
+        Self::from_transport_error(error)
+    }
+}
+
 impl CompletionError {
-    /// Maps an SSE transport error into a completion error without flattening HTTP failures.
-    ///
-    /// Non-success HTTP responses remain [`CompletionError::HttpError`] so provider response
-    /// helpers can read status and body. Other transport failures keep the existing
-    /// [`CompletionError::ProviderError`] display string behavior.
+    /// Maps an SSE transport error like every other transport error: the
+    /// provider's reply becomes [`Self::ProviderResponse`], a response-less
+    /// failure stays [`Self::HttpError`] with its own retryability.
     pub(crate) fn from_stream_transport(error: http_client::Error) -> Self {
-        if error.non_success_status().is_some() {
-            Self::HttpError(error)
-        } else {
-            Self::ProviderError(error.to_string())
-        }
+        Self::from_transport_error(error)
     }
 }
 
@@ -683,12 +685,16 @@ pub trait CompletionModel: WasmCompatSend + WasmCompatSync {
     ) -> impl std::future::Future<Output = Result<StreamingCompletionResponse, CompletionError>>
     + WasmCompatSend;
 
-    /// Optionally observe one provider invocation, independently of request data.
+    /// Observe one provider invocation, independently of request data.
     ///
-    /// Ordinary providers need only implement [`Self::completion`] and
-    /// [`Self::stream`]. The default delegates without provider observations.
-    /// Observed providers override this method; forwarding wrappers pass the
-    /// context through to preserve per-call identity across retries and tasks.
+    /// Every HTTP wire in this crate implements this and attaches the
+    /// context to the request it sends, so a witness sees the request, the
+    /// response, the provider's verdict and usage where the wire projects
+    /// them, and how the attempt closed; the conformance harness requires
+    /// it. The default delegates without provider observations and is what
+    /// a model over a non-HTTP transport (an SDK, a local runtime) still
+    /// takes. Forwarding wrappers pass the context through to preserve
+    /// per-call identity across retries and tasks.
     fn completion_with_context(
         &self,
         request: CompletionRequest,

--- a/crates/rig-core/src/completion/request/tests.rs
+++ b/crates/rig-core/src/completion/request/tests.rs
@@ -783,10 +783,12 @@ fn completion_error_provider_error_is_not_a_provider_response() {
 #[test]
 fn completion_error_provider_response_helpers_with_http_non_success_body_and_status() {
     let body = r#"{"error":{"type":"invalid_request","message":"bad request"}}"#;
-    let error = CompletionError::HttpError(http_client::Error::InvalidStatusCodeWithMessage(
-        http::StatusCode::BAD_REQUEST,
-        body.to_string(),
-    ));
+    let error =
+        CompletionError::from_transport_error(http_client::Error::non_success_with_details(
+            http::StatusCode::BAD_REQUEST,
+            http::HeaderMap::new(),
+            body.to_string(),
+        ));
 
     assert_eq!(error.provider_response_body(), Some(body));
     assert_eq!(

--- a/crates/rig-core/src/embeddings/embedding/provider_response_tests.rs
+++ b/crates/rig-core/src/embeddings/embedding/provider_response_tests.rs
@@ -29,8 +29,9 @@ fn embedding_error_provider_error_is_not_a_provider_response() {
 #[test]
 fn embedding_error_provider_response_helpers_with_http_non_success() {
     let body = r#"{"error":{"message":"bad request"}}"#;
-    let error = EmbeddingError::HttpError(http_client::Error::InvalidStatusCodeWithMessage(
+    let error = EmbeddingError::from_transport_error(http_client::Error::non_success_with_details(
         StatusCode::BAD_REQUEST,
+        http::HeaderMap::new(),
         body.to_string(),
     ));
 

--- a/crates/rig-core/src/error.rs
+++ b/crates/rig-core/src/error.rs
@@ -32,14 +32,11 @@ use crate::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ErrorKind {
-    /// A transport failure that produced no provider reply: a response-less
-    /// failure (a reset connection, a timeout, a protocol error), or a
-    /// status the transport reported without a body. A non-success reply
-    /// *with* a body is the provider's and is [`Self::ProviderResponse`].
-    Http {
-        /// The status, when the transport reported one.
-        status: Option<u16>,
-    },
+    /// A transport failure that produced no provider reply: a reset
+    /// connection, a timeout, a protocol error, an unreadable response. It
+    /// never carries a status; a reply the server made, whatever its status,
+    /// is [`Self::ProviderResponse`].
+    Http,
     /// JSON serialization or deserialization failed.
     Json,
     /// A URL could not be parsed.
@@ -96,7 +93,7 @@ impl ErrorKind {
     /// deliberate change here, never a silent drift.
     pub fn code(&self) -> &'static str {
         match self {
-            Self::Http { .. } => "http",
+            Self::Http => "http",
             Self::Json => "json",
             Self::Url => "url",
             Self::Request => "request",
@@ -278,9 +275,7 @@ pub fn transient_transport(error: &crate::http_client::Error) -> bool {
         | crate::http_client::Error::InvalidHeaderValue(_)
         | crate::http_client::Error::NoHeaders
         | crate::http_client::Error::InvalidContentType(_) => false,
-        crate::http_client::Error::InvalidStatusCode(status)
-        | crate::http_client::Error::InvalidStatusCodeWithMessage(status, _)
-        | crate::http_client::Error::InvalidStatusCodeWithDetails { status, .. } => {
+        crate::http_client::Error::InvalidStatusCodeWithDetails { status, .. } => {
             retryable_status(Some(status.as_u16()))
         }
     }
@@ -299,9 +294,11 @@ fn source_chain(error: &(dyn std::error::Error + 'static)) -> Vec<String> {
 }
 
 impl CompletionError {
-    /// Whether the same request may reasonably be retried, per
-    /// [`retryable_status`]: HTTP failures classify by status, everything
-    /// else is a fault in the request or the response and is not retried.
+    /// Whether the same request may reasonably be retried: a provider's
+    /// reply classifies by status ([`retryable_status`]), a response-less
+    /// transport failure by what it is ([`transient_transport`]), and
+    /// everything else is a fault in the request or the response and is not
+    /// retried.
     pub fn is_retryable(&self) -> bool {
         match self {
             Self::HttpError(error) => transient_transport(error),
@@ -325,10 +322,7 @@ impl CompletionError {
 impl From<&CompletionError> for ErrorReport {
     fn from(error: &CompletionError) -> Self {
         let (kind, http_status) = match error {
-            CompletionError::HttpError(inner) => {
-                let status = inner.non_success_status().map(|s| s.as_u16());
-                (ErrorKind::Http { status }, status)
-            }
+            CompletionError::HttpError(_) => (ErrorKind::Http, None),
             CompletionError::JsonError(_) => (ErrorKind::Json, None),
             CompletionError::UrlError(_) => (ErrorKind::Url, None),
             CompletionError::RequestError(_) => (ErrorKind::Request, None),
@@ -353,20 +347,8 @@ impl From<&CompletionError> for ErrorReport {
         // readable after the failure crossed the wire.
         let provider_response = match error {
             CompletionError::ProviderResponse(response) => Some(Box::new(response.clone())),
-            CompletionError::HttpError(inner) => inner.non_success_status().map(|status| {
-                Box::new(
-                    crate::provider_response::ProviderResponseError::new(
-                        status,
-                        inner.non_success_body().unwrap_or_default(),
-                    )
-                    .with_headers(
-                        inner
-                            .non_success_headers()
-                            .map(|headers| Box::new(headers.clone())),
-                    ),
-                )
-            }),
-            CompletionError::JsonError(_)
+            CompletionError::HttpError(_)
+            | CompletionError::JsonError(_)
             | CompletionError::UrlError(_)
             | CompletionError::RequestError(_)
             | CompletionError::ResponseError(_)
@@ -469,12 +451,11 @@ impl From<MemoryError> for ErrorReport {
 
 impl From<&EmbeddingError> for ErrorReport {
     fn from(error: &EmbeddingError) -> Self {
-        let mut transport_retryable: Option<bool> = None;
+        let mut transport_retryable = false;
         let (kind, http_status) = match error {
             EmbeddingError::HttpError(inner) => {
-                let status = inner.non_success_status().map(|s| s.as_u16());
-                transport_retryable = Some(transient_transport(inner));
-                (ErrorKind::Http { status }, status)
+                transport_retryable = transient_transport(inner);
+                (ErrorKind::Http, None)
             }
             EmbeddingError::JsonError(_) => (ErrorKind::Json, None),
             EmbeddingError::UrlError(_) => (ErrorKind::Url, None),
@@ -492,9 +473,7 @@ impl From<&EmbeddingError> for ErrorReport {
             }
         };
         let retryable = match kind {
-            ErrorKind::Http { status } => {
-                transport_retryable.unwrap_or_else(|| retryable_status(status))
-            }
+            ErrorKind::Http => transport_retryable,
             ErrorKind::ProviderResponse => retryable_status(http_status),
             ErrorKind::Json
             | ErrorKind::Url
@@ -515,19 +494,6 @@ impl From<&EmbeddingError> for ErrorReport {
         };
         let provider_response = match error {
             EmbeddingError::ProviderResponse(response) => Some(Box::new(response.clone())),
-            EmbeddingError::HttpError(inner) => inner.non_success_status().map(|status| {
-                Box::new(
-                    crate::provider_response::ProviderResponseError::new(
-                        status,
-                        inner.non_success_body().unwrap_or_default(),
-                    )
-                    .with_headers(
-                        inner
-                            .non_success_headers()
-                            .map(|headers| Box::new(headers.clone())),
-                    ),
-                )
-            }),
             _ => None,
         };
         let request_id = provider_response
@@ -555,12 +521,11 @@ impl From<EmbeddingError> for ErrorReport {
 
 impl From<&RerankError> for ErrorReport {
     fn from(error: &RerankError) -> Self {
-        let mut transport_retryable: Option<bool> = None;
+        let mut transport_retryable = false;
         let (kind, http_status) = match error {
             RerankError::HttpError(inner) => {
-                let status = inner.non_success_status().map(|s| s.as_u16());
-                transport_retryable = Some(transient_transport(inner));
-                (ErrorKind::Http { status }, status)
+                transport_retryable = transient_transport(inner);
+                (ErrorKind::Http, None)
             }
             RerankError::JsonError(_) => (ErrorKind::Json, None),
             RerankError::UrlError(_) => (ErrorKind::Url, None),
@@ -572,9 +537,7 @@ impl From<&RerankError> for ErrorReport {
             }
         };
         let retryable = match kind {
-            ErrorKind::Http { status } => {
-                transport_retryable.unwrap_or_else(|| retryable_status(status))
-            }
+            ErrorKind::Http => transport_retryable,
             ErrorKind::ProviderResponse => retryable_status(http_status),
             ErrorKind::Json
             | ErrorKind::Url
@@ -595,19 +558,6 @@ impl From<&RerankError> for ErrorReport {
         };
         let provider_response = match error {
             RerankError::ProviderResponse(response) => Some(Box::new(response.clone())),
-            RerankError::HttpError(inner) => inner.non_success_status().map(|status| {
-                Box::new(
-                    crate::provider_response::ProviderResponseError::new(
-                        status,
-                        inner.non_success_body().unwrap_or_default(),
-                    )
-                    .with_headers(
-                        inner
-                            .non_success_headers()
-                            .map(|headers| Box::new(headers.clone())),
-                    ),
-                )
-            }),
             _ => None,
         };
         let request_id = provider_response
@@ -635,7 +585,6 @@ impl From<RerankError> for ErrorReport {
 
 impl From<&VectorStoreError> for ErrorReport {
     fn from(error: &VectorStoreError) -> Self {
-        let mut transport_retryable: Option<bool> = None;
         let (kind, http_status) = match error {
             VectorStoreError::EmbeddingError(inner) => {
                 return Self {
@@ -650,18 +599,25 @@ impl From<&VectorStoreError> for ErrorReport {
                 (ErrorKind::Request, None)
             }
             VectorStoreError::MissingIdError(_) => (ErrorKind::Response, None),
-            VectorStoreError::Http(inner) => {
-                let status = inner.non_success_status().map(|s| s.as_u16());
-                transport_retryable = Some(transient_transport(inner));
-                (ErrorKind::Http { status }, status)
-            }
+            VectorStoreError::Http(_) => (ErrorKind::Http, None),
+            // A store's own non-2xx reply: the server answered, so the status
+            // classifies it and its retryability, like any provider reply.
             VectorStoreError::ExternalAPIError(status, _) => {
-                let status = Some(status.as_u16());
-                (ErrorKind::Http { status }, status)
+                (ErrorKind::ProviderResponse, Some(status.as_u16()))
             }
         };
-        let retryable = matches!(kind, ErrorKind::Http { .. })
-            && transport_retryable.unwrap_or_else(|| retryable_status(http_status));
+        let retryable = match error {
+            VectorStoreError::Http(inner) => transient_transport(inner),
+            VectorStoreError::ExternalAPIError(..) => retryable_status(http_status),
+            _ => false,
+        };
+        // The store's reply travels with the report like any provider's.
+        let provider_response = match error {
+            VectorStoreError::ExternalAPIError(status, body) => Some(Box::new(
+                crate::provider_response::ProviderResponseError::new(*status, body.clone()),
+            )),
+            _ => None,
+        };
         ErrorReport {
             kind,
             retryable,
@@ -671,7 +627,7 @@ impl From<&VectorStoreError> for ErrorReport {
             refusal: false,
             source_chain: source_chain(error),
             request_id: None,
-            provider_response: None,
+            provider_response,
         }
     }
 }

--- a/crates/rig-core/src/error.rs
+++ b/crates/rig-core/src/error.rs
@@ -32,9 +32,12 @@ use crate::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ErrorKind {
-    /// A non-success HTTP response, or a transport failure without a status.
+    /// A transport failure that produced no provider reply: a response-less
+    /// failure (a reset connection, a timeout, a protocol error), or a
+    /// status the transport reported without a body. A non-success reply
+    /// *with* a body is the provider's and is [`Self::ProviderResponse`].
     Http {
-        /// The status, when the failure had a response.
+        /// The status, when the transport reported one.
         status: Option<u16>,
     },
     /// JSON serialization or deserialization failed.
@@ -47,7 +50,9 @@ pub enum ErrorKind {
     Response,
     /// The provider reported a failure without a preserved raw response.
     Provider,
-    /// The provider's raw error response was preserved.
+    /// The provider replied and its raw response was preserved: a non-2xx
+    /// status with a body, a 2xx error envelope, or a non-HTTP transport's
+    /// error payload. Status, body, request id and headers are on the report.
     ProviderResponse,
     /// A tool failed; the inner kind is the tool's own classification.
     Tool(ToolErrorKind),
@@ -464,9 +469,11 @@ impl From<MemoryError> for ErrorReport {
 
 impl From<&EmbeddingError> for ErrorReport {
     fn from(error: &EmbeddingError) -> Self {
+        let mut transport_retryable: Option<bool> = None;
         let (kind, http_status) = match error {
             EmbeddingError::HttpError(inner) => {
                 let status = inner.non_success_status().map(|s| s.as_u16());
+                transport_retryable = Some(transient_transport(inner));
                 (ErrorKind::Http { status }, status)
             }
             EmbeddingError::JsonError(_) => (ErrorKind::Json, None),
@@ -485,7 +492,9 @@ impl From<&EmbeddingError> for ErrorReport {
             }
         };
         let retryable = match kind {
-            ErrorKind::Http { status } => retryable_status(status),
+            ErrorKind::Http { status } => {
+                transport_retryable.unwrap_or_else(|| retryable_status(status))
+            }
             ErrorKind::ProviderResponse => retryable_status(http_status),
             ErrorKind::Json
             | ErrorKind::Url
@@ -546,9 +555,11 @@ impl From<EmbeddingError> for ErrorReport {
 
 impl From<&RerankError> for ErrorReport {
     fn from(error: &RerankError) -> Self {
+        let mut transport_retryable: Option<bool> = None;
         let (kind, http_status) = match error {
             RerankError::HttpError(inner) => {
                 let status = inner.non_success_status().map(|s| s.as_u16());
+                transport_retryable = Some(transient_transport(inner));
                 (ErrorKind::Http { status }, status)
             }
             RerankError::JsonError(_) => (ErrorKind::Json, None),
@@ -561,7 +572,9 @@ impl From<&RerankError> for ErrorReport {
             }
         };
         let retryable = match kind {
-            ErrorKind::Http { status } => retryable_status(status),
+            ErrorKind::Http { status } => {
+                transport_retryable.unwrap_or_else(|| retryable_status(status))
+            }
             ErrorKind::ProviderResponse => retryable_status(http_status),
             ErrorKind::Json
             | ErrorKind::Url
@@ -622,6 +635,7 @@ impl From<RerankError> for ErrorReport {
 
 impl From<&VectorStoreError> for ErrorReport {
     fn from(error: &VectorStoreError) -> Self {
+        let mut transport_retryable: Option<bool> = None;
         let (kind, http_status) = match error {
             VectorStoreError::EmbeddingError(inner) => {
                 return Self {
@@ -638,6 +652,7 @@ impl From<&VectorStoreError> for ErrorReport {
             VectorStoreError::MissingIdError(_) => (ErrorKind::Response, None),
             VectorStoreError::Http(inner) => {
                 let status = inner.non_success_status().map(|s| s.as_u16());
+                transport_retryable = Some(transient_transport(inner));
                 (ErrorKind::Http { status }, status)
             }
             VectorStoreError::ExternalAPIError(status, _) => {
@@ -645,7 +660,8 @@ impl From<&VectorStoreError> for ErrorReport {
                 (ErrorKind::Http { status }, status)
             }
         };
-        let retryable = matches!(kind, ErrorKind::Http { .. }) && retryable_status(http_status);
+        let retryable = matches!(kind, ErrorKind::Http { .. })
+            && transport_retryable.unwrap_or_else(|| retryable_status(http_status));
         ErrorReport {
             kind,
             retryable,

--- a/crates/rig-core/src/error/tests.rs
+++ b/crates/rig-core/src/error/tests.rs
@@ -3,9 +3,11 @@ use http::StatusCode;
 use super::*;
 use crate::{http_client, provider_response::ProviderResponseError};
 
+/// A non-success reply as a transport reports it, routed like a `?` would.
 fn http_error(status: u16) -> CompletionError {
-    CompletionError::HttpError(http_client::Error::InvalidStatusCodeWithMessage(
+    CompletionError::from_transport_error(http_client::Error::non_success_with_details(
         StatusCode::from_u16(status).expect("valid status"),
+        http::HeaderMap::new(),
         "body".to_string(),
     ))
 }
@@ -61,8 +63,10 @@ fn retry_table_per_status() {
 
 #[test]
 fn completion_http_error_reports_status_and_retryability() {
+    // The transport's rejection is the provider's reply: the kind says so,
+    // and the status decides retryability.
     let report = http_error(429).report();
-    assert_eq!(report.kind, ErrorKind::Http { status: Some(429) });
+    assert_eq!(report.kind, ErrorKind::ProviderResponse);
     assert_eq!(report.http_status, Some(429));
     assert!(report.retryable);
     assert!(http_error(429).is_retryable());
@@ -85,7 +89,7 @@ fn transport_failures_without_a_status_classify_by_what_they_are() {
         let error = CompletionError::HttpError(error);
         assert!(error.is_retryable(), "{error}");
         let report = error.report();
-        assert_eq!(report.kind, ErrorKind::Http { status: None });
+        assert_eq!(report.kind, ErrorKind::Http);
         assert_eq!(report.http_status, None);
         assert!(report.retryable, "{report:?}");
     }
@@ -101,13 +105,9 @@ fn transport_failures_without_a_status_classify_by_what_they_are() {
         assert!(!error.is_retryable(), "{error}");
         assert!(!error.report().retryable, "{error}");
     }
-    // A status-carrying transport failure follows the status table.
-    assert!(
-        CompletionError::HttpError(http_client::Error::InvalidStatusCode(
-            StatusCode::SERVICE_UNAVAILABLE
-        ))
-        .is_retryable()
-    );
+    // A transport error never carries a status: a status-carrying
+    // rejection routes to the provider's reply and follows the status table.
+    assert!(http_error(503).is_retryable());
     // A provider response without a status decides nothing either.
     assert!(
         !CompletionError::ProviderResponse(ProviderResponseError::without_status("body"))
@@ -304,8 +304,8 @@ fn a_provider_response_travels_with_the_report() {
         .map(|response| Box::new(response.with_headers(None)));
     assert_eq!(back, without_headers);
 
-    // A non-success HTTP failure carries its status and body the same way;
-    // a diagnostic with no provider response carries nothing.
+    // A non-success reply the transport rejected carries its status and body
+    // the same way; a diagnostic with no provider response carries nothing.
     let http = ErrorReport::from(&http_error(503));
     assert_eq!(
         http.provider_response_status(),
@@ -343,8 +343,21 @@ fn embedding_and_rerank_reports_retain_structured_provider_metadata() {
     }
 }
 
+/// A transport rejection routed through the `From` conversion is the
+/// provider's reply on every capability: body, headers and status ride on
+/// the report, and the kind says so. `HttpError` itself cannot carry any of
+/// them, so a report from one has no provider response.
 #[test]
 fn embedding_and_rerank_http_reports_retain_body_and_headers() {
+    for report in [
+        ErrorReport::from(EmbeddingError::HttpError(http_client::Error::StreamEnded)),
+        ErrorReport::from(RerankError::HttpError(http_client::Error::StreamEnded)),
+    ] {
+        assert_eq!(report.kind, ErrorKind::Http);
+        assert_eq!(report.http_status, None);
+        assert!(report.provider_response.is_none());
+        assert!(report.retryable);
+    }
     let make_error = || {
         let mut headers = http::HeaderMap::new();
         headers.insert("retry-after", http::HeaderValue::from_static("7"));
@@ -355,9 +368,10 @@ fn embedding_and_rerank_http_reports_retain_body_and_headers() {
         }
     };
     for report in [
-        ErrorReport::from(EmbeddingError::HttpError(make_error())),
-        ErrorReport::from(RerankError::HttpError(make_error())),
+        ErrorReport::from(EmbeddingError::from(make_error())),
+        ErrorReport::from(RerankError::from(make_error())),
     ] {
+        assert_eq!(report.kind, ErrorKind::ProviderResponse);
         let response = report.provider_response.expect("structured HTTP response");
         assert_eq!(response.body, "temporary outage");
         assert_eq!(

--- a/crates/rig-core/src/http_client/erased/tests.rs
+++ b/crates/rig-core/src/http_client/erased/tests.rs
@@ -176,8 +176,9 @@ mod middleware {
             let fail = self.0 == "headers";
             Box::pin(async move {
                 if fail {
-                    return Err(crate::http_client::Error::InvalidStatusCodeWithMessage(
+                    return Err(crate::http_client::Error::non_success_with_details(
                         StatusCode::BAD_REQUEST,
+                        http::HeaderMap::new(),
                         "rejected headers".into(),
                     ));
                 }
@@ -195,8 +196,9 @@ mod middleware {
             let fail = self.0 == "response";
             Box::pin(async move {
                 if fail {
-                    return Err(crate::http_client::Error::InvalidStatusCodeWithMessage(
+                    return Err(crate::http_client::Error::non_success_with_details(
                         StatusCode::TOO_MANY_REQUESTS,
+                        http::HeaderMap::new(),
                         "rejected response".into(),
                     ));
                 }

--- a/crates/rig-core/src/http_client/mod.rs
+++ b/crates/rig-core/src/http_client/mod.rs
@@ -18,14 +18,13 @@ pub use multipart::MultipartForm;
 pub enum Error {
     #[error("Http error: {0}")]
     Protocol(#[from] http::Error),
-    #[error("Invalid status code: {0}")]
-    InvalidStatusCode(StatusCode),
-    #[error("Invalid status code {0} with message: {1}")]
-    InvalidStatusCodeWithMessage(StatusCode, String),
-    /// A non-success HTTP response whose headers were preserved alongside the
-    /// body, so provider layers can read transport metadata — e.g. their
-    /// request-id contract — off the failed response (rig#2314). Displays
-    /// identically to [`Self::InvalidStatusCodeWithMessage`].
+    /// The one non-success response shape: the server answered, and the
+    /// transport kept everything it said — status, body and headers — so
+    /// provider layers can read the reply and its transport metadata (their
+    /// request-id contract, `Retry-After`) off the error (rig#2314). A
+    /// transport never reports a status without the body behind it; a
+    /// response-less failure is [`Self::Instance`] or one of the protocol
+    /// variants.
     #[error("Invalid status code {status} with message: {body}")]
     InvalidStatusCodeWithDetails {
         /// The non-success status.
@@ -61,9 +60,6 @@ impl Error {
     /// layer that maps it back into its own error model reads the status here.
     pub fn non_success_status(&self) -> Option<StatusCode> {
         match self {
-            Self::InvalidStatusCode(status) | Self::InvalidStatusCodeWithMessage(status, _) => {
-                Some(*status)
-            }
             Self::InvalidStatusCodeWithDetails { status, .. } => Some(*status),
             _ => None,
         }
@@ -73,7 +69,6 @@ impl Error {
     /// [`Self::non_success_status`] and [`Self::non_success_headers`].
     pub fn non_success_body(&self) -> Option<&str> {
         match self {
-            Self::InvalidStatusCodeWithMessage(_, body) => Some(body.as_str()),
             Self::InvalidStatusCodeWithDetails { body, .. } => Some(body.as_str()),
             _ => None,
         }
@@ -114,9 +109,8 @@ impl Error {
     /// }
     /// ```
     ///
-    /// Returns `None` when the error carries no captured headers: transports
-    /// that report a non-success status without them, and errors built from
-    /// only a status and body.
+    /// Returns `None` for a response-less failure: every non-success error
+    /// carries its headers.
     pub fn non_success_headers(&self) -> Option<&HeaderMap> {
         match self {
             Self::InvalidStatusCodeWithDetails { headers, .. } => Some(headers),

--- a/crates/rig-core/src/http_client/non_success_header_tests.rs
+++ b/crates/rig-core/src/http_client/non_success_header_tests.rs
@@ -1,18 +1,16 @@
 use super::*;
 
-/// `None` means "not captured" and must not be confused with an empty map:
-/// every other shape of this error reports it.
+/// `None` means "no response" and must not be confused with an empty map:
+/// a response-less failure has no headers, a reply always reports its own.
 #[test]
 fn non_success_headers_absent_when_not_captured() {
     for error in [
-        Error::InvalidStatusCodeWithMessage(
-            StatusCode::TOO_MANY_REQUESTS,
-            "rate limited".to_string(),
-        ),
-        Error::InvalidStatusCode(StatusCode::TOO_MANY_REQUESTS),
         Error::StreamEnded,
+        Error::NoHeaders,
+        Error::instance(std::io::Error::other("connection reset")),
     ] {
         assert!(error.non_success_headers().is_none());
+        assert!(error.non_success_status().is_none());
     }
 
     // A captured-but-empty map is `Some`, not `None`.

--- a/crates/rig-core/src/http_client/sse.rs
+++ b/crates/rig-core/src/http_client/sse.rs
@@ -168,7 +168,16 @@ where
             if let Some(observation) = &observation {
                 observation.start(&req_clone);
             }
-            let response = client_clone.send_streaming(req_clone).await;
+            let response = match client_clone.send_streaming(req_clone).await {
+                // The bundled transports reject a non-success reply before it
+                // gets here; a custom `HttpClientExt` may hand it back as a
+                // response. Either way the server answered, and its answer —
+                // status, headers, body — is the error, never a bare status.
+                Ok(response) if response.status() != StatusCode::OK => {
+                    Err(reject_response(response).await)
+                }
+                other => other,
+            };
             if let Some(observation) = &observation {
                 match &response {
                     Ok(response) => observation
@@ -272,9 +281,12 @@ where
                                             crate::observe::AdapterErrorBoundary::from_http(&err),
                                         );
                                     }
-                                    // Transition: Connecting -> Closed. A rejected
-                                    // response is terminal: the retry policy governs
-                                    // transport failures, not a server that answered.
+                                    // Transition: Connecting -> Closed. Only a
+                                    // content-type failure reaches here (a non-200
+                                    // was rejected in the response future and goes
+                                    // to the retry policy like any transport
+                                    // rejection); a 200 that is not an event stream
+                                    // is terminal.
                                     this.state.set(SourceState::Closed);
                                     return Poll::Ready(Some(Err(err)));
                                 }
@@ -409,14 +421,46 @@ fn capture_request_id_header<T>(capture: Option<&(String, RequestIdSlot)>, respo
     }
 }
 
+/// Bytes of a rejected reply's body kept on the error; a reply longer than
+/// this is cut there, the way a provider's error payload never is (a cut
+/// body is not JSON any more, so `provider_response_json` reports it as
+/// malformed rather than absent).
+const REJECTED_BODY_LIMIT: usize = 1 << 20;
+
+/// Chunks read off a rejected reply before giving up on it, so a transport
+/// that keeps yielding empty chunks cannot hold the opener.
+const REJECTED_CHUNK_LIMIT: usize = 4096;
+
+/// Turn a reply the event source will not stream (any status but 200,
+/// a 204 included: a status is a status) into the non-success error,
+/// reading the body to its end (bounded in bytes and chunks; the transport's
+/// own timeouts bound the time) so the provider's payload and the
+/// transport's headers ride on the error.
+async fn reject_response(response: Response<BoxedStream>) -> super::Error {
+    let (parts, mut body) = response.into_parts();
+    let mut collected = Vec::new();
+    let mut chunks = 0;
+    while let Some(chunk) = body.next().await {
+        chunks += 1;
+        let room = REJECTED_BODY_LIMIT.saturating_sub(collected.len());
+        match chunk {
+            Ok(bytes) if room > 0 && chunks <= REJECTED_CHUNK_LIMIT => {
+                collected.extend(bytes.iter().take(room));
+            }
+            _ => break,
+        }
+    }
+    super::Error::non_success_with_details(
+        parts.status,
+        parts.headers,
+        String::from_utf8_lossy(&collected).into_owned(),
+    )
+}
+
 fn check_response<T>(
     response: Response<T>,
     allow_missing_content_type: bool,
 ) -> Result<Response<T>, super::Error> {
-    let StatusCode::OK = response.status() else {
-        return Err(super::Error::InvalidStatusCode(response.status()));
-    };
-
     let Some(content_type) = response.headers().get(&http::header::CONTENT_TYPE) else {
         if allow_missing_content_type {
             return Ok(response);

--- a/crates/rig-core/src/http_client/sse/tests.rs
+++ b/crates/rig-core/src/http_client/sse/tests.rs
@@ -36,8 +36,10 @@ impl HttpClientExt for SequencedStreamingClient {
         T: Into<Bytes> + WasmCompatSend,
         U: From<Bytes> + WasmCompatSend + 'static,
     {
-        std::future::ready(Err(http_client::Error::InvalidStatusCode(
+        std::future::ready(Err(http_client::Error::non_success_with_details(
             StatusCode::NOT_IMPLEMENTED,
+            http::HeaderMap::new(),
+            String::new(),
         )))
     }
 
@@ -50,8 +52,10 @@ impl HttpClientExt for SequencedStreamingClient {
     where
         U: From<Bytes> + WasmCompatSend + 'static,
     {
-        std::future::ready(Err(http_client::Error::InvalidStatusCode(
+        std::future::ready(Err(http_client::Error::non_success_with_details(
             StatusCode::NOT_IMPLEMENTED,
+            http::HeaderMap::new(),
+            String::new(),
         )))
     }
 
@@ -169,5 +173,122 @@ async fn reconnect_replaces_request_id_slot_including_with_none() {
         None,
         "the reconnect omitted the header, so the slot must not retain the \
              first connection's id"
+    );
+}
+
+/// A transport that hands a non-200 reply back as a response, with a body
+/// stream and headers, so the opener has to read the reply itself.
+#[derive(Clone)]
+struct RejectingClient {
+    status: StatusCode,
+    body: &'static [u8],
+}
+
+impl HttpClientExt for RejectingClient {
+    fn send<T, U>(
+        &self,
+        _req: Request<T>,
+    ) -> impl Future<Output = http_client::Result<Response<http_client::LazyBody<U>>>>
+    + WasmCompatSend
+    + 'static
+    where
+        T: Into<Bytes> + WasmCompatSend,
+        U: From<Bytes> + WasmCompatSend + 'static,
+    {
+        std::future::ready(Err(http_client::Error::StreamEnded))
+    }
+
+    fn send_multipart<U>(
+        &self,
+        _req: Request<crate::http_client::MultipartForm>,
+    ) -> impl Future<Output = http_client::Result<Response<http_client::LazyBody<U>>>>
+    + WasmCompatSend
+    + 'static
+    where
+        U: From<Bytes> + WasmCompatSend + 'static,
+    {
+        std::future::ready(Err(http_client::Error::StreamEnded))
+    }
+
+    fn send_streaming<T>(
+        &self,
+        _req: Request<T>,
+    ) -> impl Future<Output = http_client::Result<http_client::StreamingResponse>> + WasmCompatSend
+    where
+        T: Into<Bytes> + WasmCompatSend,
+    {
+        let (status, body) = (self.status, self.body);
+        async move {
+            // Two chunks, so the opener has to drain the stream rather than
+            // read one frame.
+            let (head, tail) = body.split_at(body.len() / 2);
+            let boxed: BoxedStream = Box::pin(futures::stream::iter([
+                Ok(Bytes::copy_from_slice(head)),
+                Ok(Bytes::copy_from_slice(tail)),
+            ]));
+            Response::builder()
+                .status(status)
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(http::header::RETRY_AFTER, "20")
+                .header("x-request-id", "req-rejected")
+                .body(boxed)
+                .map_err(http_client::Error::Protocol)
+        }
+    }
+}
+
+/// A reply the opener will not stream is the provider's reply, whole: the
+/// error carries its status, its full body and its headers, never a bare
+/// status. Like a rejection the bundled transports report themselves, it
+/// then goes to the retry policy, which sees `Retry-After` on it.
+#[tokio::test]
+async fn a_rejected_open_keeps_the_reply_body_and_headers_on_the_error() {
+    const BODY: &[u8] = br#"{"error":{"type":"rate_limit_error","message":"slow down"}}"#;
+    let client = RejectingClient {
+        status: StatusCode::TOO_MANY_REQUESTS,
+        body: BODY,
+    };
+    let req = Request::builder()
+        .uri("http://mock.invalid/stream")
+        .body(Vec::<u8>::new())
+        .expect("request should build");
+    let mut source = GenericEventSource::new(client, req);
+    // The policy always grants the first reconnect; `Some(0)` stops there.
+    source.retry_policy = ExponentialBackoff::new(
+        Duration::from_millis(1),
+        1.,
+        Some(Duration::from_millis(1)),
+        Some(0),
+    );
+    let mut source = Box::pin(source);
+
+    let mut rejections = 0;
+    while let Some(item) = source.next().await {
+        let error = item.expect_err("a 429 does not open");
+        let http_client::Error::InvalidStatusCodeWithDetails {
+            status,
+            body,
+            headers,
+        } = &error
+        else {
+            panic!("the reply must ride on the error whole: {error:?}");
+        };
+        assert_eq!(*status, StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(body.as_bytes(), BODY, "the body is drained to its end");
+        assert_eq!(
+            headers
+                .get(http::header::RETRY_AFTER)
+                .and_then(|v| v.to_str().ok()),
+            Some("20")
+        );
+        assert_eq!(
+            headers.get("x-request-id").and_then(|v| v.to_str().ok()),
+            Some("req-rejected")
+        );
+        rejections += 1;
+    }
+    assert_eq!(
+        rejections, 2,
+        "the connect and the one reconnect the policy grants, then it closes"
     );
 }

--- a/crates/rig-core/src/image_generation/provider_response_tests.rs
+++ b/crates/rig-core/src/image_generation/provider_response_tests.rs
@@ -20,10 +20,12 @@ fn image_generation_error_provider_response_helpers_with_preserved_json_body() {
 #[test]
 fn image_generation_error_provider_response_helpers_with_http_non_success() {
     let body = r#"{"error":{"message":"bad request"}}"#;
-    let error = ImageGenerationError::HttpError(http_client::Error::InvalidStatusCodeWithMessage(
-        StatusCode::BAD_REQUEST,
-        body.to_string(),
-    ));
+    let error =
+        ImageGenerationError::from_transport_error(http_client::Error::non_success_with_details(
+            StatusCode::BAD_REQUEST,
+            http::HeaderMap::new(),
+            body.to_string(),
+        ));
 
     assert_eq!(error.provider_response_body(), Some(body));
     assert_eq!(

--- a/crates/rig-core/src/observe/adapter.rs
+++ b/crates/rig-core/src/observe/adapter.rs
@@ -187,9 +187,7 @@ impl AdapterErrorBoundary {
             H::Protocol(_) | H::InvalidHeaderValue(_) | H::NoHeaders => Self::Request,
             H::InvalidContentType(_) => Self::Decode,
             H::StreamEnded => Self::Transport,
-            H::InvalidStatusCode(_)
-            | H::InvalidStatusCodeWithMessage(..)
-            | H::InvalidStatusCodeWithDetails { .. } => Self::ProviderResponse,
+            H::InvalidStatusCodeWithDetails { .. } => Self::ProviderResponse,
             H::Instance(_) => Self::Unknown,
         }
     }

--- a/crates/rig-core/src/observe/adapter/tests.rs
+++ b/crates/rig-core/src/observe/adapter/tests.rs
@@ -18,7 +18,7 @@ fn native_http_errors_preserve_distinct_boundaries_before_report_erasure() {
     ] {
         let error = CompletionError::HttpError(native);
         let report = crate::error::ErrorReport::from(&error);
-        assert_eq!(report.kind, crate::error::ErrorKind::Http { status: None });
+        assert_eq!(report.kind, crate::error::ErrorKind::Http);
         let log = Arc::new(ObservationLog::default());
         let context = AdapterContext::new(log.clone(), Subject::default(), "call");
         let mut request = http::Request::new(());

--- a/crates/rig-core/src/observe/adapter/tests.rs
+++ b/crates/rig-core/src/observe/adapter/tests.rs
@@ -356,7 +356,7 @@ async fn unary_failure_facts_preserve_retryability_without_copying_error_bodies(
                 AdapterEvent::Finished {
                     ending: AdapterEnding::Error {
                         boundary: AdapterErrorBoundary::ProviderResponse,
-                        kind: "http".into(),
+                        kind: "provider_response".into(),
                         status: Some(429),
                         retryable: true
                     }
@@ -637,7 +637,7 @@ async fn stream_terminal_eof_error_and_drop_have_distinct_closures() {
             false,
             AdapterEnding::Error {
                 boundary: AdapterErrorBoundary::ProviderResponse,
-                kind: "http".into(),
+                kind: "provider_response".into(),
                 status: Some(503),
                 retryable: true,
             },

--- a/crates/rig-core/src/provider_response.rs
+++ b/crates/rig-core/src/provider_response.rs
@@ -159,96 +159,74 @@ pub(crate) fn completion_error_from_body(
 macro_rules! impl_provider_response_helpers {
     ($error:ty $(, $report:ident)?) => {
         impl $error {
-            /// Builds an error from a captured HTTP status and raw response body,
-            /// routing it so the `provider_response_*` helpers stay useful.
+            /// Builds an error from a captured HTTP status and raw response
+            /// body: the one funnel every HTTP-error path uses.
             ///
-            /// This is the single funnel every HTTP-error path should use instead
-            /// of flattening a status and body into a `ProviderError(String)`:
-            /// - A **success (2xx)** status carries a provider-authored error
-            ///   envelope, so it is preserved as [`Self::ProviderResponse`]
-            ///   together with the status.
-            /// - A **non-success** status is preserved as
-            ///   [`Self::HttpError`]`(`[`http_client::Error::InvalidStatusCodeWithMessage`](crate::http_client::Error::InvalidStatusCodeWithMessage)`)`.
-            ///
-            /// Either way the raw `body` is kept verbatim and the status stays
-            /// recoverable through [`Self::provider_response_status`]. Read the
-            /// response body exactly once and hand it here for both branches.
+            /// The body is the provider's own reply — a 2xx error envelope or
+            /// a non-success response — so it is preserved verbatim as
+            /// [`Self::ProviderResponse`] with its status, whatever the
+            /// status is. Stamp transport metadata with
+            /// [`Self::with_provider_request_id`] and
+            /// [`Self::with_response_headers`]. A transport failure that
+            /// never produced a provider reply is [`Self::HttpError`]; a
+            /// transport that reported the reply as an error goes through
+            /// [`Self::from_transport_error`]. Read the response body exactly
+            /// once and hand it here.
             pub fn from_http_response(status: http::StatusCode, body: impl Into<String>) -> Self {
-                if status.is_success() {
-                    Self::ProviderResponse($crate::provider_response::ProviderResponseError::new(
-                        status, body,
-                    ))
-                } else {
-                    Self::HttpError($crate::http_client::Error::InvalidStatusCodeWithMessage(
+                Self::ProviderResponse($crate::provider_response::ProviderResponseError::new(
+                    status, body,
+                ))
+            }
+
+            /// Routes a transport error. A non-success response the
+            /// transport reported as an error, body in hand, is the
+            /// provider's reply and becomes [`Self::ProviderResponse`] (with
+            /// the headers when the transport kept them); everything else — a
+            /// response-less failure, or a status the transport reported
+            /// without a body — stays [`Self::HttpError`]. This is the
+            /// `From<http_client::Error>` conversion, so a `?` on a transport
+            /// call classifies like an explicit funnel call.
+            pub fn from_transport_error(error: $crate::http_client::Error) -> Self {
+                match error {
+                    $crate::http_client::Error::InvalidStatusCodeWithMessage(status, body) => {
+                        Self::from_http_response(status, body)
+                    }
+                    $crate::http_client::Error::InvalidStatusCodeWithDetails {
                         status,
-                        body.into(),
-                    ))
+                        body,
+                        headers,
+                    } => Self::from_http_response(status, body).with_response_headers(Some(headers)),
+                    other => Self::HttpError(other),
                 }
             }
 
-            /// [`Self::from_http_response`] for paths that captured the
-            /// provider's transport request id alongside the response
-            /// (rig#2314).
-            ///
-            /// Unlike the metadata-less funnel, a **non-success** status is
-            /// preserved as [`Self::ProviderResponse`] too — `http_client`'s
-            /// error type has no slot for provider metadata, and the id the
-            /// provider reported on a failed call is exactly what support
-            /// asks for. Classification therefore follows the *code path*
-            /// (did this call site capture transport metadata?), never the
-            /// presence of the header on a particular response, so a given
-            /// provider's errors classify consistently. The status stays
-            /// recoverable through [`Self::provider_response_status`] and the
-            /// id through [`Self::provider_request_id`].
-            pub fn from_http_response_with_request_id(
-                status: http::StatusCode,
-                body: impl Into<String>,
-                provider_request_id: Option<String>,
-            ) -> Self {
-                Self::ProviderResponse(
-                    $crate::provider_response::ProviderResponseError::new(status, body)
-                        .with_provider_request_id(provider_request_id),
-                )
+            /// Attaches the provider's transport request id (rig#2314) to a
+            /// preserved provider response. A slot already filled keeps the
+            /// id that saw the response; no other variant has a slot, so
+            /// those pass through untouched.
+            pub fn with_provider_request_id(self, provider_request_id: Option<String>) -> Self {
+                match self {
+                    Self::ProviderResponse(response) if response.provider_request_id.is_none() => {
+                        Self::ProviderResponse(response.with_provider_request_id(provider_request_id))
+                    }
+                    other => other,
+                }
             }
 
-            /// Attaches the response's headers to an error just built by one of
-            /// the `from_http_response*` funnels, so rate-limit metadata
-            /// (`Retry-After`, `x-ratelimit-*`) survives onto it (rig#2210).
-            ///
-            /// This is a separate step rather than a funnel parameter because
-            /// the funnels' classification is fixed by the *call path* (does
-            /// this provider have a request-id contract?), while header capture
-            /// depends only on whether the transport handed the response back.
-            /// Both routes can therefore carry headers:
-            /// [`Self::ProviderResponse`] stores them alongside the request id,
-            /// and a non-success [`Self::HttpError`] is upgraded in place to
-            /// [`http_client::Error::InvalidStatusCodeWithDetails`](crate::http_client::Error::InvalidStatusCodeWithDetails),
-            /// which displays identically to the header-less variant.
-            ///
-            /// Passing `None` leaves the error untouched, as does calling this
-            /// on a variant with no response to annotate. An error that already
-            /// captured headers keeps the ones it has: the first capture is the
-            /// one that saw the response, so this never overwrites.
+            /// Attaches the response's headers to a preserved provider
+            /// response, so rate-limit metadata (`Retry-After`,
+            /// `x-ratelimit-*`) survives onto it (rig#2210). Passing `None`
+            /// leaves the error untouched, as does calling this on a variant
+            /// with no response to annotate. An error that already captured
+            /// headers keeps the ones it has: the first capture is the one
+            /// that saw the response, so this never overwrites.
             pub fn with_response_headers(self, headers: Option<Box<http::HeaderMap>>) -> Self {
                 let Some(headers) = headers else {
                     return self;
                 };
                 match self {
-                    // The first capture is the one that saw the response; a
-                    // later caller only fills the gap, mirroring how the
-                    // request-id slot is stamped (rig#2314).
                     Self::ProviderResponse(response) if response.headers.is_none() => {
                         Self::ProviderResponse(response.with_headers(Some(headers)))
-                    }
-                    Self::HttpError($crate::http_client::Error::InvalidStatusCodeWithMessage(
-                        status,
-                        body,
-                    )) => {
-                        Self::HttpError($crate::http_client::Error::InvalidStatusCodeWithDetails {
-                            status,
-                            body,
-                            headers,
-                        })
                     }
                     other => other,
                 }
@@ -564,9 +542,11 @@ macro_rules! provider_error_enum {
         $(#[$extra_doc])*
         #[derive(Debug, thiserror::Error)]
         pub enum $name {
-            /// Http error (e.g.: connection error, timeout, etc.)
+            /// A transport failure that produced no provider reply (a
+            /// connection error, a timeout, a status reported without a
+            /// body); a reply with a body is [`Self::ProviderResponse`].
             #[error("HttpError: {0}")]
-            HttpError(#[from] $crate::http_client::Error),
+            HttpError($crate::http_client::Error),
 
             /// Json error (e.g.: serialization, deserialization)
             #[error("JsonError: {0}")]
@@ -590,6 +570,12 @@ macro_rules! provider_error_enum {
         }
 
         $crate::provider_response::impl_provider_response_helpers!($name);
+
+        impl From<$crate::http_client::Error> for $name {
+            fn from(error: $crate::http_client::Error) -> Self {
+                Self::from_transport_error(error)
+            }
+        }
     };
 }
 

--- a/crates/rig-core/src/provider_response.rs
+++ b/crates/rig-core/src/provider_response.rs
@@ -179,18 +179,14 @@ macro_rules! impl_provider_response_helpers {
             }
 
             /// Routes a transport error. A non-success response the
-            /// transport reported as an error, body in hand, is the
-            /// provider's reply and becomes [`Self::ProviderResponse`] (with
-            /// the headers when the transport kept them); everything else — a
-            /// response-less failure, or a status the transport reported
-            /// without a body — stays [`Self::HttpError`]. This is the
+            /// transport reported as an error — status, body and headers in
+            /// hand — is the provider's reply and becomes
+            /// [`Self::ProviderResponse`]; a response-less failure stays
+            /// [`Self::HttpError`] and never carries a status. This is the
             /// `From<http_client::Error>` conversion, so a `?` on a transport
             /// call classifies like an explicit funnel call.
             pub fn from_transport_error(error: $crate::http_client::Error) -> Self {
                 match error {
-                    $crate::http_client::Error::InvalidStatusCodeWithMessage(status, body) => {
-                        Self::from_http_response(status, body)
-                    }
                     $crate::http_client::Error::InvalidStatusCodeWithDetails {
                         status,
                         body,
@@ -248,21 +244,17 @@ macro_rules! impl_provider_response_helpers {
 
             /// Returns the raw provider response body when available.
             ///
-            /// This is available for:
-            /// - `Self::ProviderResponse` using its preserved body.
-            /// - `Self::HttpError` when it wraps an HTTP non-success response that
-            ///   carries a body.
+            /// This is available for `Self::ProviderResponse`, using its
+            /// preserved body.
             ///
             /// Returns `None` for any other variant — for example a Rig-generated
-            /// `ProviderError` diagnostic, or a failure from a transport with no
-            /// provider response body to preserve. An empty preserved body is
+            /// `ProviderError` diagnostic, or a response-less transport failure. An empty preserved body is
             /// reported as `Some("")` (the provider returned no payload), which is
             /// distinct from `None`; note that [`Self::provider_response_json`]
             /// maps that same empty body to `Ok(None)`.
             pub fn provider_response_body(&self) -> Option<&str> {
                 match self {
                     Self::ProviderResponse(response) => Some(response.body.as_str()),
-                    Self::HttpError(error) => error.non_success_body(),
                     _ => None,
                 }
             }
@@ -292,7 +284,6 @@ macro_rules! impl_provider_response_helpers {
             pub fn provider_response_status(&self) -> Option<http::StatusCode> {
                 match self {
                     Self::ProviderResponse(response) => response.status,
-                    Self::HttpError(error) => error.non_success_status(),
                     $(Self::$report(report) => report
                         .http_status
                         .and_then(|status| http::StatusCode::from_u16(status).ok()),)?
@@ -334,14 +325,12 @@ macro_rules! impl_provider_response_helpers {
             ///
             /// Returns `None` when no headers were captured: non-HTTP
             /// transports (gRPC / SDK clients), Rig-generated diagnostics,
-            /// errors funnelled from only a status and body (e.g. via
-            /// [`Self::from_http_response`]), and transports that report a
-            /// non-success status without preserving them. `None` therefore
-            /// means "not captured", never "the response had no headers".
+            /// and errors funnelled from only a status and body (e.g. via
+            /// [`Self::from_http_response`]). `None` therefore means "not
+            /// captured", never "the response had no headers".
             pub fn provider_response_headers(&self) -> Option<&http::HeaderMap> {
                 match self {
                     Self::ProviderResponse(response) => response.headers.as_deref(),
-                    Self::HttpError(error) => error.non_success_headers(),
                     _ => None,
                 }
             }

--- a/crates/rig-core/src/provider_response/tests.rs
+++ b/crates/rig-core/src/provider_response/tests.rs
@@ -64,17 +64,8 @@ macro_rules! assert_funnel {
         assert!(err.provider_response_json().expect("ok").is_none());
 
         // A transport that reported the reply as an error routes through the
-        // same funnel: body -> ProviderResponse (headers kept when the
-        // transport kept them); a status without a body, or no response at
-        // all, stays a transport error.
-        let err =
-            E::from_transport_error($crate::http_client::Error::InvalidStatusCodeWithMessage(
-                StatusCode::TOO_MANY_REQUESTS,
-                body.to_string(),
-            ));
-        assert!(matches!(err, E::ProviderResponse(_)));
-        assert_eq!(err.provider_response_body(), Some(body));
-        assert!(err.provider_response_headers().is_none());
+        // same funnel: status, body and headers -> ProviderResponse; no
+        // response at all stays a transport error, with no status.
         let err =
             E::from_transport_error($crate::http_client::Error::InvalidStatusCodeWithDetails {
                 status: StatusCode::TOO_MANY_REQUESTS,
@@ -82,27 +73,20 @@ macro_rules! assert_funnel {
                 headers: retry_after_headers(),
             });
         assert!(matches!(err, E::ProviderResponse(_)));
+        assert_eq!(err.provider_response_body(), Some(body));
         assert_eq!(
             err.provider_response_headers()
                 .and_then(|headers| headers.get(http::header::RETRY_AFTER))
                 .and_then(|value| value.to_str().ok()),
             Some("20"),
         );
-        let err = E::from_transport_error($crate::http_client::Error::InvalidStatusCode(
-            StatusCode::BAD_GATEWAY,
-        ));
-        assert!(matches!(err, E::HttpError(_)));
-        assert_eq!(
-            err.provider_response_status(),
-            Some(StatusCode::BAD_GATEWAY)
-        );
-        assert_eq!(err.provider_response_body(), None);
         let err = E::from_transport_error($crate::http_client::Error::StreamEnded);
         assert!(matches!(err, E::HttpError(_)));
         assert_eq!(err.provider_response_status(), None);
         // The `?` conversion is the same route.
-        let err: E = $crate::http_client::Error::InvalidStatusCodeWithMessage(
+        let err: E = $crate::http_client::Error::non_success_with_details(
             StatusCode::NOT_FOUND,
+            http::HeaderMap::new(),
             body.to_string(),
         )
         .into();
@@ -296,8 +280,8 @@ fn attaching_headers_never_overwrites_an_earlier_capture() {
 }
 
 /// Variants with no slot for a response absorb the call unchanged, so a
-/// capture site can attach unconditionally. A transport error that carries
-/// a status but no body has no response to annotate either.
+/// capture site can attach unconditionally. A response-less transport error
+/// has no response to annotate either.
 #[test]
 fn attaching_headers_to_a_slotless_variant_is_a_no_op() {
     let error = crate::completion::CompletionError::ProviderError("rig diagnostic".to_string())
@@ -309,16 +293,14 @@ fn attaching_headers_to_a_slotless_variant_is_a_no_op() {
     assert!(error.provider_response_headers().is_none());
     assert_eq!(error.to_string(), "ProviderError: rig diagnostic");
 
-    let error = crate::completion::CompletionError::HttpError(
-        crate::http_client::Error::InvalidStatusCode(StatusCode::BAD_GATEWAY),
-    )
-    .with_response_headers(Some(retry_after_headers()));
+    let error =
+        crate::completion::CompletionError::HttpError(crate::http_client::Error::StreamEnded)
+            .with_response_headers(Some(retry_after_headers()));
     assert!(matches!(
         error,
-        crate::completion::CompletionError::HttpError(
-            crate::http_client::Error::InvalidStatusCode(_)
-        )
+        crate::completion::CompletionError::HttpError(crate::http_client::Error::StreamEnded)
     ));
+    assert!(error.provider_response_headers().is_none());
 }
 
 /// Display goldens (rig#2315 error matrix): error strings are what
@@ -344,27 +326,22 @@ fn display_goldens_for_error_shapes() {
         r#"ProviderResponseError: status 404 Not Found: {"error":"nope"}"#
     );
 
-    // A status the transport reported without a body is still a transport
-    // error, and says so.
-    let bodiless = crate::completion::CompletionError::from_transport_error(
-        crate::http_client::Error::InvalidStatusCode(StatusCode::NOT_FOUND),
+    // A response-less transport failure is a transport error, and says so.
+    let dropped = crate::completion::CompletionError::from_transport_error(
+        crate::http_client::Error::StreamEnded,
     );
-    assert_eq!(
-        bodiless.to_string(),
-        "HttpError: Invalid status code: 404 Not Found"
-    );
+    assert_eq!(dropped.to_string(), "HttpError: Stream ended");
 
-    // The two transport variants display identically.
+    // The transport's own rejection text names the status and body.
     let details = crate::http_client::Error::InvalidStatusCodeWithDetails {
         status: StatusCode::NOT_FOUND,
         body: "x".to_string(),
         headers: Box::new(http::HeaderMap::new()),
     };
-    let message = crate::http_client::Error::InvalidStatusCodeWithMessage(
-        StatusCode::NOT_FOUND,
-        "x".to_string(),
+    assert_eq!(
+        details.to_string(),
+        "Invalid status code 404 Not Found with message: x"
     );
-    assert_eq!(details.to_string(), message.to_string());
 
     // rig#2210: capturing headers must never change the text a caller logs.
     for build in [

--- a/crates/rig-core/src/provider_response/tests.rs
+++ b/crates/rig-core/src/provider_response/tests.rs
@@ -1,14 +1,23 @@
 use http::StatusCode;
 
-/// Asserts the shared funnel preserves a provider's status + body across the
-/// three routes every capability error exposes: a non-success HTTP response,
-/// a 2xx provider error envelope, and a non-HTTP (gRPC/SDK) transport.
+/// Asserts the one funnel preserves a provider's status + body across the
+/// routes every capability error exposes: a non-success HTTP response, a
+/// 2xx provider error envelope, a non-HTTP (gRPC/SDK) transport, and a
+/// transport that reported the reply as an error.
 macro_rules! assert_funnel {
     ($err:ty) => {{
+        type E = $err;
         let body = r#"{"error":{"message":"boom"}}"#;
 
-        // Non-success status -> HttpError, with status + body recoverable.
-        let err = <$err>::from_http_response(StatusCode::SERVICE_UNAVAILABLE, body);
+        // Non-success status -> ProviderResponse, with status + body recoverable.
+        let err = E::from_http_response(StatusCode::SERVICE_UNAVAILABLE, body);
+        assert!(
+            matches!(err, E::ProviderResponse(_)),
+            concat!(
+                stringify!($err),
+                ": a provider's reply is a ProviderResponse"
+            ),
+        );
         assert_eq!(
             err.provider_response_status(),
             Some(StatusCode::SERVICE_UNAVAILABLE),
@@ -25,10 +34,11 @@ macro_rules! assert_funnel {
                 .expect("present json")["error"]["message"],
             "boom",
         );
+        assert_eq!(err.provider_request_id(), None);
 
         // A provider error envelope returned with a 2xx status -> ProviderResponse,
         // preserving the (success) status so callers can still see it.
-        let err = <$err>::from_http_response(StatusCode::OK, body);
+        let err = E::from_http_response(StatusCode::OK, body);
         assert_eq!(
             err.provider_response_status(),
             Some(StatusCode::OK),
@@ -37,7 +47,7 @@ macro_rules! assert_funnel {
         assert_eq!(err.provider_response_body(), Some(body));
 
         // No HTTP status available (gRPC/SDK) -> ProviderResponse with status None.
-        let err = <$err>::from_provider_body(body);
+        let err = E::from_provider_body(body);
         assert_eq!(
             err.provider_response_status(),
             None,
@@ -49,21 +59,63 @@ macro_rules! assert_funnel {
         assert_eq!(err.provider_response_body(), Some(body));
 
         // Empty-body asymmetry: the body is `Some("")` but JSON parses to `Ok(None)`.
-        let err = <$err>::from_provider_body("");
+        let err = E::from_provider_body("");
         assert_eq!(err.provider_response_body(), Some(""));
         assert!(err.provider_response_json().expect("ok").is_none());
+
+        // A transport that reported the reply as an error routes through the
+        // same funnel: body -> ProviderResponse (headers kept when the
+        // transport kept them); a status without a body, or no response at
+        // all, stays a transport error.
+        let err =
+            E::from_transport_error($crate::http_client::Error::InvalidStatusCodeWithMessage(
+                StatusCode::TOO_MANY_REQUESTS,
+                body.to_string(),
+            ));
+        assert!(matches!(err, E::ProviderResponse(_)));
+        assert_eq!(err.provider_response_body(), Some(body));
+        assert!(err.provider_response_headers().is_none());
+        let err =
+            E::from_transport_error($crate::http_client::Error::InvalidStatusCodeWithDetails {
+                status: StatusCode::TOO_MANY_REQUESTS,
+                body: body.to_string(),
+                headers: retry_after_headers(),
+            });
+        assert!(matches!(err, E::ProviderResponse(_)));
+        assert_eq!(
+            err.provider_response_headers()
+                .and_then(|headers| headers.get(http::header::RETRY_AFTER))
+                .and_then(|value| value.to_str().ok()),
+            Some("20"),
+        );
+        let err = E::from_transport_error($crate::http_client::Error::InvalidStatusCode(
+            StatusCode::BAD_GATEWAY,
+        ));
+        assert!(matches!(err, E::HttpError(_)));
+        assert_eq!(
+            err.provider_response_status(),
+            Some(StatusCode::BAD_GATEWAY)
+        );
+        assert_eq!(err.provider_response_body(), None);
+        let err = E::from_transport_error($crate::http_client::Error::StreamEnded);
+        assert!(matches!(err, E::HttpError(_)));
+        assert_eq!(err.provider_response_status(), None);
+        // The `?` conversion is the same route.
+        let err: E = $crate::http_client::Error::InvalidStatusCodeWithMessage(
+            StatusCode::NOT_FOUND,
+            body.to_string(),
+        )
+        .into();
+        assert!(matches!(err, E::ProviderResponse(_)));
 
         // rig#2210 — headers are only present when a capture path
         // preserved them. The status+body funnels never have any...
         for err in [
-            <$err>::from_http_response(StatusCode::TOO_MANY_REQUESTS, body),
-            <$err>::from_http_response(StatusCode::OK, body),
-            <$err>::from_provider_body(body),
-            <$err>::from_http_response_with_request_id(
-                StatusCode::TOO_MANY_REQUESTS,
-                body,
-                Some("req_abc".to_string()),
-            ),
+            E::from_http_response(StatusCode::TOO_MANY_REQUESTS, body),
+            E::from_http_response(StatusCode::OK, body),
+            E::from_provider_body(body),
+            E::from_http_response(StatusCode::TOO_MANY_REQUESTS, body)
+                .with_provider_request_id(Some("req_abc".to_string())),
         ] {
             assert!(
                 err.provider_response_headers().is_none(),
@@ -75,19 +127,16 @@ macro_rules! assert_funnel {
             assert_eq!(untouched.provider_response_body(), Some(body));
         }
 
-        // ...but both classifications carry headers once attached, so
-        // `Retry-After` stays readable on a 429 whether the provider has a
-        // request-id contract (ProviderResponse) or not (HttpError).
-        let contract_less = <$err>::from_http_response(StatusCode::TOO_MANY_REQUESTS, body)
+        // ...but a preserved response carries headers once attached, so
+        // `Retry-After` stays readable on a 429 whether or not the provider
+        // reported a request id.
+        let without_id = E::from_http_response(StatusCode::TOO_MANY_REQUESTS, body)
             .with_response_headers(Some(retry_after_headers()));
-        let contract = <$err>::from_http_response_with_request_id(
-            StatusCode::TOO_MANY_REQUESTS,
-            body,
-            Some("req_abc".to_string()),
-        )
-        .with_response_headers(Some(retry_after_headers()));
+        let with_id = E::from_http_response(StatusCode::TOO_MANY_REQUESTS, body)
+            .with_provider_request_id(Some("req_abc".to_string()))
+            .with_response_headers(Some(retry_after_headers()));
 
-        for (label, err) in [("contract-less", contract_less), ("contract", contract)] {
+        for (label, err) in [("without id", without_id), ("with id", with_id)] {
             let err_ty = stringify!($err);
             assert_eq!(
                 err.provider_response_headers()
@@ -136,16 +185,16 @@ fn funnel_preserves_status_and_body_for_every_capability_error() {
     assert_funnel!(crate::audio_generation::AudioGenerationError);
 }
 
-/// rig#2314: the metadata-aware funnel preserves non-success statuses as
-/// `ProviderResponse` so the transport id has a home; status, body, and
-/// id all stay recoverable, and the id appears in the logged message.
+/// rig#2314: the transport id stamps onto the preserved response, so
+/// status, body and id all stay recoverable and the id appears in the
+/// logged message.
 #[test]
-fn with_request_id_funnel_preserves_non_success_as_provider_response() {
-    let error = crate::completion::CompletionError::from_http_response_with_request_id(
+fn stamping_a_request_id_keeps_status_body_and_names_the_id() {
+    let error = crate::completion::CompletionError::from_http_response(
         StatusCode::NOT_FOUND,
         r#"{"error":"nope"}"#,
-        Some("req_abc".to_string()),
-    );
+    )
+    .with_provider_request_id(Some("req_abc".to_string()));
     assert!(matches!(
         error,
         crate::completion::CompletionError::ProviderResponse(_)
@@ -163,27 +212,34 @@ fn with_request_id_funnel_preserves_non_success_as_provider_response() {
 }
 
 /// A missing id is `None`, never a secondary failure, and leaves the
-/// message unchanged.
+/// message unchanged; an empty header value is a missing id.
 #[test]
-fn with_request_id_funnel_tolerates_absent_id() {
-    let error = crate::completion::CompletionError::from_http_response_with_request_id(
-        StatusCode::BAD_REQUEST,
-        "bad",
-        None,
-    );
-    assert_eq!(error.provider_request_id(), None);
-    assert!(!error.to_string().contains("request id"));
+fn an_absent_id_leaves_the_message_unchanged() {
+    for id in [None, Some(String::new())] {
+        let error =
+            crate::completion::CompletionError::from_http_response(StatusCode::BAD_REQUEST, "bad")
+                .with_provider_request_id(id);
+        assert_eq!(error.provider_request_id(), None);
+        assert!(!error.to_string().contains("request id"));
+    }
 }
 
-/// The metadata-less funnel's classification is untouched: non-success
-/// stays transport-shaped, and its accessor reports no id.
+/// First capture wins: the site that saw the response is the authority on
+/// its id, and a later stamp only fills a gap. Variants with no slot
+/// absorb the call unchanged.
 #[test]
-fn metadata_less_funnel_classification_is_unchanged() {
+fn stamping_never_overwrites_an_earlier_id_and_is_a_no_op_without_a_slot() {
     let error =
-        crate::completion::CompletionError::from_http_response(StatusCode::BAD_REQUEST, "bad");
+        crate::completion::CompletionError::from_http_response(StatusCode::BAD_REQUEST, "bad")
+            .with_provider_request_id(Some("first".to_string()))
+            .with_provider_request_id(Some("second".to_string()));
+    assert_eq!(error.provider_request_id(), Some("first"));
+
+    let error = crate::completion::CompletionError::ProviderError("rig diagnostic".to_string())
+        .with_provider_request_id(Some("req_abc".to_string()));
     assert!(matches!(
         error,
-        crate::completion::CompletionError::HttpError(_)
+        crate::completion::CompletionError::ProviderError(_)
     ));
     assert_eq!(error.provider_request_id(), None);
 }
@@ -192,11 +248,11 @@ fn metadata_less_funnel_classification_is_unchanged() {
 /// on the same path and must not evict each other.
 #[test]
 fn request_id_and_headers_coexist_on_one_error() {
-    let error = crate::completion::CompletionError::from_http_response_with_request_id(
+    let error = crate::completion::CompletionError::from_http_response(
         StatusCode::TOO_MANY_REQUESTS,
         r#"{"error":"slow down"}"#,
-        Some("req_abc".to_string()),
     )
+    .with_provider_request_id(Some("req_abc".to_string()))
     .with_response_headers(Some(retry_after_headers()));
 
     assert_eq!(error.provider_request_id(), Some("req_abc"));
@@ -209,36 +265,9 @@ fn request_id_and_headers_coexist_on_one_error() {
     );
 }
 
-/// Attaching headers to a contract-less non-success error upgrades the
-/// transport variant in place, leaving the classification callers match on
-/// (`HttpError`) and the preserved status/body untouched.
-#[test]
-fn attaching_headers_upgrades_the_transport_variant_in_place() {
-    let error = crate::completion::CompletionError::from_http_response(
-        StatusCode::TOO_MANY_REQUESTS,
-        "slow down",
-    )
-    .with_response_headers(Some(retry_after_headers()));
-
-    assert!(matches!(
-        error,
-        crate::completion::CompletionError::HttpError(
-            crate::http_client::Error::InvalidStatusCodeWithDetails { .. }
-        ),
-    ));
-    assert_eq!(
-        error.provider_response_status(),
-        Some(StatusCode::TOO_MANY_REQUESTS)
-    );
-    assert_eq!(error.provider_response_body(), Some("slow down"));
-    // The contract-less path reports no id whether or not headers rode along.
-    assert_eq!(error.provider_request_id(), None);
-}
-
-/// First capture wins on both classifications: the site that saw the
-/// response is the authority, and a later attach only fills a gap. Without
-/// this, a wrapper that re-attaches would silently replace the real
-/// response's headers.
+/// First capture wins on headers too: the site that saw the response is the
+/// authority, and a later attach only fills a gap. Without this, a wrapper
+/// that re-attaches would silently replace the real response's headers.
 #[test]
 fn attaching_headers_never_overwrites_an_earlier_capture() {
     let mut later = http::HeaderMap::new();
@@ -247,11 +276,8 @@ fn attaching_headers_never_overwrites_an_earlier_capture() {
     for build in [
         crate::completion::CompletionError::from_http_response,
         |status, body| {
-            crate::completion::CompletionError::from_http_response_with_request_id(
-                status,
-                body,
-                Some("req_abc".to_string()),
-            )
+            crate::completion::CompletionError::from_http_response(status, body)
+                .with_provider_request_id(Some("req_abc".to_string()))
         },
     ] {
         let error = build(StatusCode::TOO_MANY_REQUESTS, "slow down")
@@ -270,51 +296,62 @@ fn attaching_headers_never_overwrites_an_earlier_capture() {
 }
 
 /// Variants with no slot for a response absorb the call unchanged, so a
-/// capture site can attach unconditionally.
+/// capture site can attach unconditionally. A transport error that carries
+/// a status but no body has no response to annotate either.
 #[test]
 fn attaching_headers_to_a_slotless_variant_is_a_no_op() {
     let error = crate::completion::CompletionError::ProviderError("rig diagnostic".to_string())
         .with_response_headers(Some(retry_after_headers()));
-
     assert!(matches!(
         error,
         crate::completion::CompletionError::ProviderError(_)
     ));
     assert!(error.provider_response_headers().is_none());
     assert_eq!(error.to_string(), "ProviderError: rig diagnostic");
+
+    let error = crate::completion::CompletionError::HttpError(
+        crate::http_client::Error::InvalidStatusCode(StatusCode::BAD_GATEWAY),
+    )
+    .with_response_headers(Some(retry_after_headers()));
+    assert!(matches!(
+        error,
+        crate::completion::CompletionError::HttpError(
+            crate::http_client::Error::InvalidStatusCode(_)
+        )
+    ));
 }
 
 /// Display goldens (rig#2315 error matrix): error strings are what
 /// callers grep and alert on — message churn must be a reviewed diff.
 #[test]
 fn display_goldens_for_error_shapes() {
-    let with_id = crate::completion::CompletionError::from_http_response_with_request_id(
+    let with_id = crate::completion::CompletionError::from_http_response(
         StatusCode::NOT_FOUND,
         r#"{"error":"nope"}"#,
-        Some("req_abc".to_string()),
-    );
+    )
+    .with_provider_request_id(Some("req_abc".to_string()));
     assert_eq!(
         with_id.to_string(),
         r#"ProviderResponseError: status 404 Not Found: {"error":"nope"} (request id: req_abc)"#
     );
 
-    let without_id = crate::completion::CompletionError::from_http_response_with_request_id(
+    let without_id = crate::completion::CompletionError::from_http_response(
         StatusCode::NOT_FOUND,
         r#"{"error":"nope"}"#,
-        None,
     );
     assert_eq!(
         without_id.to_string(),
         r#"ProviderResponseError: status 404 Not Found: {"error":"nope"}"#
     );
 
-    let contract_less = crate::completion::CompletionError::from_http_response(
-        StatusCode::NOT_FOUND,
-        r#"{"error":"nope"}"#,
+    // A status the transport reported without a body is still a transport
+    // error, and says so.
+    let bodiless = crate::completion::CompletionError::from_transport_error(
+        crate::http_client::Error::InvalidStatusCode(StatusCode::NOT_FOUND),
     );
     assert_eq!(
-        contract_less.to_string(),
-        r#"HttpError: Invalid status code 404 Not Found with message: {"error":"nope"}"#
+        bodiless.to_string(),
+        "HttpError: Invalid status code: 404 Not Found"
     );
 
     // The two transport variants display identically.
@@ -329,16 +366,12 @@ fn display_goldens_for_error_shapes() {
     );
     assert_eq!(details.to_string(), message.to_string());
 
-    // rig#2210: capturing headers must never change the text a caller
-    // logs, on either classification.
+    // rig#2210: capturing headers must never change the text a caller logs.
     for build in [
         crate::completion::CompletionError::from_http_response,
         |status, body| {
-            crate::completion::CompletionError::from_http_response_with_request_id(
-                status,
-                body,
-                Some("req_abc".to_string()),
-            )
+            crate::completion::CompletionError::from_http_response(status, body)
+                .with_provider_request_id(Some("req_abc".to_string()))
         },
     ] {
         let bare = build(StatusCode::TOO_MANY_REQUESTS, r#"{"error":"slow down"}"#);

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -3002,6 +3002,16 @@ where
         &self,
         completion_request: completion::CompletionRequest,
     ) -> Result<CompletionResponse, CompletionError> {
+        self.raw_completion_observed(completion_request, None).await
+    }
+
+    /// [`Self::raw_completion`] with observation context owned by this
+    /// invocation.
+    async fn raw_completion_observed(
+        &self,
+        completion_request: completion::CompletionRequest,
+        observation: Option<crate::observe::AdapterContext>,
+    ) -> Result<CompletionResponse, CompletionError> {
         let (span, request) =
             self.prepare_request(completion_request, CompletionOperation::Chat)?;
 
@@ -3013,11 +3023,14 @@ where
 
         let request: Vec<u8> = serde_json::to_vec(&request)?;
 
-        let req = self
+        let mut req = self
             .client
             .post("/v1/messages")?
             .body(request)
             .map_err(|e| CompletionError::HttpError(e.into()))?;
+        if let Some(observation) = observation {
+            super::observation::attach(observation, &mut req, "/v1/messages");
+        }
 
         let (mut completion, provider_request_id) =
             send_completion::<_, ApiResponse<CompletionResponse>, _>(
@@ -3054,17 +3067,35 @@ where
         &self,
         completion_request: completion::CompletionRequest,
     ) -> Result<completion::CompletionResponse, CompletionError> {
-        // Capture before `normalize` consumes the raw value.
-        let response = self.raw_completion(completion_request).await?;
-        let captured = serde_json::to_value(&response)?;
-        Ok(response.normalize(Ext::PROVIDER_NAME)?.with_raw(captured))
+        self.completion_with_context(completion_request, None).await
     }
 
     async fn stream(
         &self,
         request: CompletionRequest,
     ) -> Result<crate::streaming::StreamingCompletionResponse, CompletionError> {
-        GenericCompletionModel::stream(self, request).await
+        self.stream_with_context(request, None).await
+    }
+
+    async fn completion_with_context(
+        &self,
+        completion_request: completion::CompletionRequest,
+        context: Option<crate::observe::AdapterContext>,
+    ) -> Result<completion::CompletionResponse, CompletionError> {
+        // Capture before `normalize` consumes the raw value.
+        let response = self
+            .raw_completion_observed(completion_request, context)
+            .await?;
+        let captured = serde_json::to_value(&response)?;
+        Ok(response.normalize(Ext::PROVIDER_NAME)?.with_raw(captured))
+    }
+
+    async fn stream_with_context(
+        &self,
+        request: CompletionRequest,
+        context: Option<crate::observe::AdapterContext>,
+    ) -> Result<crate::streaming::StreamingCompletionResponse, CompletionError> {
+        GenericCompletionModel::stream_observed(self, request, context).await
     }
 }
 

--- a/crates/rig-core/src/providers/anthropic/completion/tests.rs
+++ b/crates/rig-core/src/providers/anthropic/completion/tests.rs
@@ -3965,15 +3965,9 @@ async fn completion_streaming_http_non_success_preserves_status_and_body() {
         }
     };
 
-    // Streaming *connect* failures stay transport-shaped (HttpError):
-    // rig#2314's ProviderResponse classification covers the unary driver
-    // and in-band stream envelopes, not the SSE handshake.
-    assert_eq!(
-        error.kind,
-        crate::error::ErrorKind::Http {
-            status: Some(http::StatusCode::SERVICE_UNAVAILABLE.as_u16())
-        }
-    );
+    // A rejected SSE handshake is the provider's reply, classified like the
+    // unary driver's and the in-band envelopes': one funnel.
+    assert_eq!(error.kind, crate::error::ErrorKind::ProviderResponse);
     assert_eq!(
         error.http_status,
         Some(http::StatusCode::SERVICE_UNAVAILABLE.as_u16())

--- a/crates/rig-core/src/providers/anthropic/mod.rs
+++ b/crates/rig-core/src/providers/anthropic/mod.rs
@@ -15,6 +15,7 @@
 pub mod client;
 pub mod completion;
 pub mod model_listing;
+mod observation;
 pub mod streaming;
 
 pub use client::{Client, ClientBuilder};

--- a/crates/rig-core/src/providers/anthropic/observation.rs
+++ b/crates/rig-core/src/providers/anthropic/observation.rs
@@ -1,0 +1,112 @@
+//! Messages metadata projected before normalization can discard it: the
+//! stop reason, the model, the message id, the usage and any error
+//! envelope, on the unary reply and on the stream's `message_start`,
+//! `message_delta` and `error` events.
+
+use crate::observe::{
+    AdapterAttempt, AdapterContext, AdapterErrorEnvelope, AdapterEvent, AdapterUsage,
+    AdapterVerdict, PayloadObserver,
+};
+use serde::Deserialize;
+
+/// Attach `context` to a Messages request, with the Messages projector.
+pub(crate) fn attach<B>(
+    context: AdapterContext,
+    request: &mut http::Request<B>,
+    route: &'static str,
+) {
+    context.attach(request, route);
+    request.extensions_mut().insert(PayloadObserver(payload));
+}
+
+fn count<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<Option<u64>, D::Error> {
+    Ok(serde_json::Value::deserialize(deserializer)?.as_u64())
+}
+
+#[derive(Deserialize)]
+struct Usage {
+    #[serde(default, deserialize_with = "count")]
+    input_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "count")]
+    output_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "count")]
+    cache_read_input_tokens: Option<u64>,
+}
+
+#[derive(Deserialize)]
+struct Envelope {
+    #[serde(rename = "type")]
+    kind: Option<String>,
+    message: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct Delta {
+    stop_reason: Option<String>,
+}
+
+/// One object covers the unary reply and every stream event: a
+/// `message_start` nests the message, a `message_delta` carries the stop
+/// reason under `delta` and the cumulative output usage beside it.
+#[derive(Deserialize)]
+struct Payload {
+    id: Option<String>,
+    model: Option<String>,
+    stop_reason: Option<String>,
+    usage: Option<Usage>,
+    message: Option<Box<Payload>>,
+    delta: Option<Delta>,
+    error: Option<Envelope>,
+}
+
+fn payload(bytes: &[u8], attempt: &mut AdapterAttempt) {
+    let Ok(payload) = serde_json::from_slice::<Payload>(bytes) else {
+        return;
+    };
+    let usage = payload.usage;
+    let (id, model, stop_reason, nested_usage) = match payload.message {
+        Some(message) => (
+            message.id,
+            message.model,
+            message.stop_reason,
+            message.usage,
+        ),
+        None => (payload.id, payload.model, payload.stop_reason, None),
+    };
+    // Anthropic reports the prompt on `message_start` and the answer's
+    // running total on each `message_delta`: each is a snapshot of what it
+    // knows, never a sum.
+    if let Some(usage) = usage.or(nested_usage) {
+        attempt.emit(AdapterEvent::Usage {
+            usage: AdapterUsage {
+                input_tokens: usage.input_tokens,
+                output_tokens: usage.output_tokens,
+                total_tokens: None,
+                cached_input_tokens: usage.cache_read_input_tokens,
+                reasoning_tokens: None,
+                tool_input_tokens: None,
+            },
+        });
+    }
+    let stop_reason = stop_reason.or(payload.delta.and_then(|delta| delta.stop_reason));
+    let verdict = AdapterVerdict {
+        finish_reason: stop_reason.map(|v| attempt.text(&v)),
+        block_reason: None,
+        detail: None,
+        model: model.map(|v| attempt.text(&v)),
+    };
+    let response_id = id.map(|v| attempt.text(&v));
+    attempt.provider(verdict, response_id);
+    if let Some(error) = payload.error {
+        attempt.emit(AdapterEvent::ErrorEnvelope {
+            error: AdapterErrorEnvelope {
+                code: None,
+                status: error.kind.map(|v| attempt.text(&v)),
+                message: error.message.map(|v| attempt.text(&v)),
+            },
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/rig-core/src/providers/anthropic/observation/tests.rs
+++ b/crates/rig-core/src/providers/anthropic/observation/tests.rs
@@ -1,0 +1,138 @@
+use std::sync::Arc;
+
+use crate::client::CompletionClient;
+use crate::completion::CompletionModel as _;
+use crate::observe::{
+    Action, AdapterContext, AdapterEnding, AdapterErrorBoundary, AdapterErrorEnvelope,
+    AdapterEvent, AdapterUsage, AdapterVerdict, ObservationLog, Subject,
+};
+use crate::test_utils::{MockStreamingClient, RecordingHttpClient};
+use futures::StreamExt;
+
+fn adapter_events(log: &ObservationLog) -> Vec<AdapterEvent> {
+    log.trace()
+        .observations
+        .iter()
+        .filter_map(|o| match &o.action {
+            Action::Adapter { observation } => Some(observation.event.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn context(log: &Arc<ObservationLog>) -> Option<AdapterContext> {
+    Some(AdapterContext::new(log.clone(), Subject::default(), "call"))
+}
+
+/// A rejected Messages call: the envelope's type and message, and the
+/// closure with the one funnel's classification.
+#[tokio::test]
+async fn messages_rejection_projects_the_envelope() {
+    let http = RecordingHttpClient::with_error(
+        http::StatusCode::SERVICE_UNAVAILABLE,
+        r#"{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}"#,
+    );
+    let client = crate::providers::anthropic::Client::builder()
+        .api_key("test-key")
+        .http_client(http)
+        .build()
+        .unwrap();
+    let model = client.completion_model("claude-test");
+    let log = Arc::new(ObservationLog::default());
+    let error = model
+        .completion_with_context(
+            model.completion_request("hello").max_tokens(64).build(),
+            context(&log),
+        )
+        .await
+        .unwrap_err();
+    assert!(error.is_retryable());
+    let events = adapter_events(&log);
+    assert!(
+        matches!(&events[0], AdapterEvent::Started { method, route } if method == "POST" && route == "/v1/messages")
+    );
+    assert!(events.contains(&AdapterEvent::Response { status: 503 }));
+    assert!(events.contains(&AdapterEvent::ErrorEnvelope {
+        error: AdapterErrorEnvelope {
+            code: None,
+            status: Some("overloaded_error".into()),
+            message: Some("Overloaded".into()),
+        }
+    }));
+    assert_eq!(
+        events.last(),
+        Some(&AdapterEvent::Finished {
+            ending: AdapterEnding::Error {
+                boundary: AdapterErrorBoundary::ProviderResponse,
+                kind: "provider_response".into(),
+                status: Some(503),
+                retryable: true,
+            }
+        })
+    );
+}
+
+/// A Messages stream: `message_start` carries the id, the model and the
+/// prompt usage; `message_delta` carries the stop reason and the answer's
+/// usage; the terminal closes the attempt.
+#[tokio::test]
+async fn messages_stream_projects_usage_stop_reason_and_model() {
+    let sse = "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-4-6\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":9,\"output_tokens\":1,\"cache_read_input_tokens\":0}}}\n\n\
+event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n\
+event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n\
+event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n\
+event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":3}}\n\n\
+event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
+    let client = crate::providers::anthropic::Client::builder()
+        .api_key("test-key")
+        .http_client(MockStreamingClient {
+            sse_bytes: bytes::Bytes::from(sse),
+        })
+        .build()
+        .unwrap();
+    let model = client.completion_model("claude-test");
+    let log = Arc::new(ObservationLog::default());
+    let mut stream = model
+        .stream_with_context(
+            model.completion_request("hello").max_tokens(64).build(),
+            context(&log),
+        )
+        .await
+        .unwrap();
+    while let Some(item) = stream.next().await {
+        item.unwrap();
+    }
+    drop(stream);
+
+    let events = adapter_events(&log);
+    assert!(events.contains(&AdapterEvent::Usage {
+        usage: AdapterUsage {
+            input_tokens: Some(9),
+            output_tokens: Some(1),
+            cached_input_tokens: Some(0),
+            ..AdapterUsage::default()
+        }
+    }));
+    assert!(events.contains(&AdapterEvent::Usage {
+        usage: AdapterUsage {
+            output_tokens: Some(3),
+            ..AdapterUsage::default()
+        }
+    }));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        AdapterEvent::Provider { verdict: AdapterVerdict { model: Some(model), finish_reason: None, .. } }
+            if model == "claude-sonnet-4-6"
+    )));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        AdapterEvent::Provider { verdict: AdapterVerdict { finish_reason: Some(reason), .. } }
+            if reason == "end_turn"
+    )));
+    assert_eq!(
+        events.last(),
+        Some(&AdapterEvent::Finished {
+            ending: AdapterEnding::Terminal
+        })
+    );
+}

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -793,9 +793,12 @@ where
     T: HttpClientExt + Clone + 'static,
     Ext: AnthropicCompatibleProvider + Clone + WasmCompatSend + WasmCompatSync + 'static,
 {
-    pub(crate) async fn stream(
+    /// Open a Messages stream with observation context owned by this
+    /// invocation.
+    pub(crate) async fn stream_observed(
         &self,
         completion_request: CompletionRequest,
+        observation: Option<crate::observe::AdapterContext>,
     ) -> Result<streaming::StreamingCompletionResponse, CompletionError> {
         let (span, request) =
             self.prepare_request(completion_request, CompletionOperation::ChatStreaming)?;
@@ -812,11 +815,14 @@ where
 
         let body: Vec<u8> = serde_json::to_vec(&body)?;
 
-        let req = self
+        let mut req = self
             .client
             .post("/v1/messages")?
             .body(body)
             .map_err(http_client::Error::Protocol)?;
+        if let Some(observation) = observation {
+            super::observation::attach(observation, &mut req, "/v1/messages");
+        }
 
         let event_source = GenericEventSource::new(self.client.clone(), req);
         let (event_source, request_id_slot) = match Ext::REQUEST_ID_HEADER {

--- a/crates/rig-core/src/providers/anthropic/streaming/tests.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming/tests.rs
@@ -1834,8 +1834,9 @@ mod terminal_emission {
             .api_key("test-key")
             .http_client(SequencedStreamingHttpClient::new(vec![
                 Ok(sse(&[MESSAGE_START, TEXT_START, TEXT_DELTA])),
-                Err(crate::http_client::Error::InvalidStatusCodeWithMessage(
+                Err(crate::http_client::Error::non_success_with_details(
                     http::StatusCode::BAD_GATEWAY,
+                    http::HeaderMap::new(),
                     "connection reset".to_string(),
                 )),
             ]))

--- a/crates/rig-core/src/providers/azure/azure_tests.rs
+++ b/crates/rig-core/src/providers/azure/azure_tests.rs
@@ -72,7 +72,7 @@ async fn image_generation_non_success_response_preserves_status_and_body() {
         .await
         .expect_err("image generation should fail with non-success status");
 
-    assert!(matches!(error, ImageGenerationError::HttpError(_)));
+    assert!(matches!(error, ImageGenerationError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::BAD_REQUEST)
@@ -161,7 +161,7 @@ async fn audio_generation_non_success_response_preserves_status_and_body() {
         panic!("audio generation should fail with non-success status")
     };
 
-    assert!(matches!(error, AudioGenerationError::HttpError(_)));
+    assert!(matches!(error, AudioGenerationError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::UNPROCESSABLE_ENTITY)
@@ -193,7 +193,7 @@ async fn transcription_http_non_success_preserves_status_and_body() {
         panic!("transcription should fail with non-success status")
     };
 
-    assert!(matches!(error, TranscriptionError::HttpError(_)));
+    assert!(matches!(error, TranscriptionError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::BAD_REQUEST)
@@ -260,7 +260,7 @@ async fn embedding_http_non_success_preserves_status_and_body() {
         panic!("embedding should fail with non-success status")
     };
 
-    assert!(matches!(error, EmbeddingError::HttpError(_)));
+    assert!(matches!(error, EmbeddingError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::BAD_REQUEST)
@@ -400,7 +400,7 @@ async fn completion_http_non_success_preserves_status_and_body() {
         panic!("completion should fail with non-success status")
     };
 
-    assert!(matches!(error, CompletionError::HttpError(_)));
+    assert!(matches!(error, CompletionError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::BAD_REQUEST)

--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -487,11 +487,13 @@ where
             .body(body)
             .map_err(|err| CompletionError::HttpError(err.into()))?;
 
-        let response = self.client.send(req).await?;
-        let status = response.status();
-        let text = http_client::text(response).await?;
+        let response = self.client.send::<_, Vec<u8>>(req).await?;
+        let (parts, body) = response.into_parts();
+        let status = parts.status;
+        let text = String::from(String::from_utf8_lossy(&body.await?));
         if !status.is_success() {
-            return Err(CompletionError::from_http_response(status, text));
+            return Err(CompletionError::from_http_response(status, text)
+                .with_response_headers(Some(Box::new(parts.headers))));
         }
 
         // The `/responses` endpoint answers with an SSE body even for a

--- a/crates/rig-core/src/providers/chatgpt/tests.rs
+++ b/crates/rig-core/src/providers/chatgpt/tests.rs
@@ -228,7 +228,7 @@ async fn completion_http_non_success_preserves_status_and_body() {
             .await
             .expect_err("completion should fail with non-success status");
 
-        assert!(matches!(&error, CompletionError::HttpError(_)));
+        assert!(matches!(&error, CompletionError::ProviderResponse(_)));
         assert_eq!(error.provider_response_status(), Some(status));
         assert_eq!(error.provider_response_body(), Some(body));
         assert!(

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -747,6 +747,16 @@ where
         &self,
         completion_request: completion::CompletionRequest,
     ) -> Result<CompletionResponse, CompletionError> {
+        self.raw_completion_observed(completion_request, None).await
+    }
+
+    /// [`Self::raw_completion`] with observation context owned by this
+    /// invocation.
+    async fn raw_completion_observed(
+        &self,
+        completion_request: completion::CompletionRequest,
+        observation: Option<crate::observe::AdapterContext>,
+    ) -> Result<CompletionResponse, CompletionError> {
         let system_instructions = completion_request.system_instructions().map(str::to_owned);
         let record_telemetry_content = completion_request.record_telemetry_content;
         let request = CohereCompletionRequest::try_from((self.model.as_ref(), completion_request))?;
@@ -764,11 +774,14 @@ where
 
         let req_body = serde_json::to_vec(&request)?;
 
-        let req = self
+        let mut req = self
             .client
             .post("/v2/chat")?
             .body(req_body)
             .map_err(|e| CompletionError::HttpError(e.into()))?;
+        if let Some(observation) = observation {
+            observation.attach(&mut req, "/v2/chat");
+        }
 
         // Left unboxed so `provider_response_status`/`_body` can read the
         // status and body straight off the transport error.
@@ -805,18 +818,36 @@ where
         &self,
         completion_request: completion::CompletionRequest,
     ) -> Result<completion::CompletionResponse, CompletionError> {
-        // Capture before `try_into` consumes the raw value.
-        let raw = self.raw_completion(completion_request).await?;
-        let captured = serde_json::to_value(&raw)?;
-        let response: completion::CompletionResponse = raw.try_into()?;
-        Ok(response.with_raw(captured))
+        self.completion_with_context(completion_request, None).await
     }
 
     async fn stream(
         &self,
         request: CompletionRequest,
     ) -> Result<crate::streaming::StreamingCompletionResponse, CompletionError> {
-        CompletionModel::stream(self, request).await
+        self.stream_with_context(request, None).await
+    }
+
+    async fn completion_with_context(
+        &self,
+        completion_request: completion::CompletionRequest,
+        context: Option<crate::observe::AdapterContext>,
+    ) -> Result<completion::CompletionResponse, CompletionError> {
+        // Capture before `try_into` consumes the raw value.
+        let raw = self
+            .raw_completion_observed(completion_request, context)
+            .await?;
+        let captured = serde_json::to_value(&raw)?;
+        let response: completion::CompletionResponse = raw.try_into()?;
+        Ok(response.with_raw(captured))
+    }
+
+    async fn stream_with_context(
+        &self,
+        request: CompletionRequest,
+        context: Option<crate::observe::AdapterContext>,
+    ) -> Result<crate::streaming::StreamingCompletionResponse, CompletionError> {
+        CompletionModel::stream_observed(self, request, context).await
     }
 }
 #[cfg(test)]

--- a/crates/rig-core/src/providers/cohere/completion/tests.rs
+++ b/crates/rig-core/src/providers/cohere/completion/tests.rs
@@ -469,7 +469,7 @@ async fn completion_non_success_preserves_status_and_body() {
         .await
         .expect_err("should fail with non-success status");
 
-    assert!(matches!(error, CompletionError::HttpError(_)));
+    assert!(matches!(error, CompletionError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)

--- a/crates/rig-core/src/providers/cohere/embeddings.rs
+++ b/crates/rig-core/src/providers/cohere/embeddings.rs
@@ -232,14 +232,12 @@ where
             .body(body)
             .map_err(|e| EmbeddingError::HttpError(e.into()))?;
 
-        let response = self
-            .client
-            .send::<_, Vec<u8>>(req)
-            .await
-            .map_err(EmbeddingError::HttpError)?;
+        let response = self.client.send::<_, Vec<u8>>(req).await?;
 
-        let status = response.status();
-        let raw_body = response.into_body().await?;
+        let (parts, body) = response.into_parts();
+        let status = parts.status;
+        let headers = Box::new(parts.headers);
+        let raw_body = body.await?;
 
         if status.is_success() {
             let body: ApiResponse<EmbeddingResponse> = serde_json::from_slice(raw_body.as_slice())?;
@@ -265,14 +263,15 @@ where
                     Err(EmbeddingError::from_http_response(
                         status,
                         String::from_utf8_lossy(&raw_body),
-                    ))
+                    )
+                    .with_response_headers(Some(headers)))
                 }
             }
         } else {
-            Err(EmbeddingError::from_http_response(
-                status,
-                String::from_utf8_lossy(&raw_body),
-            ))
+            Err(
+                EmbeddingError::from_http_response(status, String::from_utf8_lossy(&raw_body))
+                    .with_response_headers(Some(headers)),
+            )
         }
     }
 }
@@ -463,19 +462,18 @@ where
             .post("/v1/embed")?
             .body(body)
             .map_err(|error| EmbeddingError::HttpError(error.into()))?;
-        let response = self
-            .client
-            .send::<_, Vec<u8>>(request)
-            .await
-            .map_err(EmbeddingError::HttpError)?;
-        let status = response.status();
-        let raw_body = response.into_body().await?;
+        let response = self.client.send::<_, Vec<u8>>(request).await?;
+        let (parts, body) = response.into_parts();
+        let status = parts.status;
+        let headers = Box::new(parts.headers);
+        let raw_body = body.await?;
 
         if !status.is_success() {
             return Err(EmbeddingError::from_http_response(
                 status,
                 String::from_utf8_lossy(&raw_body),
-            ));
+            )
+            .with_response_headers(Some(headers)));
         }
 
         let body: ApiResponse<ImageEmbeddingResponse> =
@@ -490,7 +488,8 @@ where
                 return Err(EmbeddingError::from_http_response(
                     status,
                     String::from_utf8_lossy(&raw_body),
-                ));
+                )
+                .with_response_headers(Some(headers)));
             }
         };
 

--- a/crates/rig-core/src/providers/cohere/embeddings/tests.rs
+++ b/crates/rig-core/src/providers/cohere/embeddings/tests.rs
@@ -23,7 +23,7 @@ async fn embeddings_non_success_preserves_status_and_body() {
         .await
         .expect_err("should fail with non-success status");
 
-    assert!(matches!(error, EmbeddingError::HttpError(_)));
+    assert!(matches!(error, EmbeddingError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)
@@ -153,7 +153,7 @@ async fn image_embeddings_non_success_preserves_status_and_body() {
         .await
         .expect_err("should fail with non-success status");
 
-    assert!(matches!(error, EmbeddingError::HttpError(_)));
+    assert!(matches!(error, EmbeddingError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)

--- a/crates/rig-core/src/providers/cohere/streaming.rs
+++ b/crates/rig-core/src/providers/cohere/streaming.rs
@@ -313,9 +313,11 @@ impl<T> CompletionModel<T>
 where
     T: HttpClientExt + Clone + 'static,
 {
-    pub(crate) async fn stream(
+    /// Open a chat stream with observation context owned by this invocation.
+    pub(crate) async fn stream_observed(
         &self,
         request: CompletionRequest,
+        observation: Option<crate::observe::AdapterContext>,
     ) -> Result<streaming::StreamingCompletionResponse, CompletionError> {
         let system_instructions = request.system_instructions().map(str::to_owned);
         let record_telemetry_content = request.record_telemetry_content;
@@ -343,11 +345,14 @@ where
 
         let body = serde_json::to_vec(&request)?;
 
-        let req = self
+        let mut req = self
             .client
             .post("/v2/chat")?
             .body(body)
             .map_err(|e| CompletionError::HttpError(e.into()))?;
+        if let Some(observation) = observation {
+            observation.attach(&mut req, "/v2/chat");
+        }
 
         let stream = open_wire_stream(
             GenericEventSource::new(self.client.clone(), req),

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -1185,11 +1185,10 @@ where
         let response = self.client.send(req).await?;
         let (parts, body) = response.into_parts();
         let status = parts.status;
-        let provider_request_id =
-            crate::providers::internal::transcription::request_id_from_headers(
-                &parts.headers,
-                Some("x-request-id"),
-            );
+        let provider_request_id = crate::providers::internal::request_id_from_headers(
+            &parts.headers,
+            Some("x-request-id"),
+        );
         let body: Vec<u8> = body.await?;
         if status.is_success() {
             #[derive(Deserialize)]
@@ -1210,7 +1209,9 @@ where
                         return Err(EmbeddingError::from_http_response(
                             status,
                             String::from_utf8_lossy(&body).into_owned(),
-                        ));
+                        )
+                        .with_provider_request_id(provider_request_id)
+                        .with_response_headers(Some(Box::new(parts.headers))));
                     }
 
                     let preview = String::from_utf8_lossy(&body);
@@ -1231,7 +1232,9 @@ where
             Err(EmbeddingError::from_http_response(
                 status,
                 String::from_utf8_lossy(&body).into_owned(),
-            ))
+            )
+            .with_provider_request_id(provider_request_id)
+            .with_response_headers(Some(Box::new(parts.headers))))
         }
     }
 }

--- a/crates/rig-core/src/providers/copilot/tests.rs
+++ b/crates/rig-core/src/providers/copilot/tests.rs
@@ -870,9 +870,11 @@ async fn chat_stream_terminates_after_transport_error() {
         Ok(sse_bytes_from_data_lines([
             "{\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_123\",\"function\":{\"name\":\"ping\",\"arguments\":\"\"}}]},\"finish_reason\":null}],\"usage\":null}",
         ])),
-        Err(http_client::Error::InvalidStatusCode(
-            http::StatusCode::BAD_GATEWAY,
-        )),
+        // The connection drops mid-stream: no reply, no status.
+        Err(http_client::Error::instance(std::io::Error::new(
+            std::io::ErrorKind::ConnectionReset,
+            "connection reset",
+        ))),
     ];
 
     let http_client = SequencedStreamingHttpClient::new(chunks);
@@ -909,14 +911,11 @@ async fn chat_stream_terminates_after_transport_error() {
             Err(err) => {
                 assert_eq!(
                     err.to_string(),
-                    "HttpError: Invalid status code: 502 Bad Gateway"
+                    "HttpError: Http client error: connection reset"
                 );
-                assert_eq!(
-                    err.http_status,
-                    Some(http::StatusCode::BAD_GATEWAY.as_u16())
-                );
-                // A status-only `HttpError` preserves no provider body.
-                assert!(err.provider_response_body().is_none_or(str::is_empty));
+                // A transport failure carries no status and no provider body.
+                assert_eq!(err.http_status, None);
+                assert!(err.provider_response_body().is_none());
                 saw_error = true;
             }
             Ok(other) => panic!("unexpected stream item: {other:?}"),

--- a/crates/rig-core/src/providers/gemini/cached_content.rs
+++ b/crates/rig-core/src/providers/gemini/cached_content.rs
@@ -605,14 +605,9 @@ where
             Ok(response) => http_client::text(response)
                 .await
                 .map_err(CachedContentError::Http)?,
-            // Triage on the *status*, not on one error variant. The bundled
-            // reqwest transports always report a non-success status as
-            // `InvalidStatusCodeWithDetails`, but `H` is a public extension
-            // point (`ClientBuilder::http_client`) and a custom `HttpClientExt`
-            // may report `InvalidStatusCode` or `InvalidStatusCodeWithMessage`
-            // instead. Matching the one variant dropped those into `Http`
-            // below, so the recovery this module documents — recreate the cache
-            // on `Expired` — never fired outside the bundled clients.
+            // Triage on the *status*: a transport that rejected the reply as
+            // an error still carries it, and the recovery this module
+            // documents — recreate the cache on `Expired` — must fire on it.
             Err(error) => {
                 let Some(status) = error.non_success_status() else {
                     // No status at all: a genuine transport failure (DNS, TLS,
@@ -645,8 +640,7 @@ fn qualify_model(model: &str) -> String {
 
 /// Stand-in for the provider's message when a failure carried no text.
 ///
-/// [`http_client::Error::InvalidStatusCode`] carries a status and nothing else,
-/// and a non-success response can have an empty body; either way there is
+/// A non-success response can have an empty body, and then there is
 /// nothing to quote. An empty `message` would leave both [`CachedContentError`]
 /// Displays ending in a bare colon, which reads as a truncated error rather
 /// than as a silent provider.

--- a/crates/rig-core/src/providers/gemini/cached_content/status_triage_tests.rs
+++ b/crates/rig-core/src/providers/gemini/cached_content/status_triage_tests.rs
@@ -1,14 +1,14 @@
 //! Non-success triage across every shape a transport can report one in.
 //!
-//! The recorded cassettes only ever exercise the bundled reqwest shape,
-//! `http_client::Error::InvalidStatusCodeWithDetails`. But `H` is a public
-//! extension point (`ClientBuilder::http_client`), and a custom
-//! [`HttpClientExt`] may report the same 404 as a bare
-//! `InvalidStatusCode`, as `InvalidStatusCodeWithMessage`, or as an `Ok`
-//! response carrying the status — shapes rig's own test double produces.
-//! On those the triage used to fall through to `CachedContentError::Http`
-//! or to a bogus deserialization error, so the recovery this module
-//! documents (`Expired { .. } => recreate the cache`) silently never fired.
+//! The recorded cassettes only ever exercise the bundled reqwest shape: the
+//! transport rejects the reply as `InvalidStatusCodeWithDetails`. But `H` is
+//! a public extension point (`ClientBuilder::http_client`), and a custom
+//! [`HttpClientExt`] may hand the same 404 back as an `Ok` response carrying
+//! the status, or reject it with an empty body — shapes rig's own test
+//! double produces. On those the triage used to fall through to
+//! `CachedContentError::Http` or to a bogus deserialization error, so the
+//! recovery this module documents (`Expired { .. } => recreate the cache`)
+//! silently never fired.
 
 use super::*;
 use crate::test_utils::{MockHttpResponse, SequencedHttpClient};
@@ -27,9 +27,8 @@ fn caches(response: MockHttpResponse) -> CachedContentClient<SequencedHttpClient
 const GONE: &str =
     r#"{"error":{"code":404,"message":"CachedContent not found (or permission denied)."}}"#;
 
-/// A transport that reports the 404 as `InvalidStatusCodeWithMessage` —
-/// the variant every non-bundled `HttpClientExt` in rig produces — must
-/// still reach `Expired`.
+/// A transport that rejects the 404 without headers — the shape rig's test
+/// double produces — must still reach `Expired`.
 ///
 /// Before the triage moved from the variant to the status this fell into
 /// the catch-all `Err(error) => Http(error)` arm, so a caller matching
@@ -135,14 +134,14 @@ async fn a_server_error_reports_the_status_rather_than_an_expiry() {
     assert!(message.contains("Internal error"), "{message}");
 }
 
-/// `InvalidStatusCode` carries no body, so there is no provider text to
-/// quote. The message must still say something: an empty one leaves the
-/// error Display ending in a bare colon, which reads as truncated output
-/// rather than as a provider that said nothing.
+/// A rejection with an empty body has no provider text to quote. The
+/// message must still say something: an empty one leaves the error Display
+/// ending in a bare colon, which reads as truncated output rather than as a
+/// provider that said nothing.
 #[tokio::test]
 async fn a_status_error_with_no_body_still_names_why_it_has_no_message() {
-    // `SequencedHttpClient` reports `InvalidStatusCode(501)` once its
-    // scripted responses run out, which is the body-less shape.
+    // `SequencedHttpClient` answers 501 with an empty body once its scripted
+    // responses run out.
     let caches = Client::builder()
         .api_key("test-key")
         .http_client(SequencedHttpClient::new(Vec::new()))

--- a/crates/rig-core/src/providers/gemini/completion/tests.rs
+++ b/crates/rig-core/src/providers/gemini/completion/tests.rs
@@ -1763,7 +1763,7 @@ async fn completion_non_success_preserves_status_and_body() {
         .await
         .expect_err("should fail with non-success status");
 
-    assert!(matches!(error, CompletionError::HttpError(_)));
+    assert!(matches!(error, CompletionError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)

--- a/crates/rig-core/src/providers/gemini/embedding.rs
+++ b/crates/rig-core/src/providers/gemini/embedding.rs
@@ -112,26 +112,28 @@ where
             .map_err(|e| EmbeddingError::HttpError(e.into()))?;
         let response = self.client.send::<_, Vec<u8>>(req).await?;
 
-        let status = response.status();
-        let body = response.into_body().await?;
+        let (parts, body) = response.into_parts();
+        let status = parts.status;
+        let headers = Box::new(parts.headers);
+        let body = body.await?;
 
         // Preserve non-success bodies before deserialization because providers
         // may return empty, non-JSON, or otherwise unexpected error payloads.
         if !status.is_success() {
-            return Err(EmbeddingError::from_http_response(
-                status,
-                String::from_utf8_lossy(&body),
-            ));
+            return Err(
+                EmbeddingError::from_http_response(status, String::from_utf8_lossy(&body))
+                    .with_response_headers(Some(headers)),
+            );
         }
 
         match serde_json::from_slice::<ApiResponse<gemini_api_types::EmbeddingResponse>>(&body)? {
             ApiResponse::Ok(response) => Ok(response),
             ApiResponse::Err(err) => {
                 tracing::warn!(message = %err.error.message, "provider returned an error response");
-                Err(EmbeddingError::from_http_response(
-                    status,
-                    String::from_utf8_lossy(&body),
-                ))
+                Err(
+                    EmbeddingError::from_http_response(status, String::from_utf8_lossy(&body))
+                        .with_response_headers(Some(headers)),
+                )
             }
         }
     }

--- a/crates/rig-core/src/providers/gemini/embedding/tests.rs
+++ b/crates/rig-core/src/providers/gemini/embedding/tests.rs
@@ -74,7 +74,7 @@ async fn embedding_non_success_preserves_status_and_body() {
         .await
         .expect_err("should fail with non-success status");
 
-    assert!(matches!(error, EmbeddingError::HttpError(_)));
+    assert!(matches!(error, EmbeddingError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)

--- a/crates/rig-core/src/providers/gemini/image_generation.rs
+++ b/crates/rig-core/src/providers/gemini/image_generation.rs
@@ -7,11 +7,11 @@ use super::completion::gemini_api_types::{
 };
 use crate::completion::Usage;
 use crate::http_client::HttpClientExt;
+use crate::image_generation;
 use crate::image_generation::{
     ImageGenerationError, ImageGenerationRequest, NormalizeImageGenerationResponse,
 };
 use crate::wasm_compat::WasmCompatSend;
-use crate::{http_client, image_generation};
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
 use serde_json::Value;
@@ -78,20 +78,24 @@ where
             .body(body)
             .map_err(|e| ImageGenerationError::HttpError(e.into()))?;
 
-        let response = self.client.send(request).await?;
+        let response = self.client.send::<_, Vec<u8>>(request).await?;
 
-        let status = response.status();
-        let text = http_client::text(response).await?;
+        let (parts, body) = response.into_parts();
+        let status = parts.status;
+        let headers = Box::new(parts.headers);
+        let text = String::from(String::from_utf8_lossy(&body.await?));
 
         if !status.is_success() {
-            return Err(ImageGenerationError::from_http_response(status, text));
+            return Err(ImageGenerationError::from_http_response(status, text)
+                .with_response_headers(Some(headers)));
         }
 
         match serde_json::from_str::<ApiResponse<GenerateContentResponse>>(&text)? {
             ApiResponse::Ok(response) => Ok(response),
             ApiResponse::Err(err) => {
                 tracing::warn!(message = %err.error.message, "provider returned an error response");
-                Err(ImageGenerationError::from_http_response(status, text))
+                Err(ImageGenerationError::from_http_response(status, text)
+                    .with_response_headers(Some(headers)))
             }
         }
     }

--- a/crates/rig-core/src/providers/gemini/image_generation/tests.rs
+++ b/crates/rig-core/src/providers/gemini/image_generation/tests.rs
@@ -200,7 +200,7 @@ async fn image_generation_non_success_preserves_status_and_body() {
         .await
         .expect_err("should fail with non-success status");
 
-    assert!(matches!(error, ImageGenerationError::HttpError(_)));
+    assert!(matches!(error, ImageGenerationError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -128,6 +128,16 @@ where
         &self,
         completion_request: CompletionRequest,
     ) -> Result<Interaction, CompletionError> {
+        self.raw_completion_observed(completion_request, None).await
+    }
+
+    /// [`Self::raw_completion`] with observation context owned by this
+    /// invocation.
+    async fn raw_completion_observed(
+        &self,
+        completion_request: CompletionRequest,
+        observation: Option<crate::observe::AdapterContext>,
+    ) -> Result<Interaction, CompletionError> {
         let span = CompletionSpanBuilder::new(
             PROVIDER_NAME,
             &self.model,
@@ -148,11 +158,14 @@ where
         );
 
         let body = serde_json::to_vec(&request)?;
-        let request = self
+        let mut request = self
             .client
             .post("/v1beta/interactions")?
             .body(body)
             .map_err(|e| CompletionError::HttpError(e.into()))?;
+        if let Some(observation) = observation {
+            observation.attach(&mut request, "/v1beta/interactions");
+        }
 
         send_completion::<_, DirectPayload<Interaction>, _>(
             &self.client,
@@ -182,18 +195,36 @@ where
         &self,
         completion_request: CompletionRequest,
     ) -> Result<completion::CompletionResponse, CompletionError> {
-        // Capture before `try_into` consumes the raw value.
-        let raw = self.raw_completion(completion_request).await?;
-        let captured = serde_json::to_value(&raw)?;
-        let response: completion::CompletionResponse = raw.try_into()?;
-        Ok(response.with_raw(captured))
+        self.completion_with_context(completion_request, None).await
     }
 
     async fn stream(
         &self,
         request: CompletionRequest,
     ) -> Result<crate::streaming::StreamingCompletionResponse, CompletionError> {
-        InteractionsCompletionModel::stream(self, request).await
+        self.stream_with_context(request, None).await
+    }
+
+    async fn completion_with_context(
+        &self,
+        completion_request: CompletionRequest,
+        context: Option<crate::observe::AdapterContext>,
+    ) -> Result<completion::CompletionResponse, CompletionError> {
+        // Capture before `try_into` consumes the raw value.
+        let raw = self
+            .raw_completion_observed(completion_request, context)
+            .await?;
+        let captured = serde_json::to_value(&raw)?;
+        let response: completion::CompletionResponse = raw.try_into()?;
+        Ok(response.with_raw(captured))
+    }
+
+    async fn stream_with_context(
+        &self,
+        request: CompletionRequest,
+        context: Option<crate::observe::AdapterContext>,
+    ) -> Result<crate::streaming::StreamingCompletionResponse, CompletionError> {
+        InteractionsCompletionModel::stream_observed(self, request, context).await
     }
 }
 
@@ -395,12 +426,10 @@ where
     T: HttpClientExt + Clone + 'static,
 {
     let response = client.send::<_, Vec<u8>>(request).await?;
+    let (parts, body) = response.into_parts();
 
-    if response.status().is_success() {
-        let response_body = response
-            .into_body()
-            .await
-            .map_err(CompletionError::HttpError)?;
+    if parts.status.is_success() {
+        let response_body = body.await?;
 
         let response_text = String::from_utf8_lossy(&response_body).to_string();
 
@@ -415,16 +444,12 @@ where
 
         Ok(response)
     } else {
-        let status = response.status();
-        let body = response
-            .into_body()
-            .await
-            .map_err(CompletionError::HttpError)?;
+        let body = body.await?;
 
-        Err(CompletionError::from_http_response(
-            status,
-            String::from_utf8_lossy(&body),
-        ))
+        Err(
+            CompletionError::from_http_response(parts.status, String::from_utf8_lossy(&body))
+                .with_response_headers(Some(Box::new(parts.headers))),
+        )
     }
 }
 

--- a/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
@@ -94,9 +94,12 @@ impl<T> InteractionsCompletionModel<T>
 where
     T: HttpClientExt + Clone + 'static,
 {
-    pub(crate) async fn stream(
+    /// Open an interaction stream with observation context owned by this
+    /// invocation.
+    pub(crate) async fn stream_observed(
         &self,
         completion_request: CompletionRequest,
+        observation: Option<crate::observe::AdapterContext>,
     ) -> Result<streaming::StreamingCompletionResponse, CompletionError> {
         let span = CompletionSpanBuilder::new(
             PROVIDER_NAME,
@@ -118,12 +121,15 @@ where
         );
 
         let body = serde_json::to_vec(&request)?;
-        let req = self
+        let mut req = self
             .client
             .post("/v1beta/interactions?alt=sse")?
             .header("Content-Type", "application/json")
             .body(body)
             .map_err(|e| CompletionError::HttpError(e.into()))?;
+        if let Some(observation) = observation {
+            observation.attach(&mut req, "/v1beta/interactions");
+        }
 
         Ok(streaming::StreamingCompletionResponse::stream(
             PROVIDER_NAME,

--- a/crates/rig-core/src/providers/gemini/streaming/tests.rs
+++ b/crates/rig-core/src/providers/gemini/streaming/tests.rs
@@ -719,8 +719,9 @@ mod terminal_emission {
             .api_key("test-key")
             .http_client(SequencedStreamingHttpClient::new(vec![
                 Ok(sse(&[CONTENT_CHUNK])),
-                Err(crate::http_client::Error::InvalidStatusCodeWithMessage(
+                Err(crate::http_client::Error::non_success_with_details(
                     http::StatusCode::BAD_GATEWAY,
+                    http::HeaderMap::new(),
                     "connection reset".to_string(),
                 )),
             ]))

--- a/crates/rig-core/src/providers/gemini/transcription/tests.rs
+++ b/crates/rig-core/src/providers/gemini/transcription/tests.rs
@@ -33,7 +33,7 @@ async fn transcription_non_success_preserves_status_and_body() {
         .await
         .expect_err("should fail with non-success status");
 
-    assert!(matches!(error, TranscriptionError::HttpError(_)));
+    assert!(matches!(error, TranscriptionError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)

--- a/crates/rig-core/src/providers/groq/tests.rs
+++ b/crates/rig-core/src/providers/groq/tests.rs
@@ -303,7 +303,7 @@ async fn transcription_http_non_success_preserves_status_and_body() {
         panic!("transcription should fail with non-success status")
     };
 
-    assert!(matches!(error, TranscriptionError::HttpError(_)));
+    assert!(matches!(error, TranscriptionError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::BAD_REQUEST)

--- a/crates/rig-core/src/providers/huggingface/image_generation.rs
+++ b/crates/rig-core/src/providers/huggingface/image_generation.rs
@@ -84,18 +84,16 @@ where
             .map_err(|e| ImageGenerationError::HttpError(e.into()))?;
 
         let response = self.client.send(req).await?;
+        let (parts, body) = response.into_parts();
+        let data: Vec<u8> = body.await?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let text: Vec<u8> = response.into_body().await?;
-
+        if !parts.status.is_success() {
             return Err(ImageGenerationError::from_http_response(
-                status,
-                String::from_utf8_lossy(&text),
-            ));
+                parts.status,
+                String::from_utf8_lossy(&data),
+            )
+            .with_response_headers(Some(Box::new(parts.headers))));
         }
-
-        let data: Vec<u8> = response.into_body().await?;
 
         Ok(ImageGenerationResponse { data })
     }

--- a/crates/rig-core/src/providers/huggingface/image_generation/tests.rs
+++ b/crates/rig-core/src/providers/huggingface/image_generation/tests.rs
@@ -25,7 +25,7 @@ async fn image_generation_non_success_preserves_status_and_body() {
         .await
         .expect_err("should fail with non-success status");
 
-    assert!(matches!(error, ImageGenerationError::HttpError(_)));
+    assert!(matches!(error, ImageGenerationError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)

--- a/crates/rig-core/src/providers/huggingface/transcription/tests.rs
+++ b/crates/rig-core/src/providers/huggingface/transcription/tests.rs
@@ -23,7 +23,7 @@ async fn transcription_non_success_preserves_status_and_body() {
         .await
         .expect_err("should fail with non-success status");
 
-    assert!(matches!(error, TranscriptionError::HttpError(_)));
+    assert!(matches!(error, TranscriptionError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)

--- a/crates/rig-core/src/providers/hyperbolic.rs
+++ b/crates/rig-core/src/providers/hyperbolic.rs
@@ -349,14 +349,17 @@ mod audio_generation {
                 .map_err(http_client::Error::from)?;
 
             let response = self.client.send::<_, Bytes>(req).await?;
-            let status = response.status();
-            let response_body = response.into_body().into_future().await?.to_vec();
+            let (parts, body) = response.into_parts();
+            let status = parts.status;
+            let headers = Box::new(parts.headers);
+            let response_body = body.into_future().await?.to_vec();
 
             if !status.is_success() {
                 return Err(AudioGenerationError::from_http_response(
                     status,
                     String::from_utf8_lossy(&response_body),
-                ));
+                )
+                .with_response_headers(Some(headers)));
             }
 
             match serde_json::from_slice::<ApiResponse<AudioGenerationResponse>>(&response_body)? {
@@ -366,7 +369,8 @@ mod audio_generation {
                     Err(AudioGenerationError::from_http_response(
                         status,
                         String::from_utf8_lossy(&response_body),
-                    ))
+                    )
+                    .with_response_headers(Some(headers)))
                 }
             }
         }

--- a/crates/rig-core/src/providers/hyperbolic/tests.rs
+++ b/crates/rig-core/src/providers/hyperbolic/tests.rs
@@ -74,7 +74,7 @@ async fn completion_non_success_preserves_status_and_body() {
         .await
         .expect_err("completion should fail with non-success status");
 
-    assert!(matches!(error, CompletionError::HttpError(_)));
+    assert!(matches!(error, CompletionError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)
@@ -143,7 +143,7 @@ async fn image_generation_non_success_preserves_status_and_body() {
         .await
         .expect_err("image generation should fail with non-success status");
 
-    assert!(matches!(error, ImageGenerationError::HttpError(_)));
+    assert!(matches!(error, ImageGenerationError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)
@@ -221,7 +221,7 @@ async fn audio_generation_non_success_preserves_status_and_body() {
         .await
         .expect_err("audio generation should fail with non-success status");
 
-    assert!(matches!(error, AudioGenerationError::HttpError(_)));
+    assert!(matches!(error, AudioGenerationError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)

--- a/crates/rig-core/src/providers/internal/audio_generation.rs
+++ b/crates/rig-core/src/providers/internal/audio_generation.rs
@@ -177,8 +177,7 @@ where
     // (rig#2210).
     let (parts, body) = response.into_parts();
     let status = parts.status;
-    let provider_request_id =
-        super::transcription::request_id_from_headers(&parts.headers, request_id_header);
+    let provider_request_id = super::request_id_from_headers(&parts.headers, request_id_header);
     let bytes: Bytes = body.await?;
 
     if !status.is_success() {
@@ -186,6 +185,7 @@ where
             status,
             String::from_utf8_lossy(&bytes),
         )
+        .with_provider_request_id(provider_request_id)
         .with_response_headers(Some(Box::new(parts.headers))));
     }
 

--- a/crates/rig-core/src/providers/internal/completion_send.rs
+++ b/crates/rig-core/src/providers/internal/completion_send.rs
@@ -30,9 +30,10 @@ use crate::http_client::HttpClientExt;
 /// does not report one", never an error.
 ///
 /// Error paths, preserved exactly:
-/// - non-success status → `from_http_response(status, raw_body)`, with the
-///   failed response's headers attached so rate-limit metadata such as
-///   `Retry-After` stays readable (rig#2210);
+/// - non-success status → `from_http_response(status, raw_body)` with the
+///   provider's request id and the failed response's headers attached, so
+///   support's id and rate-limit metadata such as `Retry-After` stay
+///   readable (rig#2314, rig#2210);
 /// - 2xx error envelope → warn-log the provider message, preserve raw body;
 /// - undecodable 2xx body → error-log the body, surface the JSON error.
 pub(crate) async fn send_completion<C, A, F>(
@@ -89,57 +90,17 @@ where
             }
         }) {
             Ok(response) => response,
-            // The reqwest transport reports a non-success status as an error with
-            // the failed response's headers preserved. A provider with a
-            // request-id contract reads its header off them so the failed call's
-            // transport id — the one support asks for — survives onto the error
-            // (rig#2314); classification then follows the contract, so a given
-            // provider's errors stay one shape. Either way the whole header map
-            // rides along, so a caller can still read `Retry-After` off a 429
-            // (rig#2210).
-            Err(crate::http_client::Error::InvalidStatusCodeWithDetails {
-                status,
-                body,
-                headers,
-            }) => {
-                return Err(match request_id_header {
-                    Some(header) => {
-                        let provider_request_id = headers
-                            .get(header)
-                            .and_then(|value| value.to_str().ok())
-                            .filter(|value| !value.is_empty())
-                            .map(str::to_string);
-                        CompletionError::from_http_response_with_request_id(
-                            status,
-                            body,
-                            provider_request_id,
-                        )
-                        .with_response_headers(Some(headers))
-                    }
-                    // Contract-less providers keep the pre-#2314 transport shape;
-                    // the details variant is that shape plus the headers, and
-                    // displays identically.
-                    None => CompletionError::HttpError(
-                        crate::http_client::Error::InvalidStatusCodeWithDetails {
-                            status,
-                            body,
-                            headers,
-                        },
-                    ),
-                });
+            // A transport that reports the non-success reply as an error: the
+            // reply is the provider's, so it funnels to ProviderResponse with
+            // the id read off its headers (rig#2314) and the headers themselves
+            // (rig#2210); a response-less failure stays a transport error.
+            Err(error) => {
+                let provider_request_id = error
+                    .non_success_headers()
+                    .and_then(|headers| super::request_id_from_headers(headers, request_id_header));
+                return Err(CompletionError::from_transport_error(error)
+                    .with_provider_request_id(provider_request_id));
             }
-            // A transport that reports non-success without preserved headers (a
-            // custom `HttpClientExt`): a contract provider still classifies as
-            // ProviderResponse — the shape follows the contract on every
-            // transport — with no id to read.
-            Err(crate::http_client::Error::InvalidStatusCodeWithMessage(status, body))
-                if request_id_header.is_some() =>
-            {
-                return Err(CompletionError::from_http_response_with_request_id(
-                    status, body, None,
-                ));
-            }
-            Err(other) => return Err(other.into()),
         };
 
         // Take the response apart before awaiting the body: that hands over the
@@ -167,19 +128,11 @@ where
         }
 
         if !status.is_success() {
-            // A provider with a request-id contract routes through the
-            // metadata-aware funnel so the failed call's transport id — the one
-            // support asks for — survives onto the error (rig#2314).
-            // Classification follows the contract, not the header's presence on
-            // a particular response, so a given provider's errors stay one shape.
-            return Err(match request_id_header {
-                Some(_) => CompletionError::from_http_response_with_request_id(
-                    status,
-                    String::from_utf8_lossy(&body),
-                    provider_request_id,
-                ),
-                None => CompletionError::from_http_response(status, String::from_utf8_lossy(&body)),
-            }
+            return Err(CompletionError::from_http_response(
+                status,
+                String::from_utf8_lossy(&body),
+            )
+            .with_provider_request_id(provider_request_id)
             .with_response_headers(response_headers));
         }
 
@@ -204,21 +157,14 @@ where
             }
             Err(message) => {
                 tracing::warn!(message = %message, "provider returned an error response");
-                // A 2xx error envelope preserves as ProviderResponse either way;
-                // the metadata-aware funnel just adds the captured id. Its headers
-                // matter as much as a non-success response's: gateways report rate
-                // limits this way, with `Retry-After` alongside a 200 (rig#2210).
-                Err(match request_id_header {
-                    Some(_) => CompletionError::from_http_response_with_request_id(
-                        status,
-                        String::from_utf8_lossy(&body),
-                        provider_request_id,
-                    ),
-                    None => {
-                        CompletionError::from_http_response(status, String::from_utf8_lossy(&body))
-                    }
-                }
-                .with_response_headers(response_headers))
+                // A 2xx error envelope's headers matter as much as a
+                // non-success response's: gateways report rate limits this
+                // way, with `Retry-After` alongside a 200 (rig#2210).
+                Err(
+                    CompletionError::from_http_response(status, String::from_utf8_lossy(&body))
+                        .with_provider_request_id(provider_request_id)
+                        .with_response_headers(response_headers),
+                )
             }
         }
     }

--- a/crates/rig-core/src/providers/internal/completion_send/header_preservation_tests.rs
+++ b/crates/rig-core/src/providers/internal/completion_send/header_preservation_tests.rs
@@ -149,16 +149,21 @@ async fn non_success_response_preserves_headers_for_a_contract_less_provider() {
     assert!(matches!(error, CompletionError::ProviderResponse(_)));
 }
 
-/// A transport that reports non-success *without* headers classifies the
-/// same, reporting `None` rather than an empty map — "not captured" must
-/// stay distinguishable from "the response had none".
+/// A rejection whose reply carried no rate-limit headers classifies the
+/// same and reports the empty map it captured, never `None`: every reply
+/// a transport rejects comes with its headers, so `None` is reserved for
+/// a failure with no reply at all.
 #[tokio::test]
-async fn header_less_transport_reports_no_headers() {
+async fn header_less_rejection_reports_an_empty_map() {
     for contract in [CONTRACT, NO_CONTRACT] {
         let client = RecordingHttpClient::with_error(http::StatusCode::TOO_MANY_REQUESTS, BODY);
         let error = drive(client, contract).await;
 
-        assert!(error.provider_response_headers().is_none());
+        assert!(
+            error
+                .provider_response_headers()
+                .is_some_and(http::HeaderMap::is_empty)
+        );
         assert!(
             matches!(error, CompletionError::ProviderResponse(_)),
             "classification must not depend on header capture",

--- a/crates/rig-core/src/providers/internal/completion_send/header_preservation_tests.rs
+++ b/crates/rig-core/src/providers/internal/completion_send/header_preservation_tests.rs
@@ -117,8 +117,8 @@ async fn transport_error_preserves_headers_for_a_contract_less_provider() {
     let error = drive(client, NO_CONTRACT).await;
 
     assert_rate_limit_metadata_survived(&error, "transport-error/contract-less");
-    // Contract-less providers keep the transport classification.
-    assert!(matches!(error, CompletionError::HttpError(_)));
+    // The reply is the provider's whether or not it names a request id.
+    assert!(matches!(error, CompletionError::ProviderResponse(_)));
     assert_eq!(error.provider_request_id(), None);
 }
 
@@ -146,22 +146,21 @@ async fn non_success_response_preserves_headers_for_a_contract_less_provider() {
     let error = drive(client, NO_CONTRACT).await;
 
     assert_rate_limit_metadata_survived(&error, "response/contract-less");
-    assert!(matches!(error, CompletionError::HttpError(_)));
+    assert!(matches!(error, CompletionError::ProviderResponse(_)));
 }
 
-/// A transport that reports non-success *without* headers still classifies
-/// exactly as before, reporting `None` rather than an empty map — "not
-/// captured" must stay distinguishable from "the response had none".
+/// A transport that reports non-success *without* headers classifies the
+/// same, reporting `None` rather than an empty map — "not captured" must
+/// stay distinguishable from "the response had none".
 #[tokio::test]
 async fn header_less_transport_reports_no_headers() {
-    for (contract, expect_provider_response) in [(CONTRACT, true), (NO_CONTRACT, false)] {
+    for contract in [CONTRACT, NO_CONTRACT] {
         let client = RecordingHttpClient::with_error(http::StatusCode::TOO_MANY_REQUESTS, BODY);
         let error = drive(client, contract).await;
 
         assert!(error.provider_response_headers().is_none());
-        assert_eq!(
+        assert!(
             matches!(error, CompletionError::ProviderResponse(_)),
-            expect_provider_response,
             "classification must not depend on header capture",
         );
         assert_eq!(error.provider_response_body(), Some(BODY));

--- a/crates/rig-core/src/providers/internal/image_generation.rs
+++ b/crates/rig-core/src/providers/internal/image_generation.rs
@@ -185,8 +185,7 @@ where
     // path (rig#2210).
     let (parts, body) = response.into_parts();
     let status = parts.status;
-    let provider_request_id =
-        super::transcription::request_id_from_headers(&parts.headers, request_id_header);
+    let provider_request_id = super::request_id_from_headers(&parts.headers, request_id_header);
     let headers = Box::new(parts.headers);
     let response_body = body.into_future().await?;
 
@@ -195,6 +194,7 @@ where
             status,
             String::from_utf8_lossy(&response_body).into_owned(),
         )
+        .with_provider_request_id(provider_request_id)
         .with_response_headers(Some(headers)));
     }
 
@@ -206,6 +206,7 @@ where
                 status,
                 String::from_utf8_lossy(&response_body).into_owned(),
             )
+            .with_provider_request_id(provider_request_id)
             .with_response_headers(Some(headers)))
         }
     }

--- a/crates/rig-core/src/providers/internal/mod.rs
+++ b/crates/rig-core/src/providers/internal/mod.rs
@@ -168,3 +168,19 @@ mod tests;
 
 #[cfg(test)]
 mod tool_call_id_tests;
+
+/// Reads the provider's transport request id off a response's headers, when
+/// the provider names such a header and the response carries a non-empty
+/// value. `None` is the documented "not reported" outcome.
+pub(crate) fn request_id_from_headers(
+    headers: &http::HeaderMap,
+    request_id_header: Option<&str>,
+) -> Option<String> {
+    request_id_header.and_then(|header| {
+        headers
+            .get(header)
+            .and_then(|value| value.to_str().ok())
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    })
+}

--- a/crates/rig-core/src/providers/internal/model_listing.rs
+++ b/crates/rig-core/src/providers/internal/model_listing.rs
@@ -91,11 +91,10 @@ macro_rules! impl_model_lister {
 }
 pub(crate) use impl_model_lister;
 
-/// Map a transport-level send error into listing-flavored context: an
-/// [`http_client::Error::InvalidStatusCodeWithMessage`] (backends that reject
-/// non-2xx before handing back a response) keeps the provider label, path,
-/// status, and body preview, exactly like a non-2xx status on a returned
-/// response. Shared with listings that build their own request (copilot's
+/// Map a transport-level send error into listing-flavored context: a
+/// non-success reply the transport reported as an error keeps the provider
+/// label, path, status, and body preview, exactly like a non-2xx status on
+/// a returned response. Shared with listings that build their own request (copilot's
 /// auth-derived base URL cannot go through [`get_json`]).
 pub(crate) fn map_transport_error(
     provider_name: &str,
@@ -103,17 +102,8 @@ pub(crate) fn map_transport_error(
     error: http_client::Error,
 ) -> ModelListingError {
     match error {
-        http_client::Error::InvalidStatusCodeWithMessage(status, message) => {
-            ModelListingError::api_error_with_context(
-                provider_name,
-                path,
-                status.as_u16(),
-                message.as_bytes(),
-            )
-        }
-        // The reqwest transport reports non-success with preserved headers
-        // (rig#2314); listings have no request-id contract, so only the
-        // status and body matter here.
+        // Listings have no request-id contract, so only the status and body
+        // matter here.
         http_client::Error::InvalidStatusCodeWithDetails { status, body, .. } => {
             ModelListingError::api_error_with_context(
                 provider_name,
@@ -129,10 +119,9 @@ pub(crate) fn map_transport_error(
 /// GET `path` and decode the response body as `T`, with listing-flavored
 /// error context.
 ///
-/// Error triage is standardized on the most informative behavior: an
-/// [`http_client::Error::InvalidStatusCodeWithMessage`] surfaced by the
-/// transport (backends that reject non-2xx before handing back a response)
-/// is mapped into [`ModelListingError::api_error_with_context`] so the
+/// Error triage is standardized on the most informative behavior: a
+/// non-success reply surfaced by the transport as an error (backends that
+/// reject non-2xx before handing back a response) is mapped into [`ModelListingError::api_error_with_context`] so the
 /// provider label, path, status, and body preview survive, exactly like a
 /// non-2xx status on a returned response.
 pub(crate) async fn get_json<T, Ext, H>(

--- a/crates/rig-core/src/providers/internal/model_listing/transport_error_tests.rs
+++ b/crates/rig-core/src/providers/internal/model_listing/transport_error_tests.rs
@@ -18,8 +18,9 @@ fn details_variant_maps_to_api_error_with_context() {
     let with_message = map_transport_error(
         "test-provider",
         "/models",
-        http_client::Error::InvalidStatusCodeWithMessage(
+        http_client::Error::non_success_with_details(
             http::StatusCode::UNAUTHORIZED,
+            http::HeaderMap::new(),
             r#"{"error":"no"}"#.to_string(),
         ),
     );

--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible/tests.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible/tests.rs
@@ -470,7 +470,7 @@ async fn streaming_http_non_success_preserves_status_and_body() {
     assert_eq!(
         err.to_string(),
         format!(
-            "HttpError: Invalid status code {} with message: {}",
+            "ProviderResponseError: status {}: {}",
             http::StatusCode::TOO_MANY_REQUESTS,
             body
         )
@@ -642,7 +642,7 @@ async fn streaming_http_non_success_json_parse_error_is_visible() {
 }
 
 #[tokio::test]
-async fn streaming_non_http_transport_error_stays_provider_error() {
+async fn streaming_non_http_transport_error_stays_a_transport_error() {
     use crate::test_utils::SequencedStreamingHttpClient;
 
     use crate::providers::openai::send_compatible_streaming_request;
@@ -668,10 +668,10 @@ async fn streaming_non_http_transport_error_stays_provider_error() {
     };
     assert_eq!(
         err.to_string(),
-        "ProviderError: Invalid content type was returned: \"application/json\""
+        "HttpError: Invalid content type was returned: \"application/json\""
     );
-    assert_eq!(err.kind, ErrorKind::Provider);
-    // Rig-generated transport diagnostics are not provider response bodies.
+    assert_eq!(err.kind, ErrorKind::Http { status: None });
+    // A response-less transport failure has no provider response body.
     assert_eq!(err.provider_response_body(), None);
     assert_eq!(err.http_status, None);
 }

--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible/tests.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible/tests.rs
@@ -564,8 +564,9 @@ async fn streaming_mid_stream_http_non_success_preserves_status_and_body() {
         Ok(sse_bytes_from_data_lines([
             "{\"choices\":[{\"delta\":{\"content\":\"partial\",\"tool_calls\":[]}}],\"usage\":null}",
         ])),
-        Err(http_client::Error::InvalidStatusCodeWithMessage(
+        Err(http_client::Error::non_success_with_details(
             http::StatusCode::BAD_GATEWAY,
+            http::HeaderMap::new(),
             body.to_string(),
         )),
     ];
@@ -670,7 +671,7 @@ async fn streaming_non_http_transport_error_stays_a_transport_error() {
         err.to_string(),
         "HttpError: Invalid content type was returned: \"application/json\""
     );
-    assert_eq!(err.kind, ErrorKind::Http { status: None });
+    assert_eq!(err.kind, ErrorKind::Http);
     // A response-less transport failure has no provider response body.
     assert_eq!(err.provider_response_body(), None);
     assert_eq!(err.http_status, None);
@@ -852,8 +853,9 @@ async fn transport_error_still_flushes_fully_delivered_tool_calls() {
         Ok(sse_bytes_from_data_lines([
             "{\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_123\",\"function\":{\"name\":\"ping\",\"arguments\":\"{\\\"x\\\":1}\"}}]}}],\"usage\":null}",
         ])),
-        Err(http_client::Error::InvalidStatusCodeWithMessage(
+        Err(http_client::Error::non_success_with_details(
             http::StatusCode::BAD_GATEWAY,
+            http::HeaderMap::new(),
             r#"{"error":{"message":"upstream unavailable"}}"#.to_string(),
         )),
     ];

--- a/crates/rig-core/src/providers/internal/rerank.rs
+++ b/crates/rig-core/src/providers/internal/rerank.rs
@@ -187,13 +187,14 @@ where
         let (parts, body) = response.into_parts();
         let status = parts.status;
         let provider_request_id =
-            super::transcription::request_id_from_headers(&parts.headers, Ext::REQUEST_ID_HEADER);
+            super::request_id_from_headers(&parts.headers, Ext::REQUEST_ID_HEADER);
         let response_body: Vec<u8> = body.await?;
         if !status.is_success() {
             return Err(RerankError::from_http_response(
                 status,
                 String::from_utf8_lossy(&response_body).into_owned(),
             )
+            .with_provider_request_id(provider_request_id)
             .with_response_headers(Some(Box::new(parts.headers))));
         }
 

--- a/crates/rig-core/src/providers/internal/sse_transport.rs
+++ b/crates/rig-core/src/providers/internal/sse_transport.rs
@@ -163,46 +163,22 @@ pub(crate) fn stamp_terminal_request_id(
                     _ => response,
                 }))
             }
-            // A mid-stream in-band provider error envelope (yielded as an
-            // error item) also came over this connection: attach the same
-            // connection's transport id so a failed stream reports the id
-            // support asks for (rig#2314). Only the ProviderResponse variant
-            // has a slot for it; transport-level failures stay untouched.
-            // A failed SSE handshake (connect-time non-success) surfaces as
-            // a details-preserving transport error; this helper is installed
-            // exactly by providers with a request-id contract, so classify it
-            // like the unary driver would — ProviderResponse with the failed
-            // response's own id (rig#2314 follow-up: the streaming 4xx now
-            // matches its blocking twin instead of losing body and id).
-            Err(crate::completion::CompletionError::HttpError(
-                crate::http_client::Error::InvalidStatusCodeWithDetails {
-                    status,
-                    body,
-                    headers,
-                },
-            )) if request_id_header.is_some() => {
-                let provider_request_id = request_id_header
-                    .and_then(|header| headers.get(header))
-                    .and_then(|value| value.to_str().ok())
-                    .filter(|value| !value.is_empty())
-                    .map(str::to_string);
-                Err(
-                    crate::completion::CompletionError::from_http_response_with_request_id(
-                        status,
-                        body,
-                        provider_request_id,
-                    )
-                    // The handshake's headers ride along too, so a streamed
-                    // 429 exposes `Retry-After` exactly like its blocking
-                    // twin (rig#2210).
-                    .with_response_headers(Some(headers)),
-                )
-            }
+            // A failed SSE handshake (connect-time non-success) is the
+            // provider's reply: `from_transport_error` already classified it
+            // as ProviderResponse with the handshake's headers (rig#2210);
+            // stamp the id read off those headers, like the unary driver
+            // (rig#2314). An in-band envelope yielded as an error item came
+            // over the same connection and takes the slot's id below.
             Err(crate::completion::CompletionError::ProviderResponse(response)) => {
                 // Never clear an id an upstream constructor already attached;
-                // the slot only fills the gap.
+                // the slot only fills the gap, and a handshake rejection's own
+                // headers fill it before the slot does.
+                let from_headers = response
+                    .headers
+                    .as_deref()
+                    .and_then(|headers| super::request_id_from_headers(headers, request_id_header));
                 let stamped = if response.provider_request_id.is_none() {
-                    response.with_provider_request_id(request_id)
+                    response.with_provider_request_id(from_headers.or(request_id))
                 } else {
                     response
                 };

--- a/crates/rig-core/src/providers/internal/sse_transport/request_id_stamp_tests.rs
+++ b/crates/rig-core/src/providers/internal/sse_transport/request_id_stamp_tests.rs
@@ -41,19 +41,21 @@ async fn stamps_provider_response_stream_errors_from_the_slot() {
     }
 }
 
-/// rig#2315 follow-up: a failed SSE handshake (details-preserving
-/// transport error) classifies like the unary driver for contract
-/// providers — ProviderResponse carrying the failed response's own id.
+/// rig#2315 follow-up: a failed SSE handshake arrives through the one
+/// funnel as a ProviderResponse with the handshake's headers; the stamp
+/// reads the failed response's own id off them.
 #[tokio::test]
 async fn handshake_details_error_classifies_with_contract() {
     let mut headers = http::HeaderMap::new();
     headers.insert("x-request-id", "req_handshake".parse().expect("value"));
     let stream: crate::streaming::StreamingResult = Box::pin(futures::stream::iter(vec![Err(
-        CompletionError::HttpError(crate::http_client::Error::InvalidStatusCodeWithDetails {
-            status: http::StatusCode::NOT_FOUND,
-            body: r#"{"error":"no model"}"#.to_string(),
-            headers: Box::new(headers),
-        }),
+        CompletionError::from_transport_error(
+            crate::http_client::Error::InvalidStatusCodeWithDetails {
+                status: http::StatusCode::NOT_FOUND,
+                body: r#"{"error":"no model"}"#.to_string(),
+                headers: Box::new(headers),
+            },
+        ),
     )]));
 
     let stamped = stamp_terminal_request_id(
@@ -86,11 +88,13 @@ async fn handshake_details_error_preserves_rate_limit_headers() {
     headers.insert("retry-after", "20".parse().expect("value"));
     headers.insert("x-ratelimit-remaining", "0".parse().expect("value"));
     let stream: crate::streaming::StreamingResult = Box::pin(futures::stream::iter(vec![Err(
-        CompletionError::HttpError(crate::http_client::Error::InvalidStatusCodeWithDetails {
-            status: http::StatusCode::TOO_MANY_REQUESTS,
-            body: r#"{"error":"slow down"}"#.to_string(),
-            headers: Box::new(headers),
-        }),
+        CompletionError::from_transport_error(
+            crate::http_client::Error::InvalidStatusCodeWithDetails {
+                status: http::StatusCode::TOO_MANY_REQUESTS,
+                body: r#"{"error":"slow down"}"#.to_string(),
+                headers: Box::new(headers),
+            },
+        ),
     )]));
 
     let stamped = stamp_terminal_request_id(

--- a/crates/rig-core/src/providers/internal/sse_transport/tests.rs
+++ b/crates/rig-core/src/providers/internal/sse_transport/tests.rs
@@ -28,8 +28,10 @@ impl http_client::HttpClientExt for ChunkedStreamingClient {
         T: Into<Bytes> + WasmCompatSend,
         U: From<Bytes> + WasmCompatSend + 'static,
     {
-        future::ready(Err(http_client::Error::InvalidStatusCode(
+        future::ready(Err(http_client::Error::non_success_with_details(
             http::StatusCode::NOT_IMPLEMENTED,
+            http::HeaderMap::new(),
+            String::new(),
         )))
     }
 
@@ -42,8 +44,10 @@ impl http_client::HttpClientExt for ChunkedStreamingClient {
     where
         U: From<Bytes> + WasmCompatSend + 'static,
     {
-        future::ready(Err(http_client::Error::InvalidStatusCode(
+        future::ready(Err(http_client::Error::non_success_with_details(
             http::StatusCode::NOT_IMPLEMENTED,
+            http::HeaderMap::new(),
+            String::new(),
         )))
     }
 

--- a/crates/rig-core/src/providers/internal/transcription.rs
+++ b/crates/rig-core/src/providers/internal/transcription.rs
@@ -245,7 +245,7 @@ where
     // path (rig#2210).
     let (parts, body) = response.into_parts();
     let status = parts.status;
-    let provider_request_id = request_id_from_headers(&parts.headers, request_id_header);
+    let provider_request_id = super::request_id_from_headers(&parts.headers, request_id_header);
     let headers = Box::new(parts.headers);
     let response_body = body.into_future().await?;
 
@@ -258,6 +258,7 @@ where
                     status,
                     String::from_utf8_lossy(&response_body).into_owned(),
                 )
+                .with_provider_request_id(provider_request_id)
                 .with_response_headers(Some(headers)))
             }
         }
@@ -266,24 +267,9 @@ where
             status,
             String::from_utf8_lossy(&response_body).into_owned(),
         )
+        .with_provider_request_id(provider_request_id)
         .with_response_headers(Some(headers)))
     }
-}
-
-/// Reads the provider's transport request id off a response's headers, when
-/// the provider names such a header and the response carries a non-empty
-/// value. `None` is the documented "not reported" outcome.
-pub(crate) fn request_id_from_headers(
-    headers: &http::HeaderMap,
-    request_id_header: Option<&str>,
-) -> Option<String> {
-    request_id_header.and_then(|header| {
-        headers
-            .get(header)
-            .and_then(|value| value.to_str().ok())
-            .filter(|value| !value.is_empty())
-            .map(str::to_string)
-    })
 }
 
 /// Sends a JSON-bodied transcription request and splits the response on
@@ -314,7 +300,7 @@ where
     let response = client.send::<_, Vec<u8>>(req).await?;
     let (parts, body) = response.into_parts();
     let status = parts.status;
-    let provider_request_id = request_id_from_headers(&parts.headers, request_id_header);
+    let provider_request_id = super::request_id_from_headers(&parts.headers, request_id_header);
     let headers = Box::new(parts.headers);
     let body = body.await?;
 
@@ -325,6 +311,7 @@ where
             status,
             String::from_utf8_lossy(&body).into_owned(),
         )
+        .with_provider_request_id(provider_request_id)
         .with_response_headers(Some(headers)))
     }
 }

--- a/crates/rig-core/src/providers/mira/tests.rs
+++ b/crates/rig-core/src/providers/mira/tests.rs
@@ -140,7 +140,7 @@ async fn completion_non_success_preserves_status_and_body() {
         .await
         .expect_err("should fail with non-success status");
 
-    assert!(matches!(error, CompletionError::HttpError(_)));
+    assert!(matches!(error, CompletionError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)

--- a/crates/rig-core/src/providers/mistral/transcription.rs
+++ b/crates/rig-core/src/providers/mistral/transcription.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::completion::Usage;
 use crate::http_client::HttpClientExt;
-use crate::providers::internal::transcription::request_id_from_headers;
+use crate::providers::internal::request_id_from_headers;
 use crate::providers::internal::transcription::{TranscriptionFields, transcription_form};
 use crate::transcription::{self, NormalizeTranscriptionResponse, TranscriptionError};
 use crate::wasm_compat::WasmCompatSend;
@@ -143,11 +143,7 @@ where
             .body(body)
             .map_err(|e| TranscriptionError::RequestError(e.into()))?;
 
-        let response = self
-            .client
-            .send_multipart::<Bytes>(req)
-            .await
-            .map_err(TranscriptionError::HttpError)?;
+        let response = self.client.send_multipart::<Bytes>(req).await?;
 
         let (parts, body) = response.into_parts();
         let status = parts.status;
@@ -169,6 +165,7 @@ where
                 status,
                 String::from_utf8_lossy(&response_bytes),
             )
+            .with_provider_request_id(provider_request_id)
             .with_response_headers(Some(Box::new(parts.headers))))
         }
     }

--- a/crates/rig-core/src/providers/mistral/transcription/test.rs
+++ b/crates/rig-core/src/providers/mistral/transcription/test.rs
@@ -116,7 +116,7 @@ async fn transcription_non_success_preserves_status_and_body() {
         panic!("transcription should fail with non-success status")
     };
 
-    assert!(matches!(error, TranscriptionError::HttpError(_)));
+    assert!(matches!(error, TranscriptionError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -311,13 +311,17 @@ where
 
         let response = self.client.send::<_, Vec<u8>>(req).await?;
 
-        let status = response.status();
+        let (parts, body) = response.into_parts();
+        let status = parts.status;
+        let bytes: Vec<u8> = body.await?;
         if !status.is_success() {
-            let text = http_client::text(response).await?;
-            return Err(EmbeddingError::from_http_response(status, text));
+            return Err(EmbeddingError::from_http_response(
+                status,
+                String::from_utf8_lossy(&bytes),
+            )
+            .with_response_headers(Some(Box::new(parts.headers))));
         }
 
-        let bytes: Vec<u8> = response.into_body().await?;
         let api_resp: EmbeddingResponse = serde_json::from_slice(&bytes)?;
         Ok(api_resp)
     }
@@ -785,6 +789,16 @@ where
         &self,
         completion_request: CompletionRequest,
     ) -> Result<CompletionResponse, CompletionError> {
+        self.raw_completion_observed(completion_request, None).await
+    }
+
+    /// [`Self::raw_completion`] with observation context owned by this
+    /// invocation.
+    async fn raw_completion_observed(
+        &self,
+        completion_request: CompletionRequest,
+        observation: Option<crate::observe::AdapterContext>,
+    ) -> Result<CompletionResponse, CompletionError> {
         let system_instructions = completion_request.system_instructions().map(str::to_owned);
         let record_telemetry_content = completion_request.record_telemetry_content;
         let request = OllamaCompletionRequest::try_from((self.model.as_ref(), completion_request))?;
@@ -801,11 +815,14 @@ where
 
         let body = serde_json::to_vec(&request)?;
 
-        let req = self
+        let mut req = self
             .client
             .post("api/chat")?
             .body(body)
             .map_err(http_client::Error::from)?;
+        if let Some(observation) = observation {
+            observation.attach(&mut req, "/api/chat");
+        }
 
         let async_block = internal::completion_send::send_completion::<
             _,
@@ -969,16 +986,34 @@ where
         &self,
         completion_request: CompletionRequest,
     ) -> Result<completion::CompletionResponse, CompletionError> {
-        // Capture before `try_into` consumes the raw value.
-        let raw = self.raw_completion(completion_request).await?;
-        let captured = serde_json::to_value(&raw)?;
-        let response: completion::CompletionResponse = raw.try_into()?;
-        Ok(response.with_raw(captured))
+        self.completion_with_context(completion_request, None).await
     }
 
     async fn stream(
         &self,
         request: CompletionRequest,
+    ) -> Result<streaming::StreamingCompletionResponse, CompletionError> {
+        self.stream_with_context(request, None).await
+    }
+
+    async fn completion_with_context(
+        &self,
+        completion_request: CompletionRequest,
+        context: Option<crate::observe::AdapterContext>,
+    ) -> Result<completion::CompletionResponse, CompletionError> {
+        // Capture before `try_into` consumes the raw value.
+        let raw = self
+            .raw_completion_observed(completion_request, context)
+            .await?;
+        let captured = serde_json::to_value(&raw)?;
+        let response: completion::CompletionResponse = raw.try_into()?;
+        Ok(response.with_raw(captured))
+    }
+
+    async fn stream_with_context(
+        &self,
+        request: CompletionRequest,
+        observation: Option<crate::observe::AdapterContext>,
     ) -> Result<streaming::StreamingCompletionResponse, CompletionError> {
         let system_instructions = request.system_instructions().map(str::to_owned);
         let record_telemetry_content = request.record_telemetry_content;
@@ -1000,19 +1035,45 @@ where
 
         let body = serde_json::to_vec(&request)?;
 
-        let req = self
+        let mut req = self
             .client
             .post("api/chat")?
             .body(body)
             .map_err(http_client::Error::from)?;
+        if let Some(observation) = observation {
+            observation.attach(&mut req, "/api/chat");
+        }
+        // This wire is NDJSON over a plain streaming response, not SSE, so
+        // the transport boundary is observed here rather than by the shared
+        // event source: the request, the response, each frame's bytes, and
+        // the closure the frame driver records. No payload projector is
+        // attached yet, and the SSE slot's frame tail is not fed, so EOF
+        // after a partial final line reports `Eof`, not `PartialFrame`.
+        let observation = crate::observe::AdapterContext::slot_for_request(&req);
+        if let Some(observation) = &observation {
+            observation.start(&req);
+        }
 
-        let response = self
+        let response = match self
             .client
             .send_streaming(req)
             .instrument(span.clone())
-            .await?;
-        let status = response.status();
-        let mut byte_stream = response.into_body();
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                let error = CompletionError::from_transport_error(error);
+                if let Some(observation) = &observation {
+                    observation.fail(&error);
+                }
+                return Err(error);
+            }
+        };
+        let (parts, mut byte_stream) = response.into_parts();
+        let status = parts.status;
+        if let Some(observation) = &observation {
+            observation.response_with_headers(status, Some(&parts.headers));
+        }
 
         if !status.is_success() {
             let mut body = Vec::new();
@@ -1025,15 +1086,19 @@ where
                     }
                 }
             }
-            return Err(CompletionError::from_http_response(
-                status,
-                String::from_utf8_lossy(&body),
-            ));
+            let error = CompletionError::from_http_response(status, String::from_utf8_lossy(&body))
+                .with_response_headers(Some(Box::new(parts.headers)));
+            if let Some(observation) = &observation {
+                observation.payload(&body);
+                observation.fail(&error);
+            }
+            return Err(error);
         }
 
         // Transport layer: HTTP byte chunks → NDJSON-line `WireFrame`s. Byte
         // splitting and framing only — classification and policy live
         // downstream.
+        let frame_observation = observation.clone();
         let transport = stream! {
             let mut line_buf = NdjsonBuffer::new();
             while let Some(chunk) = byte_stream.next().await {
@@ -1047,14 +1112,21 @@ where
 
                 for line in line_buf.decode(&bytes) {
                     tracing::debug!(target: "rig", "Received NDJSON line from Ollama: {}", String::from_utf8_lossy(&line));
+                    if let Some(observation) = &frame_observation {
+                        observation.payload(&line);
+                    }
                     yield Ok(internal::adapter::WireFrame::Bytes(line));
                 }
             }
         };
 
         let stream: streaming::StreamingResult = Box::pin(
-            internal::adapter::run_wire_stream(transport, OllamaAdapter::default())
-                .instrument(span),
+            internal::adapter::run_wire_stream_observed(
+                transport,
+                OllamaAdapter::default(),
+                observation,
+            )
+            .instrument(span),
         );
 
         Ok(streaming::StreamingCompletionResponse::stream(

--- a/crates/rig-core/src/providers/ollama/tests.rs
+++ b/crates/rig-core/src/providers/ollama/tests.rs
@@ -1511,7 +1511,7 @@ async fn completion_non_success_preserves_status_and_body() {
         .await
         .expect_err("should fail with non-success status");
 
-    assert!(matches!(error, CompletionError::HttpError(_)));
+    assert!(matches!(error, CompletionError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)
@@ -1543,7 +1543,7 @@ async fn embeddings_non_success_preserves_status_and_body() {
         .await
         .expect_err("should fail with non-success status");
 
-    assert!(matches!(error, EmbeddingError::HttpError(_)));
+    assert!(matches!(error, EmbeddingError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)

--- a/crates/rig-core/src/providers/openai/audio_generation/tests.rs
+++ b/crates/rig-core/src/providers/openai/audio_generation/tests.rs
@@ -27,7 +27,7 @@ async fn audio_generation_non_success_preserves_status_and_body() {
         .await
         .expect_err("should fail with non-success status");
 
-    assert!(matches!(error, AudioGenerationError::HttpError(_)));
+    assert!(matches!(error, AudioGenerationError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -2456,6 +2456,16 @@ where
         &self,
         completion_request: CoreCompletionRequest,
     ) -> Result<(Ext::Response, Option<String>), CompletionError> {
+        self.raw_completion_observed(completion_request, None).await
+    }
+
+    /// [`Self::raw_completion_with_request_id`] with observation context owned
+    /// by this invocation.
+    async fn raw_completion_observed(
+        &self,
+        completion_request: CoreCompletionRequest,
+        observation: Option<crate::observe::AdapterContext>,
+    ) -> Result<(Ext::Response, Option<String>), CompletionError> {
         let system_instructions = completion_request.system_instructions().map(str::to_owned);
         let record_telemetry_content = completion_request.record_telemetry_content;
         let options = CompletionModelOptions {
@@ -2493,11 +2503,18 @@ where
         // Azure's deployment URL is pinned to the model handle.
         let path = self.client.provider().completion_path(&self.model);
 
-        let req = self
+        let mut req = self
             .client
             .post(&path)?
             .body(body)
             .map_err(|e| CompletionError::HttpError(e.into()))?;
+        if let Some(observation) = observation {
+            crate::providers::openai::observation::attach_chat(
+                observation,
+                &mut req,
+                "/chat/completions",
+            );
+        }
 
         send_completion::<_, ApiResponse<Ext::Response>, _>(
             &self.client,
@@ -2548,9 +2565,24 @@ where
         &self,
         completion_request: CoreCompletionRequest,
     ) -> Result<completion::CompletionResponse, CompletionError> {
+        self.completion_with_context(completion_request, None).await
+    }
+
+    async fn stream(
+        &self,
+        request: CoreCompletionRequest,
+    ) -> Result<crate::streaming::StreamingCompletionResponse, CompletionError> {
+        self.stream_with_context(request, None).await
+    }
+
+    async fn completion_with_context(
+        &self,
+        completion_request: CoreCompletionRequest,
+        context: Option<crate::observe::AdapterContext>,
+    ) -> Result<completion::CompletionResponse, CompletionError> {
         // Capture before `normalize` consumes the raw value.
         let (response, provider_request_id) = self
-            .raw_completion_with_request_id(completion_request)
+            .raw_completion_observed(completion_request, context)
             .await?;
         let captured = serde_json::to_value(&response)?;
         Ok(response
@@ -2559,11 +2591,12 @@ where
             .with_raw(captured))
     }
 
-    async fn stream(
+    async fn stream_with_context(
         &self,
         request: CoreCompletionRequest,
+        context: Option<crate::observe::AdapterContext>,
     ) -> Result<crate::streaming::StreamingCompletionResponse, CompletionError> {
-        GenericCompletionModel::stream(self, request).await
+        GenericCompletionModel::stream_observed(self, request, context).await
     }
 }
 

--- a/crates/rig-core/src/providers/openai/completion/streaming.rs
+++ b/crates/rig-core/src/providers/openai/completion/streaming.rs
@@ -307,10 +307,12 @@ where
         + crate::wasm_compat::WasmCompatSend
         + 'static,
 {
-    /// Open a chat-completions stream.
-    pub(crate) async fn stream(
+    /// Open a chat-completions stream with observation context owned by this
+    /// invocation.
+    pub(crate) async fn stream_observed(
         &self,
         completion_request: CompletionRequest,
+        observation: Option<crate::observe::AdapterContext>,
     ) -> Result<streaming::StreamingCompletionResponse, CompletionError> {
         let preamble = completion_request.system_instructions().map(str::to_owned);
         let record_telemetry_content = completion_request.record_telemetry_content;
@@ -366,11 +368,18 @@ where
 
         let req_body = serde_json::to_vec(&request_as_json)?;
 
-        let req = self
+        let mut req = self
             .client
             .post(&path)?
             .body(req_body)
             .map_err(|e| CompletionError::HttpError(e.into()))?;
+        if let Some(observation) = observation {
+            crate::providers::openai::observation::attach_chat(
+                observation,
+                &mut req,
+                "/chat/completions",
+            );
+        }
 
         let span = CompletionSpanBuilder::new(
             Ext::PROVIDER_NAME,

--- a/crates/rig-core/src/providers/openai/embedding.rs
+++ b/crates/rig-core/src/providers/openai/embedding.rs
@@ -324,11 +324,10 @@ where
 
         let (parts, body) = response.into_parts();
         let status = parts.status;
-        let provider_request_id =
-            crate::providers::internal::transcription::request_id_from_headers(
-                &parts.headers,
-                Ext::REQUEST_ID_HEADER,
-            );
+        let provider_request_id = crate::providers::internal::request_id_from_headers(
+            &parts.headers,
+            Ext::REQUEST_ID_HEADER,
+        );
         let response_body: Vec<u8> = body.await?;
         if status.is_success() {
             let parsed: ApiResponse<CompatibleEmbeddingResponse> =
@@ -347,14 +346,18 @@ where
                     Err(EmbeddingError::from_http_response(
                         status,
                         String::from_utf8_lossy(&response_body).into_owned(),
-                    ))
+                    )
+                    .with_provider_request_id(provider_request_id)
+                    .with_response_headers(Some(Box::new(parts.headers))))
                 }
             }
         } else {
             Err(EmbeddingError::from_http_response(
                 status,
                 String::from_utf8_lossy(&response_body).into_owned(),
-            ))
+            )
+            .with_provider_request_id(provider_request_id)
+            .with_response_headers(Some(Box::new(parts.headers))))
         }
     }
 }

--- a/crates/rig-core/src/providers/openai/embedding/tests.rs
+++ b/crates/rig-core/src/providers/openai/embedding/tests.rs
@@ -299,7 +299,7 @@ async fn embedding_http_non_success_preserves_status_and_body() {
         .await
         .expect_err("embedding should fail with non-success status");
 
-    assert!(matches!(error, EmbeddingError::HttpError(_)));
+    assert!(matches!(error, EmbeddingError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::UNAUTHORIZED)

--- a/crates/rig-core/src/providers/openai/image_generation/tests.rs
+++ b/crates/rig-core/src/providers/openai/image_generation/tests.rs
@@ -131,7 +131,7 @@ async fn image_generation_non_success_response_preserves_status_and_body() {
         .await
         .expect_err("image generation should fail with non-success status");
 
-    assert!(matches!(error, ImageGenerationError::HttpError(_)));
+    assert!(matches!(error, ImageGenerationError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::BAD_REQUEST)

--- a/crates/rig-core/src/providers/openai/mod.rs
+++ b/crates/rig-core/src/providers/openai/mod.rs
@@ -15,6 +15,7 @@ pub mod client;
 pub mod completion;
 pub mod embedding;
 pub mod model_listing;
+mod observation;
 pub mod responses_api;
 
 #[cfg(feature = "audio")]

--- a/crates/rig-core/src/providers/openai/observation.rs
+++ b/crates/rig-core/src/providers/openai/observation.rs
@@ -1,0 +1,247 @@
+//! Chat Completions and Responses metadata projected before normalization
+//! can discard it: the verdict, the model, the response id, the usage and
+//! any error envelope, on the unary reply and on every stream frame.
+
+use crate::observe::{
+    AdapterAttempt, AdapterContext, AdapterErrorEnvelope, AdapterEvent, AdapterUsage,
+    AdapterVerdict, PayloadObserver,
+};
+use serde::Deserialize;
+
+/// Attach `context` to a Chat Completions request, with the chat projector.
+pub(crate) fn attach_chat<B>(
+    context: AdapterContext,
+    request: &mut http::Request<B>,
+    route: &'static str,
+) {
+    context.attach(request, route);
+    request
+        .extensions_mut()
+        .insert(PayloadObserver(chat_payload));
+}
+
+/// Attach `context` to a Responses request, with the Responses projector.
+pub(crate) fn attach_responses<B>(
+    context: AdapterContext,
+    request: &mut http::Request<B>,
+    route: &'static str,
+) {
+    context.attach(request, route);
+    request
+        .extensions_mut()
+        .insert(PayloadObserver(responses_payload));
+}
+
+fn count<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<Option<u64>, D::Error> {
+    Ok(serde_json::Value::deserialize(deserializer)?.as_u64())
+}
+
+#[derive(Default, Deserialize)]
+struct TokenDetails {
+    #[serde(default, deserialize_with = "count")]
+    cached_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "count")]
+    reasoning_tokens: Option<u64>,
+}
+
+/// The error envelope both wires share: `{"error": {code, message, type}}`;
+/// the Responses stream's `error` event carries the same fields at the top.
+#[derive(Deserialize)]
+struct Envelope {
+    code: Option<serde_json::Value>,
+    #[serde(rename = "type")]
+    kind: Option<String>,
+    message: Option<String>,
+}
+
+fn envelope(attempt: &mut AdapterAttempt, error: Envelope) {
+    let code = error.code.map(|code| match code {
+        serde_json::Value::String(code) => attempt.text(&code),
+        serde_json::Value::Number(code) => code.to_string(),
+        _ => "[invalid]".to_owned(),
+    });
+    attempt.emit(AdapterEvent::ErrorEnvelope {
+        error: AdapterErrorEnvelope {
+            code,
+            status: error.kind.map(|value| attempt.text(&value)),
+            message: error.message.map(|value| attempt.text(&value)),
+        },
+    });
+}
+
+// Chat Completions: one object for the unary reply and each stream chunk.
+// Every field is optional: a chunk carries a delta, the last chunk (or the
+// reply) carries the usage, and `[DONE]` is not JSON at all.
+#[derive(Deserialize)]
+struct ChatUsage {
+    #[serde(default, deserialize_with = "count")]
+    prompt_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "count")]
+    completion_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "count")]
+    total_tokens: Option<u64>,
+    #[serde(default)]
+    prompt_tokens_details: Option<TokenDetails>,
+    #[serde(default)]
+    completion_tokens_details: Option<TokenDetails>,
+}
+
+#[derive(Default, Deserialize)]
+struct ChatChoice {
+    finish_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ChatPayload {
+    id: Option<String>,
+    model: Option<String>,
+    usage: Option<ChatUsage>,
+    #[serde(default)]
+    choices: Vec<ChatChoice>,
+    error: Option<Envelope>,
+}
+
+fn chat_payload(bytes: &[u8], attempt: &mut AdapterAttempt) {
+    let Ok(payload) = serde_json::from_slice::<ChatPayload>(bytes) else {
+        return;
+    };
+    if let Some(usage) = payload.usage {
+        attempt.emit(AdapterEvent::Usage {
+            usage: AdapterUsage {
+                input_tokens: usage.prompt_tokens,
+                output_tokens: usage.completion_tokens,
+                total_tokens: usage.total_tokens,
+                cached_input_tokens: usage.prompt_tokens_details.and_then(|d| d.cached_tokens),
+                reasoning_tokens: usage
+                    .completion_tokens_details
+                    .and_then(|d| d.reasoning_tokens),
+                tool_input_tokens: None,
+            },
+        });
+    }
+    // Every chunk names the model; only the chunk that carries the finish
+    // reason is a verdict, so the model rides with it rather than on each
+    // delta. The id still lands on the terminal verdict or the closure.
+    let choice = payload.choices.into_iter().next().unwrap_or_default();
+    let verdict = match choice.finish_reason {
+        Some(reason) => AdapterVerdict {
+            finish_reason: Some(attempt.text(&reason)),
+            block_reason: None,
+            detail: None,
+            model: payload.model.map(|v| attempt.text(&v)),
+        },
+        None => AdapterVerdict::default(),
+    };
+    let response_id = payload.id.map(|v| attempt.text(&v));
+    attempt.provider(verdict, response_id);
+    if let Some(error) = payload.error {
+        envelope(attempt, error);
+    }
+}
+
+// Responses: the unary reply is the response object; a stream event wraps
+// the object under `response` (`response.created`, `.completed`, `.failed`,
+// `.incomplete`) or, for `error`, carries the envelope's fields itself.
+#[derive(Deserialize)]
+struct ResponsesUsage {
+    #[serde(default, deserialize_with = "count")]
+    input_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "count")]
+    output_tokens: Option<u64>,
+    #[serde(default, deserialize_with = "count")]
+    total_tokens: Option<u64>,
+    #[serde(default)]
+    input_tokens_details: Option<TokenDetails>,
+    #[serde(default)]
+    output_tokens_details: Option<TokenDetails>,
+}
+
+#[derive(Deserialize)]
+struct IncompleteDetails {
+    reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ResponseObject {
+    id: Option<String>,
+    model: Option<String>,
+    status: Option<String>,
+    incomplete_details: Option<IncompleteDetails>,
+    usage: Option<ResponsesUsage>,
+    error: Option<Envelope>,
+}
+
+#[derive(Deserialize)]
+struct ResponsesPayload {
+    #[serde(rename = "type")]
+    kind: Option<String>,
+    response: Option<ResponseObject>,
+    // The unary reply's own fields, and the stream `error` event's.
+    id: Option<String>,
+    model: Option<String>,
+    status: Option<String>,
+    incomplete_details: Option<IncompleteDetails>,
+    usage: Option<ResponsesUsage>,
+    error: Option<Envelope>,
+    code: Option<serde_json::Value>,
+    message: Option<String>,
+}
+
+fn responses_payload(bytes: &[u8], attempt: &mut AdapterAttempt) {
+    let Ok(payload) = serde_json::from_slice::<ResponsesPayload>(bytes) else {
+        return;
+    };
+    if payload.kind.as_deref() == Some("error") {
+        // The event carries its envelope either nested under `error` or as
+        // its own top-level fields; the nested form names the error type.
+        let error = payload.error.unwrap_or(Envelope {
+            code: payload.code,
+            kind: None,
+            message: payload.message,
+        });
+        envelope(attempt, error);
+        return;
+    }
+    let object = payload.response.unwrap_or(ResponseObject {
+        id: payload.id,
+        model: payload.model,
+        status: payload.status,
+        incomplete_details: payload.incomplete_details,
+        usage: payload.usage,
+        error: payload.error,
+    });
+    if let Some(usage) = object.usage {
+        attempt.emit(AdapterEvent::Usage {
+            usage: AdapterUsage {
+                input_tokens: usage.input_tokens,
+                output_tokens: usage.output_tokens,
+                total_tokens: usage.total_tokens,
+                cached_input_tokens: usage.input_tokens_details.and_then(|d| d.cached_tokens),
+                reasoning_tokens: usage.output_tokens_details.and_then(|d| d.reasoning_tokens),
+                tool_input_tokens: None,
+            },
+        });
+    }
+    // `status` is the provider's verdict; `in_progress` on a stream's
+    // opening event is not one yet, so it is left out of the projection.
+    let finish_reason = object
+        .status
+        .filter(|status| status != "in_progress" && status != "queued");
+    let verdict = AdapterVerdict {
+        finish_reason: finish_reason.map(|v| attempt.text(&v)),
+        block_reason: None,
+        detail: object
+            .incomplete_details
+            .and_then(|details| details.reason)
+            .map(|v| attempt.text(&v)),
+        model: object.model.map(|v| attempt.text(&v)),
+    };
+    let response_id = object.id.map(|v| attempt.text(&v));
+    attempt.provider(verdict, response_id);
+    if let Some(error) = object.error {
+        envelope(attempt, error);
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/rig-core/src/providers/openai/observation/tests.rs
+++ b/crates/rig-core/src/providers/openai/observation/tests.rs
@@ -1,0 +1,252 @@
+use std::sync::Arc;
+
+use crate::client::CompletionClient;
+use crate::completion::CompletionModel as _;
+use crate::observe::{
+    Action, AdapterContext, AdapterEnding, AdapterErrorBoundary, AdapterErrorEnvelope,
+    AdapterEvent, AdapterUsage, AdapterVerdict, ObservationLog, Subject,
+};
+use crate::test_utils::{MockStreamingClient, RecordingHttpClient};
+use futures::StreamExt;
+
+fn adapter_events(log: &ObservationLog) -> Vec<AdapterEvent> {
+    log.trace()
+        .observations
+        .iter()
+        .filter_map(|o| match &o.action {
+            Action::Adapter { observation } => Some(observation.event.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn context(log: &Arc<ObservationLog>) -> Option<AdapterContext> {
+    Some(AdapterContext::new(log.clone(), Subject::default(), "call"))
+}
+
+/// A rejected Chat Completions call: the envelope, the usage the provider
+/// billed anyway, and the closure with the one funnel's classification.
+#[tokio::test]
+async fn chat_completions_rejection_projects_envelope_and_usage() {
+    let http = RecordingHttpClient::with_error(
+        http::StatusCode::TOO_MANY_REQUESTS,
+        r#"{"error":{"message":"slow down","type":"rate_limit_error","code":"rate_limit_exceeded"},"usage":{"prompt_tokens":7,"completion_tokens":0,"total_tokens":7}}"#,
+    );
+    let client = crate::providers::openai::Client::builder()
+        .api_key("test-key")
+        .http_client(http)
+        .build()
+        .unwrap()
+        .completions_api();
+    let model = client.completion_model("gpt-4o");
+    let log = Arc::new(ObservationLog::default());
+    let error = model
+        .completion_with_context(model.completion_request("hello").build(), context(&log))
+        .await
+        .unwrap_err();
+    assert!(error.is_retryable());
+
+    let events = adapter_events(&log);
+    assert!(
+        matches!(&events[0], AdapterEvent::Started { method, route } if method == "POST" && route == "/chat/completions")
+    );
+    assert!(events.contains(&AdapterEvent::Response { status: 429 }));
+    assert!(events.contains(&AdapterEvent::Usage {
+        usage: AdapterUsage {
+            input_tokens: Some(7),
+            output_tokens: Some(0),
+            total_tokens: Some(7),
+            ..AdapterUsage::default()
+        }
+    }));
+    assert!(events.contains(&AdapterEvent::ErrorEnvelope {
+        error: AdapterErrorEnvelope {
+            code: Some("rate_limit_exceeded".into()),
+            status: Some("rate_limit_error".into()),
+            message: Some("slow down".into()),
+        }
+    }));
+    assert_eq!(
+        events.last(),
+        Some(&AdapterEvent::Finished {
+            ending: AdapterEnding::Error {
+                boundary: AdapterErrorBoundary::ProviderResponse,
+                kind: "provider_response".into(),
+                status: Some(429),
+                retryable: true,
+            }
+        })
+    );
+}
+
+/// A Chat Completions stream: the verdict and the usage ride on the last
+/// chunks, and `[DONE]` is not a payload.
+#[tokio::test]
+async fn chat_completions_stream_projects_finish_reason_model_and_usage() {
+    let sse = "data: {\"id\":\"chatcmpl-1\",\"model\":\"gpt-4o-2024-08-06\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n\
+data: {\"id\":\"chatcmpl-1\",\"model\":\"gpt-4o-2024-08-06\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n\
+data: {\"id\":\"chatcmpl-1\",\"model\":\"gpt-4o-2024-08-06\",\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":1,\"total_tokens\":6,\"completion_tokens_details\":{\"reasoning_tokens\":0}}}\n\n\
+data: [DONE]\n\n";
+    let client = crate::providers::openai::Client::builder()
+        .api_key("test-key")
+        .http_client(MockStreamingClient {
+            sse_bytes: bytes::Bytes::from(sse),
+        })
+        .build()
+        .unwrap()
+        .completions_api();
+    let model = client.completion_model("gpt-4o");
+    let log = Arc::new(ObservationLog::default());
+    let mut stream = model
+        .stream_with_context(model.completion_request("hello").build(), context(&log))
+        .await
+        .unwrap();
+    while let Some(item) = stream.next().await {
+        item.unwrap();
+    }
+    drop(stream);
+
+    let events = adapter_events(&log);
+    assert!(events.contains(&AdapterEvent::Response { status: 200 }));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        AdapterEvent::Provider { verdict: AdapterVerdict { finish_reason: Some(reason), model: Some(model), .. } }
+            if reason == "stop" && model == "gpt-4o-2024-08-06"
+    )));
+    assert!(events.contains(&AdapterEvent::Usage {
+        usage: AdapterUsage {
+            input_tokens: Some(5),
+            output_tokens: Some(1),
+            total_tokens: Some(6),
+            reasoning_tokens: Some(0),
+            ..AdapterUsage::default()
+        }
+    }));
+    assert_eq!(
+        events.last(),
+        Some(&AdapterEvent::Finished {
+            ending: AdapterEnding::Terminal
+        })
+    );
+}
+
+/// A Responses stream: the completed event carries the response object with
+/// its status, model and usage; an `error` event carries the envelope.
+#[tokio::test]
+async fn responses_stream_projects_status_usage_and_error_events() {
+    let completed = "data: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"hi\",\"item_id\":\"msg_1\",\"output_index\":0,\"sequence_number\":1}\n\n\
+data: {\"type\":\"response.completed\",\"sequence_number\":99,\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":0,\"status\":\"completed\",\"model\":\"gpt-5.4\",\"output\":[{\"type\":\"message\",\"id\":\"msg_1\",\"role\":\"assistant\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"text\":\"hi\",\"annotations\":[]}]}],\"tools\":[],\"usage\":{\"input_tokens\":4,\"output_tokens\":1,\"total_tokens\":5,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens_details\":{\"reasoning_tokens\":0}}}}\n\n";
+    let log = Arc::new(ObservationLog::default());
+    {
+        let client = crate::providers::openai::Client::builder()
+            .api_key("test-key")
+            .http_client(MockStreamingClient {
+                sse_bytes: bytes::Bytes::from(completed),
+            })
+            .build()
+            .unwrap();
+        let model = client.completion_model("gpt-5.4");
+        let mut stream = model
+            .stream_with_context(model.completion_request("hello").build(), context(&log))
+            .await
+            .unwrap();
+        while let Some(item) = stream.next().await {
+            item.unwrap();
+        }
+    }
+    let events = adapter_events(&log);
+    assert!(matches!(&events[0], AdapterEvent::Started { route, .. } if route == "/responses"));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        AdapterEvent::Provider { verdict: AdapterVerdict { finish_reason: Some(reason), model: Some(model), .. } }
+            if reason == "completed" && model == "gpt-5.4"
+    )));
+    assert!(events.contains(&AdapterEvent::Usage {
+        usage: AdapterUsage {
+            input_tokens: Some(4),
+            output_tokens: Some(1),
+            total_tokens: Some(5),
+            cached_input_tokens: Some(0),
+            reasoning_tokens: Some(0),
+            ..AdapterUsage::default()
+        }
+    }));
+    assert_eq!(
+        events.last(),
+        Some(&AdapterEvent::Finished {
+            ending: AdapterEnding::Terminal
+        })
+    );
+
+    let failed = "data: {\"type\":\"error\",\"code\":\"server_error\",\"message\":\"boom\",\"param\":null,\"sequence_number\":1}\n\n";
+    let log = Arc::new(ObservationLog::default());
+    {
+        let client = crate::providers::openai::Client::builder()
+            .api_key("test-key")
+            .http_client(MockStreamingClient {
+                sse_bytes: bytes::Bytes::from(failed),
+            })
+            .build()
+            .unwrap();
+        let model = client.completion_model("gpt-5.4");
+        let mut stream = model
+            .stream_with_context(model.completion_request("hello").build(), context(&log))
+            .await
+            .unwrap();
+        let mut errors = 0;
+        while let Some(item) = stream.next().await {
+            if item.is_err() {
+                errors += 1;
+            }
+        }
+        assert_eq!(errors, 1);
+    }
+    let events = adapter_events(&log);
+    assert!(events.contains(&AdapterEvent::ErrorEnvelope {
+        error: AdapterErrorEnvelope {
+            code: Some("server_error".into()),
+            status: None,
+            message: Some("boom".into()),
+        }
+    }));
+}
+
+/// A rejected Responses call: the unary envelope, projected off the reply.
+#[tokio::test]
+async fn responses_rejection_projects_the_envelope() {
+    let http = RecordingHttpClient::with_error(
+        http::StatusCode::BAD_REQUEST,
+        r#"{"error":{"message":"The requested model does not exist.","type":"invalid_request_error","param":"model","code":"model_not_found"}}"#,
+    );
+    let client = crate::providers::openai::Client::builder()
+        .api_key("test-key")
+        .http_client(http)
+        .build()
+        .unwrap();
+    let model = client.completion_model("gpt-nonexistent");
+    let log = Arc::new(ObservationLog::default());
+    let error = model
+        .completion_with_context(model.completion_request("hello").build(), context(&log))
+        .await
+        .unwrap_err();
+    assert!(!error.is_retryable());
+    let events = adapter_events(&log);
+    assert!(events.contains(&AdapterEvent::ErrorEnvelope {
+        error: AdapterErrorEnvelope {
+            code: Some("model_not_found".into()),
+            status: Some("invalid_request_error".into()),
+            message: Some("The requested model does not exist.".into()),
+        }
+    }));
+    assert_eq!(
+        events.last(),
+        Some(&AdapterEvent::Finished {
+            ending: AdapterEnding::Error {
+                boundary: AdapterErrorBoundary::ProviderResponse,
+                kind: "provider_response".into(),
+                status: Some(400),
+                retryable: false,
+            }
+        })
+    );
+}

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -2531,6 +2531,16 @@ where
         &self,
         completion_request: crate::completion::CompletionRequest,
     ) -> Result<CompletionResponse, CompletionError> {
+        self.raw_completion_observed(completion_request, None).await
+    }
+
+    /// [`Self::raw_completion`] with observation context owned by this
+    /// invocation.
+    async fn raw_completion_observed(
+        &self,
+        completion_request: crate::completion::CompletionRequest,
+        observation: Option<crate::observe::AdapterContext>,
+    ) -> Result<CompletionResponse, CompletionError> {
         let system_instructions = completion_request.system_instructions().map(str::to_owned);
         let record_telemetry_content = completion_request.record_telemetry_content;
         let (request_model, request) = self.create_provider_request(completion_request, false)?;
@@ -2549,11 +2559,18 @@ where
             &request,
         );
 
-        let req = self
+        let mut req = self
             .client
             .post(Ext::RESPONSES_PATH)?
             .body(body)
             .map_err(|e| CompletionError::HttpError(e.into()))?;
+        if let Some(observation) = observation {
+            crate::providers::openai::observation::attach_responses(
+                observation,
+                &mut req,
+                "/responses",
+            );
+        }
 
         fn record_response(response: &CompletionResponse) {
             let span = tracing::Span::current();
@@ -2624,17 +2641,35 @@ where
         &self,
         completion_request: crate::completion::CompletionRequest,
     ) -> Result<completion::CompletionResponse, CompletionError> {
-        // Capture before `normalize` consumes the raw value.
-        let response = self.raw_completion(completion_request).await?;
-        let captured = serde_json::to_value(&response)?;
-        Ok(response.normalize(Ext::PROVIDER_NAME)?.with_raw(captured))
+        self.completion_with_context(completion_request, None).await
     }
 
     async fn stream(
         &self,
         request: crate::completion::CompletionRequest,
     ) -> Result<crate::streaming::StreamingCompletionResponse, CompletionError> {
-        GenericResponsesCompletionModel::stream(self, request).await
+        self.stream_with_context(request, None).await
+    }
+
+    async fn completion_with_context(
+        &self,
+        completion_request: crate::completion::CompletionRequest,
+        context: Option<crate::observe::AdapterContext>,
+    ) -> Result<completion::CompletionResponse, CompletionError> {
+        // Capture before `normalize` consumes the raw value.
+        let response = self
+            .raw_completion_observed(completion_request, context)
+            .await?;
+        let captured = serde_json::to_value(&response)?;
+        Ok(response.normalize(Ext::PROVIDER_NAME)?.with_raw(captured))
+    }
+
+    async fn stream_with_context(
+        &self,
+        request: crate::completion::CompletionRequest,
+        context: Option<crate::observe::AdapterContext>,
+    ) -> Result<crate::streaming::StreamingCompletionResponse, CompletionError> {
+        GenericResponsesCompletionModel::stream_observed(self, request, context).await
     }
 }
 

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -1457,14 +1457,16 @@ where
     Ext: crate::client::Provider + ResponsesProviderExt + Clone + 'static,
     H: Clone + WasmCompatSend + 'static,
 {
-    /// Open a Responses stream.
+    /// Open a Responses stream with observation context owned by this
+    /// invocation.
     ///
     /// The terminal record's provider-native form — the escape hatch for
     /// Responses-API terminal fields rig does not normalize — rides on
     /// [`StreamFinal::raw`] as the serialized [`StreamingCompletionResponse`].
-    pub(crate) async fn stream(
+    pub(crate) async fn stream_observed(
         &self,
         completion_request: crate::completion::CompletionRequest,
+        observation: Option<crate::observe::AdapterContext>,
     ) -> Result<streaming::StreamingCompletionResponse, CompletionError> {
         let system_instructions = completion_request.system_instructions().map(str::to_owned);
         let record_telemetry_content = completion_request.record_telemetry_content;
@@ -1478,11 +1480,18 @@ where
 
         let body = serde_json::to_vec(&request)?;
 
-        let req = self
+        let mut req = self
             .client
             .post(Ext::RESPONSES_PATH)?
             .body(body)
             .map_err(|e| CompletionError::HttpError(e.into()))?;
+        if let Some(observation) = observation {
+            crate::providers::openai::observation::attach_responses(
+                observation,
+                &mut req,
+                "/responses",
+            );
+        }
 
         let span = CompletionSpanBuilder::new(
             Ext::PROVIDER_NAME,

--- a/crates/rig-core/src/providers/openai/responses_api/streaming/tests.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming/tests.rs
@@ -998,8 +998,9 @@ async fn transport_error_flushes_delivered_tool_calls_before_the_error() {
     });
     let chunks = vec![
         Ok(sse_bytes_from_data_lines([tool_call_done.to_string()])),
-        Err(crate::http_client::Error::InvalidStatusCodeWithMessage(
+        Err(crate::http_client::Error::non_success_with_details(
             http::StatusCode::BAD_GATEWAY,
+            http::HeaderMap::new(),
             r#"{"error":{"message":"upstream unavailable"}}"#.to_string(),
         )),
     ];
@@ -2263,7 +2264,7 @@ async fn streaming_non_http_transport_error_stays_a_transport_error() {
         err.to_string(),
         "HttpError: Invalid content type was returned: \"application/json\""
     );
-    assert_eq!(err.kind, ErrorKind::Http { status: None });
+    assert_eq!(err.kind, ErrorKind::Http);
     // A response-less transport failure has no provider response body.
     assert_eq!(err.provider_response_body(), None);
     assert_eq!(err.http_status, None);

--- a/crates/rig-core/src/providers/openai/responses_api/streaming/tests.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming/tests.rs
@@ -2234,7 +2234,7 @@ fn streaming_error_event_preserves_full_payload() {
 }
 
 #[tokio::test]
-async fn streaming_non_http_transport_error_stays_provider_error() {
+async fn streaming_non_http_transport_error_stays_a_transport_error() {
     use crate::http_client::sse::GenericEventSource;
     use crate::test_utils::SequencedStreamingHttpClient;
 
@@ -2258,13 +2258,13 @@ async fn streaming_non_http_transport_error_stays_provider_error() {
         .next()
         .await
         .expect("stream should yield transport error")
-        .expect_err("non-HTTP transport failure should surface as provider error");
+        .expect_err("non-HTTP transport failure should surface as a transport error");
     assert_eq!(
         err.to_string(),
-        "ProviderError: Invalid content type was returned: \"application/json\""
+        "HttpError: Invalid content type was returned: \"application/json\""
     );
-    assert_eq!(err.kind, ErrorKind::Provider);
-    // Rig-generated transport diagnostics are not provider response bodies.
+    assert_eq!(err.kind, ErrorKind::Http { status: None });
+    // A response-less transport failure has no provider response body.
     assert_eq!(err.provider_response_body(), None);
     assert_eq!(err.http_status, None);
 }

--- a/crates/rig-core/src/providers/openai/responses_api/websocket.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/websocket.rs
@@ -916,55 +916,22 @@ fn event_timeout_error(timeout: Duration) -> CompletionError {
     ))
 }
 
-/// Map a transport failure onto rig's error model, preserving the provider's
-/// own response when the failure carried one.
+/// Map a transport failure onto rig's error model: the one funnel, with
+/// OpenAI's own request id read off a rejected upgrade's headers.
 ///
-/// A websocket upgrade that the provider *rejects* never becomes a websocket:
-/// it is an ordinary HTTP response, and this endpoint answers it exactly as
-/// the HTTP twin answers a bad request — a status, an `x-request-id`, and a
-/// JSON error body naming the cause. A live handshake with an invalid key
-/// returns `401` with `x-request-id` and
-/// `{"error":{"code":"invalid_api_key",…}}`. Flattening that to a display
-/// string — `"HTTP error: 401 Unauthorized"` — discards the status, the body
-/// and the request id, leaving `provider_response_status()`,
-/// `provider_response_body()` and `provider_request_id()` all `None`.
-///
-/// That is the contract the crate's other two completion transports keep
-/// (rig#2314, rig#2315): the blocking path through `send_completion` and the
-/// SSE path through `sse_transport` both classify a connect failure as
-/// [`CompletionError::ProviderResponse`] with the body and id attached. This
-/// makes the websocket the third.
-///
-/// The rejection's **headers** ride along too, by the same rule and for the
-/// same reason (rig#2210): a `429` upgrade carries `Retry-After`, and a caller
-/// that has to back off needs it from whichever transport it was refused on.
-/// This mirrors `sse_transport`, which attaches its handshake's headers to the
-/// error it builds.
-///
-/// The backend's job is to report the rejection as
-/// [`http_client::Error::non_success_with_details`]; reading OpenAI's own
-/// request-id header off it is provider knowledge and belongs here.
-///
-/// Failures that never reached the provider — TLS, DNS, a protocol violation —
-/// have no response to preserve and stay [`CompletionError::ProviderError`].
+/// A rejected upgrade is the provider's reply — its status, body and headers
+/// are exactly what a caller that has to back off needs from whichever
+/// transport it was refused on — so it becomes `ProviderResponse` like the
+/// unary and SSE paths. Reading OpenAI's request-id header off it is
+/// provider knowledge and belongs here; the backend's job is to report the
+/// rejection as [`http_client::Error::non_success_with_details`]. A failure
+/// that never reached the provider (TLS, DNS, a protocol violation) stays a
+/// transport error with its own retryability.
 fn websocket_provider_error(error: http_client::Error) -> CompletionError {
-    let Some(status) = error.non_success_status() else {
-        return CompletionError::ProviderError(error.to_string());
-    };
-
-    let provider_request_id = REQUEST_ID_HEADER
-        .and_then(|header| error.non_success_headers()?.get(header))
-        .and_then(|value| value.to_str().ok())
-        .filter(|value| !value.is_empty())
-        .map(str::to_string);
-    // The body is the provider's own error envelope; an upgrade rejected
-    // without one still carries its status, which is more than the string form
-    // preserved.
-    let body = error.non_success_body().unwrap_or_default().to_string();
-    let headers = error.non_success_headers().cloned().map(Box::new);
-
-    CompletionError::from_http_response_with_request_id(status, body, provider_request_id)
-        .with_response_headers(headers)
+    let provider_request_id = error.non_success_headers().and_then(|headers| {
+        crate::providers::internal::request_id_from_headers(headers, REQUEST_ID_HEADER)
+    });
+    CompletionError::from_transport_error(error).with_provider_request_id(provider_request_id)
 }
 
 /// OpenAI Responses websocket mode on an OpenAI client.

--- a/crates/rig-core/src/providers/openai/responses_api/websocket/tests.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/websocket/tests.rs
@@ -146,12 +146,13 @@ fn websocket_provider_error_preserves_the_rejections_headers() {
 }
 
 /// A failure that never reached the provider has no response to preserve
-/// and stays a plain diagnostic.
+/// and stays a transport error, with the transport table's retryability.
 #[test]
 fn websocket_provider_error_leaves_a_transport_failure_alone() {
     let error = websocket_provider_error(http_client::Error::StreamEnded);
 
-    assert!(matches!(error, CompletionError::ProviderError(_)));
+    assert!(matches!(error, CompletionError::HttpError(_)));
+    assert!(error.is_retryable());
     assert_eq!(error.provider_response_status(), None);
     assert_eq!(error.provider_response_body(), None);
     assert_eq!(error.provider_request_id(), None);

--- a/crates/rig-core/src/providers/openai/transcription/tests.rs
+++ b/crates/rig-core/src/providers/openai/transcription/tests.rs
@@ -140,7 +140,7 @@ async fn transcription_http_non_success_preserves_status_and_body() {
         panic!("transcription should fail with non-success status")
     };
 
-    assert!(matches!(error, TranscriptionError::HttpError(_)));
+    assert!(matches!(error, TranscriptionError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::BAD_REQUEST)

--- a/crates/rig-core/src/providers/openrouter/audio_generation/tests.rs
+++ b/crates/rig-core/src/providers/openrouter/audio_generation/tests.rs
@@ -66,7 +66,7 @@ async fn audio_generation_non_success_preserves_status_and_body() {
         .await
         .expect_err("should fail with non-success status");
 
-    assert!(matches!(error, AudioGenerationError::HttpError(_)));
+    assert!(matches!(error, AudioGenerationError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)

--- a/crates/rig-core/src/providers/openrouter/transcription/tests.rs
+++ b/crates/rig-core/src/providers/openrouter/transcription/tests.rs
@@ -58,7 +58,7 @@ async fn transcription_non_success_preserves_status_and_body() {
         .await
         .expect_err("should fail with non-success status");
 
-    assert!(matches!(error, TranscriptionError::HttpError(_)));
+    assert!(matches!(error, TranscriptionError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)

--- a/crates/rig-core/src/providers/venice/audio_generation/tests.rs
+++ b/crates/rig-core/src/providers/venice/audio_generation/tests.rs
@@ -26,7 +26,7 @@ async fn audio_generation_non_success_preserves_status_and_body() {
         .await
         .expect_err("should fail with non-success status");
 
-    assert!(matches!(error, AudioGenerationError::HttpError(_)));
+    assert!(matches!(error, AudioGenerationError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::PAYMENT_REQUIRED)

--- a/crates/rig-core/src/providers/venice/image_generation/tests.rs
+++ b/crates/rig-core/src/providers/venice/image_generation/tests.rs
@@ -32,7 +32,7 @@ async fn image_generation_non_success_preserves_status_and_body() {
         .await
         .expect_err("should fail with non-success status");
 
-    assert!(matches!(error, ImageGenerationError::HttpError(_)));
+    assert!(matches!(error, ImageGenerationError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::NOT_FOUND)

--- a/crates/rig-core/src/providers/voyageai.rs
+++ b/crates/rig-core/src/providers/voyageai.rs
@@ -292,8 +292,10 @@ where
             .map_err(|x| EmbeddingError::HttpError(x.into()))?;
 
         let response = self.client.send::<_, Bytes>(req).await?;
-        let status = response.status();
-        let response_body = response.into_body().into_future().await?.to_vec();
+        let (parts, body) = response.into_parts();
+        let status = parts.status;
+        let headers = Box::new(parts.headers);
+        let response_body = body.into_future().await?.to_vec();
 
         if status.is_success() {
             match serde_json::from_slice::<ApiResponse<EmbeddingResponse>>(&response_body)? {
@@ -309,14 +311,15 @@ where
                     Err(EmbeddingError::from_http_response(
                         status,
                         String::from_utf8_lossy(&response_body),
-                    ))
+                    )
+                    .with_response_headers(Some(headers)))
                 }
             }
         } else {
-            Err(EmbeddingError::from_http_response(
-                status,
-                String::from_utf8_lossy(&response_body),
-            ))
+            Err(
+                EmbeddingError::from_http_response(status, String::from_utf8_lossy(&response_body))
+                    .with_response_headers(Some(headers)),
+            )
         }
     }
 }
@@ -508,8 +511,10 @@ where
             .map_err(|x| RerankError::HttpError(x.into()))?;
 
         let response = self.client.send::<_, Bytes>(req).await?;
-        let status = response.status();
-        let response_body = response.into_body().into_future().await?.to_vec();
+        let (parts, body) = response.into_parts();
+        let status = parts.status;
+        let headers = Box::new(parts.headers);
+        let response_body = body.into_future().await?.to_vec();
 
         if status.is_success() {
             match serde_json::from_slice::<ApiResponse<RerankApiResponse>>(&response_body)? {
@@ -525,14 +530,15 @@ where
                     Err(RerankError::from_http_response(
                         status,
                         String::from_utf8_lossy(&response_body),
-                    ))
+                    )
+                    .with_response_headers(Some(headers)))
                 }
             }
         } else {
-            Err(RerankError::from_http_response(
-                status,
-                String::from_utf8_lossy(&response_body),
-            ))
+            Err(
+                RerankError::from_http_response(status, String::from_utf8_lossy(&response_body))
+                    .with_response_headers(Some(headers)),
+            )
         }
     }
 }

--- a/crates/rig-core/src/providers/voyageai/tests.rs
+++ b/crates/rig-core/src/providers/voyageai/tests.rs
@@ -33,7 +33,7 @@ async fn rerank_non_success_preserves_status_and_body() {
         .await
         .expect_err("rerank should fail with non-success status");
 
-    assert!(matches!(error, RerankError::HttpError(_)));
+    assert!(matches!(error, RerankError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)

--- a/crates/rig-core/src/providers/xai/audio_generation/tests.rs
+++ b/crates/rig-core/src/providers/xai/audio_generation/tests.rs
@@ -58,7 +58,7 @@ async fn audio_generation_non_success_preserves_status_and_body() {
         .await
         .expect_err("should fail with non-success status");
 
-    assert!(matches!(error, AudioGenerationError::HttpError(_)));
+    assert!(matches!(error, AudioGenerationError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)

--- a/crates/rig-core/src/providers/xai/image_generation/tests.rs
+++ b/crates/rig-core/src/providers/xai/image_generation/tests.rs
@@ -30,7 +30,7 @@ async fn image_generation_non_success_preserves_status_and_body() {
         .await
         .expect_err("should fail with non-success status");
 
-    assert!(matches!(error, ImageGenerationError::HttpError(_)));
+    assert!(matches!(error, ImageGenerationError::ProviderResponse(_)));
     assert_eq!(
         error.provider_response_status(),
         Some(http::StatusCode::SERVICE_UNAVAILABLE)

--- a/crates/rig-core/src/test_utils/http.rs
+++ b/crates/rig-core/src/test_utils/http.rs
@@ -31,8 +31,6 @@ pub struct CapturedHttpRequest {
 pub enum MockHttpResponse {
     /// Return this body with a successful HTTP status.
     Success(Bytes),
-    /// Return a status-code error with the given body text.
-    Error(http::StatusCode, String),
     /// Return an HTTP response with the given (typically non-success) status
     /// and body, instead of a transport-level error.
     ErrorResponse(http::StatusCode, Bytes),
@@ -50,13 +48,11 @@ impl MockHttpResponse {
         Self::Success(body.into())
     }
 
-    /// Create an error response with a status code and message.
-    ///
-    /// Models a transport that reports a non-success status *without*
-    /// preserving the response headers (a custom [`HttpClientExt`]); use
-    /// [`Self::error_with_headers`] for the bundled reqwest behavior.
+    /// Create a transport-level status error whose reply carried no headers
+    /// of interest: the same shape as [`Self::error_with_headers`] with an
+    /// empty map, since a rejection always comes with its headers.
     pub fn error(status: http::StatusCode, message: impl Into<String>) -> Self {
-        Self::Error(status, message.into())
+        Self::error_with_headers(status, message, http::HeaderMap::new())
     }
 
     /// Create a transport-level status error that preserved the failed
@@ -183,11 +179,6 @@ impl RecordingHttpClient {
     {
         let (status, response_body, response_headers) = match response {
             MockHttpResponse::Success(response_body) => (http::StatusCode::OK, response_body, None),
-            MockHttpResponse::Error(status, message) => {
-                return Err(http_client::Error::InvalidStatusCodeWithMessage(
-                    status, message,
-                ));
-            }
             MockHttpResponse::ErrorWithHeaders(status, body, headers) => {
                 return Err(http_client::Error::InvalidStatusCodeWithDetails {
                     status,
@@ -249,8 +240,10 @@ impl HttpClientExt for RecordingHttpClient {
     where
         T: Into<Bytes> + WasmCompatSend,
     {
-        future::ready(Err(http_client::Error::InvalidStatusCode(
+        future::ready(Err(http_client::Error::non_success_with_details(
             http::StatusCode::NOT_IMPLEMENTED,
+            http::HeaderMap::new(),
+            String::new(),
         )))
     }
 }
@@ -323,8 +316,10 @@ impl HttpClientExt for SequencedHttpClient {
         async move {
             match response {
                 Some(response) => RecordingHttpClient::build_unary_response(response),
-                None => Err(http_client::Error::InvalidStatusCode(
+                None => Err(http_client::Error::non_success_with_details(
                     http::StatusCode::NOT_IMPLEMENTED,
+                    http::HeaderMap::new(),
+                    String::new(),
                 )),
             }
         }
@@ -344,8 +339,10 @@ impl HttpClientExt for SequencedHttpClient {
         async move {
             match response {
                 Some(response) => RecordingHttpClient::build_unary_response(response),
-                None => Err(http_client::Error::InvalidStatusCode(
+                None => Err(http_client::Error::non_success_with_details(
                     http::StatusCode::NOT_IMPLEMENTED,
+                    http::HeaderMap::new(),
+                    String::new(),
                 )),
             }
         }
@@ -358,8 +355,10 @@ impl HttpClientExt for SequencedHttpClient {
     where
         T: Into<Bytes> + WasmCompatSend,
     {
-        future::ready(Err(http_client::Error::InvalidStatusCode(
+        future::ready(Err(http_client::Error::non_success_with_details(
             http::StatusCode::NOT_IMPLEMENTED,
+            http::HeaderMap::new(),
+            String::new(),
         )))
     }
 }
@@ -382,8 +381,10 @@ impl HttpClientExt for MockStreamingClient {
         T: Into<Bytes> + WasmCompatSend,
         U: From<Bytes> + WasmCompatSend + 'static,
     {
-        future::ready(Err(http_client::Error::InvalidStatusCode(
+        future::ready(Err(http_client::Error::non_success_with_details(
             http::StatusCode::NOT_IMPLEMENTED,
+            http::HeaderMap::new(),
+            String::new(),
         )))
     }
 
@@ -394,8 +395,10 @@ impl HttpClientExt for MockStreamingClient {
     where
         U: From<Bytes> + WasmCompatSend + 'static,
     {
-        future::ready(Err(http_client::Error::InvalidStatusCode(
+        future::ready(Err(http_client::Error::non_success_with_details(
             http::StatusCode::NOT_IMPLEMENTED,
+            http::HeaderMap::new(),
+            String::new(),
         )))
     }
 
@@ -456,8 +459,10 @@ impl HttpClientExt for HttpErrorStreamingClient {
         T: Into<Bytes> + WasmCompatSend,
         U: From<Bytes> + WasmCompatSend + 'static,
     {
-        future::ready(Err(http_client::Error::InvalidStatusCode(
+        future::ready(Err(http_client::Error::non_success_with_details(
             http::StatusCode::NOT_IMPLEMENTED,
+            http::HeaderMap::new(),
+            String::new(),
         )))
     }
 
@@ -468,8 +473,10 @@ impl HttpClientExt for HttpErrorStreamingClient {
     where
         U: From<Bytes> + WasmCompatSend + 'static,
     {
-        future::ready(Err(http_client::Error::InvalidStatusCode(
+        future::ready(Err(http_client::Error::non_success_with_details(
             http::StatusCode::NOT_IMPLEMENTED,
+            http::HeaderMap::new(),
+            String::new(),
         )))
     }
 
@@ -483,8 +490,10 @@ impl HttpClientExt for HttpErrorStreamingClient {
         let status = self.status;
         let body = self.body.clone();
         async move {
-            Err(http_client::Error::InvalidStatusCodeWithMessage(
-                status, body,
+            Err(http_client::Error::non_success_with_details(
+                status,
+                http::HeaderMap::new(),
+                body,
             ))
         }
     }
@@ -515,8 +524,10 @@ impl HttpClientExt for SequencedStreamingHttpClient {
         T: Into<Bytes> + WasmCompatSend,
         U: From<Bytes> + WasmCompatSend + 'static,
     {
-        future::ready(Err(http_client::Error::InvalidStatusCode(
+        future::ready(Err(http_client::Error::non_success_with_details(
             http::StatusCode::NOT_IMPLEMENTED,
+            http::HeaderMap::new(),
+            String::new(),
         )))
     }
 
@@ -527,8 +538,10 @@ impl HttpClientExt for SequencedStreamingHttpClient {
     where
         U: From<Bytes> + WasmCompatSend + 'static,
     {
-        future::ready(Err(http_client::Error::InvalidStatusCode(
+        future::ready(Err(http_client::Error::non_success_with_details(
             http::StatusCode::NOT_IMPLEMENTED,
+            http::HeaderMap::new(),
+            String::new(),
         )))
     }
 
@@ -546,8 +559,9 @@ impl HttpClientExt for SequencedStreamingHttpClient {
 
         async move {
             let Some(chunks) = chunks else {
-                return Err(http_client::Error::InvalidStatusCodeWithMessage(
+                return Err(http_client::Error::non_success_with_details(
                     http::StatusCode::INTERNAL_SERVER_ERROR,
+                    http::HeaderMap::new(),
                     "streaming chunks should only be consumed once".to_string(),
                 ));
             };

--- a/crates/rig-core/src/test_utils/streaming_conformance.rs
+++ b/crates/rig-core/src/test_utils/streaming_conformance.rs
@@ -349,12 +349,13 @@ pub fn ok_chunks(frames: impl IntoIterator<Item = impl Into<WireInput>>) -> Wire
     frames.into_iter().map(|frame| Ok(frame.into())).collect()
 }
 
-/// A scripted mid-stream transport failure chunk.
+/// A scripted mid-stream transport failure chunk: the connection dropped,
+/// so there is no reply and no status.
 pub fn transport_error_chunk() -> http_client::Result<WireInput> {
-    Err(http_client::Error::InvalidStatusCodeWithMessage(
-        http::StatusCode::BAD_GATEWAY,
-        "connection reset".to_string(),
-    ))
+    Err(http_client::Error::instance(std::io::Error::new(
+        std::io::ErrorKind::ConnectionReset,
+        "connection reset",
+    )))
 }
 
 /// Executable stream-lifecycle validator (#2258 C1).

--- a/crates/rig-core/src/test_utils/streaming_conformance.rs
+++ b/crates/rig-core/src/test_utils/streaming_conformance.rs
@@ -1803,6 +1803,52 @@ pub mod fixtures {
         drained
     }
 
+    /// Drive `model` through the observed stream entry and drain it. Every
+    /// wire threads the context it is handed: the trace must show the
+    /// request it sent and how the attempt closed, or the wire has silently
+    /// taken the context-discarding default.
+    pub async fn drain_observed<M: CompletionModel>(
+        model: &M,
+        request: crate::completion::CompletionRequest,
+    ) -> Result<DrainedStream, CompletionError> {
+        let log = std::sync::Arc::new(crate::observe::ObservationLog::default());
+        let context = crate::observe::AdapterContext::new(
+            log.clone(),
+            crate::observe::Subject::default(),
+            "conformance",
+        );
+        // A stream that fails to open still sent (or failed to send) a
+        // request: the facts are asserted before the error propagates.
+        let drained = match model.stream_with_context(request, Some(context)).await {
+            Ok(stream) => Ok(drain(stream).await),
+            Err(error) => Err(error),
+        };
+        let events: Vec<_> = log
+            .trace()
+            .observations
+            .iter()
+            .filter_map(|o| match &o.action {
+                crate::observe::Action::Adapter { observation } => Some(observation.event.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            matches!(
+                events.first(),
+                Some(crate::observe::AdapterEvent::Started { .. })
+            ),
+            "the wire must attach the observation context it was handed: {events:?}"
+        );
+        assert!(
+            matches!(
+                events.last(),
+                Some(crate::observe::AdapterEvent::Finished { .. })
+            ),
+            "the attempt must close: {events:?}"
+        );
+        drained
+    }
+
     /// Lower fixture frames onto the byte transport a `SequencedStreamingHttpClient`
     /// replays. Only byte frames are valid here — an event frame in a
     /// byte-driver fixture is a fixture authoring error.
@@ -1854,8 +1900,7 @@ pub mod fixtures {
                         .completions_api();
                     let model = client.completion_model("gpt-4o");
                     let request = model.completion_request("hello").build();
-                    let stream = model.stream(request).await?;
-                    Ok(drain(stream).await)
+                    drain_observed(&model, request).await
                 })
             })
         }
@@ -1962,8 +2007,7 @@ pub mod fixtures {
                         .build()?;
                     let model = client.completion_model("gpt-5.4");
                     let request = model.completion_request("hello").build();
-                    let stream = model.stream(request).await?;
-                    Ok(drain(stream).await)
+                    drain_observed(&model, request).await
                 })
             })
         }
@@ -2364,8 +2408,7 @@ pub mod fixtures {
                         crate::providers::gemini::completion::GEMINI_2_5_PRO_PREVIEW_06_05,
                     );
                     let request = model.completion_request("hello").build();
-                    let stream = model.stream(request).await?;
-                    Ok(drain(stream).await)
+                    drain_observed(&model, request).await
                 })
             })
         }
@@ -2502,8 +2545,7 @@ pub mod fixtures {
                         .interactions_api();
                     let model = client.completion_model("gemini-2.5-pro");
                     let request = model.completion_request("hello").build();
-                    let stream = model.stream(request).await?;
-                    Ok(drain(stream).await)
+                    drain_observed(&model, request).await
                 })
             })
         }
@@ -2633,8 +2675,7 @@ pub mod fixtures {
                         crate::providers::anthropic::completion::CLAUDE_SONNET_4_6,
                     );
                     let request = model.completion_request("hello").build();
-                    let stream = model.stream(request).await?;
-                    Ok(drain(stream).await)
+                    drain_observed(&model, request).await
                 })
             })
         }
@@ -2755,8 +2796,7 @@ pub mod fixtures {
                     let model =
                         client.completion_model(crate::providers::cohere::COMMAND_R_08_2024);
                     let request = model.completion_request("hello").build();
-                    let stream = model.stream(request).await?;
-                    Ok(drain(stream).await)
+                    drain_observed(&model, request).await
                 })
             })
         }
@@ -2872,8 +2912,7 @@ pub mod fixtures {
                         .build()?;
                     let model = client.completion_model("llama3.2");
                     let request = model.completion_request("hello").build();
-                    let stream = model.stream(request).await?;
-                    Ok(drain(stream).await)
+                    drain_observed(&model, request).await
                 })
             })
         }

--- a/crates/rig-core/src/transcription/provider_response_tests.rs
+++ b/crates/rig-core/src/transcription/provider_response_tests.rs
@@ -20,10 +20,12 @@ fn transcription_error_provider_response_helpers_with_preserved_json_body() {
 #[test]
 fn transcription_error_provider_response_helpers_with_http_non_success() {
     let body = r#"{"error":{"message":"bad request"}}"#;
-    let error = TranscriptionError::HttpError(http_client::Error::InvalidStatusCodeWithMessage(
-        StatusCode::BAD_REQUEST,
-        body.to_string(),
-    ));
+    let error =
+        TranscriptionError::from_transport_error(http_client::Error::non_success_with_details(
+            StatusCode::BAD_REQUEST,
+            http::HeaderMap::new(),
+            body.to_string(),
+        ));
 
     assert_eq!(error.provider_response_body(), Some(body));
     assert_eq!(

--- a/crates/rig-reqwest/src/lib.rs
+++ b/crates/rig-reqwest/src/lib.rs
@@ -166,13 +166,13 @@ use std::pin::Pin;
 /// Map a transport-level `reqwest::Error` onto the transport-agnostic
 /// [`Error`].
 ///
-/// A failure that carries a status (an `error_for_status` rejection) keeps
-/// it as [`Error::InvalidStatusCode`] so provider retry and error-inspection
-/// paths can still read the code; a response-less failure (connect, decode,
-/// timeout) becomes [`Error::Instance`].
+/// This is the response-less side (connect, decode, timeout): a reply the
+/// server made is read off the `reqwest::Response` with its body and headers
+/// by [`non_success_status_error`] instead, never reduced to a bare status.
+/// Rig never calls `error_for_status`, so a `reqwest::Error` here carries no
+/// reply to preserve.
 pub fn from_reqwest(err: reqwest::Error) -> Error {
-    err.status()
-        .map_or_else(|| Error::instance(err), Error::InvalidStatusCode)
+    Error::instance(err)
 }
 
 /// Read the status, headers and body off a failed `reqwest::Response` and

--- a/crates/rig-reqwest/src/lib.rs
+++ b/crates/rig-reqwest/src/lib.rs
@@ -168,7 +168,7 @@ use std::pin::Pin;
 ///
 /// This is the response-less side (connect, decode, timeout): a reply the
 /// server made is read off the `reqwest::Response` with its body and headers
-/// by [`non_success_status_error`] instead, never reduced to a bare status.
+/// by the send path instead, never reduced to a bare status.
 /// Rig never calls `error_for_status`, so a `reqwest::Error` here carries no
 /// reply to preserve.
 pub fn from_reqwest(err: reqwest::Error) -> Error {

--- a/tests/README.md
+++ b/tests/README.md
@@ -458,10 +458,16 @@ hand-edited and no new fixture is committed. A scripted cell pins what the
 runtime does with the fault (the failure kind, the record, the committed
 history, the tools that never ran, the witness's facts); the request shape it
 would have sent is pinned by the recording's owning test, not by the cell.
-The same fault classifies differently by wire — Gemini's HTTP error envelope
-is `ErrorKind::Http { status }`, the Responses wire's is `ProviderResponse` —
-because the two go through different funnels in `rig_core::provider_response`
-(with and without a captured request id); the cells pin each wire's own kind.
+Every HTTP wire threads the witness's `AdapterContext` through its request,
+so a native cell reads the adapter's boundary facts (the request, the
+status, the provider's verdict, usage and error envelope, the closure) for
+Gemini, the OpenAI Chat Completions and Responses wires and Anthropic;
+Cohere, Ollama and the Gemini Interactions wire report the transport facts
+without a payload projection.
+A provider's error reply classifies the same on every wire —
+`ErrorKind::ProviderResponse`, status, body, headers and request id on the
+report — through the one funnel in `rig_core::provider_response`;
+`ErrorKind::Http` is a transport failure that produced no reply.
 
 Historical execution logs, proof snapshots, review-application commands and
 archive infrastructure are intentionally not maintained. No historical download

--- a/tests/README.md
+++ b/tests/README.md
@@ -467,7 +467,8 @@ without a payload projection.
 A provider's error reply classifies the same on every wire —
 `ErrorKind::ProviderResponse`, status, body, headers and request id on the
 report — through the one funnel in `rig_core::provider_response`;
-`ErrorKind::Http` is a transport failure that produced no reply.
+`ErrorKind::Http` is a transport failure that produced no reply and carries
+no status: a transport never reports a status without the reply behind it.
 
 Historical execution logs, proof snapshots, review-application commands and
 archive infrastructure are intentionally not maintained. No historical download

--- a/tests/anthropic.rs
+++ b/tests/anthropic.rs
@@ -28,6 +28,8 @@ mod ecs_termination;
 mod goldens;
 #[path = "common/reasoning.rs"]
 mod reasoning;
+#[path = "common/stream_faults.rs"]
+mod stream_faults;
 #[path = "common/support.rs"]
 mod support;
 

--- a/tests/core/pull_parser.rs
+++ b/tests/core/pull_parser.rs
@@ -56,8 +56,10 @@ impl HttpClientExt for Replay {
         T: Into<Bytes> + WasmCompatSend,
         U: From<Bytes> + WasmCompatSend + 'static,
     {
-        std::future::ready(Err(http_client::Error::InvalidStatusCode(
+        std::future::ready(Err(http_client::Error::non_success_with_details(
             StatusCode::NOT_IMPLEMENTED,
+            rig::http_client::HeaderMap::new(),
+            String::new(),
         )))
     }
     fn send_multipart<U>(
@@ -67,8 +69,10 @@ impl HttpClientExt for Replay {
     where
         U: From<Bytes> + WasmCompatSend + 'static,
     {
-        std::future::ready(Err(http_client::Error::InvalidStatusCode(
+        std::future::ready(Err(http_client::Error::non_success_with_details(
             StatusCode::NOT_IMPLEMENTED,
+            rig::http_client::HeaderMap::new(),
+            String::new(),
         )))
     }
     fn send_streaming<T>(

--- a/tests/providers/anthropic/cassette/ecs_stream_faults.rs
+++ b/tests/providers/anthropic/cassette/ecs_stream_faults.rs
@@ -1,0 +1,106 @@
+//! The recorded Messages setup failure through the native runtime with the
+//! world's witness installed: the Messages adapter's boundary facts beside
+//! the bus's, on the recording (`corpus_outcome/model_error_streamed`) that
+//! `ecs_outcome::model_error_streamed` pins. Observation is a side channel: the failure, the record and the
+//! history read the same with and without it.
+
+use rig::error::ErrorKind;
+use rig::observe::{AdapterEnding, AdapterErrorBoundary, AdapterEvent};
+use rig::prelude::*;
+use rig::providers::anthropic::completion::CLAUDE_SONNET_4_6;
+use rig_ecs::agent::{Role, Temperature};
+
+use super::super::support::with_anthropic_cassette_bogus_key;
+use crate::{
+    ecs_agent::EcsAgent,
+    stream_faults::{
+        adapter_events, assert_setup_failure, bus_actions, comparable_failure, endings, native_run,
+        sole_failed_completion, trace_json,
+    },
+    support::{BASIC_PREAMBLE, BASIC_PROMPT},
+};
+
+/// The recorded 401 through the native runtime: the run fails as the
+/// provider's response, streams nothing, commits only the prompt, and the
+/// witness sees the request, the status, the envelope and the ending.
+#[tokio::test]
+async fn setup_failure_fails_the_run_with_the_recorded_status() {
+    let configure = |ecs: &mut EcsAgent| {
+        ecs.app
+            .world_mut()
+            .entity_mut(ecs.agent)
+            .insert(Temperature(Some(0.0)));
+    };
+    let mut runs = Vec::new();
+    for witness in [true, false] {
+        let runs = &mut runs;
+        with_anthropic_cassette_bogus_key(
+            "corpus_outcome/model_error_streamed",
+            |client| async move {
+                let run = native_run(
+                    client.completion_model(CLAUDE_SONNET_4_6),
+                    BASIC_PREAMBLE,
+                    BASIC_PROMPT,
+                    witness,
+                    configure,
+                )
+                .await;
+                assert_setup_failure(run.provider_report(), ErrorKind::ProviderResponse, 401);
+                assert_setup_failure(
+                    sole_failed_completion(&run.log),
+                    ErrorKind::ProviderResponse,
+                    401,
+                );
+                assert_eq!(run.roles, [Role::User], "only the prompt is history");
+                assert!(run.stream().text.is_empty(), "{:?}", run.stream());
+                assert_eq!(run.stream().errors.len(), 1, "{:?}", run.stream().errors);
+                runs.push(run);
+            },
+        )
+        .await;
+    }
+    let (observed, plain) = (&runs[0], &runs[1]);
+    assert_eq!(
+        comparable_failure(observed.failure()),
+        comparable_failure(plain.failure())
+    );
+    assert_eq!(observed.log_json(), plain.log_json());
+
+    let trace = observed.trace();
+    assert_eq!(bus_actions(trace), ["issued", "landed_err"]);
+    assert_eq!(endings(trace), ["provider"]);
+    let events = adapter_events(trace);
+    assert!(
+        matches!(events.first(), Some(AdapterEvent::Started { route, .. }) if route == "/v1/messages"),
+        "{events:?}"
+    );
+    assert!(
+        events.contains(&AdapterEvent::Response { status: 401 }),
+        "{events:?}"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AdapterEvent::ErrorEnvelope { error }
+                if error.status.as_deref() == Some("authentication_error")
+        )),
+        "the envelope's own fields are projected: {events:?}"
+    );
+    assert_eq!(
+        events.last(),
+        Some(&AdapterEvent::Finished {
+            ending: AdapterEnding::Error {
+                boundary: AdapterErrorBoundary::ProviderResponse,
+                kind: "provider_response".into(),
+                status: Some(401),
+                retryable: false,
+            }
+        }),
+        "{events:?}"
+    );
+    let rendered = trace_json(trace);
+    assert!(
+        !rendered.contains(BASIC_PROMPT) && !rendered.contains("sk-invalid"),
+        "neither the request nor the credential reaches the trace"
+    );
+}

--- a/tests/providers/anthropic/mod.rs
+++ b/tests/providers/anthropic/mod.rs
@@ -37,6 +37,7 @@ mod cassette {
     mod ecs_serving;
     mod ecs_shaping;
     mod ecs_stop_sequences;
+    mod ecs_stream_faults;
     mod ecs_termination;
     mod effect_corpus;
     mod empty_end_turn;

--- a/tests/providers/chatgpt/cassette/http_errors.rs
+++ b/tests/providers/chatgpt/cassette/http_errors.rs
@@ -36,7 +36,7 @@ async fn assert_nonstreaming_http_error(
         .await
         .expect_err("non-success response should fail");
 
-    assert!(matches!(&error, CompletionError::HttpError(_)));
+    assert!(matches!(&error, CompletionError::ProviderResponse(_)));
     assert_eq!(error.provider_response_status(), Some(expected_status));
     let body = error
         .provider_response_body()

--- a/tests/providers/cohere/cassette/errors.rs
+++ b/tests/providers/cohere/cassette/errors.rs
@@ -27,8 +27,8 @@ async fn completion_error_preserves_status_and_body() {
                 .expect_err("an unknown model should fail");
 
             assert!(
-                matches!(error, CompletionError::HttpError(_)),
-                "expected an HTTP error, got {error:?}"
+                matches!(error, CompletionError::ProviderResponse(_)),
+                "the provider's reply is preserved as its response, got {error:?}"
             );
             assert_eq!(
                 error.provider_response_status(),

--- a/tests/providers/gemini/cassette/ecs_stream_faults.rs
+++ b/tests/providers/gemini/cassette/ecs_stream_faults.rs
@@ -22,7 +22,7 @@ use rig_ecs::agent::{AdditionalParams, MaxTokens, Preamble, Role};
 use super::super::support::with_gemini_cassette;
 use super::stream_faults::{
     BLOCKED_FRAME, CONTENT_FRAME, CONTENT_TEXT, IN_BAND_ERROR_FRAME, MISSING_MODEL, SCRIPTED_KEY,
-    SETUP_MAX_TOKENS, SETUP_PROMPT, gemini_sse, http_error, scripted_client,
+    SETUP_MAX_TOKENS, SETUP_PROMPT, gemini_sse, scripted_client,
 };
 use crate::{
     ecs_agent::EcsAgent,
@@ -83,8 +83,12 @@ async fn setup_failure_fails_the_run_with_the_recorded_status() {
                     configure,
                 )
                 .await;
-                assert_setup_failure(run.provider_report(), http_error(404), 404);
-                assert_setup_failure(sole_failed_completion(&run.log), http_error(404), 404);
+                assert_setup_failure(run.provider_report(), ErrorKind::ProviderResponse, 404);
+                assert_setup_failure(
+                    sole_failed_completion(&run.log),
+                    ErrorKind::ProviderResponse,
+                    404,
+                );
                 assert_eq!(run.roles, [Role::User], "only the prompt is history");
                 assert!(run.stream().text.is_empty(), "{:?}", run.stream);
                 assert_eq!(
@@ -259,7 +263,7 @@ async fn in_band_error_after_content_fails_with_the_envelope() {
         )
         .await;
         let report = run.provider_report();
-        assert_eq!(report.kind, http_error(503), "{report:?}");
+        assert_eq!(report.kind, ErrorKind::ProviderResponse, "{report:?}");
         assert_eq!(report.http_status, Some(503), "{report:?}");
         assert!(report.is_retryable(), "{report:?}");
         assert_eq!(

--- a/tests/providers/gemini/cassette/response_identity.rs
+++ b/tests/providers/gemini/cassette/response_identity.rs
@@ -128,9 +128,9 @@ async fn streamed_agent_run_reports_none_identity() {
     .await;
 }
 
-/// The contract-less provider keeps the exact pre-#2314 error shape: a 4xx
-/// stays a transport-shaped `HttpError` and `provider_request_id()` is `None`
-/// — absence on the error path too, never a secondary failure.
+/// A provider that reports no request id still classifies a 4xx as its
+/// own response — one funnel — and `provider_request_id()` is `None`:
+/// absence on the error path too, never a secondary failure.
 #[tokio::test]
 async fn provider_error_keeps_transport_shape_and_none_id() {
     with_gemini_cassette(
@@ -143,8 +143,8 @@ async fn provider_error_keeps_transport_shape_and_none_id() {
                 .await
                 .expect_err("a nonexistent model must fail");
             assert!(
-                matches!(error, rig::completion::CompletionError::HttpError(_)),
-                "no request-id contract, so the classification is unchanged: {error:?}"
+                matches!(error, rig::completion::CompletionError::ProviderResponse(_)),
+                "the reply is the provider's, id contract or not: {error:?}"
             );
             assert_eq!(error.provider_request_id(), None);
         },
@@ -153,7 +153,7 @@ async fn provider_error_keeps_transport_shape_and_none_id() {
 }
 
 /// 401/403 control cell (rig#2314 error matrix): the contract-less provider's
-/// auth failure keeps the transport-shaped error, id `None`.
+/// auth failure is the provider's response, id `None`.
 #[tokio::test]
 async fn auth_rejection_keeps_transport_shape() {
     use super::super::support::with_gemini_cassette_bogus_key;
@@ -168,8 +168,8 @@ async fn auth_rejection_keeps_transport_shape() {
                 .await
                 .expect_err("a bogus key must be rejected");
             assert!(
-                matches!(error, rig::completion::CompletionError::HttpError(_)),
-                "contract-less classification unchanged: {error:?}"
+                matches!(error, rig::completion::CompletionError::ProviderResponse(_)),
+                "the reply is the provider's, id contract or not: {error:?}"
             );
             assert_eq!(error.provider_request_id(), None);
         },

--- a/tests/providers/gemini/cassette/stream_faults.rs
+++ b/tests/providers/gemini/cassette/stream_faults.rs
@@ -39,15 +39,6 @@ pub(super) const BLOCKED_FRAME: &str = r#"{"promptFeedback":{"blockReason":"SAFE
 /// for an overloaded model in the same capture, in the frame position the
 /// adapter's unit tests pin (`in_band_http_errors_match_unary_classification`).
 pub(super) const IN_BAND_ERROR_FRAME: &str = r#"{"error":{"code":503,"message":"The model is overloaded. Please try again later.","status":"UNAVAILABLE"}}"#;
-/// Gemini's classification of an HTTP error envelope on the streamed path:
-/// the transport's status, with the envelope preserved on the report (the
-/// metadata-less funnel in `rig_core::provider_response`; the Responses
-/// wire's request-id funnel classifies the same fault as `ProviderResponse`).
-pub(super) fn http_error(status: u16) -> ErrorKind {
-    ErrorKind::Http {
-        status: Some(status),
-    }
-}
 /// A key the scripted cells send: it must never reach a trace.
 pub(super) const SCRIPTED_KEY: &str = "scripted-fault-key-7f3a9c";
 
@@ -93,10 +84,14 @@ async fn setup_failure_fails_the_run_with_the_recorded_status() {
             assert_eq!(drained.terminals, 0, "no terminal record: {drained:?}");
             assert!(drained.text.is_empty(), "no text: {drained:?}");
             assert_eq!(drained.errors.len(), 1, "one error item: {drained:?}");
-            assert_setup_failure(&drained.errors[0], http_error(404), 404);
+            assert_setup_failure(&drained.errors[0], ErrorKind::ProviderResponse, 404);
 
             let log = agent.take_effect_log().expect("recording");
-            assert_setup_failure(sole_failed_completion(&log), http_error(404), 404);
+            assert_setup_failure(
+                sole_failed_completion(&log),
+                ErrorKind::ProviderResponse,
+                404,
+            );
             let errors = recorded_stream_errors(&log);
             assert_eq!(errors.len(), 1, "one recorded error item: {errors:?}");
             assert_eq!(errors[0].0, 0, "the error is the stream's first item");
@@ -190,7 +185,7 @@ async fn in_band_error_after_content_fails_with_the_envelope() {
     assert_eq!(drained.terminals, 0, "{drained:?}");
     assert_eq!(drained.errors.len(), 1, "{drained:?}");
     let report = &drained.errors[0];
-    assert_eq!(report.kind, http_error(503), "{report:?}");
+    assert_eq!(report.kind, ErrorKind::ProviderResponse, "{report:?}");
     assert_eq!(report.http_status, Some(503), "{report:?}");
     assert!(report.is_retryable(), "{report:?}");
     assert_eq!(
@@ -203,7 +198,7 @@ async fn in_band_error_after_content_fails_with_the_envelope() {
 
     let log = agent.take_effect_log().expect("recording");
     let recorded = sole_failed_completion(&log);
-    assert_eq!(recorded.kind, http_error(503), "{recorded:?}");
+    assert_eq!(recorded.kind, ErrorKind::ProviderResponse, "{recorded:?}");
     assert_eq!(recorded.http_status, Some(503), "{recorded:?}");
     let errors = recorded_stream_errors(&log);
     assert_eq!(errors.len(), 1, "{errors:?}");
@@ -215,5 +210,66 @@ async fn in_band_error_after_content_fails_with_the_envelope() {
     assert_eq!(
         errors[0].0, delivered,
         "the error item sits after the delivered content"
+    );
+}
+
+/// The recording the two cells below derive from, once it exists: one
+/// streamed prompt long enough for `gemini-3-flash-preview` to answer in
+/// several `streamGenerateContent` frames, so a prefix can be cut from a
+/// real Gemini stream instead of assembled from a downstream capture. The
+/// prompt is the runner's own; the assertion is the ordinary smoke.
+#[ignore = "needs a live recording: no committed Gemini REST stream carries more than one frame; record `stream_faults/multi_frame_stream` with GEMINI_API_KEY (one streamed prompt, gemini-3-flash-preview, a few hundred output tokens)"]
+#[tokio::test]
+async fn multi_frame_stream_recording() {
+    with_gemini_cassette("stream_faults/multi_frame_stream", |client| async move {
+        let agent = client
+            .agent(rig::providers::gemini::completion::GEMINI_3_FLASH_PREVIEW)
+            .preamble(crate::support::STREAMING_PREAMBLE)
+            .build();
+        let mut stream = agent
+            .prompt(
+                "Write four short paragraphs about the history of the Rust programming language.",
+            )
+            .stream();
+        let drained = drain(&mut stream).await;
+        assert_eq!(drained.finals, 1, "{drained:?}");
+        assert!(!drained.text.is_empty(), "{drained:?}");
+    })
+    .await;
+}
+
+/// EOF before the terminal frame of a real multi-frame Gemini stream: the
+/// same hypothesis as `truncation_after_content_fails_the_run_and_keeps_the_prefix`,
+/// on frames Gemini itself streamed in sequence.
+#[ignore = "derives from `stream_faults/multi_frame_stream`; see multi_frame_stream_recording"]
+#[tokio::test]
+async fn multi_frame_stream_cut_before_its_terminal_is_a_truncation() {
+    let frames =
+        crate::stream_faults::recorded_sse_frames("gemini", "stream_faults/multi_frame_stream", 0);
+    let prefix =
+        crate::stream_faults::frames_before(&frames, |frame| frame.contains("finishReason"));
+    let expected: String = prefix
+        .iter()
+        .filter_map(|frame| {
+            crate::stream_faults::frame_data(frame)["candidates"][0]["content"]["parts"][0]["text"]
+                .as_str()
+                .map(str::to_owned)
+        })
+        .collect();
+    let client = scripted_client(vec![crate::stream_faults::sse_bytes(&prefix)]);
+    let agent = client
+        .agent(GEMINI_2_5_FLASH)
+        .record_effects_with_events()
+        .build();
+    let mut stream = agent.prompt("pong?").stream();
+    let drained = drain(&mut stream).await;
+    drop(stream);
+
+    assert_eq!(drained.text, expected, "{drained:?}");
+    assert_eq!(drained.finals, 0, "{drained:?}");
+    let log = agent.take_effect_log().expect("recording");
+    assert_eq!(
+        sole_failed_completion(&log).message,
+        rig::serve::stream_truncated().message
     );
 }

--- a/tests/providers/gemini/cassette/stream_terminal_matrix.rs
+++ b/tests/providers/gemini/cassette/stream_terminal_matrix.rs
@@ -952,10 +952,10 @@ mod unit {
     async fn a_transport_error_after_a_finish_reason_yields_no_terminal_record() {
         let run = run_client(SequencedStreamingHttpClient::new(vec![
             Ok(sse(&[INTERMEDIATE_TERMINAL, ANSWER])),
-            Err(rig::http_client::Error::InvalidStatusCodeWithMessage(
-                reqwest::StatusCode::BAD_GATEWAY,
-                "connection reset".to_string(),
-            )),
+            Err(rig::http_client::Error::instance(std::io::Error::new(
+                std::io::ErrorKind::ConnectionReset,
+                "connection reset",
+            ))),
         ]))
         .await;
 
@@ -991,10 +991,10 @@ mod unit {
     async fn a_transport_error_after_the_real_terminal_also_reports_truncation() {
         let run = run_client(SequencedStreamingHttpClient::new(vec![
             Ok(sse(&[ANSWER, REAL_TERMINAL])),
-            Err(rig::http_client::Error::InvalidStatusCodeWithMessage(
-                reqwest::StatusCode::BAD_GATEWAY,
-                "connection reset".to_string(),
-            )),
+            Err(rig::http_client::Error::instance(std::io::Error::new(
+                std::io::ErrorKind::ConnectionReset,
+                "connection reset",
+            ))),
         ]))
         .await;
 

--- a/tests/providers/llamacpp/cassette/error_matrix.rs
+++ b/tests/providers/llamacpp/cassette/error_matrix.rs
@@ -528,10 +528,7 @@ async fn embeddings_with_pooling_none_are_a_400() {
                 "{error}"
             );
             assert!(
-                matches!(
-                    error,
-                    EmbeddingError::ProviderResponse(_) | EmbeddingError::HttpError(_)
-                ),
+                matches!(error, EmbeddingError::ProviderResponse(_)),
                 "the provider envelope must be preserved rather than reduced: {error}"
             );
         },

--- a/tests/providers/openai/cassette/ecs_stream_faults.rs
+++ b/tests/providers/openai/cassette/ecs_stream_faults.rs
@@ -3,12 +3,13 @@
 //! faults through the ECS runtime and the real Responses adapter, with the
 //! world's witness installed. Each cell runs with and without a witness:
 //! observation is a side channel, so the failure, the record and the
-//! history must not change with it. The Responses adapter attaches no
-//! provider diagnostics yet, so the trace carries the bus's facts only.
+//! history must not change with it, and the trace carries the bus's facts
+//! beside the Responses adapter's own boundary facts.
 
 use bevy_ecs::prelude::*;
 use bytes::Bytes;
 use rig::error::ErrorKind;
+use rig::observe::{AdapterEnding, AdapterErrorBoundary, AdapterEvent};
 use rig::prelude::*;
 use rig::providers::openai::{self, GPT_4O};
 use rig::test_utils::SequencedStreamingHttpClient;
@@ -48,17 +49,27 @@ fn assert_witness_is_a_side_channel(observed: &NativeRun, plain: &NativeRun) {
     crate::stream_faults::assert_witness_is_a_side_channel(observed, plain, SCRIPTED_KEY);
 }
 
-/// The bus's facts for a failed run, in order, and no provider facts: the
-/// Responses adapter does not attach diagnostics.
-fn assert_bus_only_failure(run: &NativeRun, actions: &[&str]) {
+/// The bus's facts for a failed run, in order, and the Responses adapter's
+/// boundary facts: the request it sent and how the attempt closed.
+fn assert_failure_facts(
+    run: &NativeRun,
+    actions: &[&str],
+    ending: AdapterEnding,
+) -> Vec<AdapterEvent> {
     let trace = run.trace();
     assert_eq!(bus_actions(trace), actions);
     assert_eq!(endings(trace), ["provider"]);
+    let events = adapter_events(trace);
     assert!(
-        adapter_events(trace).is_empty(),
-        "no provider diagnostics on this wire: {:?}",
-        adapter_events(trace)
+        matches!(events.first(), Some(AdapterEvent::Started { route, .. }) if route == "/responses"),
+        "the adapter announces its request: {events:?}"
     );
+    assert_eq!(
+        events.last(),
+        Some(&AdapterEvent::Finished { ending }),
+        "the attempt closes as the fault: {events:?}"
+    );
+    events
 }
 
 /// The recorded 400 through the native runtime: the run fails as the
@@ -105,7 +116,28 @@ async fn setup_failure_fails_the_run_with_the_recorded_status() {
         comparable_failure(plain.failure())
     );
     assert_eq!(observed.log_json(), plain.log_json());
-    assert_bus_only_failure(observed, &["issued", "landed_err"]);
+    let events = assert_failure_facts(
+        observed,
+        &["issued", "landed_err"],
+        AdapterEnding::Error {
+            boundary: AdapterErrorBoundary::ProviderResponse,
+            kind: "provider_response".into(),
+            status: Some(400),
+            retryable: false,
+        },
+    );
+    assert!(
+        events.contains(&AdapterEvent::Response { status: 400 }),
+        "{events:?}"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AdapterEvent::ErrorEnvelope { error }
+                if error.status.as_deref() == Some("invalid_request_error")
+        )),
+        "the envelope's own fields are projected: {events:?}"
+    );
     assert!(
         !trace_json(observed.trace()).contains(SETUP_PROMPT),
         "the request body never reaches the trace"
@@ -144,7 +176,17 @@ async fn truncation_after_content_fails_the_run_and_keeps_the_prefix() {
     }
     let (observed, plain) = (&runs[0], &runs[1]);
     assert_witness_is_a_side_channel(observed, plain);
-    assert_bus_only_failure(observed, &["issued", "truncated", "landed_err"]);
+    let events = assert_failure_facts(
+        observed,
+        &["issued", "truncated", "landed_err"],
+        AdapterEnding::Eof {
+            after: frames.len(),
+        },
+    );
+    assert!(
+        events.contains(&AdapterEvent::Response { status: 200 }),
+        "{events:?}"
+    );
     let delivered = observed.stream().events.len();
     assert_eq!(truncations(observed.trace()), [(delivered, 0)]);
 }
@@ -191,7 +233,13 @@ async fn truncation_after_a_complete_tool_call_never_runs_the_tool() {
     }
     let (observed, plain) = (&runs[0], &runs[1]);
     assert_witness_is_a_side_channel(observed, plain);
-    assert_bus_only_failure(observed, &["issued", "truncated", "landed_err"]);
+    assert_failure_facts(
+        observed,
+        &["issued", "truncated", "landed_err"],
+        AdapterEnding::Eof {
+            after: frames.len(),
+        },
+    );
     assert_eq!(truncations(observed.trace()).len(), 1);
 }
 
@@ -237,7 +285,26 @@ async fn error_event_after_content_fails_with_the_provider_error() {
     }
     let (observed, plain) = (&runs[0], &runs[1]);
     assert_witness_is_a_side_channel(observed, plain);
-    assert_bus_only_failure(observed, &["issued", "landed_err"]);
+    let events = assert_failure_facts(
+        observed,
+        &["issued", "landed_err"],
+        AdapterEnding::Error {
+            boundary: AdapterErrorBoundary::ProviderResponse,
+            kind: "provider_response".into(),
+            status: None,
+            retryable: false,
+        },
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AdapterEvent::ErrorEnvelope { error }
+                if error.code.as_deref() == Some("server_error")
+                    && error.status.as_deref() == Some("server_error")
+                    && error.message.as_deref() == Some("boom")
+        )),
+        "the event's envelope is projected: {events:?}"
+    );
     assert!(
         truncations(observed.trace()).is_empty(),
         "an error, not EOF"

--- a/tests/providers/openrouter/cassette/response_identity_edge.rs
+++ b/tests/providers/openrouter/cassette/response_identity_edge.rs
@@ -78,10 +78,10 @@ async fn routed_failure_error_shape() {
                 .send()
                 .await
                 .expect_err("an unroutable model must fail");
-            // Derived from the recording: OpenRouter answers a body-ful 4xx;
-            // contract-less classification keeps the transport shape.
+            // Derived from the recording: OpenRouter answers a body-ful 4xx,
+            // preserved as its response through the one funnel.
             assert!(
-                matches!(error, rig::completion::CompletionError::HttpError(_)),
+                matches!(error, rig::completion::CompletionError::ProviderResponse(_)),
                 "got {error:?}"
             );
             assert!(error.provider_response_body().is_some());


### PR DESCRIPTION
## Description

Child of #2443 (base `feat/effect-bus`), following #2490. Two older paths
survived beside newer ones; both are gone.

**One error funnel.** `rig_core::provider_response` had two: the older
`from_http_response` turned a non-2xx reply into `HttpError` (kind
`Http { status }`), the newer `from_http_response_with_request_id` kept it as
`ProviderResponse`. Which one a call site used depended on whether the
provider named a request-id header, so the same fault classified differently
by wire — and five shared drivers computed the request id and then discarded
it by calling the older funnel. Now:

- `from_http_response(status, body)` is the only funnel and always preserves
  the reply as `ProviderResponse`; `with_provider_request_id` and
  `with_response_headers` stamp the transport metadata a site has.
  `from_http_response_with_request_id` is deleted, as is the completion
  driver's "classification follows the contract" fallback.
- `from_transport_error` routes a transport-reported reply (body in hand)
  through the same funnel, headers included, and is the `From<http_client::Error>`
  conversion of every capability error and `VerifyError`, so `?` classifies
  like an explicit call. `HttpError` / `ErrorKind::Http` now mean one thing:
  a transport failure that produced no provider reply, and they never carry
  a status.
- `http_client::Error` has one non-success shape, `InvalidStatusCodeWithDetails`
  (status, body, headers). The bodiless `InvalidStatusCode` and the
  header-less `InvalidStatusCodeWithMessage` are deleted: the only producer
  of a bodiless status was the SSE opener, which dropped the reply's body on
  a non-200 open; it now reads the body (bounded) and headers and rejects
  with the reply whole, so `Retry-After` and the request id reach the retry
  policy and the error on a rejected stream open too. `ErrorKind::Http` is a
  unit variant; a vector store's own non-2xx reply reports as
  `ProviderResponse` with its status.
- The five drivers (transcription, image, audio, rerank, OpenAI-compatible
  embeddings) stamp the id they already held; fourteen hand-rolled provider
  sites take the response apart and attach its headers (`Retry-After` on a
  429 now survives on every capability); the verify path, the websocket
  handshake and the SSE stream transport go through the funnel; a
  response-less SSE transport failure is a retryable transport error instead
  of a non-retryable string.
- Pre-existing `ProviderError(String)` and `ResponseError(String)` sites were
  audited: all are Rig-authored diagnostics with no provider payload behind
  them and stay; the one real flatten (the CLI chatbot turning a stream error
  into its `Display`) now keeps the run's error.

Retryability is unchanged for every status (both tables key on the status).
Tests moved with the rule and none were loosened: the funnel contract tests
are rewritten, 36 provider unit tests and 6 cassette tests retarget
`ProviderResponse`, and the #2490 Gemini cells pin the one kind.

**Adapter facts on every HTTP wire.** Only Gemini threaded the witness's
`AdapterContext` through its request. The OpenAI Chat Completions, OpenAI
Responses and Anthropic Messages wires now implement `completion_with_context`
/ `stream_with_context` with their own payload projectors (usage incl. cached
and reasoning details, finish/stop reason, model, response id, error
envelope on the reply and on stream frames); Cohere, Ollama and the Gemini
Interactions wire attach the context and report the transport facts. The
streaming conformance harness drives every wire through the observed entry
and requires a `Started` first and a `Finished` last, so a wire that takes
the context-discarding default fails its own suite. The delegating
context-less `stream` wrappers are deleted.

**Cells.** The OpenAI native stream-fault cells now assert the Responses
adapter's boundary facts; a new Anthropic native cell reads the Messages
facts off the committed 401 recording with the witness on and off.

**Recordings requested, not made.** A multi-frame Gemini REST stream cannot
be cut from any committed recording (all single-frame). Two `#[ignore]`d
cells are in place: the recorder (`stream_faults/multi_frame_stream`,
`gemini-3-flash-preview`, one streamed prompt, well under a cent) and the
cell that derives a truncation from it. Recording needs `GEMINI_API_KEY` and
creates one fixture. A transient 429/5xx followed by success cannot be
recorded on demand and is recorded as unsupported; neither runtime retries a
stream setup failure by design — that belongs to the transport's
`RetryPolicy`, which now sees `Retry-After` on every wire.

**Downstream (rigcoder), audited read-only.** Two replay-session paths would
trip the #2490 drop guard on the next pin bump (an early `?` before
`complete_capture`, and a test cell that drops an unfinished session before
`resume_unwind`); both are fixable with the existing `finish_after_test`
API. Its evidence fixtures carry `"kind": "http"` for provider replies and
will flip to `provider_response`. No Rig change is needed.

**Left for a follow-up.** Payload projectors for Cohere/Ollama/Interactions;
a public attempt API so the non-HTTP adapters (Bedrock, Vertex, gRPC Gemini,
Candle) can report facts, after which the agent-level conformance parity
scenario can require them too.

## Changelog

- *(core)* [**breaking**] one error funnel: a provider's non-2xx reply is always `ProviderResponse` with status, body, request id and headers on the report; `from_http_response_with_request_id` removed (use `from_http_response(..).with_provider_request_id(..)`); `from_transport_error` is the transport conversion; `HttpError` / `ErrorKind::Http` mean a transport failure without a provider reply and never carry a status; `http_client::Error::InvalidStatusCode` and `InvalidStatusCodeWithMessage` removed (one non-success shape, `InvalidStatusCodeWithDetails`), `ErrorKind::Http` is a unit variant, and the SSE opener rejects a non-200 open with the reply's body and headers.
- *(core)* request ids and `Retry-After` headers now survive onto errors on every capability and every hand-rolled provider path, not only completion.
- *(core)* a response-less SSE transport failure is a retryable transport error, no longer a `ProviderError` string.
- *(core)* adapter observation facts on the OpenAI Chat Completions, OpenAI Responses and Anthropic wires (payload projectors) and on Cohere, Ollama and Gemini Interactions (transport facts); the streaming conformance harness requires every wire to thread its context.
- *(agent)* the CLI chatbot keeps the run's error instead of its display string.

## Migration

- `CompletionError::from_http_response_with_request_id(status, body, id)` → `CompletionError::from_http_response(status, body).with_provider_request_id(id)` (same for every capability error and `VerifyError`).
- Code matching `CompletionError::HttpError(_)` for a provider's non-2xx reply now sees `ProviderResponse(_)`; `provider_response_status()` / `provider_response_body()` / `provider_request_id()` / `provider_response_headers()` read the same on both. `ErrorKind::Http { status: _ }` patterns become `ErrorKind::Http`; `http_client::Error::InvalidStatusCode(s)` / `InvalidStatusCodeWithMessage(s, body)` patterns become `InvalidStatusCodeWithDetails { status: s, body, headers }` (build one with `Error::non_success_with_details`); a `reqwest::Error` mapped by `rig_reqwest::from_reqwest` is always `Error::Instance`.
- Serialized `ErrorReport`s: `ErrorKind::Http` is now the bare string `"http"` (was `{"http":{"status":..}}`); `VectorStoreError::ExternalAPIError` reports `provider_response` with its status and body. `MIGRATING.md`'s unreleased section still shows `match` arms on the deleted variants; it is regenerated at release.
- Observation traces: a provider reply's `Reason` / `AdapterEnding::Error` kind code is `provider_response` where it was `http`.

## Testing

```sh
cargo nextest run --locked -p rig-core -p rig-agent -p rig-cassette -p rig-ecs -p rig-effect-log --all-features
RIG_PROVIDER_TEST_MODE=replay cargo nextest run --locked -p rig --all-features --test gemini --test openai --test anthropic --test core --test chatgpt --test cohere --test openrouter --test mistral --test groq --test ollama --test azure
cargo clippy --locked --all-features --all-targets -- -D warnings
RIG_PROVIDER_TEST_MODE=replay cargo xtask verify --pr --base origin/feat/effect-bus
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated READMEs and Rust docs affected by this change
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did not edit `CHANGELOG.md` or `MIGRATING.md` (they are generated at release)

## Notes

Ledger with per-site dispositions and the downstream audit:
`many_rigs/reviews/rig-2443-06-one-funnel/ledger.md`.
