### PR TITLE
fix(rig-cassette): restore start_at and checkpoint_recording for consumers that stage candidates

### DIFF
--- a/crates/rig-cassette/README.md
+++ b/crates/rig-cassette/README.md
@@ -24,9 +24,15 @@ fixtures and failed assertions panic, preserving the original test-support
 behavior.
 
 `RIG_PROVIDER_TEST_MODE` defaults to `replay`. `record` contacts the configured
-upstream and overwrites the selected fixture after scrubbing; the mode is read from
-the environment by every constructor, and a recording reaches the provider through
-the proxy (`start`) or directly (`start_via(Transport::Direct, ..)`).
+upstream and overwrites the selected fixture after scrubbing; `start` and
+`start_via` read the mode from the environment, and a recording reaches the
+provider through the proxy (`start`) or directly (`start_via(Transport::Direct, ..)`).
+Consumers that stage candidates use `ProviderCassette::start_at` with an explicit
+mode and exact path: a live capture records into a candidate path, and a
+verification pass replays with `CassetteMode::Replay` even when the environment
+asks for recording, so a candidate is never implicitly promoted to a fixture.
+While a live run is in progress, `checkpoint_recording` writes the completed,
+scrubbed exchanges to a partial path without finalizing the recording.
 
 `DirectRecorder`, its request/response types and `DirectRecordingHttpClient`
 preserve binary bodies that a text proxy cannot record. SSE and ordinary binary

--- a/crates/rig-cassette/src/explicit_destination_tests.rs
+++ b/crates/rig-cassette/src/explicit_destination_tests.rs
@@ -1,0 +1,118 @@
+//! `start_at` and `checkpoint_recording`: a consumer that stages candidates
+//! records into an explicit path outside the fixture layout, keeps partial
+//! snapshots while the live run is in progress, and replays an exact path
+//! without consulting the environment.
+
+use super::*;
+use serde_json::json;
+
+fn client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("HTTP client")
+}
+
+fn interactions_in(path: &Path) -> Vec<CassetteInteraction> {
+    let yaml = fs::read_to_string(path).expect("cassette should be readable");
+    serde_yaml::Deserializer::from_str(&yaml)
+        .map(CassetteInteraction::deserialize)
+        .collect::<Result<Vec<_>, _>>()
+        .expect("cassette should parse")
+}
+
+#[tokio::test]
+async fn recording_to_an_explicit_path_keeps_partial_snapshots_before_finalizing() {
+    let upstream = httpmock::MockServer::start_async().await;
+    upstream
+        .mock_async(|when, then| {
+            when.path("/v1/answer");
+            then.status(200)
+                .json_body(json!({"text": "recorded exchange"}));
+        })
+        .await;
+    let candidate = assert_fs::TempDir::new().expect("candidate directory");
+    let path = candidate.path().join("provider.yaml");
+    let partial = candidate.path().join("provider.partial.yaml");
+    let cassette = ProviderCassette::start_at(
+        Transport::Proxy,
+        "example",
+        CassetteSpec::new("explicit-destination"),
+        &format!("{}/v1", upstream.base_url()),
+        CassetteMode::Record,
+        path.clone(),
+    )
+    .await;
+
+    // Nothing has been exchanged: no snapshot, and no empty file either.
+    assert!(!cassette.checkpoint_recording(&partial).await);
+    assert!(!partial.exists());
+
+    let status = client()
+        .post(format!("{}/answer", cassette.base_url()))
+        .json(&json!({"input": 0}))
+        .send()
+        .await
+        .expect("proxied response")
+        .status();
+    assert_eq!(status, StatusCode::OK);
+
+    assert!(cassette.checkpoint_recording(&partial).await);
+    let snapshot = interactions_in(&partial);
+    assert_eq!(snapshot.len(), 1);
+    assert_eq!(snapshot[0].when.path, "/v1/answer");
+    assert!(!path.exists(), "a snapshot is not the finalized recording");
+
+    cassette.finish().await;
+    assert_eq!(interactions_in(&path).len(), 1);
+    assert!(partial.exists(), "finalization leaves the snapshot alone");
+}
+
+#[tokio::test]
+async fn replaying_an_explicit_path_ignores_the_fixture_layout_and_never_snapshots() {
+    let candidate = assert_fs::TempDir::new().expect("candidate directory");
+    let path = candidate.path().join("provider.yaml");
+    let interaction = CassetteInteraction {
+        when: CassetteRequest {
+            path: "/v1/answer".into(),
+            method: "POST".into(),
+            query_param: Vec::new(),
+            header: vec![NameValue {
+                name: "content-type".into(),
+                value: "application/json".into(),
+            }],
+            body: Some(json!({"input": 0}).to_string()),
+            body_encoding: BodyEncoding::Utf8,
+        },
+        then: CassetteResponse {
+            status: 200,
+            header: Vec::new(),
+            body: Some(json!({"text": "replayed"}).to_string()),
+            body_encoding: BodyEncoding::Utf8,
+        },
+    };
+    fs::write(&path, serialize_cassette_interactions(&[interaction])).expect("write fixture");
+    let cassette = ProviderCassette::start_at(
+        Transport::Proxy,
+        "example",
+        CassetteSpec::new("explicit-destination"),
+        "https://example.invalid/v1",
+        CassetteMode::Replay,
+        path.clone(),
+    )
+    .await;
+
+    let partial = candidate.path().join("provider.partial.yaml");
+    assert!(!cassette.checkpoint_recording(&partial).await);
+    assert!(!partial.exists());
+
+    let status = client()
+        .post(format!("{}/answer", cassette.base_url()))
+        .json(&json!({"input": 0}))
+        .send()
+        .await
+        .expect("replayed response")
+        .status();
+    assert_eq!(status, StatusCode::OK);
+    cassette.finish().await;
+}

