### PR TITLE
chore(cassette): make rig-cassette publishable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -307,7 +307,7 @@ rig-tungstenite = { path = "crates/rig-tungstenite", version = "0.42.0", optiona
 
 [dev-dependencies]
 # The repository census checks Bedrock binary fixtures even in default suites.
-rig-cassette = { path = "crates/rig-cassette", features = ["bedrock"] }
+rig-cassette = { path = "crates/rig-cassette", version = "0.42.0", features = ["bedrock"] }
 rig-ecs = { path = "crates/rig-ecs" }
 bevy_app = { workspace = true }
 bevy_ecs = { workspace = true }

--- a/crates/rig-cassette/Cargo.toml
+++ b/crates/rig-cassette/Cargo.toml
@@ -3,8 +3,13 @@ name = "rig-cassette"
 version.workspace = true
 edition.workspace = true
 license = "MIT"
-publish = false
+readme = "README.md"
 description = "Reusable provider cassette recording, replay, scrubbing and safety checks."
+repository = "https://github.com/0xPlaygrounds/rig"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true
@@ -14,8 +19,8 @@ default = []
 bedrock = ["dep:aws-smithy-eventstream", "dep:aws-smithy-types"]
 
 [dependencies]
-rig-core = { path = "../rig-core", default-features = false }
-rig-reqwest = { path = "../rig-reqwest", default-features = false, features = ["rustls"] }
+rig-core = { path = "../rig-core", version = "0.42.0", default-features = false }
+rig-reqwest = { path = "../rig-reqwest", version = "0.42.0", default-features = false, features = ["rustls"] }
 aws-smithy-eventstream = { workspace = true, optional = true }
 aws-smithy-types = { workspace = true, optional = true }
 axum = { workspace = true }


### PR DESCRIPTION
## Summary

`rig-cassette` is the provider cassette engine: record, replay, scrubbing and safety checks, with no dependency on either agent runtime or the `rig` facade. Downstream application test suites already consume it as a git dependency. This makes it a publishable crate so the next release ships it to crates.io alongside `rig-reqwest` and `rig-tungstenite`, which are in the same not-yet-released state.

Manifest changes only:

- drop `publish = false`
- add `readme`, `repository` and the docs.rs metadata every other published companion carries
- add `version = "0.42.0"` to the `rig-core` and `rig-reqwest` path dependencies, and to the facade's dev-dependency on `rig-cassette`, so a registry build can resolve them

No source changes. The `bedrock` feature stays optional, so the Smithy event-stream scrubber is opt-in for consumers.

## Verification

- `cargo package -p rig-cassette --list` packages `Cargo.toml`, `README.md` and `src/` only
- a full `cargo package` verify cannot resolve until `rig-reqwest` is on crates.io; it will resolve in release-plz's dependency-ordered publish
- `cargo nextest run -p rig-cassette --all-features`: 64 passed, including the downstream-graph probe that pins the no-default-features dependency set
- `cargo clippy -p rig-cassette --all-features --all-targets` and `cargo fmt --check` clean

## Changelog

- *(cassette)* `rig-cassette` is now published to crates.io: provider cassette recording, replay, scrubbing and safety checks for downstream test suites, with the `bedrock` feature opting into binary Smithy event-stream scrubbing

## Migration

None.