--- a/crates/rig-cassette/src/lib.rs
+++ b/crates/rig-cassette/src/lib.rs
@@ -410,10 +410,35 @@ impl ProviderCassette {
         real_base_url: &str,
     ) -> Self {
         let spec = spec.into();
+        let cassette_path = cassette_path(cassette_root, provider, spec.scenario);
+        Self::start_at(
+            transport,
+            provider,
+            spec,
+            real_base_url,
+            CassetteMode::current(),
+            cassette_path,
+        )
+        .await
+    }
+
+    /// Start with an explicit mode and destination instead of the ambient
+    /// environment and fixture layout. Consumers that stage candidates use
+    /// this: a live capture records into a candidate path that is validated
+    /// before promotion, and a verification pass replays an exact path even
+    /// when the environment asks for recording, so a candidate is never
+    /// implicitly promoted to a fixture. `transport` only matters when
+    /// `mode` records.
+    pub async fn start_at(
+        transport: Transport,
+        provider: &'static str,
+        spec: CassetteSpec,
+        real_base_url: &str,
+        mode: CassetteMode,
+        cassette_path: PathBuf,
+    ) -> Self {
         let scenario = spec.scenario;
-        let mode = CassetteMode::current();
         let policy = CassettePolicy::for_scenario(provider, scenario, spec.replay_matching);
-        let cassette_path = cassette_path(cassette_root, provider, scenario);
         let upstream = UpstreamBase::parse(real_base_url);
         let server = if !mode.records() {
             if !cassette_path.exists() {
@@ -464,6 +489,58 @@ impl ProviderCassette {
             mode,
             policy,
         }
+    }
+
+    /// Retain the completed, scrubbed exchanges of a recording that is still
+    /// in progress. This is a best-effort partial snapshot for a consumer
+    /// whose live run may exceed its budget, not finalization: it never
+    /// panics, never replaces an earlier snapshot with an empty document,
+    /// and returns whether `path` was written. Replay sessions return
+    /// `false`.
+    pub async fn checkpoint_recording(&self, path: &Path) -> bool {
+        if !self.mode.records() {
+            return false;
+        }
+        let yaml = match &self.server {
+            CassetteServer::Recording {
+                server,
+                recording_id,
+            } => {
+                let recording = httpmock::Recording::new(*recording_id, server);
+                let Ok(Some(bytes)) = recording.export_async().await else {
+                    return false;
+                };
+                let Ok(yaml) = String::from_utf8(bytes.to_vec()) else {
+                    return false;
+                };
+                yaml
+            }
+            CassetteServer::DirectRecording(server) => {
+                let interactions = server.interactions.lock().await;
+                if interactions.is_empty() {
+                    return false;
+                }
+                serialize_cassette_interactions(&interactions)
+            }
+            CassetteServer::Replay(_) => return false,
+        };
+        // httpmock can export an empty YAML document before the first response.
+        let parsed = serde_yaml::Deserializer::from_str(&yaml)
+            .map(CassetteInteraction::deserialize)
+            .collect::<Result<Vec<_>, _>>();
+        let Ok(interactions) = parsed else {
+            return false;
+        };
+        if interactions.is_empty() {
+            return false;
+        }
+        let redacted = scrub_cassette_contents_with_policy(self.policy, &yaml);
+        if !cassette_safety_failures_with_policy(self.policy, path, &redacted).is_empty() {
+            return false;
+        }
+        write_cassette_atomically(path, redacted.as_bytes())
+            .await
+            .is_ok()
     }
 
     /// Return the direct recorder only for an active direct-recording session.
@@ -3296,6 +3373,8 @@ pub fn owned_headers(headers: &http_client::HeaderMap) -> Vec<(String, String)> 
         .collect()
 }
 
+#[cfg(test)]
+mod explicit_destination_tests;
 #[cfg(test)]
 mod paths;
 #[cfg(test)]


### PR DESCRIPTION
## Description

#2496 deleted `ProviderCassette::checkpoint_recording` as dead public API and made `start_at` private under the one-constructor rule. The audit covered this workspace, so it could not see the caller: **rigcoder-verify**, the ECS consumer verification harness that #2474 moved to [gold-silver-copper/rigcoder](https://github.com/gold-silver-copper/rigcoder). That harness is built around both functions:

- A live capture records into `<candidate>/provider.yaml`, a path that is not `<root>/<provider>/<scenario>.yaml`. `start` and `start_via` cannot address it.
- The verification pass replays an exact candidate path with `CassetteMode::Replay` even when `RIG_PROVIDER_TEST_MODE=record`, so a candidate is never implicitly promoted to a fixture. Every remaining constructor reads the mode from the environment.
- While a live run may exceed its budget, the harness snapshots the completed, scrubbed exchanges to `provider.partial.yaml` every second. That is `checkpoint_recording`; without it a run that hits its deadline loses all traffic.

Found while moving rigcoder's pin from the #2443 branch head to the `main` squash: the last two commits on the branch (#2495, #2496) landed after the pin and rigcoder-verify no longer compiles against `main`.

**Observed:** `ProviderCassette::start_at` and `checkpoint_recording` are gone; the #2496 migration section names no replacement for either.
**Expected:** a consumer that stages candidates can pick the mode and destination explicitly and snapshot an in-progress recording.

**Implementation:** `start_at` is public again and takes the `Transport` parameter `start_via` grew; `start_via` now delegates to it, so there is still one construction path. `checkpoint_recording` is restored on top of the `CassetteServer::Recording { server, recording_id }` variant, with the same best-effort contract: never panics, never writes an empty document, returns `false` for replay sessions. README updated.

## Changelog

- *(rig-cassette)* `ProviderCassette::start_at(Transport, provider, spec, base_url, mode, path)` is public again for consumers that stage candidate recordings outside the fixture layout, and `checkpoint_recording` is restored so a live capture can retain partial, scrubbed traffic before finalization. Both were removed in #2496 as unused; the caller is the out-of-tree rigcoder-verify harness moved in #2474.

## Migration

None. `start` and `start_via` are unchanged. Callers migrated by #2496 need no further change.

## Testing

- `cargo test -p rig-cassette` (65 passed, including the two new tests in `explicit_destination_tests.rs`: recording to an explicit path keeps partial snapshots before finalizing; replaying an explicit path ignores the fixture layout and never snapshots)
- `cargo clippy -p rig-cassette --all-targets -- -D warnings`
- `cargo fmt -p rig-cassette -- --check`
- `cargo xtask verify --changed` (all 3 checks passed)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated READMEs and Rust docs affected by this change
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did not edit `CHANGELOG.md` or `MIGRATING.md` (they are generated at release)

## Notes

`start_at` gains a `Transport` argument compared to its pre-#2496 signature, so it is not a byte-for-byte revert; the consumer passes `Transport::Proxy`.
